### PR TITLE
feat: add GitHub Actions CI (lint, typecheck, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,test]"
+
+      - name: Run ruff
+        run: ruff check app tests
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,test]"
+
+      - name: Run mypy
+        run: mypy app tests
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        # NOTE: TRD mentions PostgreSQL 18 (planned); latest stable is 17.
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: draupnir_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,test]"
+
+      - name: Run pytest
+        run: pytest
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/draupnir_test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # draupnir
 
+[![CI](https://github.com/momoshell/draupnir/actions/workflows/ci.yml/badge.svg)](https://github.com/momoshell/draupnir/actions/workflows/ci.yml)
+
 Draupnir is a backend-first CAD/BIM ingestion and estimation system. The MVP
 focuses on accepting common real-world drawing inputs, extracting structured
 geometry and semantic data, producing deterministic quantities and estimates,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+"""Draupnir — CAD/BIM ingestion, estimation, and revision system."""
+
+__version__: str = "0.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@
 requires = ["hatchling>=1.21"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
 [project]
 name = "draupnir"
 version = "0.1.0"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for Draupnir."""

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,9 @@
+"""Smoke tests for Draupnir."""
+
+from app import __version__
+
+
+def test_version() -> None:
+    """Test that version is a non-empty string."""
+    assert isinstance(__version__, str)
+    assert len(__version__) > 0


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with 3 jobs: lint (ruff), typecheck (mypy strict), test (pytest + Postgres 17 service container)
- Add `permissions: contents: read` for least-privilege token scope
- Scaffold `app/__init__.py`, `tests/__init__.py`, `tests/test_smoke.py` so CI jobs have something to analyze
- Add CI badge to README.md
- Add hatch wheel build config to `pyproject.toml`

## Acceptance Criteria

- ✅ A trivial PR triggers CI; all jobs pass
- ✅ A deliberately broken PR (e.g., unused import) fails the lint job
- ✅ Workflow uses Python 3.12, dependency caching, Postgres service container
- ✅ Status badge added to README

## Review Fixes Applied

- Added workflow-level `permissions: contents: read` (least-privilege)
- Postgres bumped to 17-alpine (TRD mentions 18 which doesn't exist yet; added comment)

## References

- Closes #19
- Phase 0.5 in `docs/ROADMAP.md`
- `docs/TRD.md` (Testing Strategy)