### PR TITLE
feat: scaffold app/ package layout with module docstrings

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP API routers and endpoint handlers."""

--- a/app/cad/__init__.py
+++ b/app/cad/__init__.py
@@ -1,0 +1,1 @@
+"""CAD entity and geometry utilities."""

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core configuration, logging, and shared utilities."""

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database connection, session management, and migrations."""

--- a/app/estimating/__init__.py
+++ b/app/estimating/__init__.py
@@ -1,0 +1,1 @@
+"""Quantity extraction and estimation logic."""

--- a/app/exports/__init__.py
+++ b/app/exports/__init__.py
@@ -1,0 +1,1 @@
+"""Export generators for JSON, CSV, PDF, and DXF."""

--- a/app/ingestion/__init__.py
+++ b/app/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""CAD/BIM file ingestion adapters."""

--- a/app/jobs/__init__.py
+++ b/app/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Background job definitions and Celery workers."""

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,1 @@
+"""SQLAlchemy ORM models."""

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,1 @@
+"""Pydantic request/response schemas."""

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage backends and file persistence."""


### PR DESCRIPTION
## Summary
- Creates all 11 subdirectories under `app/` with `__init__.py` files
- Each module has a one-line docstring describing its responsibility
- Matches the planned layout in `AGENTS.md` Repository Layout section

## Acceptance Criteria
- [x] Layout matches `AGENTS.md`
- [x] `python -c "import app"` succeeds
- [x] Empty test discovery passes (`pytest --collect-only`)

## References
Closes #20