### PR TITLE
feat: add FastAPI app, config, and /v1/health endpoint

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,0 +1,5 @@
+"""API v1 routers."""
+
+from app.api.v1.health import health_router
+
+__all__ = ["health_router"]

--- a/app/api/v1/health.py
+++ b/app/api/v1/health.py
@@ -1,0 +1,25 @@
+"""Health check endpoint."""
+
+from typing import Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.core.config import settings
+
+
+class HealthResponse(BaseModel):
+    """Response model for health check endpoint."""
+
+    status: Literal["ok"]
+    version: str | None = None
+
+
+health_router = APIRouter()
+
+
+@health_router.get("/health", response_model=HealthResponse)
+async def get_health() -> HealthResponse:
+    """Return service health status and optionally version."""
+    version = settings.app_version if settings.expose_version_in_health else None
+    return HealthResponse(status="ok", version=version)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,0 +1,35 @@
+"""Application configuration via pydantic-settings."""
+
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from app import __version__
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables and .env file."""
+
+    app_name: str = "Draupnir"
+    app_version: str = __version__
+    debug: bool = False
+    api_prefix: str = "/v1"
+    expose_version_in_health: bool = False
+
+    @field_validator("api_prefix")
+    @classmethod
+    def validate_api_prefix(cls, value: str) -> str:
+        if not value.startswith("/"):
+            raise ValueError("api_prefix must start with '/'")
+        if value != "/" and value.endswith("/"):
+            raise ValueError("api_prefix must not end with '/'")
+        return value
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+
+settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,22 @@
+"""FastAPI application factory."""
+
+from fastapi import FastAPI
+
+from app.api.v1 import health_router
+from app.core.config import settings
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application instance."""
+    app = FastAPI(
+        title=settings.app_name,
+        version=settings.app_version,
+        debug=settings.debug,
+    )
+
+    app.include_router(health_router, prefix=settings.api_prefix)
+
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
- `app/main.py`: FastAPI app factory with `create_app()` and module-level `app` for uvicorn
- `app/core/config.py`: Pydantic-settings config with `.env` support, env var overrides, and `api_prefix` validation
- `app/api/v1/health.py`: `GET /v1/health` returning `{"status": "ok", "version": "..."}` (version hidden by default, configurable via `EXPOSE_VERSION_IN_HEALTH`)
- `app/api/v1/__init__.py`: Package init exporting `health_router`

## Security
- Version exposure on health endpoint is behind `expose_version_in_health` config flag (default `False`) per code review feedback
- `api_prefix` validated to start with `/` and not end with `/`

## Acceptance Criteria
- [x] `uvicorn app.main:app` starts locally
- [x] `GET /v1/health` returns 200 with structured JSON
- [x] Settings can be overridden by env vars and `.env` files
- [x] Code review feedback addressed

## References
Closes #21