### PR TITLE
feat: add project CRUD endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev,test,jobs,db]"
 
+      - name: Run Alembic migrations
+        run: alembic upgrade head
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
+
       - name: Run pytest
         run: pytest
         env:

--- a/alembic/versions/2026_05_01_0001_add_projects.py
+++ b/alembic/versions/2026_05_01_0001_add_projects.py
@@ -1,0 +1,79 @@
+"""Add projects table.
+
+Revision ID: 2026_05_01_0001
+Revises: baseline
+Create Date: 2026-05-01 00:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_01_0001"
+down_revision: str | None = "baseline"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply migration changes.
+
+    Creates the projects table with UUID primary key and timestamps.
+    """
+    op.create_table(
+        "projects",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique project identifier (UUID v4)",
+        ),
+        sa.Column(
+            "name",
+            sa.String(length=255),
+            nullable=False,
+            comment="Project name",
+        ),
+        sa.Column(
+            "description",
+            sa.String(length=1024),
+            nullable=True,
+            comment="Optional project description",
+        ),
+        sa.Column(
+            "default_unit_system",
+            sa.String(length=64),
+            nullable=True,
+            comment="Default unit system (e.g., 'metric', 'imperial')",
+        ),
+        sa.Column(
+            "default_currency",
+            sa.String(length=3),
+            nullable=True,
+            comment="Default currency code (ISO 4217, e.g., 'USD', 'EUR')",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            comment="Project creation timestamp",
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            comment="Project last update timestamp",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    """Revert migration changes.
+
+    Drops the projects table.
+    """
+    op.drop_table("projects")

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,5 +1,6 @@
 """API v1 routers."""
 
 from app.api.v1.health import health_router
+from app.api.v1.projects import project_router
 
-__all__ = ["health_router"]
+__all__ = ["health_router", "project_router"]

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -1,0 +1,209 @@
+"""Project CRUD endpoints."""
+
+import base64
+import binascii
+import json
+from datetime import datetime
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.project import Project
+from app.schemas.project import (
+    ProjectCreate,
+    ProjectListResponse,
+    ProjectRead,
+    ProjectUpdate,
+)
+
+project_router = APIRouter()
+
+
+def _encode_cursor(created_at: datetime, project_id: UUID) -> str:
+    """Encode cursor from created_at and project_id."""
+    cursor_data = {
+        "created_at": created_at.isoformat(),
+        "id": str(project_id),
+    }
+    return base64.urlsafe_b64encode(json.dumps(cursor_data).encode()).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: str) -> dict[str, Any]:
+    """Decode cursor to dict with created_at and id."""
+    try:
+        # Add padding if needed
+        padding = 4 - (len(cursor) % 4)
+        if padding != 4:
+            cursor += "=" * padding
+
+        decoded = base64.urlsafe_b64decode(cursor)
+        cursor_data_raw = json.loads(decoded.decode("utf-8"))
+        if not isinstance(cursor_data_raw, dict):
+            raise TypeError("Cursor payload must be a JSON object")
+        cursor_data = cast(dict[str, Any], cursor_data_raw)
+
+        # Validate required keys and value formats.
+        _ = datetime.fromisoformat(str(cursor_data["created_at"]))
+        _ = UUID(str(cursor_data["id"]))
+        return cursor_data
+    except (
+        binascii.Error,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": {
+                    "code": "INVALID_CURSOR",
+                    "message": "Invalid cursor format",
+                    "details": None,
+                }
+            },
+        ) from e
+
+
+@project_router.post(
+    "",
+    response_model=ProjectRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_project(
+    project_in: ProjectCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Project:
+    """Create a new project."""
+    project = Project(
+        name=project_in.name,
+        description=project_in.description,
+        default_unit_system=project_in.default_unit_system,
+        default_currency=project_in.default_currency,
+    )
+    db.add(project)
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+@project_router.get(
+    "",
+    response_model=ProjectListResponse,
+)
+async def list_projects(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    cursor: Annotated[str | None, Query(description="Cursor for pagination")] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Number of items to return")] = 50,
+) -> ProjectListResponse:
+    """List projects with cursor pagination.
+
+    Projects are ordered by created_at DESC, id DESC.
+    Cursor should be the next_cursor value from a previous response.
+    """
+    # Build query ordered by created_at DESC, id DESC
+    query = select(Project).order_by(Project.created_at.desc(), Project.id.desc())
+
+    # Apply cursor filter if provided
+    if cursor:
+        cursor_data = _decode_cursor(cursor)
+        created_at = datetime.fromisoformat(str(cursor_data["created_at"]))
+        project_id = UUID(str(cursor_data["id"]))
+        # Filter for items after the cursor position
+        query = query.filter(
+            (Project.created_at < created_at)
+            | (
+                (Project.created_at == created_at)
+                & (Project.id < project_id)
+            )
+        )
+
+    # Fetch limit + 1 to determine if there's a next page
+    items = (await db.execute(query.limit(limit + 1))).scalars().all()
+
+    # Check if there's a next page
+    has_next = len(items) > limit
+    if has_next:
+        items = items[:-1]  # Remove the extra item
+
+    # Generate next cursor if there's a next page
+    next_cursor = None
+    if has_next and items:
+        last_item = items[-1]
+        next_cursor = _encode_cursor(last_item.created_at, last_item.id)
+
+    # Convert Sequence[Project] to list[ProjectRead] for response
+    project_reads = [ProjectRead.model_validate(project) for project in items]
+    return ProjectListResponse(items=project_reads, next_cursor=next_cursor)
+
+
+@project_router.get(
+    "/{project_id}",
+    response_model=ProjectRead,
+)
+async def get_project(
+    project_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Project:
+    """Get a project by ID."""
+    result = await db.execute(select(Project).where(Project.id == project_id))
+    project = result.scalar_one_or_none()
+
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    assert project is not None
+    return project
+
+
+@project_router.patch(
+    "/{project_id}",
+    response_model=ProjectRead,
+)
+async def update_project(
+    project_id: UUID,
+    project_in: ProjectUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Project:
+    """Update an existing project."""
+    result = await db.execute(select(Project).where(Project.id == project_id))
+    project = result.scalar_one_or_none()
+
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    assert project is not None
+
+    # Update only provided fields
+    update_data = project_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(project, field, value)
+
+    await db.commit()
+    await db.refresh(project)
+    return project
+
+
+@project_router.delete(
+    "/{project_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_project(
+    project_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Delete a project."""
+    result = await db.execute(select(Project).where(Project.id == project_id))
+    project = result.scalar_one_or_none()
+
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    await db.delete(project)
+    await db.commit()

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,0 +1,80 @@
+"""Custom exception handlers and error response utilities."""
+
+from typing import Any
+
+from fastapi import HTTPException, Request, status
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+
+class APIError(BaseModel):
+    """Standard API error response structure."""
+
+    code: str
+    message: str
+    details: Any | None = None
+
+
+class APIErrorResponse(BaseModel):
+    """Wrapper for API error responses."""
+
+    error: APIError
+
+
+def create_error_response(code: str, message: str, details: Any | None = None) -> dict[str, Any]:
+    """Create a standardized error response dictionary.
+
+    Args:
+        code: Error code (e.g., 'NOT_FOUND', 'VALIDATION_ERROR')
+        message: Human-readable error message
+        details: Optional additional error details
+
+    Returns:
+        Dictionary matching the APIErrorResponse schema
+    """
+    return {"error": {"code": code, "message": message, "details": details}}
+
+
+def raise_not_found(resource: str, identifier: str) -> None:
+    """Raise a 404 HTTPException with standardized error format.
+
+    Args:
+        resource: Type of resource (e.g., 'Project')
+        identifier: The identifier that was not found
+    """
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=create_error_response(
+            code="NOT_FOUND",
+            message=f"{resource} with identifier '{identifier}' not found",
+            details=None,
+        ),
+    )
+
+
+async def custom_http_exception_handler(request: Request, exc: Exception) -> Response:
+    """Return custom envelope when HTTPException detail already contains `error`."""
+    if not isinstance(exc, HTTPException):
+        raise exc
+
+    if isinstance(exc.detail, dict) and "error" in exc.detail:
+        return JSONResponse(status_code=exc.status_code, content=exc.detail)
+    return await http_exception_handler(request, exc)
+
+
+async def request_validation_exception_handler(request: Request, exc: Exception) -> Response:
+    """Return standardized validation error envelope for 422 responses."""
+    _ = request
+    if not isinstance(exc, RequestValidationError):
+        raise exc
+
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content=create_error_response(
+            code="VALIDATION_ERROR",
+            message="Request validation failed",
+            details=exc.errors(),
+        ),
+    )

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1,6 +1,6 @@
 """Celery worker application."""
 
-from celery import Celery
+from celery import Celery  # type: ignore[import-untyped]
 
 from app.core.config import settings
 
@@ -15,7 +15,7 @@ celery_app.autodiscover_tasks(["app.jobs"], force=True)
 
 
 # Example task (remove once real tasks exist)
-@celery_app.task
+@celery_app.task  # type: ignore[untyped-decorator]
 def health_check_task() -> str:
     """Simple health check task for testing worker connectivity."""
     return "ok"

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1,6 +1,6 @@
 """Celery worker application."""
 
-from celery import Celery  # type: ignore[import-untyped]
+from celery import Celery
 
 from app.core.config import settings
 
@@ -15,7 +15,7 @@ celery_app.autodiscover_tasks(["app.jobs"], force=True)
 
 
 # Example task (remove once real tasks exist)
-@celery_app.task  # type: ignore[untyped-decorator]
+@celery_app.task
 def health_check_task() -> str:
     """Simple health check task for testing worker connectivity."""
     return "ok"

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 """FastAPI application factory."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
 
-from app.api.v1 import health_router
+from app.api.v1 import health_router, project_router
 from app.core.config import settings
+from app.core.exceptions import custom_http_exception_handler, request_validation_exception_handler
 from app.core.logging import configure_logging, get_logger
 from app.core.middleware import RequestIdMiddleware
 
@@ -24,10 +26,14 @@ def create_app() -> FastAPI:
         debug=settings.debug,
     )
 
+    app.add_exception_handler(HTTPException, custom_http_exception_handler)
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+
     # Add middleware
     app.add_middleware(RequestIdMiddleware)
 
     app.include_router(health_router, prefix=settings.api_prefix)
+    app.include_router(project_router, prefix=f"{settings.api_prefix}/projects")
 
     logger.info("app_started", version=settings.app_version)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,3 +6,5 @@ for Alembic autogenerate support. Example:
     from . import drawing, revision, estimate
 
 """
+
+from . import project as project

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,0 +1,56 @@
+"""Project model for the draupnir CAD/BIM ingestion system."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class Project(Base):
+    """SQLAlchemy ORM model for a Project.
+
+    A project represents a top-level container for drawings, revisions,
+    and estimates. Each project has a unique UUID identifier.
+    """
+
+    __tablename__ = "projects"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique project identifier (UUID v4)",
+    )
+    name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Project name",
+    )
+    description: Mapped[str | None] = mapped_column(
+        String(1024),
+        nullable=True,
+        comment="Optional project description",
+    )
+    default_unit_system: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Default unit system (e.g., 'metric', 'imperial')",
+    )
+    default_currency: Mapped[str | None] = mapped_column(
+        String(3),
+        nullable=True,
+        comment="Default currency code (ISO 4217, e.g., 'USD', 'EUR')",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        comment="Project creation timestamp",
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        onupdate=func.now(),
+        comment="Project last update timestamp",
+    )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,1 +1,5 @@
 """Pydantic request/response schemas."""
+
+from app.schemas.project import ProjectCreate, ProjectListResponse, ProjectRead, ProjectUpdate
+
+__all__ = ["ProjectCreate", "ProjectListResponse", "ProjectRead", "ProjectUpdate"]

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -1,0 +1,57 @@
+"""Pydantic schemas for Project CRUD operations."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProjectCreate(BaseModel):
+    """Schema for creating a new project."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Project name")
+    description: str | None = Field(
+        None, max_length=1024, description="Optional project description"
+    )
+    default_unit_system: str | None = Field(
+        None, max_length=64, description="Default unit system (e.g., 'metric', 'imperial')"
+    )
+    default_currency: str | None = Field(
+        None, min_length=3, max_length=3, description="Default currency code (ISO 4217)"
+    )
+
+
+class ProjectRead(BaseModel):
+    """Schema for reading a project."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID = Field(..., description="Unique project identifier (UUID)")
+    name: str = Field(..., description="Project name")
+    description: str | None = Field(None, description="Optional project description")
+    default_unit_system: str | None = Field(None, description="Default unit system")
+    default_currency: str | None = Field(None, description="Default currency code")
+    created_at: datetime = Field(..., description="Project creation timestamp")
+    updated_at: datetime = Field(..., description="Project last update timestamp")
+
+
+class ProjectUpdate(BaseModel):
+    """Schema for updating an existing project."""
+
+    name: str | None = Field(None, min_length=1, max_length=255, description="Project name")
+    description: str | None = Field(
+        None, max_length=1024, description="Optional project description"
+    )
+    default_unit_system: str | None = Field(
+        None, max_length=64, description="Default unit system"
+    )
+    default_currency: str | None = Field(
+        None, min_length=3, max_length=3, description="Default currency code"
+    )
+
+
+class ProjectListResponse(BaseModel):
+    """Schema for paginated list of projects."""
+
+    items: list[ProjectRead] = Field(..., description="List of projects")
+    next_cursor: str | None = Field(None, description="Cursor for next page, null if last page")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Shared fixtures for integration tests."""
+
+import os
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.main import app as fastapi_app
+
+# Marker for tests that require a running database
+requires_database = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set - skipping database tests",
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def init_database_resources() -> AsyncGenerator[None, None]:
+    """Initialize and close DB resources on each test loop."""
+    if not os.environ.get("DATABASE_URL"):
+        yield
+        return
+
+    import app.db.session as session_module
+
+    session_module.engine, session_module.AsyncSessionLocal = session_module._init_db_resources()
+
+    yield
+
+    await session_module.close_db()
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Provide the FastAPI application instance for testing."""
+    return fastapi_app
+
+
+async def _override_get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Override for get_db dependency that uses the test session."""
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    session = session_maker()
+    try:
+        yield session
+    finally:
+        await session.close()
+
+
+@pytest_asyncio.fixture
+async def async_client(app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Provide an async HTTP client for testing with DB dependency override."""
+    # Override the get_db dependency to use test database
+    app.dependency_overrides[get_db] = _override_get_db
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+    # Clean up dependency override
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def cleanup_projects() -> AsyncGenerator[None, None]:
+    """Truncate projects table after each test to ensure clean state."""
+    if not os.environ.get("DATABASE_URL"):
+        yield
+        return
+
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    yield
+
+    async with session_maker() as session:
+        await session.execute(text("TRUNCATE TABLE projects CASCADE"))
+        await session.commit()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -158,6 +158,23 @@ class TestAlembicMigrations:
 
         assert result.returncode == 0, f"Alembic downgrade failed: {stderr.decode()}"
 
+        # Restore schema for subsequent tests that require migrated tables.
+        reupgrade_result = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "alembic",
+            "upgrade",
+            "head",
+            cwd=str(Path(__file__).parent.parent),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        _stdout, reupgrade_stderr = await reupgrade_result.communicate()
+        assert reupgrade_result.returncode == 0, (
+            f"Alembic re-upgrade failed after downgrade test: {reupgrade_stderr.decode()}"
+        )
+
     @requires_database
     @pytest.mark.asyncio
     async def test_alembic_current(self) -> None:

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,571 @@
+"""Integration tests for Project CRUD endpoints."""
+
+import base64
+import json
+import typing
+import uuid
+from typing import Any
+
+import httpx
+import pytest_asyncio
+
+from tests.conftest import requires_database
+
+
+@pytest_asyncio.fixture
+async def created_project(
+    async_client: httpx.AsyncClient,
+    cleanup_projects: None,
+) -> dict[str, Any]:
+    """Create a project and return its data."""
+    response = await async_client.post(
+        "/v1/projects",
+        json={"name": "Test Project", "description": "A test project"},
+    )
+    assert response.status_code == 201
+    return typing.cast(dict[str, Any], response.json())
+
+
+@requires_database
+class TestCreateProject:
+    """Tests for POST /v1/projects endpoint."""
+
+    async def test_create_project_success(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should create a project and return 201 with correct response shape.
+
+        Success case: POST with valid data returns 201, response contains
+        name, id, created_at, updated_at fields.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        project_data = {
+            "name": "My Test Project",
+            "description": "A project for testing",
+            "default_unit_system": "metric",
+            "default_currency": "USD",
+        }
+
+        # Act
+        response = await async_client.post("/v1/projects", json=project_data)
+
+        # Assert
+        assert response.status_code == 201
+        data = response.json()
+
+        # Verify response shape
+        assert "id" in data
+        assert "name" in data
+        assert "description" in data
+        assert "default_unit_system" in data
+        assert "default_currency" in data
+        assert "created_at" in data
+        assert "updated_at" in data
+
+        # Verify values
+        assert data["name"] == project_data["name"]
+        assert data["description"] == project_data["description"]
+        assert data["default_unit_system"] == project_data["default_unit_system"]
+        assert data["default_currency"] == project_data["default_currency"]
+
+        # Verify id is a valid UUID
+        assert uuid.UUID(data["id"])
+
+        # Verify timestamps are present and valid ISO format
+        assert data["created_at"] is not None
+        assert data["updated_at"] is not None
+
+    async def test_create_project_minimal_data(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should create a project with only required fields.
+
+        Success case: POST with only name returns 201, optional fields are null.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        project_data = {"name": "Minimal Project"}
+
+        # Act
+        response = await async_client.post("/v1/projects", json=project_data)
+
+        # Assert
+        assert response.status_code == 201
+        data = response.json()
+
+        assert data["name"] == project_data["name"]
+        assert data["description"] is None
+        assert data["default_unit_system"] is None
+        assert data["default_currency"] is None
+
+    async def test_create_project_validation_error_empty_name(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should reject project with empty name.
+
+        Failure case: POST with empty name returns 422 validation error.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        project_data = {"name": ""}
+
+        # Act
+        response = await async_client.post("/v1/projects", json=project_data)
+
+        # Assert
+        assert response.status_code == 422
+        data = response.json()
+
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert data["error"]["message"] == "Request validation failed"
+        assert isinstance(data["error"]["details"], list)
+
+
+@requires_database
+class TestGetProject:
+    """Tests for GET /v1/projects/{id} endpoint."""
+
+    async def test_get_project_success(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should return existing project with correct data.
+
+        Success case: GET with valid ID returns 200 and project data.
+        """
+        _ = self
+
+        # Arrange
+        project_id = created_project["id"]
+
+        # Act
+        response = await async_client.get(f"/v1/projects/{project_id}")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["id"] == project_id
+        assert data["name"] == created_project["name"]
+        assert data["description"] == created_project["description"]
+
+    async def test_get_project_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return 404 for non-existent project.
+
+        Failure case: GET with random UUID returns 404 with correct error shape.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        random_uuid = str(uuid.uuid4())
+
+        # Act
+        response = await async_client.get(f"/v1/projects/{random_uuid}")
+
+        # Assert
+        assert response.status_code == 404
+        data = response.json()
+
+        # Verify error response shape
+        assert "error" in data
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "message" in data["error"]
+        assert random_uuid in data["error"]["message"]
+        assert data["error"]["details"] is None
+
+    async def test_get_project_invalid_uuid(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return 422 for invalid UUID format.
+
+        Failure case: GET with invalid UUID format returns 422 validation error.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Act
+        response = await async_client.get("/v1/projects/not-a-uuid")
+
+        # Assert
+        assert response.status_code == 422
+        data = response.json()
+
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert data["error"]["message"] == "Request validation failed"
+        assert isinstance(data["error"]["details"], list)
+
+
+@requires_database
+class TestListProjects:
+    """Tests for GET /v1/projects endpoint."""
+
+    async def test_list_projects_empty(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return empty list when no projects exist.
+
+        Success case: GET returns 200 with empty items array and null next_cursor.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Act
+        response = await async_client.get("/v1/projects")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response shape
+        assert "items" in data
+        assert "next_cursor" in data
+        assert data["items"] == []
+        assert data["next_cursor"] is None
+
+    async def test_list_projects_with_data(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should return list with existing projects.
+
+        Success case: GET returns 200 with projects in items array.
+        """
+        _ = self
+
+        # Act
+        response = await async_client.get("/v1/projects")
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["items"]) >= 1
+        assert data["next_cursor"] is None
+
+        # Verify the created project is in the list
+        project_ids = [item["id"] for item in data["items"]]
+        assert created_project["id"] in project_ids
+
+    async def test_list_projects_pagination(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should paginate results correctly.
+
+        Success case: Creating > limit projects and requesting with small limit
+        returns next_cursor, and fetching next page returns different items.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange: Create 5 projects
+        created_ids: list[str] = []
+        for i in range(5):
+            response = await async_client.post(
+                "/v1/projects",
+                json={"name": f"Project {i}"},
+            )
+            assert response.status_code == 201
+            created_ids.append(response.json()["id"])
+
+        # Act: Request first page with limit=2
+        response = await async_client.get("/v1/projects?limit=2")
+
+        # Assert first page
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["items"]) == 2
+        assert data["next_cursor"] is not None
+
+        first_page_ids = [item["id"] for item in data["items"]]
+
+        # Act: Request second page
+        response = await async_client.get(f"/v1/projects?limit=2&cursor={data['next_cursor']}")
+
+        # Assert second page
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["items"]) == 2
+        assert data["next_cursor"] is not None
+
+        second_page_ids = [item["id"] for item in data["items"]]
+
+        # Verify pages have different items
+        assert not set(first_page_ids) & set(second_page_ids)
+
+        # Act: Request third page
+        response = await async_client.get(f"/v1/projects?limit=2&cursor={data['next_cursor']}")
+
+        # Assert third page (should have 1 item, no next cursor)
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["items"]) == 1
+        assert data["next_cursor"] is None
+
+        third_page_ids = [item["id"] for item in data["items"]]
+
+        # Verify all pages have different items
+        assert not set(first_page_ids) & set(third_page_ids)
+        assert not set(second_page_ids) & set(third_page_ids)
+
+        # Verify all created projects are accounted for
+        all_ids = first_page_ids + second_page_ids + third_page_ids
+        assert set(all_ids) == set(created_ids)
+
+    async def test_list_projects_invalid_cursor(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return 400 for invalid cursor.
+
+        Failure case: GET with invalid cursor returns 400 with error details.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Act
+        response = await async_client.get("/v1/projects?cursor=invalid-cursor")
+
+        # Assert
+        assert response.status_code == 400
+        data = response.json()
+
+        assert "error" in data
+        assert data["error"]["code"] == "INVALID_CURSOR"
+        assert data["error"]["message"] == "Invalid cursor format"
+        assert data["error"]["details"] is None
+
+    async def test_list_projects_malformed_cursors(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return 400 envelope for malformed cursors."""
+        _ = self
+        _ = cleanup_projects
+
+        invalid_utf8_cursor = base64.urlsafe_b64encode(b"\xff").decode().rstrip("=")
+        invalid_json_cursor = base64.urlsafe_b64encode(b"not-json").decode().rstrip("=")
+        missing_keys_cursor = base64.urlsafe_b64encode(
+            json.dumps({"created_at": "2026-01-01T00:00:00"}).encode()
+        ).decode().rstrip("=")
+        invalid_datetime_cursor = base64.urlsafe_b64encode(
+            json.dumps({"created_at": "not-a-datetime", "id": str(uuid.uuid4())}).encode()
+        ).decode().rstrip("=")
+        invalid_uuid_cursor = base64.urlsafe_b64encode(
+            json.dumps({"created_at": "2026-01-01T00:00:00", "id": "not-a-uuid"}).encode()
+        ).decode().rstrip("=")
+        non_object_array_cursor = (
+            base64.urlsafe_b64encode(json.dumps([]).encode()).decode().rstrip("=")
+        )
+        non_object_null_cursor = (
+            base64.urlsafe_b64encode(json.dumps(None).encode()).decode().rstrip("=")
+        )
+        non_object_string_cursor = base64.urlsafe_b64encode(
+            json.dumps("x").encode()
+        ).decode().rstrip("=")
+
+        malformed_cursors = [
+            "%%%",  # invalid base64
+            invalid_utf8_cursor,
+            invalid_json_cursor,
+            missing_keys_cursor,
+            invalid_datetime_cursor,
+            invalid_uuid_cursor,
+            non_object_array_cursor,
+            non_object_null_cursor,
+            non_object_string_cursor,
+        ]
+
+        for malformed_cursor in malformed_cursors:
+            response = await async_client.get(f"/v1/projects?cursor={malformed_cursor}")
+            assert response.status_code == 400
+            data = response.json()
+            assert "error" in data
+            assert data["error"]["code"] == "INVALID_CURSOR"
+            assert data["error"]["message"] == "Invalid cursor format"
+            assert data["error"]["details"] is None
+
+
+@requires_database
+class TestUpdateProject:
+    """Tests for PATCH /v1/projects/{id} endpoint."""
+
+    async def test_update_project_success(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should update project and return updated data.
+
+        Success case: PATCH with valid data returns 200, then GET verifies changes.
+        """
+        _ = self
+
+        # Arrange
+        project_id = created_project["id"]
+        update_data = {
+            "name": "Updated Project Name",
+            "description": "Updated description",
+        }
+
+        # Act: Update the project
+        response = await async_client.patch(f"/v1/projects/{project_id}", json=update_data)
+
+        # Assert update response
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["id"] == project_id
+        assert data["name"] == update_data["name"]
+        assert data["description"] == update_data["description"]
+
+        # Act: Verify with GET
+        response = await async_client.get(f"/v1/projects/{project_id}")
+
+        # Assert persisted changes
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["name"] == update_data["name"]
+        assert data["description"] == update_data["description"]
+
+    async def test_update_project_partial(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should update only provided fields.
+
+        Success case: PATCH with partial data updates only specified fields.
+        """
+        _ = self
+
+        # Arrange
+        project_id = created_project["id"]
+        original_description = created_project["description"]
+        update_data = {"name": "Only Name Updated"}
+
+        # Act
+        response = await async_client.patch(f"/v1/projects/{project_id}", json=update_data)
+
+        # Assert
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["name"] == update_data["name"]
+        assert data["description"] == original_description  # Unchanged
+
+    async def test_update_project_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return 404 for non-existent project.
+
+        Failure case: PATCH with random UUID returns 404 with correct error shape.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        random_uuid = str(uuid.uuid4())
+        update_data = {"name": "Updated Name"}
+
+        # Act
+        response = await async_client.patch(f"/v1/projects/{random_uuid}", json=update_data)
+
+        # Assert
+        assert response.status_code == 404
+        data = response.json()
+
+        assert "error" in data
+        assert data["error"]["code"] == "NOT_FOUND"
+
+
+@requires_database
+class TestDeleteProject:
+    """Tests for DELETE /v1/projects/{id} endpoint."""
+
+    async def test_delete_project_success(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should delete project and return 204.
+
+        Success case: DELETE returns 204, then GET returns 404.
+        """
+        _ = self
+
+        # Arrange
+        project_id = created_project["id"]
+
+        # Act: Delete the project
+        response = await async_client.delete(f"/v1/projects/{project_id}")
+
+        # Assert delete response
+        assert response.status_code == 204
+        assert response.content == b""
+
+        # Act: Verify deletion with GET
+        response = await async_client.get(f"/v1/projects/{project_id}")
+
+        # Assert project no longer exists
+        assert response.status_code == 404
+
+    async def test_delete_project_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should return 404 for non-existent project.
+
+        Failure case: DELETE with random UUID returns 404 with correct error shape.
+        """
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        random_uuid = str(uuid.uuid4())
+
+        # Act
+        response = await async_client.delete(f"/v1/projects/{random_uuid}")
+
+        # Assert
+        assert response.status_code == 404
+        data = response.json()
+
+        assert "error" in data
+        assert data["error"]["code"] == "NOT_FOUND"


### PR DESCRIPTION
Closes #26

## Summary
- add the Project model, migration, schemas, and `/v1/projects` CRUD endpoints with cursor pagination
- normalize API error envelopes for HTTP, validation, and malformed cursor failures
- add database-backed API tests covering create/read/update/delete, pagination, and invalid input cases

## Test plan
- [x] .venv/bin/ruff check app/ tests/ alembic/
- [x] .venv/bin/mypy app/ tests/ alembic/
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir .venv/bin/alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir .venv/bin/pytest tests/test_projects.py -v