### PR TITLE
feat: add file upload endpoint and models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ htmlcov/
 .env
 .env.local
 *.local
+
+# Local runtime artifacts
+var/

--- a/alembic/versions/2026_05_01_0002_add_files_and_jobs.py
+++ b/alembic/versions/2026_05_01_0002_add_files_and_jobs.py
@@ -1,0 +1,214 @@
+"""Add files and jobs tables.
+
+Revision ID: 2026_05_01_0002
+Revises: 2026_05_01_0001
+Create Date: 2026-05-01 00:02:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_01_0002"
+down_revision: str | None = "2026_05_01_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply migration changes for files and jobs."""
+    op.create_table(
+        "files",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique file identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "original_filename",
+            sa.String(length=512),
+            nullable=False,
+            comment="Original uploaded filename",
+        ),
+        sa.Column(
+            "media_type",
+            sa.String(length=255),
+            nullable=False,
+            comment="Uploaded media type",
+        ),
+        sa.Column(
+            "detected_format",
+            sa.String(length=32),
+            nullable=True,
+            comment="Detected drawing/document format",
+        ),
+        sa.Column(
+            "storage_uri",
+            sa.String(length=1024),
+            nullable=False,
+            comment="Immutable local/object storage URI",
+        ),
+        sa.Column(
+            "size_bytes",
+            sa.Integer(),
+            nullable=False,
+            comment="Uploaded file size in bytes",
+        ),
+        sa.Column(
+            "checksum_sha256",
+            sa.String(length=64),
+            nullable=False,
+            comment="SHA-256 checksum of uploaded bytes",
+        ),
+        sa.Column(
+            "immutable",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+            comment="Whether the original upload is immutable",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="File creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("id", "project_id", name="uq_files_id_project_id"),
+    )
+    op.create_index(
+        op.f("ix_files_project_id"),
+        "files",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_files_project_id_created_at_id_desc",
+        "files",
+        ["project_id", sa.text("created_at DESC"), sa.text("id DESC")],
+        unique=False,
+    )
+
+    op.create_table(
+        "jobs",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique job identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "file_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Associated file identifier",
+        ),
+        sa.Column(
+            "job_type",
+            sa.String(length=64),
+            nullable=False,
+            comment="Job type (e.g. ingest)",
+        ),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            nullable=False,
+            comment="Job status (e.g. pending, running, failed, succeeded)",
+        ),
+        sa.Column(
+            "attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+            comment="Current attempt count",
+        ),
+        sa.Column(
+            "max_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("3"),
+            comment="Maximum retry attempts",
+        ),
+        sa.Column(
+            "cancel_requested",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+            comment="Whether cancellation was requested",
+        ),
+        sa.Column(
+            "error_code",
+            sa.String(length=128),
+            nullable=True,
+            comment="Machine-readable error code",
+        ),
+        sa.Column(
+            "error_message",
+            sa.String(length=2048),
+            nullable=True,
+            comment="Human-readable error message",
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Job start timestamp",
+        ),
+        sa.Column(
+            "finished_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Job completion timestamp",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="Job creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(
+            ["file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_jobs_file_id_project_id_files",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_jobs_file_id"), "jobs", ["file_id"], unique=False)
+    op.create_index(
+        op.f("ix_jobs_project_id"),
+        "jobs",
+        ["project_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Revert migration changes for files and jobs."""
+    op.drop_index(op.f("ix_jobs_project_id"), table_name="jobs")
+    op.drop_index(op.f("ix_jobs_file_id"), table_name="jobs")
+    op.drop_table("jobs")
+    op.drop_index("ix_files_project_id_created_at_id_desc", table_name="files")
+    op.drop_index(op.f("ix_files_project_id"), table_name="files")
+    op.drop_table("files")

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,6 +1,7 @@
 """API v1 routers."""
 
+from app.api.v1.files import files_router
 from app.api.v1.health import health_router
 from app.api.v1.projects import project_router
 
-__all__ = ["health_router", "project_router"]
+__all__ = ["files_router", "health_router", "project_router"]

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -1,0 +1,427 @@
+"""Project-scoped file upload and retrieval endpoints."""
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+import uuid
+from contextlib import suppress
+from datetime import datetime
+from pathlib import Path
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
+from fastapi import File as FilePart
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.exceptions import create_error_response, raise_not_found
+from app.db.session import get_db
+from app.models.file import File as FileModel
+from app.models.job import Job
+from app.models.project import Project
+from app.schemas.file import FileListResponse, FileRead
+
+files_router = APIRouter()
+_UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
+_UPLOAD_SNIFF_BYTES = 4096
+_UTF8_BOM = b"\xef\xbb\xbf"
+_SUPPORTED_FORMATS_MESSAGE = "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc."
+_MAX_ORIGINAL_FILENAME_LENGTH = 512
+_MAX_MEDIA_TYPE_LENGTH = 255
+
+
+def _encode_cursor(created_at: datetime, file_id: UUID) -> str:
+    """Encode cursor from created_at and file_id."""
+    cursor_data = {
+        "created_at": created_at.isoformat(),
+        "id": str(file_id),
+    }
+    return base64.urlsafe_b64encode(json.dumps(cursor_data).encode()).decode().rstrip("=")
+
+
+def _decode_cursor(cursor: str) -> dict[str, Any]:
+    """Decode cursor to dict with created_at and id."""
+    try:
+        padding = 4 - (len(cursor) % 4)
+        if padding != 4:
+            cursor += "=" * padding
+
+        decoded = base64.urlsafe_b64decode(cursor)
+        cursor_data_raw = json.loads(decoded.decode("utf-8"))
+        if not isinstance(cursor_data_raw, dict):
+            raise TypeError("Cursor payload must be a JSON object")
+        cursor_data = cast(dict[str, Any], cursor_data_raw)
+
+        _ = datetime.fromisoformat(str(cursor_data["created_at"]))
+        _ = UUID(str(cursor_data["id"]))
+        return cursor_data
+    except (
+        binascii.Error,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=create_error_response(
+                code="INVALID_CURSOR",
+                message="Invalid cursor format",
+                details=None,
+            ),
+        ) from e
+
+
+def _sniff_format(initial_bytes: bytes) -> str | None:
+    """Infer format using file header/early bytes."""
+    if initial_bytes.startswith(b"%PDF-"):
+        return "pdf"
+    if initial_bytes.startswith(b"AC10"):
+        return "dwg"
+    if initial_bytes.startswith(b"ISO-10303-21"):
+        return "ifc"
+
+    dxf_probe = initial_bytes
+    if dxf_probe.startswith(_UTF8_BOM):
+        dxf_probe = dxf_probe[len(_UTF8_BOM) :]
+
+    dxf_probe = dxf_probe.lstrip(b" \t\n\r\f\v")
+    if dxf_probe.startswith((b"0\nSECTION", b"0\r\nSECTION")):
+        return "dxf"
+
+    return None
+
+
+def _unsupported_format_exception() -> HTTPException:
+    """Construct a consistent unsupported format error response."""
+    return HTTPException(
+        status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+        detail=create_error_response(
+            code="INPUT_UNSUPPORTED_FORMAT",
+            message=_SUPPORTED_FORMATS_MESSAGE,
+            details=None,
+        ),
+    )
+
+
+def _storage_path(file_id: UUID, detected_format: str | None) -> Path:
+    """Build a server-derived immutable local storage path for an uploaded file."""
+    extension = detected_format or "bin"
+    filename = f"{file_id}.{extension}"
+    upload_root = Path(settings.upload_storage_root).resolve()
+    return upload_root / file_id.hex[:2] / file_id.hex[2:4] / filename
+
+
+def _staging_path(file_id: UUID) -> Path:
+    """Build a temporary staging path for upload bytes before promotion."""
+    upload_root = Path(settings.upload_storage_root).resolve()
+    return upload_root / ".staging" / f"{file_id}.{uuid.uuid4().hex}.part"
+
+
+def _cleanup_uploaded_path(storage_path: Path) -> None:
+    """Best-effort cleanup of a partially or fully written upload path."""
+    upload_root = Path(settings.upload_storage_root).resolve()
+    with suppress(OSError):
+        storage_path.unlink(missing_ok=True)
+
+    current = storage_path.parent
+    while current != upload_root and upload_root in current.parents:
+        with suppress(OSError):
+            current.rmdir()
+        current = current.parent
+
+
+def _ensure_private_directory(path: Path, *, include_parents_until: Path | None = None) -> None:
+    """Ensure a directory exists with owner-only permissions."""
+    path.mkdir(parents=True, exist_ok=True)
+    targets = [path]
+    if include_parents_until is not None:
+        parent = path.parent
+        while include_parents_until in parent.parents or parent == include_parents_until:
+            targets.append(parent)
+            if parent == include_parents_until:
+                break
+            parent = parent.parent
+
+    try:
+        for target in targets:
+            target.chmod(0o700)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code="STORAGE_WRITE_FAILED",
+                message="Failed to persist uploaded file.",
+                details=None,
+            ),
+        ) from exc
+
+
+async def _raise_input_invalid_for_upload_metadata(file: UploadFile, message: str) -> None:
+    """Close upload and raise standardized client validation error envelope."""
+    await file.close()
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code="INPUT_INVALID",
+            message=message,
+            details=None,
+        ),
+    )
+
+
+def _promote_staged_upload(staging_path: Path, final_path: Path) -> None:
+    """Promote a staged upload to final immutable path without overwriting."""
+    _ensure_private_directory(
+        final_path.parent,
+        include_parents_until=Path(settings.upload_storage_root).resolve(),
+    )
+
+    try:
+        os.link(staging_path, final_path)
+    except FileExistsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code="STORAGE_CONFLICT",
+                message="Storage collision occurred during upload.",
+                details=None,
+            ),
+        ) from exc
+    except OSError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code="STORAGE_WRITE_FAILED",
+                message="Failed to persist uploaded file.",
+                details=None,
+            ),
+        ) from exc
+
+    try:
+        final_path.chmod(0o400)
+    except OSError as exc:
+        _cleanup_uploaded_path(final_path)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code="STORAGE_WRITE_FAILED",
+                message="Failed to persist uploaded file.",
+                details=None,
+            ),
+        ) from exc
+    finally:
+        _cleanup_uploaded_path(staging_path)
+
+
+@files_router.post(
+    "/projects/{project_id}/files",
+    response_model=FileRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_project_file(
+    project_id: UUID,
+    file: Annotated[UploadFile, FilePart(...)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> FileModel:
+    """Upload immutable source file bytes for a project and create ingest job."""
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    original_filename = file.filename or "upload.bin"
+    media_type = file.content_type or "application/octet-stream"
+
+    if len(original_filename) > _MAX_ORIGINAL_FILENAME_LENGTH:
+        await _raise_input_invalid_for_upload_metadata(
+            file,
+            "original_filename exceeds maximum length of 512 characters.",
+        )
+    if len(media_type) > _MAX_MEDIA_TYPE_LENGTH:
+        await _raise_input_invalid_for_upload_metadata(
+            file,
+            "media_type exceeds maximum length of 255 characters.",
+        )
+
+    file_id = uuid.uuid4()
+    staging_path = _staging_path(file_id)
+    storage_path: Path | None = None
+    detected_format: str | None = None
+    upload_root = Path(settings.upload_storage_root).resolve()
+    _ensure_private_directory(upload_root)
+    _ensure_private_directory(staging_path.parent)
+
+    max_upload_bytes = settings.max_upload_mb * 1024 * 1024
+    total_bytes = 0
+    checksum_builder = hashlib.sha256()
+    try:
+        with staging_path.open("xb") as stream:
+            initial_bytes = await file.read(_UPLOAD_SNIFF_BYTES)
+            sniffed_format = _sniff_format(initial_bytes)
+            if sniffed_format is None:
+                _cleanup_uploaded_path(staging_path)
+                raise _unsupported_format_exception()
+            detected_format = sniffed_format
+            storage_path = _storage_path(file_id, detected_format)
+
+            if initial_bytes:
+                if len(initial_bytes) > max_upload_bytes:
+                    _cleanup_uploaded_path(staging_path)
+                    if storage_path is not None:
+                        _cleanup_uploaded_path(storage_path)
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=create_error_response(
+                            code="INPUT_INVALID",
+                            message="Uploaded file exceeds maximum allowed size.",
+                            details=None,
+                        ),
+                    )
+                stream.write(initial_bytes)
+                checksum_builder.update(initial_bytes)
+                total_bytes = len(initial_bytes)
+
+            while True:
+                chunk = await file.read(_UPLOAD_CHUNK_SIZE_BYTES)
+                if not chunk:
+                    break
+
+                next_total = total_bytes + len(chunk)
+                if next_total > max_upload_bytes:
+                    _cleanup_uploaded_path(staging_path)
+                    if storage_path is not None:
+                        _cleanup_uploaded_path(storage_path)
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail=create_error_response(
+                            code="INPUT_INVALID",
+                            message="Uploaded file exceeds maximum allowed size.",
+                            details=None,
+                        ),
+                    )
+
+                stream.write(chunk)
+                checksum_builder.update(chunk)
+                total_bytes = next_total
+
+        assert storage_path is not None
+        _promote_staged_upload(staging_path=staging_path, final_path=storage_path)
+    except HTTPException:
+        _cleanup_uploaded_path(staging_path)
+        raise
+    except BaseException:
+        _cleanup_uploaded_path(staging_path)
+        if storage_path is not None:
+            _cleanup_uploaded_path(storage_path)
+        raise
+    finally:
+        await file.close()
+
+    assert detected_format is not None
+    assert storage_path is not None
+    checksum = checksum_builder.hexdigest()
+
+    file_row = FileModel(
+        id=file_id,
+        project_id=project_id,
+        original_filename=original_filename,
+        media_type=media_type,
+        detected_format=detected_format,
+        storage_uri=f"file://{storage_path}",
+        size_bytes=total_bytes,
+        checksum_sha256=checksum,
+        immutable=True,
+    )
+    db.add(file_row)
+
+    ingest_job = Job(
+        project_id=project_id,
+        file_id=file_id,
+        job_type="ingest",
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        cancel_requested=False,
+    )
+    db.add(ingest_job)
+
+    try:
+        await db.commit()
+    except BaseException:
+        _cleanup_uploaded_path(staging_path)
+        if storage_path is not None:
+            _cleanup_uploaded_path(storage_path)
+        raise
+
+    await db.refresh(file_row)
+    return file_row
+
+
+@files_router.get(
+    "/projects/{project_id}/files",
+    response_model=FileListResponse,
+)
+async def list_project_files(
+    project_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    cursor: Annotated[str | None, Query(description="Cursor for pagination")] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Number of items to return")] = 50,
+) -> FileListResponse:
+    """List files for a project with cursor pagination."""
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    query = (
+        select(FileModel)
+        .where(FileModel.project_id == project_id)
+        .order_by(FileModel.created_at.desc(), FileModel.id.desc())
+    )
+
+    if cursor:
+        cursor_data = _decode_cursor(cursor)
+        created_at = datetime.fromisoformat(str(cursor_data["created_at"]))
+        file_id = UUID(str(cursor_data["id"]))
+        query = query.filter(
+            (FileModel.created_at < created_at)
+            | ((FileModel.created_at == created_at) & (FileModel.id < file_id))
+        )
+
+    rows = (await db.execute(query.limit(limit + 1))).scalars().all()
+
+    has_next = len(rows) > limit
+    if has_next:
+        rows = rows[:-1]
+
+    next_cursor = None
+    if has_next and rows:
+        last_item = rows[-1]
+        next_cursor = _encode_cursor(last_item.created_at, last_item.id)
+
+    items = [FileRead.model_validate(row) for row in rows]
+    return FileListResponse(items=items, next_cursor=next_cursor)
+
+
+@files_router.get(
+    "/projects/{project_id}/files/{file_id}",
+    response_model=FileRead,
+)
+async def get_project_file(
+    project_id: UUID,
+    file_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> FileModel:
+    """Get a single file by id within a project scope."""
+    query = select(FileModel).where(
+        (FileModel.project_id == project_id) & (FileModel.id == file_id)
+    )
+    file_row = (await db.execute(query)).scalar_one_or_none()
+    if file_row is None:
+        raise_not_found("File", str(file_id))
+    assert file_row is not None
+    return file_row

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
 
     # Application settings
     max_upload_mb: int = 50
+    upload_storage_root: str = "var/uploads"
 
     @field_validator("api_prefix")
     @classmethod
@@ -42,6 +43,13 @@ class Settings(BaseSettings):
     def validate_max_upload_mb(cls, value: int) -> int:
         if value <= 0:
             raise ValueError("max_upload_mb must be positive")
+        return value
+
+    @field_validator("upload_storage_root")
+    @classmethod
+    def validate_upload_storage_root(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("upload_storage_root must not be empty")
         return value
 
     model_config = SettingsConfigDict(

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -4,14 +4,80 @@ import re
 import uuid
 from collections.abc import Awaitable, Callable
 
+from fastapi import status
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 from structlog.contextvars import bind_contextvars, clear_contextvars
+
+from app.core.config import settings
+from app.core.exceptions import create_error_response
 
 # Valid request ID pattern: alphanumeric, hyphens, underscores, max 64 chars
 REQUEST_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-_]{1,64}$")
 MAX_REQUEST_ID_LENGTH = 64
+
+
+class ContentLengthLimitMiddleware(BaseHTTPMiddleware):
+    """Pre-parse request-size guard for upload endpoint Content-Length."""
+
+    _MULTIPART_OVERHEAD_BYTES = 1024 * 1024
+    _UPLOAD_ROUTE_PREFIX = "" if settings.api_prefix == "/" else settings.api_prefix
+    _UPLOAD_PATH_PATTERN = re.compile(
+        rf"^{re.escape(_UPLOAD_ROUTE_PREFIX)}/projects/[^/]+/files/?$"
+    )
+
+    @classmethod
+    def _is_upload_request(cls, request: Request) -> bool:
+        """Return True only for POST upload route."""
+        return request.method == "POST" and bool(cls._UPLOAD_PATH_PATTERN.match(request.url.path))
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        if self._is_upload_request(request):
+            content_length = request.headers.get("content-length")
+            if content_length is None:
+                return JSONResponse(
+                    status_code=status.HTTP_411_LENGTH_REQUIRED,
+                    content=create_error_response(
+                        code="INPUT_INVALID",
+                        message=(
+                            "Content-Length header is required for upload requests. "
+                            "This API enforces max_upload_mb as a maximum request body size "
+                            "pre-parse guard."
+                        ),
+                        details=None,
+                    ),
+                )
+
+            try:
+                content_length_bytes = int(content_length)
+            except ValueError:
+                return JSONResponse(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    content=create_error_response(
+                        code="INPUT_INVALID",
+                        message="Content-Length header must be a valid integer.",
+                        details=None,
+                    ),
+                )
+
+            # Middleware allows bounded multipart overhead; endpoint enforces exact
+            # uploaded file-byte cap.
+            max_file_bytes = settings.max_upload_mb * 1024 * 1024
+            max_request_body_bytes = max_file_bytes + self._MULTIPART_OVERHEAD_BYTES
+            if content_length_bytes > max_request_body_bytes:
+                return JSONResponse(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    content=create_error_response(
+                        code="INPUT_INVALID",
+                        message="Request body exceeds maximum allowed size for uploads.",
+                        details=None,
+                    ),
+                )
+
+        return await call_next(request)
 
 
 class RequestIdMiddleware(BaseHTTPMiddleware):

--- a/app/main.py
+++ b/app/main.py
@@ -3,11 +3,11 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 
-from app.api.v1 import health_router, project_router
+from app.api.v1 import files_router, health_router, project_router
 from app.core.config import settings
 from app.core.exceptions import custom_http_exception_handler, request_validation_exception_handler
 from app.core.logging import configure_logging, get_logger
-from app.core.middleware import RequestIdMiddleware
+from app.core.middleware import ContentLengthLimitMiddleware, RequestIdMiddleware
 
 logger = get_logger(__name__)
 
@@ -30,10 +30,12 @@ def create_app() -> FastAPI:
     app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
 
     # Add middleware
+    app.add_middleware(ContentLengthLimitMiddleware)
     app.add_middleware(RequestIdMiddleware)
 
     app.include_router(health_router, prefix=settings.api_prefix)
     app.include_router(project_router, prefix=f"{settings.api_prefix}/projects")
+    app.include_router(files_router, prefix=settings.api_prefix)
 
     logger.info("app_started", version=settings.app_version)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,4 +7,6 @@ for Alembic autogenerate support. Example:
 
 """
 
+from . import file as file
+from . import job as job
 from . import project as project

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -1,0 +1,88 @@
+"""File model for immutable project uploads."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    desc,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class File(Base):
+    """SQLAlchemy ORM model for uploaded source files."""
+
+    __tablename__ = "files"
+    __table_args__ = (
+        UniqueConstraint("id", "project_id", name="uq_files_id_project_id"),
+        Index(
+            "ix_files_project_id_created_at_id_desc",
+            "project_id",
+            desc("created_at"),
+            desc("id"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique file identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    original_filename: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+        comment="Original uploaded filename",
+    )
+    media_type: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Uploaded media type",
+    )
+    detected_format: Mapped[str | None] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="Detected drawing/document format",
+    )
+    storage_uri: Mapped[str] = mapped_column(
+        String(1024),
+        nullable=False,
+        comment="Immutable local/object storage URI",
+    )
+    size_bytes: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Uploaded file size in bytes",
+    )
+    checksum_sha256: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="SHA-256 checksum of uploaded bytes",
+    )
+    immutable: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+        comment="Whether the original upload is immutable",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="File creation timestamp",
+    )

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,0 +1,102 @@
+"""Job model for background ingestion/export workflows."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class Job(Base):
+    """SQLAlchemy ORM model for async jobs associated with files/projects."""
+
+    __tablename__ = "jobs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_jobs_file_id_project_id_files",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique job identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Associated file identifier",
+    )
+    job_type: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Job type (e.g. ingest)",
+    )
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Job status (e.g. pending, running, failed, succeeded)",
+    )
+    attempts: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+        comment="Current attempt count",
+    )
+    max_attempts: Mapped[int] = mapped_column(
+        Integer,
+        default=3,
+        nullable=False,
+        comment="Maximum retry attempts",
+    )
+    cancel_requested: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        nullable=False,
+        comment="Whether cancellation was requested",
+    )
+    error_code: Mapped[str | None] = mapped_column(
+        String(128),
+        nullable=True,
+        comment="Machine-readable error code",
+    )
+    error_message: Mapped[str | None] = mapped_column(
+        String(2048),
+        nullable=True,
+        comment="Human-readable error message",
+    )
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Job start timestamp",
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Job completion timestamp",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Job creation timestamp",
+    )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,5 +1,13 @@
 """Pydantic request/response schemas."""
 
+from app.schemas.file import FileListResponse, FileRead
 from app.schemas.project import ProjectCreate, ProjectListResponse, ProjectRead, ProjectUpdate
 
-__all__ = ["ProjectCreate", "ProjectListResponse", "ProjectRead", "ProjectUpdate"]
+__all__ = [
+    "FileListResponse",
+    "FileRead",
+    "ProjectCreate",
+    "ProjectListResponse",
+    "ProjectRead",
+    "ProjectUpdate",
+]

--- a/app/schemas/file.py
+++ b/app/schemas/file.py
@@ -1,0 +1,29 @@
+"""Pydantic schemas for project file endpoints."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FileRead(BaseModel):
+    """Schema for reading a file resource."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID = Field(..., description="Unique file identifier (UUID)")
+    project_id: uuid.UUID = Field(..., description="Owning project identifier")
+    original_filename: str = Field(..., description="Original uploaded filename")
+    media_type: str = Field(..., description="Uploaded media type")
+    detected_format: str | None = Field(None, description="Detected drawing/document format")
+    size_bytes: int = Field(..., ge=0, description="Uploaded file size in bytes")
+    checksum_sha256: str = Field(..., min_length=64, max_length=64, description="SHA-256 checksum")
+    immutable: bool = Field(..., description="Whether original upload is immutable")
+    created_at: datetime = Field(..., description="File creation timestamp")
+
+
+class FileListResponse(BaseModel):
+    """Schema for project files list responses."""
+
+    items: list[FileRead] = Field(..., description="List of project files")
+    next_cursor: str | None = Field(None, description="Cursor for next page, null if last page")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 """Shared fixtures for integration tests."""
 
 import os
-from collections.abc import AsyncGenerator
+import shutil
+from collections.abc import AsyncGenerator, Generator
+from pathlib import Path
 
 import httpx
 import pytest
@@ -11,6 +13,7 @@ from httpx import ASGITransport
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.db.session import get_db
 from app.main import app as fastapi_app
 
@@ -35,6 +38,21 @@ async def init_database_resources() -> AsyncGenerator[None, None]:
     yield
 
     await session_module.close_db()
+
+
+@pytest.fixture(autouse=True)
+def isolate_upload_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    """Use a per-test temporary upload root and clean up only that root."""
+    upload_root = (tmp_path / "uploads").resolve()
+    monkeypatch.setattr(settings, "upload_storage_root", str(upload_root))
+
+    yield
+
+    if upload_root.exists():
+        shutil.rmtree(upload_root)
 
 
 @pytest.fixture
@@ -74,7 +92,7 @@ async def async_client(app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
 
 @pytest_asyncio.fixture
 async def cleanup_projects() -> AsyncGenerator[None, None]:
-    """Truncate projects table after each test to ensure clean state."""
+    """Truncate projects table after each test to ensure clean DB state."""
     if not os.environ.get("DATABASE_URL"):
         yield
         return

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -3,14 +3,15 @@
 import asyncio
 import hashlib
 import uuid
+from collections.abc import AsyncGenerator, Callable
 from pathlib import Path
 from typing import Any, cast
 
 import httpx
 import pytest
 import pytest_asyncio
+from fastapi import FastAPI
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.db.session as session_module
 from app.core.config import settings
@@ -50,6 +51,29 @@ async def _upload_file(
     )
     assert response.status_code == 201
     return cast(dict[str, Any], response.json())
+
+
+def _make_get_db_override_with_commit_error(
+    commit_error: BaseException,
+) -> Callable[[], AsyncGenerator[Any, None]]:
+    """Create a request-scoped get_db override with an instance-level commit failure."""
+
+    async def _override_get_db() -> AsyncGenerator[Any, None]:
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        session = session_maker()
+
+        async def _fail_commit() -> None:
+            raise commit_error
+
+        cast(Any, session).commit = _fail_commit
+
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    return _override_get_db
 
 
 @requires_database
@@ -653,21 +677,22 @@ class TestProjectFiles:
         self,
         async_client: httpx.AsyncClient,
         created_project: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
+        app: FastAPI,
     ) -> None:
         """POST should cleanup persisted bytes when DB commit raises RuntimeError."""
         _ = self
 
-        async def _fail_commit(_self: AsyncSession) -> None:
-            raise RuntimeError("forced commit failure")
-
-        monkeypatch.setattr(AsyncSession, "commit", _fail_commit)
-
-        with pytest.raises(RuntimeError, match="forced commit failure"):
-            await async_client.post(
-                f"/v1/projects/{created_project['id']}/files",
-                files={"file": ("commit-fail.pdf", b"%PDF-1.7\npayload", "application/pdf")},
-            )
+        app.dependency_overrides[session_module.get_db] = (
+            _make_get_db_override_with_commit_error(RuntimeError("forced commit failure"))
+        )
+        try:
+            with pytest.raises(RuntimeError, match="forced commit failure"):
+                await async_client.post(
+                    f"/v1/projects/{created_project['id']}/files",
+                    files={"file": ("commit-fail.pdf", b"%PDF-1.7\npayload", "application/pdf")},
+                )
+        finally:
+            app.dependency_overrides.pop(session_module.get_db, None)
 
         upload_root = Path(settings.upload_storage_root).resolve()
         assert not upload_root.exists() or not any(upload_root.iterdir())
@@ -676,21 +701,36 @@ class TestProjectFiles:
         self,
         async_client: httpx.AsyncClient,
         created_project: dict[str, Any],
-        monkeypatch: pytest.MonkeyPatch,
+        app: FastAPI,
     ) -> None:
         """POST should cleanup persisted bytes when DB commit raises CancelledError."""
         _ = self
 
-        async def _cancel_commit(_self: AsyncSession) -> None:
-            raise asyncio.CancelledError()
+        app.dependency_overrides[session_module.get_db] = (
+            _make_get_db_override_with_commit_error(asyncio.CancelledError())
+        )
+        try:
+            caught: BaseException | None = None
+            try:
+                await async_client.post(
+                    f"/v1/projects/{created_project['id']}/files",
+                    files={
+                        "file": (
+                            "commit-cancelled.pdf",
+                            b"%PDF-1.7\npayload",
+                            "application/pdf",
+                        )
+                    },
+                )
+            except BaseException as exc:
+                caught = exc
 
-        monkeypatch.setattr(AsyncSession, "commit", _cancel_commit)
-
-        with pytest.raises(asyncio.CancelledError):
-            await async_client.post(
-                f"/v1/projects/{created_project['id']}/files",
-                files={"file": ("commit-cancelled.pdf", b"%PDF-1.7\npayload", "application/pdf")},
+            assert caught is not None
+            assert isinstance(caught, asyncio.CancelledError) or (
+                isinstance(caught, RuntimeError) and str(caught) == "No response returned."
             )
+        finally:
+            app.dependency_overrides.pop(session_module.get_db, None)
 
         upload_root = Path(settings.upload_storage_root).resolve()
         assert not upload_root.exists() or not any(upload_root.iterdir())

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,696 @@
+"""Integration tests for project file upload and retrieval endpoints."""
+
+import asyncio
+import hashlib
+import uuid
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+from app.core.config import settings
+from app.models.file import File as FileModel
+from app.models.job import Job
+from tests.conftest import requires_database
+
+
+@pytest_asyncio.fixture
+async def created_project(
+    async_client: httpx.AsyncClient,
+    cleanup_projects: None,
+) -> dict[str, Any]:
+    """Create a project and return its data."""
+    response = await async_client.post(
+        "/v1/projects",
+        json={
+            "name": "Files Test Project",
+            "description": "A project for file tests",
+        },
+    )
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json())
+
+
+async def _upload_file(
+    async_client: httpx.AsyncClient,
+    project_id: str,
+    filename: str,
+    content: bytes,
+    media_type: str,
+) -> dict[str, Any]:
+    """Upload a file for a project and return response payload."""
+    response = await async_client.post(
+        f"/v1/projects/{project_id}/files",
+        files={"file": (filename, content, media_type)},
+    )
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json())
+
+
+@requires_database
+class TestProjectFiles:
+    """Tests for project file upload and retrieval endpoints."""
+
+    async def test_upload_file_creates_file_and_pending_job(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should persist file metadata/content and create a pending job."""
+        _ = self
+        payload = b"%PDF-1.7\nmock-pdf-content\n"
+
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="plan.pdf",
+            content=payload,
+            media_type="application/pdf",
+        )
+
+        assert uploaded["project_id"] == created_project["id"]
+        assert uploaded["original_filename"] == "plan.pdf"
+        assert uploaded["media_type"] == "application/pdf"
+        assert uploaded["detected_format"] == "pdf"
+        assert uploaded["size_bytes"] == len(payload)
+        assert uploaded["checksum_sha256"] == hashlib.sha256(payload).hexdigest()
+        assert uploaded["immutable"] is True
+        assert "created_at" in uploaded
+        assert "storage_uri" not in uploaded
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(FileModel.id == uuid.UUID(str(uploaded["id"])))
+            )
+            file_row = file_result.scalar_one_or_none()
+
+            result = await session.execute(
+                select(Job).where(Job.file_id == uuid.UUID(str(uploaded["id"])))
+            )
+            job = result.scalar_one_or_none()
+
+        assert file_row is not None
+        storage_uri = file_row.storage_uri
+        assert storage_uri.startswith("file://")
+        stored_path = Path(storage_uri.removeprefix("file://"))
+        assert stored_path.exists()
+        assert stored_path.name != "plan.pdf"
+        assert stored_path.read_bytes() == payload
+        mode = stored_path.stat().st_mode & 0o777
+        assert mode == 0o400
+        assert (mode & 0o077) == 0
+        assert str(stored_path).startswith(str(Path(settings.upload_storage_root).resolve()))
+
+        assert job is not None
+        assert job.project_id == uuid.UUID(str(created_project["id"]))
+        assert job.file_id == uuid.UUID(str(uploaded["id"]))
+        assert job.job_type == "ingest"
+        assert job.status == "pending"
+        assert job.attempts == 0
+        assert job.cancel_requested is False
+
+    async def test_reupload_same_bytes_creates_new_file_row(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Uploading identical bytes twice should create two distinct file rows."""
+        _ = self
+        payload = b"%PDF-1.7\nsame-content"
+
+        first = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="same-a.pdf",
+            content=payload,
+            media_type="application/pdf",
+        )
+        second = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="same-b.pdf",
+            content=payload,
+            media_type="application/pdf",
+        )
+
+        assert first["id"] != second["id"]
+        assert first["checksum_sha256"] == second["checksum_sha256"]
+
+        response = await async_client.get(f"/v1/projects/{created_project['id']}/files")
+        assert response.status_code == 200
+        listed = response.json()
+        assert len(listed["items"]) == 2
+
+    async def test_list_project_files_success(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET list should return files for the target project."""
+        _ = self
+        first = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="first.dwg",
+            content=b"AC1032-dwg-mock",
+            media_type="application/acad",
+        )
+        second = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="second.pdf",
+            content=b"%PDF-1.7\npdf-mock",
+            media_type="application/pdf",
+        )
+
+        response = await async_client.get(f"/v1/projects/{created_project['id']}/files")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert "items" in data
+        assert "next_cursor" in data
+        assert data["next_cursor"] is None
+        assert len(data["items"]) == 2
+
+        returned_ids = {item["id"] for item in data["items"]}
+        assert returned_ids == {first["id"], second["id"]}
+
+    async def test_list_project_files_pagination(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET list should paginate files with cursor + limit."""
+        _ = self
+
+        created_ids: list[str] = []
+        for i in range(5):
+            uploaded = await _upload_file(
+                async_client=async_client,
+                project_id=created_project["id"],
+                filename=f"file-{i}.pdf",
+                content=f"%PDF-1.7\npayload-{i}".encode(),
+                media_type="application/pdf",
+            )
+            created_ids.append(str(uploaded["id"]))
+
+        first_response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files?limit=2"
+        )
+        assert first_response.status_code == 200
+        first_data = first_response.json()
+        assert len(first_data["items"]) == 2
+        assert first_data["next_cursor"] is not None
+        first_page_ids = [str(item["id"]) for item in first_data["items"]]
+
+        second_response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files?limit=2&cursor={first_data['next_cursor']}"
+        )
+        assert second_response.status_code == 200
+        second_data = second_response.json()
+        assert len(second_data["items"]) == 2
+        assert second_data["next_cursor"] is not None
+        second_page_ids = [str(item["id"]) for item in second_data["items"]]
+
+        third_response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files?limit=2&cursor={second_data['next_cursor']}"
+        )
+        assert third_response.status_code == 200
+        third_data = third_response.json()
+        assert len(third_data["items"]) == 1
+        assert third_data["next_cursor"] is None
+        third_page_ids = [str(item["id"]) for item in third_data["items"]]
+
+        assert not set(first_page_ids) & set(second_page_ids)
+        assert not set(first_page_ids) & set(third_page_ids)
+        assert not set(second_page_ids) & set(third_page_ids)
+        assert set(first_page_ids + second_page_ids + third_page_ids) == set(created_ids)
+
+    async def test_list_project_files_invalid_cursor(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET list should return a 400 envelope for malformed cursors."""
+        _ = self
+
+        response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files?cursor=invalid-cursor"
+        )
+        assert response.status_code == 400
+
+        data = response.json()
+        assert data == {
+            "error": {
+                "code": "INVALID_CURSOR",
+                "message": "Invalid cursor format",
+                "details": None,
+            }
+        }
+
+    async def test_get_project_file_detail_success(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET detail should return file metadata for the matching project/file."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="detail.ifc",
+            content=b"ISO-10303-21;\nHEADER;\nENDSEC;\n",
+            media_type="application/octet-stream",
+        )
+
+        response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}"
+        )
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["id"] == uploaded["id"]
+        assert data["project_id"] == created_project["id"]
+        assert data["original_filename"] == "detail.ifc"
+
+    async def test_get_project_file_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET detail should return File 404 for unknown file id."""
+        _ = self
+        response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files/{uuid.uuid4()}"
+        )
+        assert response.status_code == 404
+        data = response.json()
+
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "File" in data["error"]["message"]
+        assert data["error"]["details"] is None
+
+    async def test_get_project_file_cross_project_returns_file_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """GET detail with mismatched project/file scope should return File 404."""
+        _ = self
+        _ = cleanup_projects
+
+        first_project_response = await async_client.post(
+            "/v1/projects",
+            json={"name": "Project One"},
+        )
+        second_project_response = await async_client.post(
+            "/v1/projects", json={"name": "Project Two"}
+        )
+        assert first_project_response.status_code == 201
+        assert second_project_response.status_code == 201
+
+        first_project_id = first_project_response.json()["id"]
+        second_project_id = second_project_response.json()["id"]
+
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=first_project_id,
+            filename="scoped.pdf",
+            content=b"%PDF-1.7\nscope-test",
+            media_type="application/pdf",
+        )
+
+        response = await async_client.get(
+            f"/v1/projects/{second_project_id}/files/{uploaded['id']}"
+        )
+        assert response.status_code == 404
+        data = response.json()
+
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "File" in data["error"]["message"]
+        assert data["error"]["details"] is None
+
+    async def test_upload_file_project_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """POST should return Project 404 when parent project does not exist."""
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.post(
+            f"/v1/projects/{uuid.uuid4()}/files",
+            files={"file": ("missing.pdf", b"%PDF-1.7\nx", "application/pdf")},
+        )
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "Project" in data["error"]["message"]
+
+    async def test_list_project_files_project_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """GET list should return Project 404 when project does not exist."""
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.get(f"/v1/projects/{uuid.uuid4()}/files")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "Project" in data["error"]["message"]
+
+    async def test_upload_file_rejects_payload_over_size_limit(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POST should reject oversize payloads with a 413 error envelope."""
+        _ = self
+        monkeypatch.setattr(settings, "max_upload_mb", 1)
+        payload = b"%PDF-1.7\n" + (b"x" * ((1024 * 1024) + 1))
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={"file": ("oversize.pdf", payload, "application/pdf")},
+        )
+        assert response.status_code == 413
+        data = response.json()
+        assert data["error"]["code"] == "INPUT_INVALID"
+        assert (
+            data["error"]["message"]
+            == "Uploaded file exceeds maximum allowed size."
+        )
+        assert data["error"]["details"] is None
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
+    async def test_upload_file_rejects_unsupported_format_before_writing(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should reject unsupported/unknown formats before file persistence/job creation."""
+        _ = self
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={"file": ("plan.xyz", b"unsupported", "application/octet-stream")},
+        )
+
+        assert response.status_code == 415
+        data = response.json()
+        assert data == {
+            "error": {
+                "code": "INPUT_UNSUPPORTED_FORMAT",
+                "message": "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc.",
+                "details": None,
+            }
+        }
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
+    async def test_upload_file_accepts_bytes_when_filename_and_media_type_mismatch(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should trust sniffed bytes over client-supplied filename/media type."""
+        _ = self
+
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="upload.bin",
+            content=b"%PDF-1.7\nmetadata-mismatch",
+            media_type="application/octet-stream",
+        )
+
+        assert uploaded["original_filename"] == "upload.bin"
+        assert uploaded["media_type"] == "application/octet-stream"
+        assert uploaded["detected_format"] == "pdf"
+
+    async def test_upload_file_rejects_overlong_original_filename_before_storage_or_db_write(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should reject overlong original_filename before storage/job persistence."""
+        _ = self
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={"file": (("a" * 513) + ".pdf", b"%PDF-1.7\ncontent", "application/pdf")},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data == {
+            "error": {
+                "code": "INPUT_INVALID",
+                "message": "original_filename exceeds maximum length of 512 characters.",
+                "details": None,
+            }
+        }
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
+    async def test_upload_file_rejects_overlong_media_type_before_storage_or_db_write(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should reject overlong media_type before storage/job persistence."""
+        _ = self
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={
+                "file": (
+                    "plan.pdf",
+                    b"%PDF-1.7\ncontent",
+                    "application/" + ("x" * 244),
+                )
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data == {
+            "error": {
+                "code": "INPUT_INVALID",
+                "message": "media_type exceeds maximum length of 255 characters.",
+                "details": None,
+            }
+        }
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
+    async def test_upload_file_rejects_text_with_nonleading_section(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should reject text that contains SECTION without leading DXF header."""
+        _ = self
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={"file": ("plan.txt", b"notes\nSECTION\nmore-notes\n", "text/plain")},
+        )
+
+        assert response.status_code == 415
+        data = response.json()
+        assert data == {
+            "error": {
+                "code": "INPUT_UNSUPPORTED_FORMAT",
+                "message": "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc.",
+                "details": None,
+            }
+        }
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
+    async def test_upload_file_accepts_dxf_with_utf8_bom_and_ascii_whitespace(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should accept DXF when only UTF-8 BOM/ASCII whitespace precedes header."""
+        _ = self
+
+        payload = b"\xef\xbb\xbf \t\r\n0\r\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="plan.dxf",
+            content=payload,
+            media_type="application/dxf",
+        )
+
+        assert uploaded["detected_format"] == "dxf"
+
+    async def test_upload_file_rejects_dxf_with_binary_prefix_before_header(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should reject DXF-like payload when binary bytes precede header."""
+        _ = self
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={
+                "file": (
+                    "plan.dxf",
+                    b"\x00\x01\t\n0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n",
+                    "application/dxf",
+                )
+            },
+        )
+
+        assert response.status_code == 415
+        assert response.json() == {
+            "error": {
+                "code": "INPUT_UNSUPPORTED_FORMAT",
+                "message": "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc.",
+                "details": None,
+            }
+        }
+
+    async def test_upload_file_commit_failure_cleans_written_bytes(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POST should cleanup persisted bytes when DB commit raises RuntimeError."""
+        _ = self
+
+        async def _fail_commit(_self: AsyncSession) -> None:
+            raise RuntimeError("forced commit failure")
+
+        monkeypatch.setattr(AsyncSession, "commit", _fail_commit)
+
+        with pytest.raises(RuntimeError, match="forced commit failure"):
+            await async_client.post(
+                f"/v1/projects/{created_project['id']}/files",
+                files={"file": ("commit-fail.pdf", b"%PDF-1.7\npayload", "application/pdf")},
+            )
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())
+
+    async def test_upload_file_commit_cancelled_error_cleans_written_bytes(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POST should cleanup persisted bytes when DB commit raises CancelledError."""
+        _ = self
+
+        async def _cancel_commit(_self: AsyncSession) -> None:
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(AsyncSession, "commit", _cancel_commit)
+
+        with pytest.raises(asyncio.CancelledError):
+            await async_client.post(
+                f"/v1/projects/{created_project['id']}/files",
+                files={"file": ("commit-cancelled.pdf", b"%PDF-1.7\npayload", "application/pdf")},
+            )
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        assert not upload_root.exists() or not any(upload_root.iterdir())

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -3,22 +3,29 @@
 import uuid
 from typing import Any
 
+import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from app.core.config import settings
 from app.core.logging import configure_logging
-from app.core.middleware import RequestIdMiddleware
+from app.core.middleware import ContentLengthLimitMiddleware, RequestIdMiddleware
 
 
 def create_test_app() -> FastAPI:
     """Create a minimal test app with the middleware."""
     configure_logging(service_name=settings.service_name, log_level="DEBUG")
     app = FastAPI()
+    app.add_middleware(ContentLengthLimitMiddleware)
     app.add_middleware(RequestIdMiddleware)
 
     @app.get("/test")
     def test_endpoint() -> dict[str, Any]:
+        return {"ok": True}
+
+    @app.post("/v1/projects/{project_id}/files")
+    def upload_endpoint(project_id: str) -> dict[str, Any]:
+        _ = project_id
         return {"ok": True}
 
     return app
@@ -94,3 +101,98 @@ class TestRequestIdMiddleware:
         id2 = response2.headers["X-Request-Id"]
 
         assert id1 != id2
+
+    def test_rejects_oversized_upload_request_with_413(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Oversized upload requests should be rejected before handler execution."""
+        monkeypatch.setattr(settings, "max_upload_mb", 1)
+        max_request_body_bytes = (
+            settings.max_upload_mb * 1024 * 1024
+            + ContentLengthLimitMiddleware._MULTIPART_OVERHEAD_BYTES
+        )
+
+        def stream() -> Any:
+            yield b"streamed-upload-body"
+
+        request = client.build_request(
+            "POST",
+            f"/v1/projects/{uuid.uuid4()}/files",
+            content=stream(),
+            headers={"content-length": str(max_request_body_bytes + 1)},
+        )
+        response = client.send(request)
+
+        assert response.status_code == 413
+        assert response.json() == {
+            "error": {
+                "code": "INPUT_INVALID",
+                "message": "Request body exceeds maximum allowed size for uploads.",
+                "details": None,
+            }
+        }
+
+    def test_allows_upload_within_file_cap_plus_multipart_overhead(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multipart requests should allow bounded envelope overhead."""
+        monkeypatch.setattr(settings, "max_upload_mb", 1)
+        file_cap_bytes = settings.max_upload_mb * 1024 * 1024
+        payload = b"%PDF-1.7\n" + (b"x" * (file_cap_bytes - len(b"%PDF-1.7\n")))
+
+        response = client.post(
+            f"/v1/projects/{uuid.uuid4()}/files",
+            files={"file": ("within-cap.pdf", payload, "application/pdf")},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+    def test_rejects_upload_request_missing_content_length_with_411(self) -> None:
+        """Upload requests without Content-Length should fail pre-parse."""
+
+        def stream() -> Any:
+            yield b"streamed-upload-body"
+
+        request = client.build_request(
+            "POST",
+            f"/v1/projects/{uuid.uuid4()}/files",
+            content=stream(),
+        )
+
+        response = client.send(request)
+        assert response.status_code == 411
+        assert response.json() == {
+            "error": {
+                "code": "INPUT_INVALID",
+                "message": (
+                    "Content-Length header is required for upload requests. "
+                    "This API enforces max_upload_mb as a maximum request body size "
+                    "pre-parse guard."
+                ),
+                "details": None,
+            }
+        }
+
+    def test_rejects_upload_request_invalid_content_length_with_400(self) -> None:
+        """Upload requests with invalid Content-Length should fail pre-parse."""
+
+        def stream() -> Any:
+            yield b"streamed-upload-body"
+
+        request = client.build_request(
+            "POST",
+            f"/v1/projects/{uuid.uuid4()}/files",
+            content=stream(),
+            headers={"content-length": "not-an-integer"},
+        )
+
+        response = client.send(request)
+        assert response.status_code == 400
+        assert response.json() == {
+            "error": {
+                "code": "INPUT_INVALID",
+                "message": "Content-Length header must be a valid integer.",
+                "details": None,
+            }
+        }


### PR DESCRIPTION
Closes #27

## Summary
- add File and Job persistence with the upload, list, and detail endpoints plus the Alembic migration
- harden uploads with bounded middleware preflight checks, exact streamed file-size enforcement, format sniffing, and best-effort cleanup on failures
- add integration and middleware coverage for success paths, cleanup paths, DXF sniffing, and upload size limits

## Test plan
- [x] uv run pytest
- [x] uv run ruff check app tests
- [x] uv run --extra jobs mypy app tests

## Notes
- `uv.lock` has a local unstaged change and is intentionally excluded from this PR