### PR TITLE
feat: add persisted job status and worker flow

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -2,6 +2,7 @@
 
 from app.api.v1.files import files_router
 from app.api.v1.health import health_router
+from app.api.v1.jobs import jobs_router
 from app.api.v1.projects import project_router
 
-__all__ = ["files_router", "health_router", "project_router"]
+__all__ = ["files_router", "health_router", "jobs_router", "project_router"]

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -7,7 +7,7 @@ import json
 import os
 import uuid
 from contextlib import suppress
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, cast
 from uuid import UUID
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
+from app.jobs.worker import enqueue_ingest_job
 from app.models.file import File as FileModel
 from app.models.job import Job
 from app.models.project import Project
@@ -359,6 +360,17 @@ async def upload_project_file(
         raise
 
     await db.refresh(file_row)
+    await db.refresh(ingest_job)
+
+    try:
+        enqueue_ingest_job(ingest_job.id)
+    except Exception as exc:
+        ingest_job.status = "failed"
+        ingest_job.error_code = None
+        ingest_job.error_message = f"Failed to enqueue ingest job: {exc}"
+        ingest_job.finished_at = datetime.now(UTC)
+        await db.commit()
+
     return file_row
 
 

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -1,0 +1,33 @@
+"""Job status endpoints."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.job import Job
+from app.schemas.job import JobRead
+
+jobs_router = APIRouter()
+
+
+@jobs_router.get(
+    "/jobs/{job_id}",
+    response_model=JobRead,
+)
+async def get_job(
+    job_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Job:
+    """Return persisted status for a single job."""
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise_not_found("Job", str(job_id))
+
+    assert job is not None
+    return job

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1,21 +1,222 @@
-"""Celery worker application."""
+"""Celery worker application and persisted job handlers."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 from celery import Celery
+from celery.signals import worker_ready
+from sqlalchemy import select
 
 from app.core.config import settings
+from app.core.logging import get_logger
+from app.db.session import get_session_maker
+from app.models.job import Job
+
+logger = get_logger(__name__)
+
+_INGEST_NOOP_DELAY_SECONDS = 0.01
+_INCOMPLETE_JOB_STATUSES = ("pending", "running")
+_TERMINAL_JOB_STATUSES = {"failed", "succeeded"}
+_DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
+_RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
 
 celery_app = Celery(
     "draupnir",
     broker=settings.broker_url,
-    backend="redis://localhost:6379/0",  # placeholder for now
+)
+celery_app.conf.update(
+    task_ignore_result=True,
+    task_store_eager_result=False,
+    task_publish_retry=False,
+    task_acks_late=True,
+    task_reject_on_worker_lost=True,
+    worker_prefetch_multiplier=1,
 )
 
 # Auto-discover tasks from the jobs module
 celery_app.autodiscover_tasks(["app.jobs"], force=True)
 
 
-# Example task (remove once real tasks exist)
-@celery_app.task
-def health_check_task() -> str:
-    """Simple health check task for testing worker connectivity."""
-    return "ok"
+def _utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(UTC)
+
+
+def _is_stale_running_job(job: Job, *, now: datetime) -> bool:
+    """Return whether a running job is old enough to treat as orphaned."""
+    if job.started_at is None:
+        return True
+
+    started_at = job.started_at
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=UTC)
+
+    return started_at <= now - _RUNNING_JOB_STALE_AFTER
+
+
+async def _mark_job_failed(job_id: UUID, *, error_message: str) -> None:
+    """Persist a failed job state with the supplied message."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "ingest_job_failure_mark_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return
+
+        job.status = "failed"
+        job.error_code = None
+        job.error_message = error_message
+        job.finished_at = _utcnow()
+        await session.commit()
+
+
+async def process_ingest_job(job_id: UUID) -> None:
+    """Load a persisted ingest job, perform a no-op, and persist state transitions."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "ingest_job_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return
+
+        job.attempts += 1
+        job.status = "running"
+        job.started_at = _utcnow()
+        job.finished_at = None
+        job.error_code = None
+        job.error_message = None
+        await session.commit()
+
+    try:
+        await asyncio.sleep(_INGEST_NOOP_DELAY_SECONDS)
+    except Exception as exc:
+        await _mark_job_failed(job_id, error_message=str(exc))
+        logger.error("ingest_job_failed", job_id=str(job_id), error=str(exc), exc_info=True)
+        raise
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "ingest_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return
+
+        job.status = "succeeded"
+        job.finished_at = _utcnow()
+        job.error_code = None
+        job.error_message = None
+        await session.commit()
+
+    logger.info("ingest_job_succeeded", job_id=str(job_id))
+
+
+async def recover_incomplete_ingest_jobs() -> list[UUID]:
+    """Requeue incomplete persisted ingest jobs on worker startup."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    now = _utcnow()
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(Job)
+            .where(
+                (Job.job_type == "ingest")
+                & (Job.status.in_(_INCOMPLETE_JOB_STATUSES))
+            )
+            .order_by(Job.created_at.asc(), Job.id.asc())
+        )
+        jobs = result.scalars().all()
+
+        recovered_job_ids: list[UUID] = []
+        for job in jobs:
+            if job.status == "running":
+                if not _is_stale_running_job(job, now=now):
+                    continue
+                job.status = "pending"
+                job.started_at = None
+                job.finished_at = None
+                job.error_code = None
+                job.error_message = None
+            recovered_job_ids.append(job.id)
+
+        await session.commit()
+
+    enqueued_job_ids: list[UUID] = []
+    for job_id in recovered_job_ids:
+        try:
+            enqueue_ingest_job(job_id)
+        except Exception as exc:
+            await _mark_job_failed(job_id, error_message=f"Failed to enqueue ingest job: {exc}")
+            logger.error(
+                "ingest_job_recovery_enqueue_failed",
+                job_id=str(job_id),
+                error=str(exc),
+                exc_info=True,
+            )
+        else:
+            enqueued_job_ids.append(job_id)
+
+    return enqueued_job_ids
+
+
+def recover_incomplete_ingest_jobs_on_worker_start(**_: object) -> None:
+    """Requeue incomplete ingest jobs when a worker starts."""
+    try:
+        recovered_job_ids = asyncio.run(recover_incomplete_ingest_jobs())
+    except Exception as exc:
+        logger.error("ingest_job_recovery_failed", error=str(exc), exc_info=True)
+        return
+
+    if recovered_job_ids:
+        logger.info(
+            "ingest_job_recovery_completed",
+            recovered_job_ids=[str(job_id) for job_id in recovered_job_ids],
+        )
+
+
+worker_ready.connect(recover_incomplete_ingest_jobs_on_worker_start)
+
+
+@celery_app.task(
+    name="app.jobs.worker.run_ingest_job",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def run_ingest_job(job_id: str) -> None:
+    """Celery task wrapper for the persisted ingest job processor."""
+    asyncio.run(process_ingest_job(UUID(job_id)))
+
+
+def enqueue_ingest_job(job_id: UUID) -> None:
+    """Publish a persisted ingest job to Celery."""
+    run_ingest_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 
-from app.api.v1 import files_router, health_router, project_router
+from app.api.v1 import files_router, health_router, jobs_router, project_router
 from app.core.config import settings
 from app.core.exceptions import custom_http_exception_handler, request_validation_exception_handler
 from app.core.logging import configure_logging, get_logger
@@ -36,6 +36,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router, prefix=settings.api_prefix)
     app.include_router(project_router, prefix=f"{settings.api_prefix}/projects")
     app.include_router(files_router, prefix=settings.api_prefix)
+    app.include_router(jobs_router, prefix=settings.api_prefix)
 
     logger.info("app_started", version=settings.app_version)
 

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,11 +1,13 @@
 """Pydantic request/response schemas."""
 
 from app.schemas.file import FileListResponse, FileRead
+from app.schemas.job import JobRead
 from app.schemas.project import ProjectCreate, ProjectListResponse, ProjectRead, ProjectUpdate
 
 __all__ = [
     "FileListResponse",
     "FileRead",
+    "JobRead",
     "ProjectCreate",
     "ProjectListResponse",
     "ProjectRead",

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for persisted jobs."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JobRead(BaseModel):
+    """Schema for reading a persisted background job."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID = Field(..., description="Unique job identifier (UUID)")
+    project_id: uuid.UUID = Field(..., description="Owning project identifier")
+    file_id: uuid.UUID = Field(..., description="Associated file identifier")
+    job_type: str = Field(..., description="Job type")
+    status: str = Field(..., description="Job status")
+    attempts: int = Field(..., ge=0, description="Current attempt count")
+    max_attempts: int = Field(..., ge=1, description="Maximum retry attempts")
+    cancel_requested: bool = Field(..., description="Whether cancellation was requested")
+    error_code: str | None = Field(None, description="Machine-readable error code")
+    error_message: str | None = Field(None, description="Human-readable error message")
+    started_at: datetime | None = Field(None, description="Job start timestamp")
+    finished_at: datetime | None = Field(None, description="Job completion timestamp")
+    created_at: datetime = Field(..., description="Job creation timestamp")

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -13,6 +13,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 from sqlalchemy import select
 
+import app.api.v1.files as files_api
 import app.db.session as session_module
 from app.core.config import settings
 from app.models.file import File as FileModel
@@ -79,6 +80,15 @@ def _make_get_db_override_with_commit_error(
 @requires_database
 class TestProjectFiles:
     """Tests for project file upload and retrieval endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_enqueue_ingest_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub enqueue publish so file endpoint tests do not require RabbitMQ."""
+
+        def _fake_enqueue(job_id: uuid.UUID) -> None:
+            _ = job_id
+
+        monkeypatch.setattr(files_api, "enqueue_ingest_job", _fake_enqueue)
 
     async def test_upload_file_creates_file_and_pending_job(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,361 @@
+"""Integration tests for persisted job status and worker transitions."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+import app.api.v1.files as files_api
+import app.db.session as session_module
+import app.jobs.worker as worker_module
+from app.jobs.worker import process_ingest_job, recover_incomplete_ingest_jobs
+from app.models.job import Job
+from tests.conftest import requires_database
+
+
+async def _create_project(async_client: httpx.AsyncClient) -> dict[str, Any]:
+    """Create a project and return its payload."""
+    response = await async_client.post(
+        "/v1/projects",
+        json={
+            "name": "Jobs Test Project",
+            "description": "A project for job tests",
+        },
+    )
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json())
+
+
+async def _upload_file(
+    async_client: httpx.AsyncClient,
+    project_id: str,
+) -> dict[str, Any]:
+    """Upload a supported file and return its payload."""
+    response = await async_client.post(
+        f"/v1/projects/{project_id}/files",
+        files={"file": ("plan.pdf", b"%PDF-1.7\njob-test\n", "application/pdf")},
+    )
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json())
+
+
+async def _get_job_for_file(file_id: str) -> Job:
+    """Load the ingest job associated with a file id."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        result = await session.execute(select(Job).where(Job.file_id == uuid.UUID(file_id)))
+        job = result.scalar_one_or_none()
+
+    assert job is not None
+    return job
+
+
+async def _get_job(job_id: uuid.UUID) -> Job:
+    """Load a job by id."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+
+    assert job is not None
+    return job
+
+
+@pytest.fixture
+def enqueued_job_ids(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture enqueue calls without requiring a live broker."""
+    recorded_job_ids: list[str] = []
+
+    def _fake_enqueue(job_id: uuid.UUID) -> None:
+        recorded_job_ids.append(str(job_id))
+
+    monkeypatch.setattr(files_api, "enqueue_ingest_job", _fake_enqueue)
+    return recorded_job_ids
+
+
+@requires_database
+class TestJobs:
+    """Tests for job status retrieval and worker state transitions."""
+
+    async def test_upload_file_enqueues_ingest_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Uploading a file should enqueue the persisted ingest job."""
+        _ = self
+        _ = cleanup_projects
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        assert enqueued_job_ids == [str(job.id)]
+        assert job.status == "pending"
+        assert job.attempts == 0
+
+    async def test_upload_file_marks_job_failed_when_enqueue_publish_fails(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Uploading should leave a visible failed job when broker publish fails."""
+        _ = self
+        _ = cleanup_projects
+
+        def _fail_enqueue(_: uuid.UUID) -> None:
+            raise RuntimeError("broker unavailable")
+
+        monkeypatch.setattr(files_api, "enqueue_ingest_job", _fail_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        assert job.status == "failed"
+        assert job.attempts == 0
+        assert job.error_code is None
+        assert job.error_message == "Failed to enqueue ingest job: broker unavailable"
+        assert job.started_at is None
+        assert job.finished_at is not None
+
+    async def test_get_job_returns_persisted_state(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """GET should return the persisted job state for a known job."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        response = await async_client.get(f"/v1/jobs/{job.id}")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["id"] == str(job.id)
+        assert data["project_id"] == project["id"]
+        assert data["file_id"] == uploaded["id"]
+        assert data["job_type"] == "ingest"
+        assert data["status"] == "pending"
+        assert data["attempts"] == 0
+        assert data["max_attempts"] == 3
+        assert data["cancel_requested"] is False
+        assert data["error_code"] is None
+        assert data["error_message"] is None
+        assert data["started_at"] is None
+        assert data["finished_at"] is None
+        assert data["created_at"] is not None
+
+    async def test_get_job_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """GET should return the standard Job 404 envelope for unknown ids."""
+        _ = self
+        _ = cleanup_projects
+
+        missing_job_id = uuid.uuid4()
+        response = await async_client.get(f"/v1/jobs/{missing_job_id}")
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"Job with identifier '{missing_job_id}' not found",
+                "details": None,
+            }
+        }
+
+    async def test_process_ingest_job_transitions_to_succeeded(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Worker processing should persist running and succeeded state transitions."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        updated_job = await _get_job_for_file(str(uploaded["id"]))
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1
+        assert updated_job.started_at is not None
+        assert updated_job.finished_at is not None
+        assert updated_job.finished_at >= updated_job.started_at
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
+
+    async def test_recover_incomplete_ingest_jobs_requeues_pending_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker startup recovery should requeue pending ingest jobs."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        enqueued_job_ids.clear()
+
+        requeued = await recover_incomplete_ingest_jobs()
+
+        assert recovered_job_ids == [str(job.id)]
+        assert requeued == [job.id]
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "pending"
+        assert updated_job.attempts == 0
+
+    async def test_recover_incomplete_ingest_jobs_requeues_orphaned_running_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker startup recovery should requeue stale running ingest jobs."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        enqueued_job_ids.clear()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = (
+                datetime.now(UTC)
+                - worker_module._RUNNING_JOB_STALE_AFTER
+                - timedelta(seconds=1)
+            )
+            await session.commit()
+
+        requeued = await recover_incomplete_ingest_jobs()
+
+        assert recovered_job_ids == [str(job.id)]
+        assert requeued == [job.id]
+
+        recovered_job = await _get_job(job.id)
+        assert recovered_job.status == "pending"
+        assert recovered_job.attempts == 1
+        assert recovered_job.started_at is None
+        assert recovered_job.finished_at is None
+
+        await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 2
+
+    async def test_recover_incomplete_ingest_jobs_skips_fresh_running_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker startup recovery should not requeue fresh running ingest jobs."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        enqueued_job_ids.clear()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = datetime.now(UTC)
+            await session.commit()
+
+        requeued = await recover_incomplete_ingest_jobs()
+
+        assert recovered_job_ids == []
+        assert requeued == []
+
+        unchanged_job = await _get_job(job.id)
+        assert unchanged_job.status == "running"
+        assert unchanged_job.attempts == 1
+        assert unchanged_job.started_at is not None
+
+    async def test_process_ingest_job_ignores_duplicate_delivery_after_success(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Duplicate delivery should not mutate terminal succeeded jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+        first_completion = await _get_job(job.id)
+        assert first_completion.status == "succeeded"
+        assert first_completion.attempts == 1
+
+        await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,19 @@ wheels = [
 ]
 
 [[package]]
+name = "celery-stubs"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/14/b853ada8706a3a301396566b6dd405d1cbb24bff756236a12a01dbe766a4/celery-stubs-0.1.3.tar.gz", hash = "sha256:0fb5345820f8a2bd14e6ffcbef2d10181e12e40f8369f551d7acc99d8d514919", size = 46583, upload-time = "2023-02-10T02:20:11.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/7a/4ab2347d13f1f59d10a7337feb9beb002664119f286036785284c6bec150/celery_stubs-0.1.3-py3-none-any.whl", hash = "sha256:dfb9ad27614a8af028b2055bb4a4ae99ca5e9a8d871428a506646d62153218d7", size = 89085, upload-time = "2023-02-10T02:20:09.409Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -498,8 +511,10 @@ all = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "celery" },
+    { name = "celery-stubs" },
     { name = "ezdxf" },
     { name = "factory-boy" },
+    { name = "flower" },
     { name = "mypy" },
     { name = "opencv-python" },
     { name = "pillow" },
@@ -540,6 +555,8 @@ ingestion = [
 ]
 jobs = [
     { name = "celery" },
+    { name = "celery-stubs" },
+    { name = "flower" },
     { name = "redis" },
 ]
 test = [
@@ -554,10 +571,12 @@ requires-dist = [
     { name = "alembic", marker = "extra == 'db'", specifier = ">=1.13" },
     { name = "asyncpg", marker = "extra == 'db'", specifier = ">=0.29" },
     { name = "celery", marker = "extra == 'jobs'", specifier = ">=5.3" },
+    { name = "celery-stubs", marker = "extra == 'jobs'", specifier = ">=0.1" },
     { name = "draupnir", extras = ["db", "jobs", "ingestion", "dev", "test"], marker = "extra == 'all'" },
     { name = "ezdxf", marker = "extra == 'ingestion'", specifier = ">=1.2" },
     { name = "factory-boy", marker = "extra == 'test'", specifier = ">=3.3" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "flower", marker = "extra == 'jobs'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "opencv-python", marker = "extra == 'ingestion'", specifier = ">=4.9" },
@@ -675,6 +694,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flower"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "celery" },
+    { name = "humanize" },
+    { name = "prometheus-client" },
+    { name = "pytz" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a1/357f1b5d8946deafdcfdd604f51baae9de10aafa2908d0b7322597155f92/flower-2.0.1.tar.gz", hash = "sha256:5ab717b979530770c16afb48b50d2a98d23c3e9fe39851dcf6bc4d01845a02a0", size = 3220408, upload-time = "2023-08-13T14:37:46.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/ff/ee2f67c0ff146ec98b5df1df637b2bc2d17beeb05df9f427a67bd7a7d79c/flower-2.0.1-py2.py3-none-any.whl", hash = "sha256:9db2c621eeefbc844c8dd88be64aef61e84e2deb29b271e02ab2b5b9f01068e2", size = 383553, upload-time = "2023-08-13T14:37:41.552Z" },
 ]
 
 [[package]]
@@ -821,6 +856,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
 ]
 
 [[package]]
@@ -1310,6 +1354,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1634,6 +1687,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
 ]
 
 [[package]]
@@ -1985,6 +2047,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #28

## Summary
- add a persisted `GET /v1/jobs/{job_id}` endpoint and `JobRead` schema so clients can poll ingest job state
- replace the placeholder Celery worker with persisted ingest transitions, late-ack delivery, duplicate guards, and stale-job startup recovery
- enqueue ingest jobs after file upload and cover enqueue, recovery, and worker lifecycle behavior with DB-backed tests

## Test plan
- [x] `uv run ruff check app tests`
- [x] `uv run mypy app tests`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run alembic upgrade head`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest`

## Notes
- `uv.lock` is included to sync already-declared jobs extras present in `pyproject.toml`