### PR TITLE
feat: add job cancel and retry handling

### DIFF
--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -1,18 +1,44 @@
 """Job status endpoints."""
 
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import raise_not_found
 from app.db.session import get_db
+from app.jobs.worker import enqueue_ingest_job
 from app.models.job import Job
 from app.schemas.job import JobRead
 
 jobs_router = APIRouter()
+
+_TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
+
+
+async def _get_job_or_404(db: AsyncSession, job_id: UUID) -> Job:
+    """Return a persisted job or raise a not-found error."""
+    result = await db.execute(select(Job).where(Job.id == job_id))
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise_not_found("Job", str(job_id))
+    assert job is not None
+
+    return job
+
+
+async def _get_job_for_update_or_404(db: AsyncSession, job_id: UUID) -> Job:
+    """Return a persisted job with a row lock or raise not found."""
+    result = await db.execute(select(Job).where(Job.id == job_id).with_for_update())
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise_not_found("Job", str(job_id))
+    assert job is not None
+
+    return job
 
 
 @jobs_router.get(
@@ -24,10 +50,60 @@ async def get_job(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Job:
     """Return persisted status for a single job."""
-    result = await db.execute(select(Job).where(Job.id == job_id))
-    job = result.scalar_one_or_none()
-    if job is None:
-        raise_not_found("Job", str(job_id))
+    return await _get_job_or_404(db, job_id)
 
-    assert job is not None
+
+@jobs_router.post(
+    "/jobs/{job_id}/cancel",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def cancel_job(
+    job_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Job:
+    """Request cancellation for a persisted job."""
+    job = await _get_job_for_update_or_404(db, job_id)
+    if job.status in _TERMINAL_JOB_STATUSES:
+        return job
+
+    job.cancel_requested = True
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@jobs_router.post(
+    "/jobs/{job_id}/retry",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def retry_job(
+    job_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Job:
+    """Requeue a failed persisted job when attempts remain."""
+    job = await _get_job_for_update_or_404(db, job_id)
+    if job.status != "failed" or job.attempts >= job.max_attempts:
+        return job
+
+    job.status = "pending"
+    job.cancel_requested = False
+    job.error_code = None
+    job.error_message = None
+    job.started_at = None
+    job.finished_at = None
+    await db.commit()
+
+    try:
+        enqueue_ingest_job(job.id)
+    except Exception as exc:
+        job.status = "failed"
+        job.error_code = None
+        job.error_message = f"Failed to enqueue ingest job: {exc}"
+        job.finished_at = datetime.now(UTC)
+        await db.commit()
+        raise
+
+    await db.refresh(job)
     return job

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from celery import Celery
 from celery.signals import worker_ready
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.logging import get_logger
@@ -17,9 +18,10 @@ logger = get_logger(__name__)
 
 _INGEST_NOOP_DELAY_SECONDS = 0.01
 _INCOMPLETE_JOB_STATUSES = ("pending", "running")
-_TERMINAL_JOB_STATUSES = {"failed", "succeeded"}
+_TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
 _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
+_JOB_CANCELLED_ERROR_CODE = "JOB_CANCELLED"
 
 celery_app = Celery(
     "draupnir",
@@ -55,6 +57,12 @@ def _is_stale_running_job(job: Job, *, now: datetime) -> bool:
     return started_at <= now - _RUNNING_JOB_STALE_AFTER
 
 
+async def _get_job_for_update(session: AsyncSession, job_id: UUID) -> Job | None:
+    """Load and lock a persisted job row."""
+    result = await session.execute(select(Job).where(Job.id == job_id).with_for_update())
+    return result.scalar_one_or_none()
+
+
 async def _mark_job_failed(job_id: UUID, *, error_message: str) -> None:
     """Persist a failed job state with the supplied message."""
     session_maker = get_session_maker()
@@ -62,7 +70,7 @@ async def _mark_job_failed(job_id: UUID, *, error_message: str) -> None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as session:
-        job = await session.get(Job, job_id)
+        job = await _get_job_for_update(session, job_id)
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
@@ -81,32 +89,82 @@ async def _mark_job_failed(job_id: UUID, *, error_message: str) -> None:
         await session.commit()
 
 
+def _finalize_job_cancelled(job: Job) -> None:
+    """Apply the persisted cancelled terminal state to a job."""
+    job.status = "cancelled"
+    job.error_code = _JOB_CANCELLED_ERROR_CODE
+    job.error_message = None
+    job.finished_at = _utcnow()
+
+
+async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
+    """Claim, resume, or cancel a persisted ingest job under a row lock."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    now = _utcnow()
+
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "ingest_job_cancel_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if not job.cancel_requested:
+            if job.status == "running":
+                if _is_stale_running_job(job, now=now):
+                    job.attempts += 1
+                    job.started_at = now
+                    job.finished_at = None
+                    job.error_code = None
+                    job.error_message = None
+                    await session.commit()
+                    logger.warning(
+                        "ingest_job_reclaimed_stale_running_status",
+                        job_id=str(job_id),
+                        status=job.status,
+                    )
+                    return True
+
+                logger.info(
+                    "ingest_job_continuing_running_status",
+                    job_id=str(job_id),
+                    status=job.status,
+                )
+                return True
+
+            job.attempts += 1
+            job.status = "running"
+            job.started_at = now
+            job.finished_at = None
+            job.error_code = None
+            job.error_message = None
+            await session.commit()
+            return True
+
+        _finalize_job_cancelled(job)
+        await session.commit()
+
+    logger.info("ingest_job_cancelled", job_id=str(job_id))
+    return False
+
+
 async def process_ingest_job(job_id: UUID) -> None:
     """Load a persisted ingest job, perform a no-op, and persist state transitions."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
-    async with session_maker() as session:
-        job = await session.get(Job, job_id)
-        if job is None:
-            raise LookupError(f"Job with identifier '{job_id}' not found")
-
-        if job.status in _TERMINAL_JOB_STATUSES:
-            logger.info(
-                "ingest_job_skipped_terminal_status",
-                job_id=str(job_id),
-                status=job.status,
-            )
-            return
-
-        job.attempts += 1
-        job.status = "running"
-        job.started_at = _utcnow()
-        job.finished_at = None
-        job.error_code = None
-        job.error_message = None
-        await session.commit()
+    if not await _begin_or_resume_ingest_job(job_id):
+        return
 
     try:
         await asyncio.sleep(_INGEST_NOOP_DELAY_SECONDS)
@@ -116,13 +174,27 @@ async def process_ingest_job(job_id: UUID) -> None:
         raise
 
     async with session_maker() as session:
-        job = await session.get(Job, job_id)
+        job = await _get_job_for_update(session, job_id)
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
         if job.status in _TERMINAL_JOB_STATUSES:
             logger.info(
                 "ingest_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return
+
+        if job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await session.commit()
+            logger.info("ingest_job_cancelled", job_id=str(job_id))
+            return
+
+        if job.status != "running":
+            logger.info(
+                "ingest_job_completion_skipped_non_running_status",
                 job_id=str(job_id),
                 status=job.status,
             )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,5 +1,6 @@
 """Integration tests for persisted job status and worker transitions."""
 
+import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -9,6 +10,7 @@ import pytest
 from sqlalchemy import select
 
 import app.api.v1.files as files_api
+import app.api.v1.jobs as jobs_api
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.jobs.worker import process_ingest_job, recover_incomplete_ingest_jobs
@@ -65,6 +67,40 @@ async def _get_job(job_id: uuid.UUID) -> Job:
 
     assert job is not None
     return job
+
+
+async def _update_job(
+    job_id: uuid.UUID,
+    *,
+    status: str | None = None,
+    attempts: int | None = None,
+    max_attempts: int | None = None,
+    cancel_requested: bool | None = None,
+    error_message: str | None = None,
+) -> Job:
+    """Update and return a persisted job for test setup."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        assert job is not None
+
+        if status is not None:
+            job.status = status
+        if attempts is not None:
+            job.attempts = attempts
+        if max_attempts is not None:
+            job.max_attempts = max_attempts
+        if cancel_requested is not None:
+            job.cancel_requested = cancel_requested
+
+        if error_message is not None:
+            job.error_message = error_message
+
+        await session.commit()
+
+    return await _get_job(job_id)
 
 
 @pytest.fixture
@@ -205,6 +241,39 @@ class TestJobs:
         assert updated_job.finished_at >= updated_job.started_at
         assert updated_job.error_code is None
         assert updated_job.error_message is None
+
+    async def test_process_ingest_job_continues_redelivered_running_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Redelivery should complete an already-running ingest attempt."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = datetime.now(UTC)
+            await session.commit()
+
+        await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1
+        assert updated_job.started_at is not None
+        assert updated_job.finished_at is not None
 
     async def test_recover_incomplete_ingest_jobs_requeues_pending_jobs(
         self,
@@ -359,3 +428,301 @@ class TestJobs:
         updated_job = await _get_job(job.id)
         assert updated_job.status == "succeeded"
         assert updated_job.attempts == 1
+
+    async def test_cancel_job_marks_pending_job_cancel_requested(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Cancel should mark a pending job for cancellation."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/cancel")
+
+        assert response.status_code == 202
+        updated_job = await _get_job(job.id)
+        assert updated_job.cancel_requested is True
+        assert updated_job.status in {"pending", "cancelled"}
+
+    async def test_cancel_job_returns_404_for_unknown_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Cancel should return 404 for unknown jobs."""
+        _ = self
+        _ = cleanup_projects
+
+        missing_job_id = uuid.uuid4()
+
+        response = await async_client.post(f"/v1/jobs/{missing_job_id}/cancel")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"Job with identifier '{missing_job_id}' not found",
+                "details": None,
+            }
+        }
+
+    async def test_cancel_job_is_terminal_no_op_for_succeeded_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Cancel should not mutate terminal succeeded jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+        completed = await _get_job(job.id)
+        assert completed.status == "succeeded"
+        assert completed.cancel_requested is False
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/cancel")
+
+        assert response.status_code == 202
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "succeeded"
+        assert unchanged.cancel_requested is False
+        assert unchanged.attempts == 1
+
+    async def test_retry_job_requeues_failed_job_below_max_attempts(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should requeue failed jobs that still have capacity."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+            retried_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            jobs_api,
+            "enqueue_ingest_job",
+            _fake_retry_enqueue,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            error_message="previous failure",
+        )
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 202
+        assert retried_job_ids == [str(job.id)]
+        updated = await _get_job(job.id)
+        assert updated.status == "pending"
+
+    async def test_retry_job_noops_when_attempt_limit_reached(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should no-op when attempts already reached max_attempts."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+            retried_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            jobs_api,
+            "enqueue_ingest_job",
+            _fake_retry_enqueue,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=3,
+            max_attempts=3,
+            error_message="maxed out",
+        )
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 202
+        assert retried_job_ids == []
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "failed"
+        assert unchanged.attempts == 3
+        assert unchanged.max_attempts == 3
+
+    async def test_retry_job_is_terminal_no_op_for_cancelled_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should no-op for terminal cancelled jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+            retried_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            jobs_api,
+            "enqueue_ingest_job",
+            _fake_retry_enqueue,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(job.id, status="cancelled", attempts=1, max_attempts=3)
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 202
+        assert retried_job_ids == []
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "cancelled"
+        assert unchanged.attempts == 1
+
+    async def test_retry_job_returns_404_for_unknown_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Retry should return 404 for unknown jobs."""
+        _ = self
+        _ = cleanup_projects
+
+        missing_job_id = uuid.uuid4()
+
+        response = await async_client.post(f"/v1/jobs/{missing_job_id}/retry")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"Job with identifier '{missing_job_id}' not found",
+                "details": None,
+            }
+        }
+
+    async def test_process_ingest_job_finalizes_cancel_requested_job_as_cancelled(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Worker should finalize cancel-requested jobs to cancelled."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(job.id, status="pending", cancel_requested=True)
+
+        await process_ingest_job(job.id)
+
+        updated = await _get_job(job.id)
+        assert updated.status == "cancelled"
+        assert updated.cancel_requested is True
+        assert updated.finished_at is not None
+        assert updated.error_message is None
+
+    async def test_process_ingest_job_finalizes_cancelled_when_requested_during_completion_race(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker should persist cancelled if cancellation commits before completion."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _cancel_during_work(_: float) -> None:
+            await _update_job(job.id, cancel_requested=True)
+
+        monkeypatch.setattr(asyncio, "sleep", _cancel_during_work)
+
+        await process_ingest_job(job.id)
+
+        updated = await _get_job(job.id)
+        assert updated.status == "cancelled"
+        assert updated.attempts == 1
+        assert updated.cancel_requested is True
+        assert updated.finished_at is not None
+        assert updated.error_code == worker_module._JOB_CANCELLED_ERROR_CODE
+
+    async def test_process_ingest_job_ignores_duplicate_delivery_after_cancelled(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Duplicate delivery should not mutate terminal cancelled jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(job.id, status="cancelled", attempts=1, cancel_requested=True)
+
+        before = await _get_job(job.id)
+        before_finished_at = before.finished_at
+
+        await process_ingest_job(job.id)
+
+        after = await _get_job(job.id)
+        assert after.status == "cancelled"
+        assert after.attempts == 1
+        assert after.cancel_requested is True
+        assert after.finished_at == before_finished_at


### PR DESCRIPTION
Closes #29

## Summary
- add `POST /v1/jobs/{job_id}/cancel` and `POST /v1/jobs/{job_id}/retry` with terminal-state no-op behavior and failed-job requeue handling
- update the ingest worker to honor cancellation under row lock and safely handle redelivered `running` jobs without leaving them stuck
- add regression coverage for cancel/retry endpoints, cancellation races, and worker redelivery behavior

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest