### PR TITLE
feat: add job events tail endpoint

### DIFF
--- a/alembic/versions/2026_05_02_0003_add_job_events.py
+++ b/alembic/versions/2026_05_02_0003_add_job_events.py
@@ -1,0 +1,51 @@
+"""add job events
+
+Revision ID: 2026_05_02_0003
+Revises: 2026_05_01_0002
+Create Date: 2026-05-02 00:03:00
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_02_0003"
+down_revision: str | None = "2026_05_01_0002"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create persisted job event storage."""
+    op.create_table(
+        "job_events",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("job_id", sa.UUID(), nullable=False),
+        sa.Column("level", sa.String(length=32), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("data_json", sa.JSON(), nullable=True),
+        sa.Column("sequence_id", sa.BigInteger(), sa.Identity(always=False), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["job_id"], ["jobs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_job_events_job_id_created_at_sequence_id_id",
+        "job_events",
+        ["job_id", "created_at", "sequence_id", "id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop persisted job event storage."""
+    op.drop_index("ix_job_events_job_id_created_at_sequence_id_id", table_name="job_events")
+    op.drop_table("job_events")

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -1,21 +1,27 @@
 """Job status endpoints."""
 
+import base64
+import binascii
+import json
 from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.exceptions import raise_not_found
+from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
 from app.jobs.worker import enqueue_ingest_job
 from app.models.job import Job
-from app.schemas.job import JobRead
+from app.models.job_event import JobEvent
+from app.schemas.job import JobEventPage, JobEventRead, JobRead
 
 jobs_router = APIRouter()
 
+_DEFAULT_EVENTS_LIMIT = 50
+_MAX_EVENTS_LIMIT = 200
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 
 
@@ -41,6 +47,51 @@ async def _get_job_for_update_or_404(db: AsyncSession, job_id: UUID) -> Job:
     return job
 
 
+def _encode_job_events_cursor(event: JobEvent) -> str:
+    """Encode a pagination cursor from a job event row."""
+    created_at = event.created_at
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+
+    payload = json.dumps(
+        {
+            "created_at": created_at.astimezone(UTC).isoformat(),
+            "sequence_id": event.sequence_id,
+            "id": str(event.id),
+        },
+        separators=(",", ":"),
+    )
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+def _decode_job_events_cursor(cursor: str) -> tuple[datetime, int | None, UUID]:
+    """Decode a pagination cursor into its sort key values."""
+    try:
+        padded_cursor = cursor + ("=" * (-len(cursor) % 4))
+        decoded = base64.urlsafe_b64decode(padded_cursor.encode("utf-8")).decode("utf-8")
+        payload = json.loads(decoded)
+        created_at = datetime.fromisoformat(payload["created_at"])
+        sequence_id_raw = payload.get("sequence_id")
+        sequence_id = int(sequence_id_raw) if sequence_id_raw is not None else None
+        if sequence_id is not None and sequence_id < 0:
+            raise ValueError("sequence_id must be non-negative")
+        cursor_id = UUID(payload["id"])
+    except (ValueError, TypeError, KeyError, json.JSONDecodeError, binascii.Error) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=create_error_response(
+                code="INVALID_CURSOR",
+                message="Invalid cursor format",
+                details=None,
+            ),
+        ) from exc
+
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+
+    return created_at.astimezone(UTC), sequence_id, cursor_id
+
+
 @jobs_router.get(
     "/jobs/{job_id}",
     response_model=JobRead,
@@ -51,6 +102,64 @@ async def get_job(
 ) -> Job:
     """Return persisted status for a single job."""
     return await _get_job_or_404(db, job_id)
+
+
+@jobs_router.get(
+    "/jobs/{job_id}/events",
+    response_model=JobEventPage,
+)
+async def list_job_events(
+    job_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=_MAX_EVENTS_LIMIT, description="Page size"),
+    ] = _DEFAULT_EVENTS_LIMIT,
+) -> JobEventPage:
+    """Return cursor-paginated lifecycle events for a single job."""
+    await _get_job_or_404(db, job_id)
+
+    statement = select(JobEvent).where(JobEvent.job_id == job_id)
+    if cursor is not None:
+        created_at, sequence_id, cursor_id = _decode_job_events_cursor(cursor)
+        if sequence_id is None:
+            statement = statement.where(
+                or_(
+                    JobEvent.created_at > created_at,
+                    and_(JobEvent.created_at == created_at, JobEvent.id > cursor_id),
+                )
+            )
+        else:
+            statement = statement.where(
+                or_(
+                    JobEvent.created_at > created_at,
+                    and_(JobEvent.created_at == created_at, JobEvent.sequence_id > sequence_id),
+                    and_(
+                        JobEvent.created_at == created_at,
+                        JobEvent.sequence_id == sequence_id,
+                        JobEvent.id > cursor_id,
+                    ),
+                )
+            )
+
+    statement = statement.order_by(
+        JobEvent.created_at.asc(),
+        JobEvent.sequence_id.asc(),
+        JobEvent.id.asc(),
+    ).limit(limit + 1)
+    result = await db.execute(statement)
+    events = list(result.scalars())
+
+    next_cursor: str | None = None
+    if len(events) > limit:
+        next_cursor = _encode_job_events_cursor(events[limit - 1])
+        events = events[:limit]
+
+    return JobEventPage(
+        items=[JobEventRead.model_validate(event) for event in events],
+        next_cursor=next_cursor,
+    )
 
 
 @jobs_router.post(

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from uuid import UUID
 
 from celery import Celery
@@ -13,6 +14,7 @@ from app.core.config import settings
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
 from app.models.job import Job
+from app.models.job_event import JobEvent
 
 logger = get_logger(__name__)
 
@@ -63,6 +65,34 @@ async def _get_job_for_update(session: AsyncSession, job_id: UUID) -> Job | None
     return result.scalar_one_or_none()
 
 
+async def emit_job_event(
+    job_id: UUID,
+    *,
+    level: str,
+    message: str,
+    data_json: dict[str, Any] | None = None,
+    session: AsyncSession | None = None,
+) -> None:
+    """Persist a job lifecycle event."""
+    event = JobEvent(
+        job_id=job_id,
+        level=level,
+        message=message,
+        data_json=data_json,
+    )
+    if session is not None:
+        session.add(event)
+        return
+
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as managed_session:
+        managed_session.add(event)
+        await managed_session.commit()
+
+
 async def _mark_job_failed(job_id: UUID, *, error_message: str) -> None:
     """Persist a failed job state with the supplied message."""
     session_maker = get_session_maker()
@@ -86,6 +116,13 @@ async def _mark_job_failed(job_id: UUID, *, error_message: str) -> None:
         job.error_code = None
         job.error_message = error_message
         job.finished_at = _utcnow()
+        await emit_job_event(
+            job_id,
+            level="error",
+            message="Job failed",
+            data_json={"status": "failed", "error_message": error_message},
+            session=session,
+        )
         await session.commit()
 
 
@@ -126,6 +163,17 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
                     job.finished_at = None
                     job.error_code = None
                     job.error_message = None
+                    await emit_job_event(
+                        job.id,
+                        level="info",
+                        message="Job started",
+                        data_json={
+                            "status": "running",
+                            "attempts": job.attempts,
+                            "reclaimed": True,
+                        },
+                        session=session,
+                    )
                     await session.commit()
                     logger.warning(
                         "ingest_job_reclaimed_stale_running_status",
@@ -147,10 +195,24 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
             job.finished_at = None
             job.error_code = None
             job.error_message = None
+            await emit_job_event(
+                job.id,
+                level="info",
+                message="Job started",
+                data_json={"status": "running", "attempts": job.attempts, "reclaimed": False},
+                session=session,
+            )
             await session.commit()
             return True
 
         _finalize_job_cancelled(job)
+        await emit_job_event(
+            job.id,
+            level="warning",
+            message="Job cancelled",
+            data_json={"status": "cancelled"},
+            session=session,
+        )
         await session.commit()
 
     logger.info("ingest_job_cancelled", job_id=str(job_id))
@@ -188,6 +250,13 @@ async def process_ingest_job(job_id: UUID) -> None:
 
         if job.cancel_requested:
             _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
             await session.commit()
             logger.info("ingest_job_cancelled", job_id=str(job_id))
             return
@@ -204,9 +273,17 @@ async def process_ingest_job(job_id: UUID) -> None:
         job.finished_at = _utcnow()
         job.error_code = None
         job.error_message = None
+        await emit_job_event(
+            job.id,
+            level="info",
+            message="Job succeeded",
+            data_json={"status": "succeeded", "attempts": job.attempts},
+            session=session,
+        )
         await session.commit()
 
     logger.info("ingest_job_succeeded", job_id=str(job_id))
+
 
 
 async def recover_incomplete_ingest_jobs() -> list[UUID]:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,4 +9,5 @@ for Alembic autogenerate support. Example:
 
 from . import file as file
 from . import job as job
+from . import job_event as job_event
 from . import project as project

--- a/app/models/job_event.py
+++ b/app/models/job_event.py
@@ -1,0 +1,48 @@
+"""SQLAlchemy ORM model for persisted job events."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, BigInteger, DateTime, ForeignKey, Identity, Index, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class JobEvent(Base):
+    """Persisted lifecycle event for a background job."""
+
+    __tablename__ = "job_events"
+    __table_args__ = (
+        Index(
+            "ix_job_events_job_id_created_at_sequence_id_id",
+            "job_id",
+            "created_at",
+            "sequence_id",
+            "id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    job_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    level: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    data_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    sequence_id: Mapped[int] = mapped_column(
+        BigInteger,
+        Identity(always=False),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -24,3 +25,23 @@ class JobRead(BaseModel):
     started_at: datetime | None = Field(None, description="Job start timestamp")
     finished_at: datetime | None = Field(None, description="Job completion timestamp")
     created_at: datetime = Field(..., description="Job creation timestamp")
+
+
+class JobEventRead(BaseModel):
+    """Schema for reading a persisted job event."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID = Field(..., description="Unique job event identifier (UUID)")
+    job_id: uuid.UUID = Field(..., description="Owning job identifier")
+    level: str = Field(..., description="Structured event level")
+    message: str = Field(..., description="Human-readable event message")
+    data_json: dict[str, Any] | None = Field(None, description="Optional structured event payload")
+    created_at: datetime = Field(..., description="Event creation timestamp")
+
+
+class JobEventPage(BaseModel):
+    """Cursor-paginated job event response."""
+
+    items: list[JobEventRead] = Field(default_factory=list, description="Ordered job events")
+    next_cursor: str | None = Field(None, description="Opaque cursor for the next page")

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -15,6 +15,7 @@ import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.jobs.worker import process_ingest_job, recover_incomplete_ingest_jobs
 from app.models.job import Job
+from app.models.job_event import JobEvent
 from tests.conftest import requires_database
 
 
@@ -101,6 +102,34 @@ async def _update_job(
         await session.commit()
 
     return await _get_job(job_id)
+
+
+async def _create_job_event(
+    job_id: uuid.UUID,
+    *,
+    level: str,
+    message: str,
+    data_json: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+) -> JobEvent:
+    """Persist and return a job event for test setup."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        event = JobEvent(
+            job_id=job_id,
+            level=level,
+            message=message,
+            data_json=data_json,
+        )
+        if created_at is not None:
+            event.created_at = created_at
+        session.add(event)
+        await session.commit()
+        await session.refresh(event)
+
+    return event
 
 
 @pytest.fixture
@@ -215,6 +244,226 @@ class TestJobs:
                 "details": None,
             }
         }
+
+    async def test_list_job_events_returns_404_for_unknown_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """GET events should return the standard Job 404 envelope for unknown ids."""
+        _ = self
+        _ = cleanup_projects
+
+        missing_job_id = uuid.uuid4()
+        response = await async_client.get(f"/v1/jobs/{missing_job_id}/events")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"Job with identifier '{missing_job_id}' not found",
+                "details": None,
+            }
+        }
+
+    async def test_list_job_events_returns_chronological_order(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """GET events should return ascending created-at ordered results."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        base = datetime.now(UTC).replace(microsecond=0)
+        await _create_job_event(
+            job.id,
+            level="info",
+            message="third",
+            created_at=base + timedelta(seconds=2),
+        )
+        await _create_job_event(
+            job.id,
+            level="info",
+            message="first",
+            created_at=base,
+        )
+        await _create_job_event(
+            job.id,
+            level="info",
+            message="second",
+            created_at=base + timedelta(seconds=1),
+        )
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == [
+            "first",
+            "second",
+            "third",
+        ]
+        assert data["next_cursor"] is None
+
+    async def test_list_job_events_supports_cursor_pagination(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """GET events should support opaque cursor pagination."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        base = datetime.now(UTC).replace(microsecond=0)
+        await _create_job_event(job.id, level="info", message="first", created_at=base)
+        await _create_job_event(
+            job.id,
+            level="info",
+            message="second",
+            created_at=base + timedelta(seconds=1),
+        )
+        await _create_job_event(
+            job.id,
+            level="info",
+            message="third",
+            created_at=base + timedelta(seconds=2),
+        )
+
+        first_response = await async_client.get(f"/v1/jobs/{job.id}/events?limit=2")
+        assert first_response.status_code == 200
+        first_data = first_response.json()
+        assert [event["message"] for event in first_data["items"]] == ["first", "second"]
+        assert first_data["next_cursor"] is not None
+
+        second_response = await async_client.get(
+            f"/v1/jobs/{job.id}/events?limit=2&cursor={first_data['next_cursor']}"
+        )
+        assert second_response.status_code == 200
+        second_data = second_response.json()
+        assert [event["message"] for event in second_data["items"]] == ["third"]
+        assert second_data["next_cursor"] is None
+
+    async def test_list_job_events_preserves_same_transaction_emission_order_on_ties(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """GET events should preserve insertion order for same-timestamp events."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        tied_created_at = datetime.now(UTC).replace(microsecond=0)
+        first_id = uuid.UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+        second_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            session.add(
+                JobEvent(
+                    id=first_id,
+                    job_id=job.id,
+                    level="info",
+                    message="first emitted",
+                    created_at=tied_created_at,
+                )
+            )
+            session.add(
+                JobEvent(
+                    id=second_id,
+                    job_id=job.id,
+                    level="info",
+                    message="second emitted",
+                    created_at=tied_created_at,
+                )
+            )
+            await session.commit()
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == [
+            "first emitted",
+            "second emitted",
+        ]
+        assert data["next_cursor"] is None
+
+    async def test_list_job_events_invalid_cursor_returns_error_envelope(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """GET events should return standard envelope for invalid cursor values."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events?cursor=not-base64")
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "error": {
+                "code": "INVALID_CURSOR",
+                "message": "Invalid cursor format",
+                "details": None,
+            }
+        }
+
+    async def test_list_job_events_includes_worker_lifecycle_events(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """GET events should expose worker-emitted lifecycle events."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert [event["message"] for event in data["items"]] == [
+            "Job started",
+            "Job succeeded",
+        ]
+        assert [event["data_json"]["status"] for event in data["items"]] == [
+            "running",
+            "succeeded",
+        ]
+        assert data["next_cursor"] is None
 
     async def test_process_ingest_job_transitions_to_succeeded(
         self,


### PR DESCRIPTION
Closes #30

## Summary
- add persisted `job_events` storage, schemas, and a `GET /v1/jobs/{job_id}/events` cursor-paginated endpoint
- emit worker lifecycle events for started, succeeded, cancelled, and failed job transitions
- cover ordering, invalid cursor handling, pagination, and worker event visibility in job tests

## Test plan
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_job_events_validation uv run alembic upgrade head`
- [x] `uv run ruff check app tests`
- [x] `uv run mypy app tests`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_job_events_validation uv run pytest tests/test_jobs.py`

## Notes
- event ordering uses a persisted `sequence_id` tie-break so same-transaction inserts keep emission order