### PR TITLE
docs: sync architecture review docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,7 +142,7 @@ Rules:
 - The local filesystem backend uses `chmod 0o444` and rejects writes to existing
   paths to enforce immutability.
 - Generated artifacts use a separate prefix (`artifacts/{artifact_id}/...`) and
-  are not marked immutable so they can be regenerated.
+  are immutable records/objects once written.
 
 ## Job Pipeline Orchestration
 
@@ -181,9 +181,9 @@ env vars stable so the same configuration can be lifted to a managed runtime.
 
 - Generated artifacts are written through the storage interface and recorded in
   `export_artifacts` with checksum, source job, and source revision.
-- An artifact can be regenerated from its source revision and changeset; clients
-  should never modify an artifact in place.
+- An artifact can be regenerated from its source revision and changeset, but
+  regeneration creates a new artifact record/object; clients should never modify
+  an artifact in place.
 - A scheduled cleanup job (post-MVP) removes orphaned artifacts whose source
   revision has been superseded and which have no active references. MVP keeps
   everything to simplify debugging.
-

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -16,3 +16,9 @@
 - Geometry validation engine (FreeCAD vs OCCT)
 - Webhook/SSE vs polling-only for MVP events
 - Materials: shared catalog vs per-project
+
+## External Review Follow-Ups
+
+- External architecture review follow-ups are tracked in issues #54-#69.
+- Keep these docs aligned with accepted ADRs; do not expand full specs for those
+  follow-up issues here.

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -132,6 +132,10 @@ core endpoint semantics.
 
 Store all extracted entities, not only summaries.
 
+Original uploads and generated artifacts are immutable once written. If an
+export is regenerated, it must produce a new artifact record/object rather than
+overwrite an existing one.
+
 Use this split:
 
 - object/file storage for original files and generated artifacts

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -40,27 +40,23 @@ Agent layer:    Pydantic AI later, optional
 ### DWG
 
 DWG is a required starting input, but it must be handled through an adapter.
-The adapter should normalize DWG into an internal representation and, where
+The accepted first DWG adapter is LibreDWG behind the adapter contract. The
+adapter should normalize DWG into an internal representation and, where
 possible, DXF-compatible geometry.
-
-Candidate adapter options:
-
-- ODA Drawings SDK
-- Autodesk RealDWG
-- QCAD Professional command-line tools
-- LibreDWG only if licensing and coverage are explicitly accepted
 
 ### Vector PDF
 
 Vector PDF is a required starting input. The system should attempt to extract
-vector geometry and normalize it into drawing entities. Semantic loss is expected
-and must be represented through confidence/provenance fields.
+vector geometry and normalize it into drawing entities. The accepted first
+vector PDF adapter is PyMuPDF behind the adapter contract. Semantic loss is
+expected and must be represented through confidence/provenance fields.
 
 ### Raster PDF
 
 Raster PDF is important for the product, but it is higher-risk than DWG/vector
-PDF. It should be implemented behind an experimental adapter. Initial support may
-produce trace candidates and review items rather than fully trusted quantities.
+PDF. It is implemented behind an experimental adapter strategy using VTracer,
+centerline extraction, and Tesseract. Initial support may produce trace
+candidates and review items rather than fully trusted quantities.
 
 ### DXF
 
@@ -279,9 +275,6 @@ Required behavior:
 
 ## Open Technical Questions
 
-- Final DWG adapter choice.
-- Final vector PDF adapter choice.
-- Final raster PDF tracing/OCR strategy.
 - Whether PDF generation uses WeasyPrint or ReportLab.
 - Whether geometry validation starts with FreeCAD or direct OCCT bindings.
 - Webhook/SSE event delivery vs polling-only for MVP.


### PR DESCRIPTION
Closes #55

## Summary
- sync planning docs with accepted ADRs 0006-0008 and remove stale open-question language
- document generated artifacts as immutable and require regeneration/re-export to create new records/objects
- note the external architecture review follow-up issue set (#54-#69) in the handoff docs

## Test plan
- [x] git diff --check -- docs/ARCHITECTURE.md docs/TRD.md docs/MVP.md docs/HANDOFF.md
- [x] re-read changed sections for consistency with ADRs 0006-0008 and issue #55 acceptance