### PR TITLE
docs: define immutable artifact contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,6 +116,8 @@ Every derived output must point back to:
 - source file
 - drawing revision
 - changeset, if any
+- takeoff, if any
+- estimate, if any
 - job that produced it
 
 ## Storage Interface
@@ -143,6 +145,8 @@ Rules:
   paths to enforce immutability.
 - Generated artifacts use a separate prefix (`artifacts/{artifact_id}/...`) and
   are immutable records/objects once written.
+- Storage backends must reject any attempt to overwrite an existing generated
+  artifact object, even when the payload is byte-identical.
 
 ## Job Pipeline Orchestration
 
@@ -179,11 +183,44 @@ env vars stable so the same configuration can be lifted to a managed runtime.
 
 ## Artifact Lifecycle
 
-- Generated artifacts are written through the storage interface and recorded in
-  `export_artifacts` with checksum, source job, and source revision.
-- An artifact can be regenerated from its source revision and changeset, but
-  regeneration creates a new artifact record/object; clients should never modify
-  an artifact in place.
-- A scheduled cleanup job (post-MVP) removes orphaned artifacts whose source
-  revision has been superseded and which have no active references. MVP keeps
-  everything to simplify debugging.
+Generated artifacts are append-only outputs. Once an artifact row/object is
+written, it is immutable and cannot be replaced in place.
+
+Each artifact record must keep enough lineage to explain exactly what produced
+it and to reproduce it later. Minimum lineage fields:
+
+- source file id
+- drawing revision id
+- changeset id, when the artifact comes from a revision export
+- quantity takeoff id, when the artifact comes from quantity output
+- estimate id, when the artifact comes from estimate output
+- job id
+- generator name
+- generator version
+- generator configuration or options snapshot
+- output checksum
+
+Rules:
+
+- Regeneration or re-export always creates a new artifact row/object with a new
+  artifact id and storage key.
+- A newer artifact may reference an older artifact as its predecessor for
+  lineage, but it must not overwrite or delete the older object as part of the
+  write path.
+- Clients may treat an artifact as superseded, but superseded does not mean
+  mutable.
+- Reproducibility is trace-based: the system must retain the lineage metadata
+  required to rerun the same generator against the same stored source revision
+  and changeset/takeoff/estimate inputs.
+- Original uploads and generated artifacts remain separate immutable classes of
+  stored objects.
+
+Retention/deletion for MVP is manual-first and soft-delete-first:
+
+- By default, MVP keeps original uploads and generated artifacts for debugging,
+  audit, and reproducibility.
+- Deletion is a metadata action first. Artifact rows may be marked deleted or
+  hidden from normal listings before any storage object is physically removed.
+- Physical deletion, if performed during MVP, is manual/administrative and must
+  never target the sole remaining copy needed for trace reproducibility.
+- Automated cleanup of superseded or orphaned artifacts is post-MVP work.

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -136,6 +136,16 @@ Original uploads and generated artifacts are immutable once written. If an
 export is regenerated, it must produce a new artifact record/object rather than
 overwrite an existing one.
 
+Generated artifact records must keep lineage back to the producing source file,
+drawing revision, changeset/takeoff/estimate context when applicable, job, and
+generator metadata so the same output can be traced and reproduced later.
+
+MVP retention/deletion is soft-delete/manual-first:
+
+- keep original uploads and generated artifacts by default
+- hide or soft-delete metadata before any physical object removal
+- do not run automatic cleanup of superseded artifacts in MVP
+
 Use this split:
 
 - object/file storage for original files and generated artifacts

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -250,7 +250,52 @@ Required data:
 - Upload size must be configurable.
 - Ingestion adapters must have timeouts.
 - Failures must be stored in job records.
-- Generated artifacts must be reproducible from stored revisions and changesets.
+- Generated artifacts must be reproducible from stored revisions and their
+  recorded lineage inputs.
+
+## Generated Artifact Contract
+
+Generated artifacts are immutable, append-only outputs. The system must never
+overwrite an existing generated artifact row/object in place, even when
+regenerating the same logical export.
+
+Minimum artifact lineage fields:
+
+- `source_file_id`
+- `drawing_revision_id`
+- `changeset_id` when produced from a revision export
+- `quantity_takeoff_id` when produced from quantity output
+- `estimate_id` when produced from estimate output
+- `job_id`
+- `generator_name`
+- `generator_version`
+- `generator_config_snapshot` or equivalent options snapshot
+- `checksum`
+
+Rules:
+
+- Regeneration or re-export creates a new artifact id, row, and storage object.
+- Artifacts may reference a prior artifact for lineage, supersession, or UI
+  history, but the prior artifact remains immutable.
+- Artifact storage keys are server-derived and unique per artifact record.
+- Reproducibility means the system can trace which stored source revision,
+  changeset/takeoff/estimate context, job, and generator configuration produced
+  the artifact.
+- Original uploads and generated artifacts follow the same immutability rule but
+  remain distinct storage classes and records.
+
+## MVP Retention And Deletion Policy
+
+For MVP, retention is conservative:
+
+- keep original uploads and generated artifacts by default
+- prefer soft-delete or hidden metadata state before physical deletion
+- require manual/administrative action for physical artifact deletion
+- do not auto-delete superseded artifacts in MVP
+
+Any physical deletion flow must preserve at least the metadata needed to explain
+what was produced and must not imply that a replacement artifact overwrote the
+prior one.
 
 ## API Conventions
 


### PR DESCRIPTION
Closes #57

## Summary
- define the generated artifact contract as append-only immutable row/object pairs with lineage and reproducibility requirements
- require regeneration and re-export to create new artifact ids, rows, and storage objects instead of overwriting prior outputs
- document conservative MVP retention as soft-delete/manual-first with no automatic cleanup of superseded artifacts

## Test plan
- [x] Re-read edited sections in docs/ARCHITECTURE.md, docs/MVP.md, and docs/TRD.md for consistency
- [x] Run `git diff --check -- docs/ARCHITECTURE.md docs/MVP.md docs/TRD.md`
- [x] Review docs for contradictory in-place overwrite implications