### PR TITLE
docs: define fixture acceptance criteria

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -2,40 +2,116 @@
 
 This directory contains test fixtures for the Draupnir CAD/BIM ingestion system.
 
-## Fixture Policy
+## Fixture Strategy v0.1
 
-### No Proprietary or Client Samples
+### Hard Rules
 
 - **Do not commit proprietary or client drawing samples** unless they have been explicitly cleared for use as test fixtures.
-- All fixtures must be legally safe to commit and distribute.
-
-### Generated Fixtures Preferred
-
-- Prefer fixtures that are **generated specifically for this repository**.
-- Generated fixtures should use permissive licenses (CC0-1.0, MIT, or equivalent).
+- All committed fixtures must be legally safe to distribute.
 - Keep generated artifacts out of git unless they are explicitly designated as fixtures.
+- Every fixture must be listed in `manifest.yaml`.
 
-### Manifest Required
+### Fixture Tiers
 
-- **Every fixture must be listed in `manifest.yaml`** with complete metadata.
-- The manifest tracks: filename, format, source, license, git status, units, and expected extraction behavior.
+Use the smallest fixture that proves the behavior under test.
 
-### Metadata Requirements
+| Tier | Purpose | Git policy |
+| --- | --- | --- |
+| `tiny_synthetic` | Minimal generated sample for deterministic parser and quantity assertions | Usually committed |
+| `realistic_public` | Publicly licensed sample that better reflects real drawing structure | Committed only with clear license and source |
+| `proprietary_local_only` | Client/proprietary sample used only in local or private validation | **Never committed** |
+| `pathological` | Deliberately awkward, malformed, or edge-case sample for robustness checks | Commit only if legally safe |
 
-Each fixture entry in the manifest must include:
+### Format Acceptance Criteria
 
-- `filename`: Path relative to fixtures directory
-- `format`: File format (DXF, DWG, PDF, IFC, etc.)
-- `source`: Origin of the fixture ("generated", "external", or specific URL)
-- `license`: SPDX license identifier (CC0-1.0, MIT, Apache-2.0, etc.)
-- `allowed_in_git`: Boolean indicating if the file can be committed
-- `units`: Measurement units (meters, millimeters, inches, etc.)
-- `expected_extraction_notes`: What the ingestion system should extract
-- `expected_quantities`: Known quantities for validation (if applicable)
+Record expectations that are stable today. Do not encode final tolerance math here; capture the fields needed for later policy.
 
-### Adding New Fixtures
+#### DXF
 
-1. Create or obtain the fixture file
-2. Ensure it has a clear license compatible with the repository
-3. Add an entry to `manifest.yaml` with complete metadata
-4. Update this README if the fixture represents a new format or category
+- Prefer `tiny_synthetic` fixtures first.
+- Capture expected entity counts, units, layers, and deterministic lengths/areas when known.
+- Use for canonical geometry and quantity smoke tests.
+
+#### IFC
+
+- Capture the expected discipline/object scope at a coarse level first (for example walls, slabs, spaces, or openings).
+- Record any required unit assumptions and whether quantities are expected to come from model geometry, not hand-entered metadata.
+- Keep acceptance focused on stable extraction behavior, not full BIM semantic completeness.
+
+#### Vector PDF
+
+- Record whether geometry is expected to remain vector-native after ingestion.
+- Capture expected page count, scale assumptions, layer/group hints if available, and whether text should be extracted separately from linework.
+- Use `pathological` fixtures for clipped paths, merged strokes, or unusual page transforms.
+
+#### Raster PDF
+
+- Treat as review-first input.
+- Capture expected OCR/tracing limitations in notes.
+- Record stable checks such as page count, known scale calibration requirement, and whether the output should remain provisional or review-required.
+
+### Quantity Acceptance Checks
+
+`acceptance_checks.quantities` is the single fixture-level source for quantity acceptance expectations. Use `expected_quantities` only as a compact summary of deterministic expected values that tests may also assert directly.
+
+Each quantity check should be keyed by the quantity name (`line_count`, `total_length`, `total_area`, `wall_count`, and similar) and document the comparison shape needed now, even if global policy values are finalized later in #61.
+
+Recommended check shape:
+
+```yaml
+acceptance_checks:
+  quantities:
+    total_length:
+      expected: 10.0
+      comparison: exact # or tolerance / review_gated
+      tolerance:
+        type: absolute # or relative
+        value: 0.0
+      rounding:
+        stage: pre_compare # or post_aggregate / none
+        mode: none # optional when stage is none
+        places: 3 # optional when rounding applies
+      provenance_required: true
+      source_entity_refs:
+        - entities.LINE:0
+      expected_review_state: approved
+```
+
+Field guidance:
+
+- `expected`: expected numeric value or count.
+- `comparison`: comparison mode for the check. Use `exact` for deterministic equality, `tolerance` when a tolerance window is required, and `review_gated` when the fixture should not pass quantity acceptance without human review.
+- `tolerance`: declare the manifest shape now when non-exact comparison may be needed. `type` should be `absolute` or `relative`; `value` may defer to a later policy value from #61 if not yet fixed.
+- `rounding`: record whether rounding happens before comparison, after aggregation, or not at all. Include `mode` and `places` only when rounding is expected to matter.
+- `provenance_required`: whether the quantity must resolve back to extracted source entities or other stable provenance evidence.
+- `source_entity_refs`: optional fixture-level references to the source entities, groups, or canonical extraction identifiers that should explain the quantity.
+- `expected_review_state`: use when quantity acceptance is intentionally gated by review posture rather than pure numeric comparison.
+
+Use `review_gated` for raster/review-first inputs and any fixture where quantities must remain provisional until review. Do not invent global tolerance defaults in the fixture manifest; record the comparison shape and any fixture-specific exception only.
+
+### Safe Manifest Fields
+
+Each fixture entry should use safe, reviewable metadata only:
+
+- `filename`: Path relative to `tests/fixtures`
+- `format`: File format such as `DXF`, `IFC`, or `PDF`
+- `tier`: Fixture tier from the table above
+- `source`: Origin of the fixture (`generated`, public URL/reference, or local-only description)
+- `license`: SPDX identifier or `Proprietary-Local-Only` for non-committed local samples
+- `allowed_in_git`: Whether the file may be committed
+- `units`: Measurement units used for extraction expectations
+- `expected_extraction_notes`: Stable extraction expectations and caveats
+- `expected_review_state`: Expected review posture when relevant
+- `expected_validation_status`: Expected validation posture when relevant
+- `expected_quantities`: Stable quantity expectations
+- `acceptance_checks`: Structured checks for format-specific and quantity-specific expectations
+
+Do not store secrets, client names, private URLs, or sensitive project details in the manifest.
+
+### Adding or Updating Fixtures
+
+1. Create or obtain the fixture file.
+2. Confirm the fixture belongs in the right tier.
+3. Ensure the license/source is safe for the intended git policy.
+4. Add or update the `manifest.yaml` entry with stable expectations only.
+5. Update this README if a new fixture tier or acceptance pattern is introduced.

--- a/tests/fixtures/manifest.yaml
+++ b/tests/fixtures/manifest.yaml
@@ -5,6 +5,7 @@
 fixtures:
   - filename: dxf/simple-line.dxf
     format: DXF
+    tier: tiny_synthetic
     source: generated
     license: CC0-1.0
     allowed_in_git: true
@@ -12,6 +13,34 @@ fixtures:
     expected_extraction_notes: |
       Single LINE entity from (0,0,0) to (10,0,0) on layer 0.
       Header sets $INSUNITS to 6 (meters).
+    expected_review_state: approved
+    expected_validation_status: valid
     expected_quantities:
       line_count: 1
       total_length: 10.0
+    acceptance_checks:
+      format:
+        entity_types:
+          - LINE
+        layer_names:
+          - "0"
+        unit_system: meters
+      quantities:
+        line_count:
+          expected: 1
+          comparison: exact
+          provenance_required: true
+          source_entity_refs:
+            - entities.LINE:0
+        total_length:
+          expected: 10.0
+          comparison: exact
+          rounding:
+            stage: none
+          provenance_required: true
+          source_entity_refs:
+            - entities.LINE:0
+          expected_review_state: approved
+      notes: |
+        This fixture is a deterministic geometry smoke test.
+        Future global tolerance values may be defined in #61.


### PR DESCRIPTION
Closes #67

## Summary
- define fixture strategy tiers for committed, local-only, and pathological samples
- add per-format acceptance guidance and structured quantity acceptance checks
- expand the DXF manifest example with deterministic review, validation, and provenance expectations

## Test plan
- [x] `git diff --check`
- [x] `uv run python` manifest parse/assertion for fixture metadata and quantity check shape