### PR TITLE
docs: define extraction profile reprocessing contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,13 +117,19 @@ AI must not directly write CAD files or compute final quantities/prices.
 ```text
 Upload
   -> file record
-  -> ingestion job
+  -> extraction profile selection/persistence
+  -> ingestion job (file_id + extraction_profile_id)
   -> source adapter
   -> canonical entities + confidence/review state + validation report
   -> quantity extraction or review gate
   -> estimate generation
   -> exports
 ```
+
+Extraction profiles are immutable configuration records that capture the
+extraction contract for a run: unit overrides, layout mode, xref/block
+handling, text/dimension extraction policy, PDF page range, raster calibration,
+and any confidence threshold used to gate the output.
 
 Quantity workers must refuse to treat review-gated ingestion output as trusted
 source-of-truth input. Provisional quantity runs are allowed only when the
@@ -142,12 +148,18 @@ For edits:
 
 ```text
 Existing drawing revision
-  -> user or agent proposed changeset
-  -> validation
+  -> user or agent proposed changeset, or file reprocess request
+  -> validation / adapter execution
   -> new drawing revision
   -> DXF export
   -> later DWG/IFC export
 ```
+
+Reprocessing a file always creates a new drawing revision from the original
+immutable `file_id`; it never overwrites the previous revision. The new revision
+records the adapter version used for the run and the `extraction_profile_id`
+that defined the extraction settings so later jobs and audits can reproduce the
+result.
 
 ## Original File Policy
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -752,6 +752,28 @@ Probe rules:
 
 ## Coordinate Systems, Units, Encoding
 
+- Ingestion settings are captured as an immutable `extraction_profile` object so
+  jobs and revisions reference a stable extraction contract instead of ad hoc
+  request flags.
+- `extraction_profile` v0.1 must include at minimum:
+  - `id` - server-generated extraction profile identifier.
+  - `version` - profile schema version, initially `v0.1`.
+  - `units_override` - optional explicit source-unit override when adapter
+    detection is missing or known to be wrong.
+  - `layout_mode` - layout selection policy, with MVP support for `modelspace`
+    by default and explicit alternate layout selection later.
+  - `xref_handling` - how external references and nested blocks are handled,
+    including whether unresolved xrefs are skipped with warnings or hard-fail.
+  - `block_handling` - whether block references stay instanced in provenance,
+    are expanded for canonical extraction, or both.
+  - `text_extraction` - whether text entities are extracted and normalized.
+  - `dimension_extraction` - whether dimensions are extracted as semantic
+    dimensions, raw geometry, or both where supported.
+  - `pdf_page_range` - optional inclusive page selection for PDF inputs.
+  - `raster_calibration` - required scale calibration input for raster-derived
+    geometry; raster extraction without calibration remains review-only.
+  - `confidence_threshold` - optional minimum entity/revision confidence the job
+    should accept before marking output review-gated.
 - Adapters must record source units, normalized units, and conversion factor.
 - Adapters must surface paperspace vs modelspace and which layouts were
   extracted. The MVP extracts modelspace by default; layout selection is
@@ -765,6 +787,24 @@ Probe rules:
 
 ## Provenance And Confidence
 
+- Ingestion and downstream jobs must reference both `file_id` and
+  `extraction_profile_id`. The file identifies the immutable source upload; the
+  extraction profile identifies the normalization/extraction settings used to
+  derive a revision.
+- Reprocessing is not an in-place rerun. Reprocessing creates a new drawing
+  revision from an existing `file_id`, records the `extraction_profile_id` used
+  for the run, and records the adapter name/version that produced the result.
+- The prior revision remains available for lineage, comparison, and audit even
+  when the newer reprocessed revision supersedes it.
+- API direction for future `POST /v1/files/{file_id}/reprocess`:
+  - request body should accept either an existing `extraction_profile_id` or a
+    profile payload to persist as a new extraction profile before job creation
+  - the server creates a new ingestion/reprocessing job bound to `file_id` and
+    the resolved `extraction_profile_id`
+  - successful completion creates a new drawing revision rather than mutating
+    the previous revision in place
+  - the resulting revision must expose adapter version, extraction profile, and
+    predecessor/superseded lineage metadata
 - `provenance_json` is a structured object, not free text. Required keys:
   `origin`, `adapter`, `source_ref`, `source_identity`, `source_hash`,
   `extraction_path`, `notes`.


### PR DESCRIPTION
Closes #62

## Summary
- define immutable extraction profile v0.1 fields for ingestion and downstream jobs
- require jobs and revisions to reference both `file_id` and `extraction_profile_id`
- document reprocessing as new drawing revision creation with adapter/profile lineage

## Test plan
- [x] git diff --check
- [x] re-read updated `docs/TRD.md` and `docs/ARCHITECTURE.md` sections for consistency