### PR TITLE
docs: define database ownership rules

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,6 +52,16 @@ Postgres is the source of truth for:
 - changesets
 - artifacts
 
+Write ownership is split by responsibility:
+
+- API services write user/request workflow records such as projects, file
+  metadata, changesets, cancel flags, and soft-delete markers.
+- Workers write execution-derived records such as drawing revisions, validation
+  outputs, quantity takeoffs, estimate versions, export artifacts, and
+  `job_events`.
+- Append-only records keep their payload and lineage immutable after commit;
+  mutable records are limited to workflow/state transitions.
+
 ### Ingestion Adapters
 
 Format-specific adapters turn source files into canonical drawing data.
@@ -315,6 +325,9 @@ Workers must:
   output scoped by job and attempt until finalization
 - commit final outputs and terminal success together under the job row lock so a
   visible artifact set and a `succeeded` job state appear atomically
+- be the only writers that promote staged execution data into committed drawing
+  revisions, quantity takeoffs, estimate versions, artifact rows, and
+  corresponding `job_events`
 - reject stale completion paths from duplicate delivery, worker loss recovery,
   or overlapping retries so only one final commit path wins
 - observe cancel checkpoints before expensive phases and again before final
@@ -325,6 +338,9 @@ Operationally, this distinguishes retry from regeneration or re-export:
 - Retry is recovery for the same job after failure. It may recreate staged
   attempt-local data, but it must still produce at most one visible committed
   final output set for that job.
+- Attempt-local staging may be rewritten or discarded during retry, but committed
+  append-only records from a prior successful finalization are never updated in
+  place.
 - Regeneration or re-export is a new job producing new immutable artifacts with
   new ids and storage keys per the artifact lifecycle rules below.
 - `job_events` are the durable trace for queueing, execution, cancellation,
@@ -376,6 +392,17 @@ Rules:
   and changeset/takeoff/estimate inputs.
 - Original uploads and generated artifacts remain separate immutable classes of
   stored objects.
+
+Append-only versus mutable record rules:
+
+- Append-only records include original file records, drawing revisions, approved
+  quantity takeoffs, finalized estimate versions, generated artifacts, and
+  `job_events`.
+- Mutable workflow/state fields include job status, progress, retry/cancel
+  control flags, `deleted_at`, and allowed review/supersession markers on
+  records that support those transitions.
+- Mutable workflow changes must never replace the stored payload, checksum,
+  provenance, or lineage of an already committed append-only record.
 
 Retention/deletion for MVP is manual-first and soft-delete-first:
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -205,6 +205,20 @@ Applying an accepted changeset is append-only. The system creates a new drawing
 revision with lineage back to the base revision and approved changeset; it never
 overwrites the base revision in place.
 
+Database ownership and mutation rules:
+
+- API services create and update request-driven workflow records such as
+  projects, file metadata rows, changesets, cancel requests, and soft-delete
+  markers.
+- Workers create and finalize execution-derived records such as drawing
+  revisions, validation reports, quantity takeoffs, estimate versions, export
+  artifacts, and `job_events`.
+- Approved apply/reprocess paths append a new drawing revision row; they do not
+  rewrite entity payloads or lineage on an existing revision.
+- A revision may transition to `superseded` or another allowed review state for
+  workflow purposes, but its stored canonical payload and provenance remain
+  historical and immutable.
+
 Example operation types:
 
 - annotate entity
@@ -513,6 +527,9 @@ Estimate snapshots:
   lineage needed to trace each frozen value back to its source.
 - Line items must reference the frozen snapshot entries they used, not only live
   catalog rows.
+- Finalized estimate versions are append-only records created by estimate
+  workers; recalculation creates a new version rather than mutating a finalized
+  one in place.
 
 Catalog scope and mutation rules:
 
@@ -572,6 +589,19 @@ Rules:
   the artifact.
 - Original uploads and generated artifacts follow the same immutability rule but
   remain distinct storage classes and records.
+
+Database ownership and append-only policy:
+
+- Original file rows are API-created metadata for immutable uploads; workers may
+  read them, but never replace the original object or rewrite the row as a new
+  source.
+- Drawing revisions, approved quantity takeoffs, finalized estimate versions,
+  export artifacts, and `job_events` are append-only historical records.
+- Mutable workflow/state records include job status, attempt counters, progress,
+  `cancel_requested`, `deleted_at`, and allowed review/supersession state
+  transitions.
+- Mutable state must not be used to rewrite the payload, lineage, checksum, or
+  source references of an already committed append-only record.
 
 ## MVP Retention And Deletion Policy
 
@@ -636,6 +666,9 @@ New codes require a docs change in this file.
   `succeeded` state must happen atomically under the job lock so clients never
   observe committed outputs with a non-terminal job or a terminal success with
   missing outputs.
+- Finalization ownership is worker-only: the worker that wins the job lock is
+  the only writer allowed to convert staged attempt data into committed
+  revision/takeoff/estimate/artifact rows.
 - Retry and duplicate-delivery handling must fence stale workers and prevent
   duplicate finalization. Redelivered messages, overlapping attempts, or stale
   completions must not create duplicate committed outputs or move the job from a
@@ -643,6 +676,10 @@ New codes require a docs change in this file.
 - Retry is only for failed work. A retry attempt may replace staged attempt
   data, but it does not overwrite or mutate already committed artifacts from a
   different completed job path.
+- Attempt-local staging is mutable until commit, but staged rows/objects are not
+  authoritative product records. Only the atomic finalization step may publish
+  new append-only records, and cancellation before that step must leave no new
+  committed output rows visible.
 - Cancellation before finalization produces `cancelled` with no new committed
   output set. A cancel request after a terminal state is a no-op.
 - `job_events` must capture the operational state machine, including enqueue,


### PR DESCRIPTION
Closes #69

## Summary
- define API vs worker ownership for core database records
- distinguish append-only historical records from mutable workflow/state fields
- align ownership rules with idempotent job staging and atomic finalization

## Test plan
- [x] git diff --check
- [x] re-read updated `docs/TRD.md` and `docs/ARCHITECTURE.md` sections for consistency