### PR TITLE
feat: define storage protocol

### DIFF
--- a/alembic/versions/2026_05_02_0003_add_job_events.py
+++ b/alembic/versions/2026_05_02_0003_add_job_events.py
@@ -7,9 +7,9 @@ Create Date: 2026-05-02 00:03:00
 
 from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "2026_05_02_0003"

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -4,7 +4,6 @@ import base64
 import binascii
 import hashlib
 import json
-import os
 import uuid
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -26,6 +25,7 @@ from app.models.file import File as FileModel
 from app.models.job import Job
 from app.models.project import Project
 from app.schemas.file import FileListResponse, FileRead
+from app.storage import Storage, get_storage
 
 files_router = APIRouter()
 _UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
@@ -111,18 +111,15 @@ def _unsupported_format_exception() -> HTTPException:
     )
 
 
-def _storage_path(file_id: UUID, detected_format: str | None) -> Path:
-    """Build a server-derived immutable local storage path for an uploaded file."""
-    extension = detected_format or "bin"
-    filename = f"{file_id}.{extension}"
-    upload_root = Path(settings.upload_storage_root).resolve()
-    return upload_root / file_id.hex[:2] / file_id.hex[2:4] / filename
-
-
 def _staging_path(file_id: UUID) -> Path:
     """Build a temporary staging path for upload bytes before promotion."""
     upload_root = Path(settings.upload_storage_root).resolve()
     return upload_root / ".staging" / f"{file_id}.{uuid.uuid4().hex}.part"
+
+
+def _storage_key(file_id: UUID, checksum: str) -> str:
+    """Build the server-derived immutable storage key for an uploaded file."""
+    return f"originals/{file_id}/{checksum}"
 
 
 def _cleanup_uploaded_path(storage_path: Path) -> None:
@@ -164,6 +161,23 @@ def _ensure_private_directory(path: Path, *, include_parents_until: Path | None 
         ) from exc
 
 
+async def _cleanup_persisted_upload(storage: Storage, storage_key: str, storage_uri: str) -> None:
+    """Best-effort cleanup for a persisted upload after downstream failure."""
+    if storage_uri.startswith("file://"):
+        upload_root = Path(settings.upload_storage_root).resolve()
+        stored_path = Path(storage_uri.removeprefix("file://")).resolve()
+        try:
+            stored_path.relative_to(upload_root)
+        except ValueError:
+            pass
+        else:
+            _cleanup_uploaded_path(stored_path)
+            return
+
+    with suppress(Exception):
+        await storage.delete(storage_key)
+
+
 async def _raise_input_invalid_for_upload_metadata(file: UploadFile, message: str) -> None:
     """Close upload and raise standardized client validation error envelope."""
     await file.close()
@@ -177,50 +191,6 @@ async def _raise_input_invalid_for_upload_metadata(file: UploadFile, message: st
     )
 
 
-def _promote_staged_upload(staging_path: Path, final_path: Path) -> None:
-    """Promote a staged upload to final immutable path without overwriting."""
-    _ensure_private_directory(
-        final_path.parent,
-        include_parents_until=Path(settings.upload_storage_root).resolve(),
-    )
-
-    try:
-        os.link(staging_path, final_path)
-    except FileExistsError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=create_error_response(
-                code=ErrorCode.STORAGE_FAILED,
-                message="Storage collision occurred during upload.",
-                details=None,
-            ),
-        ) from exc
-    except OSError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=create_error_response(
-                code=ErrorCode.STORAGE_FAILED,
-                message="Failed to persist uploaded file.",
-                details=None,
-            ),
-        ) from exc
-
-    try:
-        final_path.chmod(0o400)
-    except OSError as exc:
-        _cleanup_uploaded_path(final_path)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=create_error_response(
-                code=ErrorCode.STORAGE_FAILED,
-                message="Failed to persist uploaded file.",
-                details=None,
-            ),
-        ) from exc
-    finally:
-        _cleanup_uploaded_path(staging_path)
-
-
 @files_router.post(
     "/projects/{project_id}/files",
     response_model=FileRead,
@@ -230,6 +200,7 @@ async def upload_project_file(
     project_id: UUID,
     file: Annotated[UploadFile, FilePart(...)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    storage: Annotated[Storage, Depends(get_storage)],
 ) -> FileModel:
     """Upload immutable source file bytes for a project and create ingest job."""
     project = await db.get(Project, project_id)
@@ -252,7 +223,8 @@ async def upload_project_file(
 
     file_id = uuid.uuid4()
     staging_path = _staging_path(file_id)
-    storage_path: Path | None = None
+    storage_key: str | None = None
+    storage_uri: str | None = None
     detected_format: str | None = None
     upload_root = Path(settings.upload_storage_root).resolve()
     _ensure_private_directory(upload_root)
@@ -269,13 +241,10 @@ async def upload_project_file(
                 _cleanup_uploaded_path(staging_path)
                 raise _unsupported_format_exception()
             detected_format = sniffed_format
-            storage_path = _storage_path(file_id, detected_format)
 
             if initial_bytes:
                 if len(initial_bytes) > max_upload_bytes:
                     _cleanup_uploaded_path(staging_path)
-                    if storage_path is not None:
-                        _cleanup_uploaded_path(storage_path)
                     raise HTTPException(
                         status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                         detail=create_error_response(
@@ -296,8 +265,6 @@ async def upload_project_file(
                 next_total = total_bytes + len(chunk)
                 if next_total > max_upload_bytes:
                     _cleanup_uploaded_path(staging_path)
-                    if storage_path is not None:
-                        _cleanup_uploaded_path(storage_path)
                     raise HTTPException(
                         status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                         detail=create_error_response(
@@ -311,22 +278,43 @@ async def upload_project_file(
                 checksum_builder.update(chunk)
                 total_bytes = next_total
 
-        assert storage_path is not None
-        _promote_staged_upload(staging_path=staging_path, final_path=storage_path)
+        checksum = checksum_builder.hexdigest()
+        storage_key = _storage_key(file_id, checksum)
+
+        try:
+            stored_object = await storage.put(storage_key, staging_path, immutable=True)
+            storage_uri = stored_object.storage_uri
+        except FileExistsError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=create_error_response(
+                    code=ErrorCode.STORAGE_FAILED,
+                    message="Storage collision occurred during upload.",
+                    details=None,
+                ),
+            ) from exc
+        except OSError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=create_error_response(
+                    code=ErrorCode.STORAGE_FAILED,
+                    message="Failed to persist uploaded file.",
+                    details=None,
+                ),
+            ) from exc
     except HTTPException:
         _cleanup_uploaded_path(staging_path)
         raise
     except BaseException:
         _cleanup_uploaded_path(staging_path)
-        if storage_path is not None:
-            _cleanup_uploaded_path(storage_path)
         raise
     finally:
+        _cleanup_uploaded_path(staging_path)
         await file.close()
 
     assert detected_format is not None
-    assert storage_path is not None
-    checksum = checksum_builder.hexdigest()
+    assert storage_key is not None
+    assert storage_uri is not None
 
     file_row = FileModel(
         id=file_id,
@@ -334,7 +322,7 @@ async def upload_project_file(
         original_filename=original_filename,
         media_type=media_type,
         detected_format=detected_format,
-        storage_uri=f"file://{storage_path}",
+        storage_uri=storage_uri,
         size_bytes=total_bytes,
         checksum_sha256=checksum,
         immutable=True,
@@ -355,9 +343,9 @@ async def upload_project_file(
     try:
         await db.commit()
     except BaseException:
-        _cleanup_uploaded_path(staging_path)
-        if storage_path is not None:
-            _cleanup_uploaded_path(storage_path)
+        assert storage_key is not None
+        assert storage_uri is not None
+        await _cleanup_persisted_upload(storage, storage_key, storage_uri)
         raise
 
     await db.refresh(file_row)

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,1 +1,15 @@
 """Storage backends and file persistence."""
+
+from app.storage.base import Storage, StoredObject, StoredObjectMeta
+from app.storage.dependencies import get_storage
+from app.storage.local import LocalStorage
+from app.storage.memory import MemoryStorage
+
+__all__ = [
+    "LocalStorage",
+    "MemoryStorage",
+    "Storage",
+    "StoredObject",
+    "StoredObjectMeta",
+    "get_storage",
+]

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -1,0 +1,60 @@
+"""Storage protocol and shared storage data models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+StoragePayload = bytes | Path
+
+
+@dataclass(frozen=True, slots=True)
+class StoredObjectMeta:
+    """Metadata for a stored object."""
+
+    key: str
+    storage_uri: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class StoredObject:
+    """Stored object bytes and metadata."""
+
+    meta: StoredObjectMeta
+    body: bytes
+
+
+class Storage(Protocol):
+    """Abstract storage backend contract."""
+
+    async def put(
+        self,
+        key: str,
+        data: StoragePayload,
+        *,
+        immutable: bool = False,
+    ) -> StoredObjectMeta:
+        """Persist an object at a server-derived key without overwriting existing keys."""
+
+    async def get(self, key: str) -> StoredObject:
+        """Read an object by key."""
+
+    async def stat(self, key: str) -> StoredObjectMeta:
+        """Read object metadata without loading full bytes."""
+
+    async def exists(self, key: str) -> bool:
+        """Check whether an object exists."""
+
+    async def delete(self, key: str) -> None:
+        """Delete an object by key."""
+
+    async def presign(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in_seconds: int = 3600,
+    ) -> str | None:
+        """Return a presigned URL when supported."""

--- a/app/storage/dependencies.py
+++ b/app/storage/dependencies.py
@@ -1,0 +1,21 @@
+"""Storage dependency providers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from app.core.config import settings
+from app.storage.base import Storage
+from app.storage.local import LocalStorage
+
+
+@lru_cache(maxsize=1)
+def _get_default_storage() -> Storage:
+    """Return the default local storage backend."""
+    return LocalStorage(Path(settings.upload_storage_root).resolve())
+
+
+def get_storage() -> Storage:
+    """FastAPI dependency for storage backends."""
+    return _get_default_storage()

--- a/app/storage/local.py
+++ b/app/storage/local.py
@@ -1,0 +1,154 @@
+"""Local filesystem storage backend."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from contextlib import suppress
+from pathlib import Path
+
+from app.storage.base import StoragePayload, StoredObject, StoredObjectMeta
+
+
+class LocalStorage:
+    """Persist objects beneath a configured local root."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve()
+
+    async def put(
+        self,
+        key: str,
+        data: StoragePayload,
+        *,
+        immutable: bool = False,
+    ) -> StoredObjectMeta:
+        """Persist an object without overwriting an existing key, regardless of immutability."""
+        return await asyncio.to_thread(self._put_sync, key, data, immutable)
+
+    async def get(self, key: str) -> StoredObject:
+        """Load a stored object."""
+        return await asyncio.to_thread(self._get_sync, key)
+
+    async def stat(self, key: str) -> StoredObjectMeta:
+        """Return metadata for a stored object."""
+        return await asyncio.to_thread(self._stat_sync, key)
+
+    async def exists(self, key: str) -> bool:
+        """Check whether a stored object exists."""
+        return await asyncio.to_thread(self._exists_sync, key)
+
+    async def delete(self, key: str) -> None:
+        """Delete a stored object if present."""
+        await asyncio.to_thread(self._delete_sync, key)
+
+    async def presign(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in_seconds: int = 3600,
+    ) -> str | None:
+        """Stub presign support for local storage."""
+        _ = (key, method, expires_in_seconds)
+        return None
+
+    def _put_sync(self, key: str, data: StoragePayload, immutable: bool) -> StoredObjectMeta:
+        final_path = self._path_for_key(key)
+        self._ensure_private_directory(final_path.parent, include_parents_until=self.root)
+
+        cleanup_path: Path | None = None
+        source_path: Path
+        if isinstance(data, bytes):
+            temp_dir = self.root / ".tmp"
+            self._ensure_private_directory(temp_dir, include_parents_until=self.root)
+            source_path = temp_dir / f"{uuid.uuid4().hex}.part"
+            source_path.write_bytes(data)
+            cleanup_path = source_path
+        else:
+            source_path = Path(data)
+
+        final_path_created = False
+        try:
+            os.link(source_path, final_path)
+            final_path_created = True
+            final_path.chmod(0o400 if immutable else 0o600)
+            return StoredObjectMeta(
+                key=key,
+                storage_uri=f"file://{final_path}",
+                size_bytes=final_path.stat().st_size,
+            )
+        except BaseException:
+            if final_path_created:
+                self._cleanup_uploaded_path(final_path)
+            raise
+        finally:
+            if cleanup_path is not None:
+                self._cleanup_uploaded_path(cleanup_path)
+
+    def _get_sync(self, key: str) -> StoredObject:
+        path = self._path_for_key(key)
+        body = path.read_bytes()
+        return StoredObject(
+            meta=StoredObjectMeta(
+                key=key,
+                storage_uri=f"file://{path}",
+                size_bytes=len(body),
+            ),
+            body=body,
+        )
+
+    def _stat_sync(self, key: str) -> StoredObjectMeta:
+        path = self._path_for_key(key)
+        return StoredObjectMeta(
+            key=key,
+            storage_uri=f"file://{path}",
+            size_bytes=path.stat().st_size,
+        )
+
+    def _delete_sync(self, key: str) -> None:
+        path = self._path_for_key(key)
+        if path.exists() and self._is_immutable_path(path):
+            raise PermissionError(key)
+        self._cleanup_uploaded_path(path)
+
+    def _exists_sync(self, key: str) -> bool:
+        return self._path_for_key(key).exists()
+
+    def _path_for_key(self, key: str) -> Path:
+        path = (self.root / key).resolve()
+        path.relative_to(self.root)
+        return path
+
+    def _cleanup_uploaded_path(self, storage_path: Path) -> None:
+        with suppress(OSError):
+            storage_path.unlink(missing_ok=True)
+
+        current = storage_path.parent
+        while current != self.root and self.root in current.parents:
+            with suppress(OSError):
+                current.rmdir()
+            current = current.parent
+
+    def _is_immutable_path(self, path: Path) -> bool:
+        return (path.stat().st_mode & 0o200) == 0
+
+    def _ensure_private_directory(
+        self,
+        path: Path,
+        *,
+        include_parents_until: Path | None = None,
+    ) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        targets = [path]
+        if include_parents_until is not None:
+            parent = path.parent
+            while include_parents_until in parent.parents or parent == include_parents_until:
+                targets.append(parent)
+                if parent == include_parents_until:
+                    break
+                parent = parent.parent
+
+        for target in targets:
+            target.chmod(0o700)

--- a/app/storage/memory.py
+++ b/app/storage/memory.py
@@ -1,0 +1,80 @@
+"""In-memory storage backend for tests and local seams."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.storage.base import StoragePayload, StoredObject, StoredObjectMeta
+
+
+class MemoryStorage:
+    """Simple in-memory storage backend."""
+
+    def __init__(self) -> None:
+        self._objects: dict[str, tuple[bytes, bool]] = {}
+
+    async def put(
+        self,
+        key: str,
+        data: StoragePayload,
+        *,
+        immutable: bool = False,
+    ) -> StoredObjectMeta:
+        """Store bytes at a key without overwriting existing keys."""
+        body = data if isinstance(data, bytes) else Path(data).read_bytes()
+        existing = self._objects.get(key)
+        if existing is not None:
+            raise FileExistsError(key)
+
+        self._objects[key] = (body, immutable)
+        return StoredObjectMeta(
+            key=key,
+            storage_uri=f"memory://{key}",
+            size_bytes=len(body),
+        )
+
+    async def get(self, key: str) -> StoredObject:
+        """Return object bytes and metadata."""
+        body, _ = self._objects[key]
+        return StoredObject(
+            meta=StoredObjectMeta(
+                key=key,
+                storage_uri=f"memory://{key}",
+                size_bytes=len(body),
+            ),
+            body=body,
+        )
+
+    async def stat(self, key: str) -> StoredObjectMeta:
+        """Return metadata for a stored object."""
+        body, _ = self._objects[key]
+        return StoredObjectMeta(
+            key=key,
+            storage_uri=f"memory://{key}",
+            size_bytes=len(body),
+        )
+
+    async def exists(self, key: str) -> bool:
+        """Check whether a key exists."""
+        return key in self._objects
+
+    async def delete(self, key: str) -> None:
+        """Delete a key if present."""
+        existing = self._objects.get(key)
+        if existing is None:
+            return
+        if existing[1]:
+            raise PermissionError(key)
+
+        self._objects.pop(key, None)
+
+    async def presign(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in_seconds: int = 3600,
+    ) -> str | None:
+        """Stub presign support for interface parity."""
+        _ = (key, method, expires_in_seconds)
+        return None

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -18,6 +18,7 @@ import app.db.session as session_module
 from app.core.config import settings
 from app.models.file import File as FileModel
 from app.models.job import Job
+from app.storage import StoredObjectMeta, get_storage
 from tests.conftest import requires_database
 
 
@@ -75,6 +76,57 @@ def _make_get_db_override_with_commit_error(
             await session.close()
 
     return _override_get_db
+
+
+class RecordingStorage:
+    """Test double that records upload persistence inputs."""
+
+    def __init__(self) -> None:
+        self.put_calls: list[tuple[str, Path, bytes, bool]] = []
+
+    async def put(
+        self,
+        key: str,
+        data: bytes | Path,
+        *,
+        immutable: bool = False,
+    ) -> StoredObjectMeta:
+        """Record put calls and return deterministic metadata."""
+        assert isinstance(data, Path)
+        body = data.read_bytes()
+        self.put_calls.append((key, data, body, immutable))
+        return StoredObjectMeta(
+            key=key,
+            storage_uri=f"memory://{key}",
+            size_bytes=len(body),
+        )
+
+    async def get(self, key: str) -> Any:
+        """Unused protocol method for test double completeness."""
+        raise NotImplementedError(key)
+
+    async def stat(self, key: str) -> StoredObjectMeta:
+        """Unused protocol method for test double completeness."""
+        raise NotImplementedError(key)
+
+    async def exists(self, key: str) -> bool:
+        """Unused protocol method for test double completeness."""
+        raise NotImplementedError(key)
+
+    async def delete(self, key: str) -> None:
+        """Unused protocol method for test double completeness."""
+        raise NotImplementedError(key)
+
+    async def presign(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in_seconds: int = 3600,
+    ) -> str | None:
+        """Unused protocol method for test double completeness."""
+        _ = (key, method, expires_in_seconds)
+        return None
 
 
 @requires_database
@@ -135,7 +187,9 @@ class TestProjectFiles:
         assert storage_uri.startswith("file://")
         stored_path = Path(storage_uri.removeprefix("file://"))
         assert stored_path.exists()
-        assert stored_path.name != "plan.pdf"
+        assert stored_path.relative_to(Path(settings.upload_storage_root).resolve()).as_posix() == (
+            f"originals/{uploaded['id']}/{uploaded['checksum_sha256']}"
+        )
         assert stored_path.read_bytes() == payload
         mode = stored_path.stat().st_mode & 0o777
         assert mode == 0o400
@@ -181,6 +235,50 @@ class TestProjectFiles:
         assert response.status_code == 200
         listed = response.json()
         assert len(listed["items"]) == 2
+
+    async def test_upload_file_persists_through_storage_dependency_put(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        app: FastAPI,
+    ) -> None:
+        """POST should hand final persistence to the injected storage backend."""
+        _ = self
+        payload = b"%PDF-1.7\nstorage-spy"
+        storage = RecordingStorage()
+        app.dependency_overrides[get_storage] = lambda: storage
+        try:
+            uploaded = await _upload_file(
+                async_client=async_client,
+                project_id=created_project["id"],
+                filename="client-name.pdf",
+                content=payload,
+                media_type="application/pdf",
+            )
+        finally:
+            app.dependency_overrides.pop(get_storage, None)
+
+        expected_key = (
+            f"originals/{uploaded['id']}/{hashlib.sha256(payload).hexdigest()}"
+        )
+        assert len(storage.put_calls) == 1
+        put_key, put_path, put_body, put_immutable = storage.put_calls[0]
+        assert put_key == expected_key
+        assert put_body == payload
+        assert put_immutable is True
+        assert put_path.name.endswith(".part")
+        assert ".staging" in put_path.parts
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(FileModel.id == uuid.UUID(str(uploaded["id"])))
+            )
+            file_row = file_result.scalar_one_or_none()
+
+        assert file_row is not None
+        assert file_row.storage_uri == f"memory://{expected_key}"
 
     async def test_list_project_files_success(
         self,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,160 @@
+"""Unit tests for storage backends."""
+
+from pathlib import Path
+
+import pytest
+
+from app.storage import LocalStorage, MemoryStorage
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_round_trip_with_bytes() -> None:
+    """Memory storage should persist and return bytes plus metadata."""
+    storage = MemoryStorage()
+
+    meta = await storage.put("originals/file-1/checksum-1", b"payload", immutable=True)
+    stored = await storage.get("originals/file-1/checksum-1")
+
+    assert meta.key == "originals/file-1/checksum-1"
+    assert meta.storage_uri == "memory://originals/file-1/checksum-1"
+    assert meta.size_bytes == 7
+    assert stored.meta == meta
+    assert stored.body == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_round_trip_with_path(tmp_path: Path) -> None:
+    """Memory storage should accept staged file paths."""
+    storage = MemoryStorage()
+    staged_path = tmp_path / "upload.part"
+    staged_path.write_bytes(b"from-path")
+
+    meta = await storage.put("originals/file-2/checksum-2", staged_path, immutable=True)
+
+    assert meta.size_bytes == len(b"from-path")
+    assert await storage.exists("originals/file-2/checksum-2") is True
+    assert (await storage.get("originals/file-2/checksum-2")).body == b"from-path"
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_stat_and_presign_stub() -> None:
+    """Memory storage should support metadata checks and presign parity."""
+    storage = MemoryStorage()
+    key = "originals/file-3/checksum-3"
+    await storage.put(key, b"abc", immutable=True)
+
+    assert (await storage.stat(key)).size_bytes == 3
+    assert await storage.presign(key) is None
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_rejects_overwrite_for_mutable_keys() -> None:
+    """Memory storage should refuse overwrite operations for mutable keys."""
+    storage = MemoryStorage()
+    key = "scratch/file-3"
+    original_payload = b"abc"
+    await storage.put(key, original_payload, immutable=False)
+
+    with pytest.raises(FileExistsError):
+        await storage.put(key, b"def", immutable=False)
+
+    assert await storage.exists(key) is True
+    assert (await storage.get(key)).body == original_payload
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_rejects_overwrite_and_delete_for_immutable_keys() -> None:
+    """Memory storage should refuse immutable overwrite/delete operations."""
+    storage = MemoryStorage()
+    key = "originals/file-3/checksum-3"
+    original_payload = b"abc"
+    await storage.put(key, original_payload, immutable=True)
+
+    with pytest.raises(FileExistsError):
+        await storage.put(key, b"def", immutable=True)
+
+    with pytest.raises(PermissionError):
+        await storage.delete(key)
+
+    assert await storage.exists(key) is True
+    assert (await storage.get(key)).body == original_payload
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_allows_delete_for_mutable_keys() -> None:
+    """Memory storage should allow deleting mutable objects."""
+    storage = MemoryStorage()
+    key = "scratch/file-3"
+    await storage.put(key, b"abc", immutable=False)
+
+    await storage.delete(key)
+
+    assert await storage.exists(key) is False
+
+
+@pytest.mark.asyncio
+async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
+    """Local storage should persist server-derived keys and support cleanup."""
+    storage = LocalStorage(tmp_path)
+    key = "originals/file-4/checksum-4"
+
+    meta = await storage.put(key, b"payload", immutable=True)
+    stored = await storage.get(key)
+
+    assert meta.key == key
+    assert meta.storage_uri == f"file://{(tmp_path / key).resolve()}"
+    assert meta.size_bytes == 7
+    assert stored.meta == meta
+    assert stored.body == b"payload"
+    assert await storage.exists(key) is True
+    assert await storage.presign(key) is None
+    assert ((tmp_path / key).stat().st_mode & 0o777) == 0o400
+
+    with pytest.raises(PermissionError):
+        await storage.delete(key)
+
+    assert await storage.exists(key) is True
+
+
+@pytest.mark.asyncio
+async def test_local_storage_rejects_overwrite_for_immutable_keys(tmp_path: Path) -> None:
+    """Local storage should refuse replacing an immutable object."""
+    storage = LocalStorage(tmp_path)
+    key = "originals/file-5/checksum-5"
+    original_payload = b"payload"
+    await storage.put(key, original_payload, immutable=True)
+
+    with pytest.raises(FileExistsError):
+        await storage.put(key, b"replacement", immutable=True)
+
+    assert await storage.exists(key) is True
+    assert (await storage.get(key)).body == original_payload
+
+
+@pytest.mark.asyncio
+async def test_local_storage_rejects_overwrite_for_mutable_keys(tmp_path: Path) -> None:
+    """Local storage should refuse replacing a mutable object."""
+    storage = LocalStorage(tmp_path)
+    key = "scratch/file-7"
+    original_payload = b"payload"
+    await storage.put(key, original_payload, immutable=False)
+
+    with pytest.raises(FileExistsError):
+        await storage.put(key, b"replacement", immutable=False)
+
+    assert await storage.exists(key) is True
+    assert (await storage.get(key)).body == original_payload
+
+
+@pytest.mark.asyncio
+async def test_local_storage_allows_delete_for_mutable_keys(tmp_path: Path) -> None:
+    """Local storage should allow deleting mutable objects."""
+    storage = LocalStorage(tmp_path)
+    key = "scratch/file-6"
+    await storage.put(key, b"payload", immutable=False)
+
+    assert ((tmp_path / key).stat().st_mode & 0o777) == 0o600
+
+    await storage.delete(key)
+
+    assert await storage.exists(key) is False


### PR DESCRIPTION
Closes #32

## Summary
- add a typed storage protocol plus local and in-memory backends so uploads and future storage consumers share one persistence contract
- route file uploads through `Storage.put` with immutable server-derived keys instead of writing final files directly in the API handler
- add storage backend tests and upload DI coverage, and include the small Alembic import-order fix needed to keep repo validation green

## Test plan
- [x] uv run ruff check .
- [x] uv run mypy .
- [x] uv build
- [x] uv run pytest tests/test_storage.py tests/test_files.py
- [x] uv run pytest