### PR TITLE
feat: harden local filesystem storage backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ LOG_LEVEL=info
 
 # Upload limits
 MAX_UPLOAD_MB=50
+STORAGE_LOCAL_ROOT=var/uploads
+# Backward-compatible alias still accepted: UPLOAD_STORAGE_ROOT=var/uploads
 
 # Service identity
 SERVICE_NAME=draupnir

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -113,8 +113,12 @@ def _unsupported_format_exception() -> HTTPException:
 
 def _staging_path(file_id: UUID) -> Path:
     """Build a temporary staging path for upload bytes before promotion."""
-    upload_root = Path(settings.upload_storage_root).resolve()
-    return upload_root / ".staging" / f"{file_id}.{uuid.uuid4().hex}.part"
+    return _upload_root() / ".staging" / f"{file_id}.{uuid.uuid4().hex}.part"
+
+
+def _upload_root() -> Path:
+    """Return the canonical local storage root for uploads and artifacts."""
+    return Path(settings.storage_local_root).resolve()
 
 
 def _storage_key(file_id: UUID, checksum: str) -> str:
@@ -124,7 +128,7 @@ def _storage_key(file_id: UUID, checksum: str) -> str:
 
 def _cleanup_uploaded_path(storage_path: Path) -> None:
     """Best-effort cleanup of a partially or fully written upload path."""
-    upload_root = Path(settings.upload_storage_root).resolve()
+    upload_root = _upload_root()
     with suppress(OSError):
         storage_path.unlink(missing_ok=True)
 
@@ -163,16 +167,7 @@ def _ensure_private_directory(path: Path, *, include_parents_until: Path | None 
 
 async def _cleanup_persisted_upload(storage: Storage, storage_key: str, storage_uri: str) -> None:
     """Best-effort cleanup for a persisted upload after downstream failure."""
-    if storage_uri.startswith("file://"):
-        upload_root = Path(settings.upload_storage_root).resolve()
-        stored_path = Path(storage_uri.removeprefix("file://")).resolve()
-        try:
-            stored_path.relative_to(upload_root)
-        except ValueError:
-            pass
-        else:
-            _cleanup_uploaded_path(stored_path)
-            return
+    _ = storage_uri
 
     with suppress(Exception):
         await storage.delete(storage_key)
@@ -226,7 +221,7 @@ async def upload_project_file(
     storage_key: str | None = None
     storage_uri: str | None = None
     detected_format: str | None = None
-    upload_root = Path(settings.upload_storage_root).resolve()
+    upload_root = _upload_root()
     _ensure_private_directory(upload_root)
     _ensure_private_directory(staging_path.parent)
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,6 @@
 """Application configuration via pydantic-settings."""
 
-from pydantic import field_validator
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app import __version__
@@ -27,7 +27,10 @@ class Settings(BaseSettings):
 
     # Application settings
     max_upload_mb: int = 50
-    upload_storage_root: str = "var/uploads"
+    storage_local_root: str = Field(
+        default="var/uploads",
+        validation_alias=AliasChoices("storage_local_root", "upload_storage_root"),
+    )
 
     @field_validator("api_prefix")
     @classmethod
@@ -45,12 +48,21 @@ class Settings(BaseSettings):
             raise ValueError("max_upload_mb must be positive")
         return value
 
-    @field_validator("upload_storage_root")
+    @field_validator("storage_local_root")
     @classmethod
-    def validate_upload_storage_root(cls, value: str) -> str:
+    def validate_storage_local_root(cls, value: str) -> str:
         if not value.strip():
-            raise ValueError("upload_storage_root must not be empty")
+            raise ValueError("storage_local_root must not be empty")
         return value
+
+    @property
+    def upload_storage_root(self) -> str:
+        """Backward-compatible alias for the canonical local storage root."""
+        return self.storage_local_root
+
+    @upload_storage_root.setter
+    def upload_storage_root(self, value: str) -> None:
+        self.storage_local_root = value
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -2,10 +2,11 @@
 
 from app.storage.base import Storage, StoredObject, StoredObjectMeta
 from app.storage.dependencies import get_storage
-from app.storage.local import LocalStorage
+from app.storage.local import LocalFilesystemStorage, LocalStorage
 from app.storage.memory import MemoryStorage
 
 __all__ = [
+    "LocalFilesystemStorage",
     "LocalStorage",
     "MemoryStorage",
     "Storage",

--- a/app/storage/dependencies.py
+++ b/app/storage/dependencies.py
@@ -7,13 +7,13 @@ from pathlib import Path
 
 from app.core.config import settings
 from app.storage.base import Storage
-from app.storage.local import LocalStorage
+from app.storage.local import LocalFilesystemStorage
 
 
 @lru_cache(maxsize=1)
 def _get_default_storage() -> Storage:
     """Return the default local storage backend."""
-    return LocalStorage(Path(settings.upload_storage_root).resolve())
+    return LocalFilesystemStorage(Path(settings.storage_local_root).resolve())
 
 
 def get_storage() -> Storage:

--- a/app/storage/local.py
+++ b/app/storage/local.py
@@ -6,12 +6,15 @@ import asyncio
 import os
 import uuid
 from contextlib import suppress
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO
 
 from app.storage.base import StoragePayload, StoredObject, StoredObjectMeta
 
+_COPY_CHUNK_SIZE_BYTES = 1024 * 1024
 
-class LocalStorage:
+
+class LocalFilesystemStorage:
     """Persist objects beneath a configured local root."""
 
     def __init__(self, root: Path) -> None:
@@ -57,23 +60,15 @@ class LocalStorage:
     def _put_sync(self, key: str, data: StoragePayload, immutable: bool) -> StoredObjectMeta:
         final_path = self._path_for_key(key)
         self._ensure_private_directory(final_path.parent, include_parents_until=self.root)
-
-        cleanup_path: Path | None = None
-        source_path: Path
-        if isinstance(data, bytes):
-            temp_dir = self.root / ".tmp"
-            self._ensure_private_directory(temp_dir, include_parents_until=self.root)
-            source_path = temp_dir / f"{uuid.uuid4().hex}.part"
-            source_path.write_bytes(data)
-            cleanup_path = source_path
-        else:
-            source_path = Path(data)
+        temp_path = final_path.parent / f".{final_path.name}.{uuid.uuid4().hex}.tmp"
 
         final_path_created = False
         try:
-            os.link(source_path, final_path)
+            self._write_temp_file(temp_path, data)
+            temp_path.chmod(self._target_mode(immutable))
+            os.link(temp_path, final_path)
             final_path_created = True
-            final_path.chmod(0o400 if immutable else 0o600)
+            self._fsync_directory(final_path.parent)
             return StoredObjectMeta(
                 key=key,
                 storage_uri=f"file://{final_path}",
@@ -84,8 +79,9 @@ class LocalStorage:
                 self._cleanup_uploaded_path(final_path)
             raise
         finally:
-            if cleanup_path is not None:
-                self._cleanup_uploaded_path(cleanup_path)
+            self._cleanup_uploaded_path(temp_path)
+            if final_path_created:
+                self._fsync_directory(final_path.parent)
 
     def _get_sync(self, key: str) -> StoredObject:
         path = self._path_for_key(key)
@@ -116,9 +112,52 @@ class LocalStorage:
     def _exists_sync(self, key: str) -> bool:
         return self._path_for_key(key).exists()
 
+    def _write_temp_file(self, temp_path: Path, data: StoragePayload) -> None:
+        with temp_path.open("xb") as stream:
+            temp_path.chmod(0o600)
+            if isinstance(data, bytes):
+                stream.write(data)
+            else:
+                with Path(data).open("rb") as source_stream:
+                    self._copy_stream(source_stream, stream)
+            stream.flush()
+            os.fsync(stream.fileno())
+
+    def _copy_stream(self, source_stream: BinaryIO, destination_stream: BinaryIO) -> None:
+        while chunk := source_stream.read(_COPY_CHUNK_SIZE_BYTES):
+            destination_stream.write(chunk)
+
+    def _fsync_directory(self, path: Path) -> None:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    def _target_mode(self, immutable: bool) -> int:
+        return 0o444 if immutable else 0o600
+
     def _path_for_key(self, key: str) -> Path:
-        path = (self.root / key).resolve()
-        path.relative_to(self.root)
+        if key == "":
+            raise ValueError("Storage key must not be empty.")
+
+        key_path = PurePosixPath(key)
+        if key_path.is_absolute():
+            raise ValueError("Storage key must be relative.")
+        if key_path == PurePosixPath("."):
+            raise ValueError("Storage key must not resolve to the storage root.")
+        if any(part == ".." for part in key_path.parts):
+            raise ValueError("Storage key must not contain parent traversal segments.")
+
+        path = self.root.joinpath(*key_path.parts).resolve()
+        if path == self.root:
+            raise ValueError("Storage key must not resolve to the storage root.")
+
+        try:
+            path.relative_to(self.root)
+        except ValueError as exc:
+            raise ValueError("Storage key must resolve under the storage root.") from exc
+
         return path
 
     def _cleanup_uploaded_path(self, storage_path: Path) -> None:
@@ -152,3 +191,6 @@ class LocalStorage:
 
         for target in targets:
             target.chmod(0o700)
+
+
+LocalStorage = LocalFilesystemStorage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.db.session import get_db
 from app.main import app as fastapi_app
+from app.storage.dependencies import _get_default_storage
 
 # Marker for tests that require a running database
 requires_database = pytest.mark.skipif(
@@ -47,10 +48,13 @@ def isolate_upload_storage(
 ) -> Generator[None, None, None]:
     """Use a per-test temporary upload root and clean up only that root."""
     upload_root = (tmp_path / "uploads").resolve()
+    _get_default_storage.cache_clear()
     monkeypatch.setattr(settings, "upload_storage_root", str(upload_root))
+    _get_default_storage.cache_clear()
 
     yield
 
+    _get_default_storage.cache_clear()
     if upload_root.exists():
         shutil.rmtree(upload_root)
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -192,8 +192,8 @@ class TestProjectFiles:
         )
         assert stored_path.read_bytes() == payload
         mode = stored_path.stat().st_mode & 0o777
-        assert mode == 0o400
-        assert (mode & 0o077) == 0
+        assert mode == 0o444
+        assert (mode & 0o333) == 0
         assert str(stored_path).startswith(str(Path(settings.upload_storage_root).resolve()))
 
         assert job is not None
@@ -803,7 +803,14 @@ class TestProjectFiles:
             app.dependency_overrides.pop(session_module.get_db, None)
 
         upload_root = Path(settings.upload_storage_root).resolve()
-        assert not upload_root.exists() or not any(upload_root.iterdir())
+        staging_root = upload_root / ".staging"
+        assert not staging_root.exists() or not any(staging_root.iterdir())
+
+        stored_files = list((upload_root / "originals").rglob("*"))
+        stored_payloads = [path for path in stored_files if path.is_file()]
+        assert len(stored_payloads) == 1
+        assert stored_payloads[0].read_bytes() == b"%PDF-1.7\npayload"
+        assert (stored_payloads[0].stat().st_mode & 0o200) == 0
 
     async def test_upload_file_commit_cancelled_error_cleans_written_bytes(
         self,
@@ -841,4 +848,11 @@ class TestProjectFiles:
             app.dependency_overrides.pop(session_module.get_db, None)
 
         upload_root = Path(settings.upload_storage_root).resolve()
-        assert not upload_root.exists() or not any(upload_root.iterdir())
+        staging_root = upload_root / ".staging"
+        assert not staging_root.exists() or not any(staging_root.iterdir())
+
+        stored_files = list((upload_root / "originals").rglob("*"))
+        stored_payloads = [path for path in stored_files if path.is_file()]
+        assert len(stored_payloads) == 1
+        assert stored_payloads[0].read_bytes() == b"%PDF-1.7\npayload"
+        assert (stored_payloads[0].stat().st_mode & 0o200) == 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from app.storage import LocalStorage, MemoryStorage
+from app.storage import LocalFilesystemStorage, LocalStorage, MemoryStorage
 
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ async def test_memory_storage_allows_delete_for_mutable_keys() -> None:
 @pytest.mark.asyncio
 async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
     """Local storage should persist server-derived keys and support cleanup."""
-    storage = LocalStorage(tmp_path)
+    storage = LocalFilesystemStorage(tmp_path)
     key = "originals/file-4/checksum-4"
 
     meta = await storage.put(key, b"payload", immutable=True)
@@ -108,18 +108,21 @@ async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
     assert stored.body == b"payload"
     assert await storage.exists(key) is True
     assert await storage.presign(key) is None
-    assert ((tmp_path / key).stat().st_mode & 0o777) == 0o400
+    assert ((tmp_path / key).stat().st_mode & 0o777) == 0o444
+    assert ((tmp_path / "originals").stat().st_mode & 0o777) == 0o700
+    assert (tmp_path.stat().st_mode & 0o777) == 0o700
 
     with pytest.raises(PermissionError):
         await storage.delete(key)
 
     assert await storage.exists(key) is True
+    assert list((tmp_path / "originals" / "file-4").glob("*.tmp")) == []
 
 
 @pytest.mark.asyncio
 async def test_local_storage_rejects_overwrite_for_immutable_keys(tmp_path: Path) -> None:
     """Local storage should refuse replacing an immutable object."""
-    storage = LocalStorage(tmp_path)
+    storage = LocalFilesystemStorage(tmp_path)
     key = "originals/file-5/checksum-5"
     original_payload = b"payload"
     await storage.put(key, original_payload, immutable=True)
@@ -134,7 +137,7 @@ async def test_local_storage_rejects_overwrite_for_immutable_keys(tmp_path: Path
 @pytest.mark.asyncio
 async def test_local_storage_rejects_overwrite_for_mutable_keys(tmp_path: Path) -> None:
     """Local storage should refuse replacing a mutable object."""
-    storage = LocalStorage(tmp_path)
+    storage = LocalFilesystemStorage(tmp_path)
     key = "scratch/file-7"
     original_payload = b"payload"
     await storage.put(key, original_payload, immutable=False)
@@ -149,7 +152,7 @@ async def test_local_storage_rejects_overwrite_for_mutable_keys(tmp_path: Path) 
 @pytest.mark.asyncio
 async def test_local_storage_allows_delete_for_mutable_keys(tmp_path: Path) -> None:
     """Local storage should allow deleting mutable objects."""
-    storage = LocalStorage(tmp_path)
+    storage = LocalFilesystemStorage(tmp_path)
     key = "scratch/file-6"
     await storage.put(key, b"payload", immutable=False)
 
@@ -158,3 +161,75 @@ async def test_local_storage_allows_delete_for_mutable_keys(tmp_path: Path) -> N
     await storage.delete(key)
 
     assert await storage.exists(key) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        ".",
+        "/absolute/path",
+        "../escape",
+        "originals/../escape",
+        "originals/..",
+    ],
+)
+async def test_local_storage_rejects_unsafe_keys_before_path_resolution(
+    tmp_path: Path,
+    key: str,
+) -> None:
+    """Local storage should reject unsafe keys without mutating the storage root."""
+    storage = LocalFilesystemStorage(tmp_path)
+    root_mode = tmp_path.stat().st_mode & 0o777
+
+    with pytest.raises(ValueError):
+        await storage.put(key, b"payload", immutable=True)
+
+    with pytest.raises(ValueError):
+        await storage.exists(key)
+
+    with pytest.raises(ValueError):
+        await storage.delete(key)
+
+    assert list(tmp_path.iterdir()) == []
+    assert (tmp_path.stat().st_mode & 0o777) == root_mode
+
+
+def test_local_storage_alias_remains_available() -> None:
+    """Legacy LocalStorage import should resolve to the canonical class."""
+    assert LocalStorage is LocalFilesystemStorage
+
+
+@pytest.mark.asyncio
+async def test_local_storage_artifact_keys_are_immutable_per_key(tmp_path: Path) -> None:
+    """Artifact storage should refuse overwriting the same storage key."""
+    storage = LocalFilesystemStorage(tmp_path)
+    key = "artifacts/artifact-1/report.pdf"
+    payload = b"artifact-bytes"
+
+    await storage.put(key, payload, immutable=True)
+
+    with pytest.raises(FileExistsError):
+        await storage.put(key, payload, immutable=True)
+
+    assert (await storage.get(key)).body == payload
+
+
+@pytest.mark.asyncio
+async def test_local_storage_allows_same_artifact_name_under_new_artifact_id(
+    tmp_path: Path,
+) -> None:
+    """Artifact storage should allow identical payloads under different artifact ids."""
+    storage = LocalFilesystemStorage(tmp_path)
+    first_key = "artifacts/artifact-1/report.pdf"
+    second_key = "artifacts/artifact-2/report.pdf"
+    payload = b"artifact-bytes"
+
+    first = await storage.put(first_key, payload, immutable=True)
+    second = await storage.put(second_key, payload, immutable=True)
+
+    assert first.key == first_key
+    assert second.key == second_key
+    assert (await storage.get(first_key)).body == payload
+    assert (await storage.get(second_key)).body == payload


### PR DESCRIPTION
Closes #33

## Summary
- harden the local storage backend around atomic no-overwrite promotion, immutable `0o444` objects, and canonical `LocalFilesystemStorage` naming
- add `STORAGE_LOCAL_ROOT` as the canonical local storage setting while preserving backward compatibility with the prior upload root name
- expand storage and upload tests to cover artifact-key immutability, unsafe key rejection, and commit-failure cleanup behavior

## Test plan
- [x] uv run ruff check app/storage/local.py app/storage/__init__.py app/storage/dependencies.py app/core/config.py app/api/v1/files.py tests/test_storage.py tests/test_files.py
- [x] uv run mypy app tests
- [x] uv run pytest tests/test_storage.py
- [x] uv run pytest tests/test_files.py tests/test_storage.py