### PR TITLE
feat: verify streamed upload storage checksums

### DIFF
--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -167,10 +167,8 @@ def _ensure_private_directory(path: Path, *, include_parents_until: Path | None 
 
 async def _cleanup_persisted_upload(storage: Storage, storage_key: str, storage_uri: str) -> None:
     """Best-effort cleanup for a persisted upload after downstream failure."""
-    _ = storage_uri
-
     with suppress(Exception):
-        await storage.delete(storage_key)
+        await storage.delete_failed_put(storage_key, storage_uri=storage_uri)
 
 
 async def _raise_input_invalid_for_upload_metadata(file: UploadFile, message: str) -> None:
@@ -278,6 +276,16 @@ async def upload_project_file(
 
         try:
             stored_object = await storage.put(storage_key, staging_path, immutable=True)
+            if stored_object.checksum_sha256 != checksum:
+                await _cleanup_persisted_upload(storage, storage_key, stored_object.storage_uri)
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=create_error_response(
+                        code=ErrorCode.STORAGE_FAILED,
+                        message="Stored file checksum mismatch detected.",
+                        details=None,
+                    ),
+                )
             storage_uri = stored_object.storage_uri
         except FileExistsError as exc:
             raise HTTPException(
@@ -335,13 +343,7 @@ async def upload_project_file(
     )
     db.add(ingest_job)
 
-    try:
-        await db.commit()
-    except BaseException:
-        assert storage_key is not None
-        assert storage_uri is not None
-        await _cleanup_persisted_upload(storage, storage_key, storage_uri)
-        raise
+    await db.commit()
 
     await db.refresh(file_row)
     await db.refresh(ingest_job)

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -16,6 +16,19 @@ class StoredObjectMeta:
     key: str
     storage_uri: str
     size_bytes: int
+    checksum_sha256: str = ""
+
+
+class StorageChecksumMismatchError(ValueError):
+    """Raised when stored bytes do not match an expected checksum."""
+
+    def __init__(self, *, key: str, expected: str, actual: str) -> None:
+        self.key = key
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"Checksum mismatch for storage key '{key}': expected {expected}, got {actual}."
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,17 +51,30 @@ class Storage(Protocol):
     ) -> StoredObjectMeta:
         """Persist an object at a server-derived key without overwriting existing keys."""
 
-    async def get(self, key: str) -> StoredObject:
-        """Read an object by key."""
+    async def get(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObject:
+        """Read an object by key and optionally verify its checksum."""
 
-    async def stat(self, key: str) -> StoredObjectMeta:
-        """Read object metadata without loading full bytes."""
+    async def stat(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
+        """Read object metadata and optionally verify its checksum."""
 
     async def exists(self, key: str) -> bool:
         """Check whether an object exists."""
 
     async def delete(self, key: str) -> None:
         """Delete an object by key."""
+
+    async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+        """Delete a just-written object before database lineage is committed."""
 
     async def presign(
         self,

--- a/app/storage/local.py
+++ b/app/storage/local.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 import uuid
 from contextlib import suppress
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 
-from app.storage.base import StoragePayload, StoredObject, StoredObjectMeta
+from app.storage.base import (
+    StorageChecksumMismatchError,
+    StoragePayload,
+    StoredObject,
+    StoredObjectMeta,
+)
 
 _COPY_CHUNK_SIZE_BYTES = 1024 * 1024
 
@@ -30,13 +36,23 @@ class LocalFilesystemStorage:
         """Persist an object without overwriting an existing key, regardless of immutability."""
         return await asyncio.to_thread(self._put_sync, key, data, immutable)
 
-    async def get(self, key: str) -> StoredObject:
-        """Load a stored object."""
-        return await asyncio.to_thread(self._get_sync, key)
+    async def get(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObject:
+        """Load a stored object and optionally verify its checksum."""
+        return await asyncio.to_thread(self._get_sync, key, expected_checksum_sha256)
 
-    async def stat(self, key: str) -> StoredObjectMeta:
-        """Return metadata for a stored object."""
-        return await asyncio.to_thread(self._stat_sync, key)
+    async def stat(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
+        """Return metadata for a stored object and optionally verify its checksum."""
+        return await asyncio.to_thread(self._stat_sync, key, expected_checksum_sha256)
 
     async def exists(self, key: str) -> bool:
         """Check whether a stored object exists."""
@@ -45,6 +61,10 @@ class LocalFilesystemStorage:
     async def delete(self, key: str) -> None:
         """Delete a stored object if present."""
         await asyncio.to_thread(self._delete_sync, key)
+
+    async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+        """Delete a just-written object before immutable upload lineage is committed."""
+        await asyncio.to_thread(self._delete_failed_put_sync, key, storage_uri)
 
     async def presign(
         self,
@@ -64,7 +84,7 @@ class LocalFilesystemStorage:
 
         final_path_created = False
         try:
-            self._write_temp_file(temp_path, data)
+            size_bytes, checksum_sha256 = self._write_temp_file(temp_path, data)
             temp_path.chmod(self._target_mode(immutable))
             os.link(temp_path, final_path)
             final_path_created = True
@@ -72,7 +92,8 @@ class LocalFilesystemStorage:
             return StoredObjectMeta(
                 key=key,
                 storage_uri=f"file://{final_path}",
-                size_bytes=final_path.stat().st_size,
+                size_bytes=size_bytes,
+                checksum_sha256=checksum_sha256,
             )
         except BaseException:
             if final_path_created:
@@ -83,24 +104,37 @@ class LocalFilesystemStorage:
             if final_path_created:
                 self._fsync_directory(final_path.parent)
 
-    def _get_sync(self, key: str) -> StoredObject:
+    def _get_sync(
+        self,
+        key: str,
+        expected_checksum_sha256: str | None,
+    ) -> StoredObject:
         path = self._path_for_key(key)
-        body = path.read_bytes()
+        body, checksum_sha256 = self._read_body_with_checksum(path)
+        self._verify_checksum(key, expected_checksum_sha256, checksum_sha256)
         return StoredObject(
             meta=StoredObjectMeta(
                 key=key,
                 storage_uri=f"file://{path}",
                 size_bytes=len(body),
+                checksum_sha256=checksum_sha256,
             ),
             body=body,
         )
 
-    def _stat_sync(self, key: str) -> StoredObjectMeta:
+    def _stat_sync(
+        self,
+        key: str,
+        expected_checksum_sha256: str | None,
+    ) -> StoredObjectMeta:
         path = self._path_for_key(key)
+        size_bytes, checksum_sha256 = self._checksum_path(path)
+        self._verify_checksum(key, expected_checksum_sha256, checksum_sha256)
         return StoredObjectMeta(
             key=key,
             storage_uri=f"file://{path}",
-            size_bytes=path.stat().st_size,
+            size_bytes=size_bytes,
+            checksum_sha256=checksum_sha256,
         )
 
     def _delete_sync(self, key: str) -> None:
@@ -109,23 +143,76 @@ class LocalFilesystemStorage:
             raise PermissionError(key)
         self._cleanup_uploaded_path(path)
 
+    def _delete_failed_put_sync(self, key: str, storage_uri: str) -> None:
+        path = self._path_for_key(key)
+        expected_storage_uri = f"file://{path}"
+        if storage_uri != expected_storage_uri:
+            raise ValueError("Storage URI does not match key for failed-put cleanup.")
+        self._cleanup_uploaded_path(path)
+
     def _exists_sync(self, key: str) -> bool:
         return self._path_for_key(key).exists()
 
-    def _write_temp_file(self, temp_path: Path, data: StoragePayload) -> None:
+    def _write_temp_file(self, temp_path: Path, data: StoragePayload) -> tuple[int, str]:
         with temp_path.open("xb") as stream:
             temp_path.chmod(0o600)
             if isinstance(data, bytes):
                 stream.write(data)
+                size_bytes = len(data)
+                checksum_sha256 = hashlib.sha256(data).hexdigest()
             else:
                 with Path(data).open("rb") as source_stream:
-                    self._copy_stream(source_stream, stream)
+                    size_bytes, checksum_sha256 = self._copy_stream(source_stream, stream)
             stream.flush()
             os.fsync(stream.fileno())
+        return size_bytes, checksum_sha256
 
-    def _copy_stream(self, source_stream: BinaryIO, destination_stream: BinaryIO) -> None:
+    def _copy_stream(
+        self,
+        source_stream: BinaryIO,
+        destination_stream: BinaryIO,
+    ) -> tuple[int, str]:
+        checksum_builder = hashlib.sha256()
+        size_bytes = 0
         while chunk := source_stream.read(_COPY_CHUNK_SIZE_BYTES):
             destination_stream.write(chunk)
+            checksum_builder.update(chunk)
+            size_bytes += len(chunk)
+        return size_bytes, checksum_builder.hexdigest()
+
+    def _read_body_with_checksum(self, path: Path) -> tuple[bytes, str]:
+        checksum_builder = hashlib.sha256()
+        body = bytearray()
+        with path.open("rb") as stream:
+            while chunk := stream.read(_COPY_CHUNK_SIZE_BYTES):
+                body.extend(chunk)
+                checksum_builder.update(chunk)
+        return bytes(body), checksum_builder.hexdigest()
+
+    def _checksum_path(self, path: Path) -> tuple[int, str]:
+        checksum_builder = hashlib.sha256()
+        size_bytes = 0
+        with path.open("rb") as stream:
+            while chunk := stream.read(_COPY_CHUNK_SIZE_BYTES):
+                checksum_builder.update(chunk)
+                size_bytes += len(chunk)
+        return size_bytes, checksum_builder.hexdigest()
+
+    def _verify_checksum(
+        self,
+        key: str,
+        expected_checksum_sha256: str | None,
+        actual_checksum_sha256: str,
+    ) -> None:
+        if (
+            expected_checksum_sha256 is not None
+            and actual_checksum_sha256 != expected_checksum_sha256
+        ):
+            raise StorageChecksumMismatchError(
+                key=key,
+                expected=expected_checksum_sha256,
+                actual=actual_checksum_sha256,
+            )
 
     def _fsync_directory(self, path: Path) -> None:
         fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))

--- a/app/storage/memory.py
+++ b/app/storage/memory.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
-from app.storage.base import StoragePayload, StoredObject, StoredObjectMeta
+from app.storage.base import (
+    StorageChecksumMismatchError,
+    StoragePayload,
+    StoredObject,
+    StoredObjectMeta,
+)
+
+_MEMORY_READ_CHUNK_SIZE_BYTES = 1024 * 1024
 
 
 class MemoryStorage:
@@ -21,7 +29,8 @@ class MemoryStorage:
         immutable: bool = False,
     ) -> StoredObjectMeta:
         """Store bytes at a key without overwriting existing keys."""
-        body = data if isinstance(data, bytes) else Path(data).read_bytes()
+        body = data if isinstance(data, bytes) else self._read_path_bytes(Path(data))
+        checksum_sha256 = hashlib.sha256(body).hexdigest()
         existing = self._objects.get(key)
         if existing is not None:
             raise FileExistsError(key)
@@ -31,27 +40,44 @@ class MemoryStorage:
             key=key,
             storage_uri=f"memory://{key}",
             size_bytes=len(body),
+            checksum_sha256=checksum_sha256,
         )
 
-    async def get(self, key: str) -> StoredObject:
+    async def get(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObject:
         """Return object bytes and metadata."""
         body, _ = self._objects[key]
+        checksum_sha256 = hashlib.sha256(body).hexdigest()
+        self._verify_checksum(key, expected_checksum_sha256, checksum_sha256)
         return StoredObject(
             meta=StoredObjectMeta(
                 key=key,
                 storage_uri=f"memory://{key}",
                 size_bytes=len(body),
+                checksum_sha256=checksum_sha256,
             ),
             body=body,
         )
 
-    async def stat(self, key: str) -> StoredObjectMeta:
+    async def stat(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
         """Return metadata for a stored object."""
         body, _ = self._objects[key]
+        checksum_sha256 = hashlib.sha256(body).hexdigest()
+        self._verify_checksum(key, expected_checksum_sha256, checksum_sha256)
         return StoredObjectMeta(
             key=key,
             storage_uri=f"memory://{key}",
             size_bytes=len(body),
+            checksum_sha256=checksum_sha256,
         )
 
     async def exists(self, key: str) -> bool:
@@ -68,6 +94,14 @@ class MemoryStorage:
 
         self._objects.pop(key, None)
 
+    async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+        """Delete a just-written object before immutable upload lineage is committed."""
+        expected_storage_uri = f"memory://{key}"
+        if storage_uri != expected_storage_uri:
+            raise ValueError("Storage URI does not match key for failed-put cleanup.")
+
+        self._objects.pop(key, None)
+
     async def presign(
         self,
         key: str,
@@ -78,3 +112,26 @@ class MemoryStorage:
         """Stub presign support for interface parity."""
         _ = (key, method, expires_in_seconds)
         return None
+
+    def _read_path_bytes(self, path: Path) -> bytes:
+        body = bytearray()
+        with path.open("rb") as stream:
+            while chunk := stream.read(_MEMORY_READ_CHUNK_SIZE_BYTES):
+                body.extend(chunk)
+        return bytes(body)
+
+    def _verify_checksum(
+        self,
+        key: str,
+        expected_checksum_sha256: str | None,
+        actual_checksum_sha256: str,
+    ) -> None:
+        if (
+            expected_checksum_sha256 is not None
+            and actual_checksum_sha256 != expected_checksum_sha256
+        ):
+            raise StorageChecksumMismatchError(
+                key=key,
+                expected=expected_checksum_sha256,
+                actual=actual_checksum_sha256,
+            )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -18,7 +18,7 @@ import app.db.session as session_module
 from app.core.config import settings
 from app.models.file import File as FileModel
 from app.models.job import Job
-from app.storage import StoredObjectMeta, get_storage
+from app.storage import LocalFilesystemStorage, StoredObjectMeta, get_storage
 from tests.conftest import requires_database
 
 
@@ -81,8 +81,10 @@ def _make_get_db_override_with_commit_error(
 class RecordingStorage:
     """Test double that records upload persistence inputs."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, returned_checksum_sha256: str | None = None) -> None:
         self.put_calls: list[tuple[str, Path, bytes, bool]] = []
+        self.delete_calls: list[str] = []
+        self.returned_checksum_sha256 = returned_checksum_sha256
 
     async def put(
         self,
@@ -99,14 +101,29 @@ class RecordingStorage:
             key=key,
             storage_uri=f"memory://{key}",
             size_bytes=len(body),
+            checksum_sha256=(
+                self.returned_checksum_sha256 or hashlib.sha256(body).hexdigest()
+            ),
         )
 
-    async def get(self, key: str) -> Any:
+    async def get(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> Any:
         """Unused protocol method for test double completeness."""
+        _ = expected_checksum_sha256
         raise NotImplementedError(key)
 
-    async def stat(self, key: str) -> StoredObjectMeta:
+    async def stat(
+        self,
+        key: str,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
         """Unused protocol method for test double completeness."""
+        _ = expected_checksum_sha256
         raise NotImplementedError(key)
 
     async def exists(self, key: str) -> bool:
@@ -115,7 +132,12 @@ class RecordingStorage:
 
     async def delete(self, key: str) -> None:
         """Unused protocol method for test double completeness."""
-        raise NotImplementedError(key)
+        self.delete_calls.append(key)
+
+    async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+        """Record failed-put cleanup requests for protocol parity."""
+        _ = storage_uri
+        self.delete_calls.append(key)
 
     async def presign(
         self,
@@ -127,6 +149,26 @@ class RecordingStorage:
         """Unused protocol method for test double completeness."""
         _ = (key, method, expires_in_seconds)
         return None
+
+
+class LocalChecksumMismatchStorage(LocalFilesystemStorage):
+    """Local storage backend that reports the wrong checksum after writing."""
+
+    async def put(
+        self,
+        key: str,
+        data: bytes | Path,
+        *,
+        immutable: bool = False,
+    ) -> StoredObjectMeta:
+        """Persist bytes, then report intentionally mismatched checksum metadata."""
+        meta = await super().put(key, data, immutable=immutable)
+        return StoredObjectMeta(
+            key=meta.key,
+            storage_uri=meta.storage_uri,
+            size_bytes=meta.size_bytes,
+            checksum_sha256="0" * 64,
+        )
 
 
 @requires_database
@@ -279,6 +321,56 @@ class TestProjectFiles:
 
         assert file_row is not None
         assert file_row.storage_uri == f"memory://{expected_key}"
+
+    async def test_upload_file_rejects_storage_checksum_mismatch_and_cleans_persisted_upload(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        app: FastAPI,
+    ) -> None:
+        """POST should cleanup real local-storage writes on checksum mismatch before DB commit."""
+        _ = self
+        payload = b"%PDF-1.7\nchecksum-mismatch"
+        upload_root = Path(settings.upload_storage_root).resolve()
+        storage = LocalChecksumMismatchStorage(upload_root)
+        app.dependency_overrides[get_storage] = lambda: storage
+        try:
+            response = await async_client.post(
+                f"/v1/projects/{created_project['id']}/files",
+                files={"file": ("mismatch.pdf", payload, "application/pdf")},
+            )
+        finally:
+            app.dependency_overrides.pop(get_storage, None)
+
+        assert response.status_code == 500
+        assert response.json() == {
+            "error": {
+                "code": "STORAGE_FAILED",
+                "message": "Stored file checksum mismatch detected.",
+                "details": None,
+            }
+        }
+        staging_root = upload_root / ".staging"
+        assert not staging_root.exists() or not any(staging_root.iterdir())
+        originals_root = upload_root / "originals"
+        assert not originals_root.exists() or not any(
+            path.is_file() for path in originals_root.rglob("*")
+        )
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
 
     async def test_list_project_files_success(
         self,
@@ -781,14 +873,15 @@ class TestProjectFiles:
             }
         }
 
-    async def test_upload_file_commit_failure_cleans_written_bytes(
+    async def test_upload_file_commit_failure_retains_written_bytes_conservatively(
         self,
         async_client: httpx.AsyncClient,
         created_project: dict[str, Any],
         app: FastAPI,
     ) -> None:
-        """POST should cleanup persisted bytes when DB commit raises RuntimeError."""
+        """POST should retain persisted bytes when DB commit raises RuntimeError."""
         _ = self
+        payload = b"%PDF-1.7\npayload"
 
         app.dependency_overrides[session_module.get_db] = (
             _make_get_db_override_with_commit_error(RuntimeError("forced commit failure"))
@@ -797,7 +890,7 @@ class TestProjectFiles:
             with pytest.raises(RuntimeError, match="forced commit failure"):
                 await async_client.post(
                     f"/v1/projects/{created_project['id']}/files",
-                    files={"file": ("commit-fail.pdf", b"%PDF-1.7\npayload", "application/pdf")},
+                    files={"file": ("commit-fail.pdf", payload, "application/pdf")},
                 )
         finally:
             app.dependency_overrides.pop(session_module.get_db, None)
@@ -806,20 +899,20 @@ class TestProjectFiles:
         staging_root = upload_root / ".staging"
         assert not staging_root.exists() or not any(staging_root.iterdir())
 
-        stored_files = list((upload_root / "originals").rglob("*"))
-        stored_payloads = [path for path in stored_files if path.is_file()]
-        assert len(stored_payloads) == 1
-        assert stored_payloads[0].read_bytes() == b"%PDF-1.7\npayload"
-        assert (stored_payloads[0].stat().st_mode & 0o200) == 0
+        originals_root = upload_root / "originals"
+        persisted_paths = [path for path in originals_root.rglob("*") if path.is_file()]
+        assert len(persisted_paths) == 1
+        assert persisted_paths[0].read_bytes() == payload
 
-    async def test_upload_file_commit_cancelled_error_cleans_written_bytes(
+    async def test_upload_file_commit_cancelled_error_retains_written_bytes_conservatively(
         self,
         async_client: httpx.AsyncClient,
         created_project: dict[str, Any],
         app: FastAPI,
     ) -> None:
-        """POST should cleanup persisted bytes when DB commit raises CancelledError."""
+        """POST should retain persisted bytes when DB commit raises CancelledError."""
         _ = self
+        payload = b"%PDF-1.7\npayload"
 
         app.dependency_overrides[session_module.get_db] = (
             _make_get_db_override_with_commit_error(asyncio.CancelledError())
@@ -832,7 +925,7 @@ class TestProjectFiles:
                     files={
                         "file": (
                             "commit-cancelled.pdf",
-                            b"%PDF-1.7\npayload",
+                            payload,
                             "application/pdf",
                         )
                     },
@@ -851,8 +944,7 @@ class TestProjectFiles:
         staging_root = upload_root / ".staging"
         assert not staging_root.exists() or not any(staging_root.iterdir())
 
-        stored_files = list((upload_root / "originals").rglob("*"))
-        stored_payloads = [path for path in stored_files if path.is_file()]
-        assert len(stored_payloads) == 1
-        assert stored_payloads[0].read_bytes() == b"%PDF-1.7\npayload"
-        assert (stored_payloads[0].stat().st_mode & 0o200) == 0
+        originals_root = upload_root / "originals"
+        persisted_paths = [path for path in originals_root.rglob("*") if path.is_file()]
+        assert len(persisted_paths) == 1
+        assert persisted_paths[0].read_bytes() == payload

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,10 +1,16 @@
 """Unit tests for storage backends."""
 
+import hashlib
 from pathlib import Path
 
 import pytest
 
-from app.storage import LocalFilesystemStorage, LocalStorage, MemoryStorage
+from app.storage import (
+    LocalFilesystemStorage,
+    LocalStorage,
+    MemoryStorage,
+)
+from app.storage.base import StorageChecksumMismatchError
 
 
 @pytest.mark.asyncio
@@ -18,6 +24,7 @@ async def test_memory_storage_round_trip_with_bytes() -> None:
     assert meta.key == "originals/file-1/checksum-1"
     assert meta.storage_uri == "memory://originals/file-1/checksum-1"
     assert meta.size_bytes == 7
+    assert meta.checksum_sha256 == hashlib.sha256(b"payload").hexdigest()
     assert stored.meta == meta
     assert stored.body == b"payload"
 
@@ -32,6 +39,7 @@ async def test_memory_storage_round_trip_with_path(tmp_path: Path) -> None:
     meta = await storage.put("originals/file-2/checksum-2", staged_path, immutable=True)
 
     assert meta.size_bytes == len(b"from-path")
+    assert meta.checksum_sha256 == hashlib.sha256(b"from-path").hexdigest()
     assert await storage.exists("originals/file-2/checksum-2") is True
     assert (await storage.get("originals/file-2/checksum-2")).body == b"from-path"
 
@@ -43,7 +51,10 @@ async def test_memory_storage_stat_and_presign_stub() -> None:
     key = "originals/file-3/checksum-3"
     await storage.put(key, b"abc", immutable=True)
 
-    assert (await storage.stat(key)).size_bytes == 3
+    stat = await storage.stat(key)
+
+    assert stat.size_bytes == 3
+    assert stat.checksum_sha256 == hashlib.sha256(b"abc").hexdigest()
     assert await storage.presign(key) is None
 
 
@@ -81,6 +92,18 @@ async def test_memory_storage_rejects_overwrite_and_delete_for_immutable_keys() 
 
 
 @pytest.mark.asyncio
+async def test_memory_storage_allows_failed_put_cleanup_for_immutable_keys() -> None:
+    """Memory storage should allow pre-commit cleanup for immutable writes."""
+    storage = MemoryStorage()
+    key = "originals/file-4/checksum-4"
+    meta = await storage.put(key, b"abc", immutable=True)
+
+    await storage.delete_failed_put(key, storage_uri=meta.storage_uri)
+
+    assert await storage.exists(key) is False
+
+
+@pytest.mark.asyncio
 async def test_memory_storage_allows_delete_for_mutable_keys() -> None:
     """Memory storage should allow deleting mutable objects."""
     storage = MemoryStorage()
@@ -104,6 +127,7 @@ async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
     assert meta.key == key
     assert meta.storage_uri == f"file://{(tmp_path / key).resolve()}"
     assert meta.size_bytes == 7
+    assert meta.checksum_sha256 == hashlib.sha256(b"payload").hexdigest()
     assert stored.meta == meta
     assert stored.body == b"payload"
     assert await storage.exists(key) is True
@@ -117,6 +141,19 @@ async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
 
     assert await storage.exists(key) is True
     assert list((tmp_path / "originals" / "file-4").glob("*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_local_storage_allows_failed_put_cleanup_for_immutable_keys(tmp_path: Path) -> None:
+    """Local storage should allow pre-commit cleanup for immutable writes."""
+    storage = LocalFilesystemStorage(tmp_path)
+    key = "originals/file-cleanup/checksum-cleanup"
+    meta = await storage.put(key, b"payload", immutable=True)
+
+    await storage.delete_failed_put(key, storage_uri=meta.storage_uri)
+
+    assert await storage.exists(key) is False
+    assert not (tmp_path / "originals").exists()
 
 
 @pytest.mark.asyncio
@@ -233,3 +270,38 @@ async def test_local_storage_allows_same_artifact_name_under_new_artifact_id(
     assert second.key == second_key
     assert (await storage.get(first_key)).body == payload
     assert (await storage.get(second_key)).body == payload
+
+
+@pytest.mark.asyncio
+async def test_local_storage_put_from_path_returns_checksum_metadata(tmp_path: Path) -> None:
+    """Local storage should hash staged path payloads while copying."""
+    storage = LocalFilesystemStorage(tmp_path)
+    key = "originals/file-8/checksum-8"
+    staged_path = tmp_path / "upload.part"
+    payload = b"from-path"
+    staged_path.write_bytes(payload)
+
+    meta = await storage.put(key, staged_path, immutable=True)
+    stat = await storage.stat(key, expected_checksum_sha256=hashlib.sha256(payload).hexdigest())
+
+    assert meta.size_bytes == len(payload)
+    assert meta.checksum_sha256 == hashlib.sha256(payload).hexdigest()
+    assert stat == meta
+
+
+@pytest.mark.asyncio
+async def test_local_storage_detects_checksum_tampering_on_get_and_stat(tmp_path: Path) -> None:
+    """Local storage should detect checksum mismatches for tampered files."""
+    storage = LocalFilesystemStorage(tmp_path)
+    key = "originals/file-9/checksum-9"
+    original_payload = b"payload"
+    meta = await storage.put(key, original_payload, immutable=True)
+    stored_path = tmp_path / key
+    stored_path.chmod(0o600)
+    stored_path.write_bytes(b"tampered")
+
+    with pytest.raises(StorageChecksumMismatchError):
+        await storage.get(key, expected_checksum_sha256=meta.checksum_sha256)
+
+    with pytest.raises(StorageChecksumMismatchError):
+        await storage.stat(key, expected_checksum_sha256=meta.checksum_sha256)


### PR DESCRIPTION
Closes #34

## Summary
- compute SHA-256 during local and memory storage writes and return it in storage metadata
- verify streamed upload bytes against persisted storage bytes before creating DB lineage, with checksum validation on reads and stats
- limit failed-put cleanup to pre-lineage writes and add coverage for tamper detection and ambiguous commit retention

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_storage.py tests/test_files.py

## Notes
- Full `uv run pytest` is still blocked locally by unrelated `job_events` schema drift in `tests/test_db.py` and `tests/test_jobs.py`.