### PR TITLE
feat: enforce streaming upload size cap

### DIFF
--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -111,6 +111,11 @@ def _unsupported_format_exception() -> HTTPException:
     )
 
 
+def _upload_size_limit_message(max_upload_mb: int) -> str:
+    """Build an upload-size validation message that includes configured cap."""
+    return f"Uploaded file exceeds maximum allowed size of {max_upload_mb} MB."
+
+
 def _staging_path(file_id: UUID) -> Path:
     """Build a temporary staging path for upload bytes before promotion."""
     return _upload_root() / ".staging" / f"{file_id}.{uuid.uuid4().hex}.part"
@@ -244,7 +249,7 @@ async def upload_project_file(
                         status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                         detail=create_error_response(
                             code=ErrorCode.INPUT_INVALID,
-                            message="Uploaded file exceeds maximum allowed size.",
+                            message=_upload_size_limit_message(settings.max_upload_mb),
                             details=None,
                         ),
                     )
@@ -264,7 +269,7 @@ async def upload_project_file(
                         status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                         detail=create_error_response(
                             code=ErrorCode.INPUT_INVALID,
-                            message="Uploaded file exceeds maximum allowed size.",
+                            message=_upload_size_limit_message(settings.max_upload_mb),
                             details=None,
                         ),
                     )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     broker_url: str = "amqp://guest:guest@localhost:5672//"
 
     # Application settings
-    max_upload_mb: int = 50
+    max_upload_mb: int = 200
     storage_local_root: str = Field(
         default="var/uploads",
         validation_alias=AliasChoices("storage_local_root", "upload_storage_root"),

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -508,10 +508,12 @@ class TestProjectFiles:
         created_project: dict[str, Any],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """POST should reject oversize payloads with a 413 error envelope."""
+        """POST should reject payloads one byte over cap with a 413 envelope."""
         _ = self
         monkeypatch.setattr(settings, "max_upload_mb", 1)
-        payload = b"%PDF-1.7\n" + (b"x" * ((1024 * 1024) + 1))
+        cap_bytes = settings.max_upload_mb * 1024 * 1024
+        header = b"%PDF-1.7\n"
+        payload = header + (b"x" * ((cap_bytes - len(header)) + 1))
 
         response = await async_client.post(
             f"/v1/projects/{created_project['id']}/files",
@@ -522,7 +524,7 @@ class TestProjectFiles:
         assert data["error"]["code"] == "INPUT_INVALID"
         assert (
             data["error"]["message"]
-            == "Uploaded file exceeds maximum allowed size."
+            == f"Uploaded file exceeds maximum allowed size of {settings.max_upload_mb} MB."
         )
         assert data["error"]["details"] is None
 
@@ -543,6 +545,29 @@ class TestProjectFiles:
 
         assert file_result.scalars().all() == []
         assert job_result.scalars().all() == []
+
+    async def test_upload_file_accepts_payload_exactly_at_size_limit(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POST should accept payloads exactly at the configured size limit."""
+        _ = self
+        monkeypatch.setattr(settings, "max_upload_mb", 1)
+        cap_bytes = settings.max_upload_mb * 1024 * 1024
+        header = b"%PDF-1.7\n"
+        payload = header + (b"x" * (cap_bytes - len(header)))
+
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="at-limit.pdf",
+            content=payload,
+            media_type="application/pdf",
+        )
+
+        assert uploaded["size_bytes"] == cap_bytes
 
     async def test_upload_file_rejects_unsupported_format_before_writing(
         self,


### PR DESCRIPTION
Closes #35

## Summary
- align the default upload size cap with the MVP's 200 MB default
- return the configured limit in oversize upload errors during streaming validation
- add regression coverage for exact-cap success and cap-plus-one rejection

## Test plan
- [x] uv run ruff check .
- [x] uv run mypy app tests
- [x] uv run pytest
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_files.py::TestProjectFiles::test_upload_file_rejects_payload_over_size_limit tests/test_files.py::TestProjectFiles::test_upload_file_accepts_payload_exactly_at_size_limit

## Notes
- Full DB-backed pytest in the local environment still hits a pre-existing stale-schema issue around missing `job_events.sequence_id`, unrelated to this change.