### PR TITLE
feat: detect binary DXF uploads

### DIFF
--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -30,6 +30,16 @@ from app.storage import Storage, get_storage
 files_router = APIRouter()
 _UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
 _UPLOAD_SNIFF_BYTES = 4096
+# UPLOAD_FORMAT_SIGNATURES:
+# _sniff_format accepts these leading-byte signatures for upload detection:
+# - PDF: b"%PDF-"
+# - DWG: b"AC10"
+# - IFC: b"ISO-10303-21"
+# - Binary DXF: b"AutoCAD Binary DXF\r\n\x1a\x00"
+# - Text DXF: optional UTF-8 BOM, then optional ASCII whitespace, then the
+#   DXF group header for group code 0 and SECTION (b"0\nSECTION" or
+#   b"0\r\nSECTION").
+_BINARY_DXF_SENTINEL = b"AutoCAD Binary DXF\r\n\x1a\x00"
 _UTF8_BOM = b"\xef\xbb\xbf"
 _SUPPORTED_FORMATS_MESSAGE = "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc."
 _MAX_ORIGINAL_FILENAME_LENGTH = 512
@@ -87,6 +97,8 @@ def _sniff_format(initial_bytes: bytes) -> str | None:
         return "dwg"
     if initial_bytes.startswith(b"ISO-10303-21"):
         return "ifc"
+    if initial_bytes.startswith(_BINARY_DXF_SENTINEL):
+        return "dxf"
 
     dxf_probe = initial_bytes
     if dxf_probe.startswith(_UTF8_BOM):

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -1025,7 +1025,9 @@ Probe rules:
 
 - Upload size enforced server-side via `MAX_UPLOAD_MB` and streaming chunk
   validation.
-- Content-type detection by magic bytes, not by filename or client header.
+- Content-type detection by magic bytes, not by filename or client header; the
+  supported signature list is maintained in `app/api/v1/files.py` under
+  `UPLOAD_FORMAT_SIGNATURES` and documented in the adjacent code comment block.
 - Reject unsupported formats early with `INPUT_UNSUPPORTED_FORMAT`.
 - DXF, IFC, and PDF parsers run with strict resource limits (file handles,
   memory) to mitigate decompression bombs and pathological inputs.

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -870,6 +870,27 @@ class TestProjectFiles:
 
         assert uploaded["detected_format"] == "dxf"
 
+    async def test_upload_file_accepts_binary_dxf_with_octet_stream_media_type(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should accept binary DXF bytes even when clients send generic metadata."""
+        _ = self
+
+        payload = b"AutoCAD Binary DXF\r\n\x1a\x00\x00\x00binary-dxf-body"
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="plan.dxf",
+            content=payload,
+            media_type="application/octet-stream",
+        )
+
+        assert uploaded["original_filename"] == "plan.dxf"
+        assert uploaded["media_type"] == "application/octet-stream"
+        assert uploaded["detected_format"] == "dxf"
+
     async def test_upload_file_rejects_dxf_with_binary_prefix_before_header(
         self,
         async_client: httpx.AsyncClient,
@@ -885,6 +906,34 @@ class TestProjectFiles:
                     "plan.dxf",
                     b"\x00\x01\t\n0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n",
                     "application/dxf",
+                )
+            },
+        )
+
+        assert response.status_code == 415
+        assert response.json() == {
+            "error": {
+                "code": "INPUT_UNSUPPORTED_FORMAT",
+                "message": "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc.",
+                "details": None,
+            }
+        }
+
+    async def test_upload_file_rejects_png_bytes_renamed_as_dxf(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should reject unsupported bytes despite a .dxf filename."""
+        _ = self
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={
+                "file": (
+                    "plan.dxf",
+                    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR",
+                    "application/octet-stream",
                 )
             },
         )


### PR DESCRIPTION
Closes #36

## Summary
- Detect binary DXF uploads from magic bytes even when clients send generic content metadata.
- Document the maintained upload signature list in `app/api/v1/files.py` and reference it from the TRD.
- Add upload tests for binary DXF acceptance and renamed PNG rejection.

## Test plan
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_files.py -k \"unsupported_format_before_writing or mismatch or utf8_bom or binary_dxf or binary_prefix_before_header or png_bytes_renamed\" -rs`
- [x] `uv run ruff check .`
- [x] `uv run mypy app tests`
- [x] `uv build`

## Notes
- Full `uv run pytest` is blocked locally by an unrelated schema/migration issue: missing `job_events.sequence_id`.