### PR TITLE
feat: add immutable extraction profiles to ingest jobs

### DIFF
--- a/alembic/versions/2026_05_05_0004_add_extraction_profiles.py
+++ b/alembic/versions/2026_05_05_0004_add_extraction_profiles.py
@@ -1,0 +1,287 @@
+"""add extraction profiles
+
+Revision ID: 2026_05_05_0004
+Revises: 2026_05_02_0003
+Create Date: 2026-05-05 17:10:00
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_05_0004"
+down_revision: str | None = "2026_05_02_0003"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create immutable extraction profiles and thread them through jobs."""
+    op.create_table(
+        "extraction_profiles",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique extraction profile identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "profile_version",
+            sa.String(length=16),
+            nullable=False,
+            comment="Extraction profile schema version",
+        ),
+        sa.Column(
+            "units_override",
+            sa.String(length=64),
+            nullable=True,
+            comment="Optional extraction units override",
+        ),
+        sa.Column(
+            "layout_mode",
+            sa.String(length=64),
+            nullable=False,
+            comment="Layout extraction mode",
+        ),
+        sa.Column(
+            "xref_handling",
+            sa.String(length=64),
+            nullable=False,
+            comment="External reference handling mode",
+        ),
+        sa.Column(
+            "block_handling",
+            sa.String(length=64),
+            nullable=False,
+            comment="Block extraction handling mode",
+        ),
+        sa.Column(
+            "text_extraction",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+            comment="Whether text extraction is enabled",
+        ),
+        sa.Column(
+            "dimension_extraction",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+            comment="Whether dimension extraction is enabled",
+        ),
+        sa.Column(
+            "pdf_page_range",
+            sa.String(length=255),
+            nullable=True,
+            comment="Optional PDF page range selector",
+        ),
+        sa.Column(
+            "raster_calibration",
+            sa.JSON(),
+            nullable=True,
+            comment="Optional raster calibration payload",
+        ),
+        sa.Column(
+            "confidence_threshold",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("0.6"),
+            comment="Minimum confidence threshold for extracted results",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="Extraction profile creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("id", "project_id", name="uq_extraction_profiles_id_project_id"),
+    )
+    op.create_index(
+        op.f("ix_extraction_profiles_project_id"),
+        "extraction_profiles",
+        ["project_id"],
+        unique=False,
+    )
+
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "extraction_profile_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Immutable extraction profile identifier",
+        ),
+    )
+    op.add_column(
+        "files",
+        sa.Column(
+            "initial_job_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Initial ingest job identifier created during upload",
+        ),
+    )
+    op.add_column(
+        "files",
+        sa.Column(
+            "initial_extraction_profile_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Initial extraction profile identifier created during upload",
+        ),
+    )
+
+    bind = op.get_bind()
+    existing_files = bind.execute(sa.text("SELECT id, project_id FROM files")).mappings().all()
+    for file_row in existing_files:
+        profile_id = uuid.uuid4()
+        initial_job_row = bind.execute(
+            sa.text(
+                """
+                SELECT id
+                FROM jobs
+                WHERE file_id = :file_id
+                  AND project_id = :project_id
+                  AND job_type = 'ingest'
+                ORDER BY created_at ASC, id ASC
+                LIMIT 1
+                """
+            ),
+            {
+                "file_id": file_row["id"],
+                "project_id": file_row["project_id"],
+            },
+        ).mappings().first()
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO extraction_profiles (
+                    id,
+                    project_id,
+                    profile_version,
+                    units_override,
+                    layout_mode,
+                    xref_handling,
+                    block_handling,
+                    text_extraction,
+                    dimension_extraction,
+                    pdf_page_range,
+                    raster_calibration,
+                    confidence_threshold
+                ) VALUES (
+                    :id,
+                    :project_id,
+                    :profile_version,
+                    :units_override,
+                    :layout_mode,
+                    :xref_handling,
+                    :block_handling,
+                    :text_extraction,
+                    :dimension_extraction,
+                    :pdf_page_range,
+                    :raster_calibration,
+                    :confidence_threshold
+                )
+                """
+            ),
+            {
+                "id": profile_id,
+                "project_id": file_row["project_id"],
+                "profile_version": "v0.1",
+                "units_override": None,
+                "layout_mode": "auto",
+                "xref_handling": "preserve",
+                "block_handling": "expand",
+                "text_extraction": True,
+                "dimension_extraction": True,
+                "pdf_page_range": None,
+                "raster_calibration": None,
+                "confidence_threshold": 0.6,
+            },
+        )
+        bind.execute(
+            sa.text(
+                """
+                UPDATE jobs
+                SET extraction_profile_id = :profile_id
+                WHERE file_id = :file_id AND project_id = :project_id
+                """
+            ),
+            {
+                "profile_id": profile_id,
+                "file_id": file_row["id"],
+                "project_id": file_row["project_id"],
+            },
+        )
+        bind.execute(
+            sa.text(
+                """
+                UPDATE files
+                SET initial_job_id = :initial_job_id,
+                    initial_extraction_profile_id = :profile_id
+                WHERE id = :file_id AND project_id = :project_id
+                """
+            ),
+            {
+                "initial_job_id": None if initial_job_row is None else initial_job_row["id"],
+                "profile_id": profile_id,
+                "file_id": file_row["id"],
+                "project_id": file_row["project_id"],
+            },
+        )
+
+    # Keep this column nullable for the expand/rollback window so mixed-version
+    # nodes and old app binaries can still create jobs. A later contract
+    # migration can enforce NOT NULL after the rollback window closes.
+    op.create_index(
+        op.f("ix_jobs_extraction_profile_id"),
+        "jobs",
+        ["extraction_profile_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+        "jobs",
+        "extraction_profiles",
+        ["extraction_profile_id", "project_id"],
+        ["id", "project_id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    """Drop immutable extraction profiles and job references."""
+    bind = op.get_bind()
+    profile_rows_exist = bool(
+        bind.execute(sa.text("SELECT EXISTS (SELECT 1 FROM extraction_profiles)")).scalar()
+    )
+    if profile_rows_exist:
+        raise RuntimeError(
+            "Cannot downgrade revision 2026_05_05_0004 while extraction_profiles contains "
+            "rows. Manual data-preserving rollback is required."
+        )
+
+    op.drop_constraint(
+        "fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+        "jobs",
+        type_="foreignkey",
+    )
+    op.drop_index(op.f("ix_jobs_extraction_profile_id"), table_name="jobs")
+    op.drop_column("jobs", "extraction_profile_id")
+    op.drop_column("files", "initial_extraction_profile_id")
+    op.drop_column("files", "initial_job_id")
+    op.drop_index(op.f("ix_extraction_profiles_project_id"), table_name="extraction_profiles")
+    op.drop_table("extraction_profiles")

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -5,6 +5,7 @@ import binascii
 import hashlib
 import json
 import uuid
+from collections.abc import Sequence
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -21,15 +22,20 @@ from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
 from app.jobs.worker import enqueue_ingest_job
+from app.models.extraction_profile import ExtractionProfile
 from app.models.file import File as FileModel
 from app.models.job import Job
 from app.models.project import Project
+from app.schemas.extraction_profile import ExtractionProfileCreate, FileReprocessRequest
 from app.schemas.file import FileListResponse, FileRead
+from app.schemas.job import JobRead
 from app.storage import Storage, get_storage
 
 files_router = APIRouter()
 _UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
 _UPLOAD_SNIFF_BYTES = 4096
+_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH = 255
+_PUBLIC_ENQUEUE_FAILURE_MESSAGE = "Failed to enqueue ingest job"
 # UPLOAD_FORMAT_SIGNATURES:
 # _sniff_format accepts these leading-byte signatures for upload detection:
 # - PDF: b"%PDF-"
@@ -201,6 +207,98 @@ async def _raise_input_invalid_for_upload_metadata(file: UploadFile, message: st
     )
 
 
+def _build_extraction_profile(
+    project_id: UUID,
+    profile: ExtractionProfileCreate | None = None,
+) -> ExtractionProfile:
+    """Construct an immutable extraction profile row."""
+    profile_input = profile or ExtractionProfileCreate()
+    return ExtractionProfile(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        **profile_input.model_dump(),
+    )
+
+
+async def _get_project_file_or_404(
+    db: AsyncSession,
+    project_id: UUID,
+    file_id: UUID,
+) -> FileModel:
+    """Return a project-scoped file row or raise not found."""
+    query = select(FileModel).where(
+        (FileModel.project_id == project_id) & (FileModel.id == file_id)
+    )
+    file_row = (await db.execute(query)).scalar_one_or_none()
+    if file_row is None:
+        raise_not_found("File", str(file_id))
+    assert file_row is not None
+    return file_row
+
+
+async def _resolve_project_extraction_profile(
+    db: AsyncSession,
+    project_id: UUID,
+    request: FileReprocessRequest,
+) -> ExtractionProfile:
+    """Return an existing project profile or stage a new immutable one."""
+    if request.extraction_profile_id is not None:
+        query = select(ExtractionProfile).where(
+            (ExtractionProfile.project_id == project_id)
+            & (ExtractionProfile.id == request.extraction_profile_id)
+        )
+        profile_row = (await db.execute(query)).scalar_one_or_none()
+        if profile_row is None:
+            raise_not_found("ExtractionProfile", str(request.extraction_profile_id))
+        assert profile_row is not None
+        return profile_row
+
+    assert request.extraction_profile is not None
+    profile_row = _build_extraction_profile(project_id, request.extraction_profile)
+    db.add(profile_row)
+    return profile_row
+
+
+async def _mark_job_enqueue_failed(db: AsyncSession, job: Job, exc: Exception) -> None:
+    """Persist a visible failed job after enqueue publish errors."""
+    _ = exc
+    job.status = "failed"
+    job.error_code = ErrorCode.INTERNAL_ERROR.value
+    job.error_message = _PUBLIC_ENQUEUE_FAILURE_MESSAGE[:_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH]
+    job.finished_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(job)
+
+
+def _enqueue_failure_details(job: Job) -> dict[str, str]:
+    """Return safe durable identifiers for a failed enqueue response."""
+    assert job.extraction_profile_id is not None
+    return {
+        "job_id": str(job.id),
+        "extraction_profile_id": str(job.extraction_profile_id),
+    }
+
+
+def _attach_initial_upload_metadata(file_row: FileModel) -> FileModel:
+    """Attach durable initial-ingest metadata fields for response serialization."""
+    response_file = cast(Any, file_row)
+    response_file.initial_job_id = file_row.initial_job_id
+    response_file.initial_extraction_profile_id = file_row.initial_extraction_profile_id
+    return file_row
+
+
+async def _attach_initial_upload_metadata_for_files(
+    db: AsyncSession,
+    file_rows: Sequence[FileModel],
+) -> list[FileModel]:
+    """Attach durable initial ingest identifiers for file responses."""
+    _ = db
+    if not file_rows:
+        return []
+
+    return [_attach_initial_upload_metadata(file_row) for file_row in file_rows]
+
+
 @files_router.post(
     "/projects/{project_id}/files",
     response_model=FileRead,
@@ -336,6 +434,21 @@ async def upload_project_file(
     assert storage_key is not None
     assert storage_uri is not None
 
+    extraction_profile = _build_extraction_profile(project_id)
+    db.add(extraction_profile)
+
+    ingest_job = Job(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        file_id=file_id,
+        extraction_profile_id=extraction_profile.id,
+        job_type="ingest",
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        cancel_requested=False,
+    )
+
     file_row = FileModel(
         id=file_id,
         project_id=project_id,
@@ -346,18 +459,10 @@ async def upload_project_file(
         size_bytes=total_bytes,
         checksum_sha256=checksum,
         immutable=True,
+        initial_job_id=ingest_job.id,
+        initial_extraction_profile_id=extraction_profile.id,
     )
     db.add(file_row)
-
-    ingest_job = Job(
-        project_id=project_id,
-        file_id=file_id,
-        job_type="ingest",
-        status="pending",
-        attempts=0,
-        max_attempts=3,
-        cancel_requested=False,
-    )
     db.add(ingest_job)
 
     await db.commit()
@@ -368,13 +473,58 @@ async def upload_project_file(
     try:
         enqueue_ingest_job(ingest_job.id)
     except Exception as exc:
-        ingest_job.status = "failed"
-        ingest_job.error_code = ErrorCode.INTERNAL_ERROR.value
-        ingest_job.error_message = f"Failed to enqueue ingest job: {exc}"
-        ingest_job.finished_at = datetime.now(UTC)
-        await db.commit()
+        await _mark_job_enqueue_failed(db, ingest_job, exc)
 
-    return file_row
+    return _attach_initial_upload_metadata(file_row)
+
+
+@files_router.post(
+    "/projects/{project_id}/files/{file_id}/reprocess",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def reprocess_project_file(
+    project_id: UUID,
+    file_id: UUID,
+    request: FileReprocessRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Job:
+    """Create a new pending ingest job for an existing file and profile selection."""
+    project = await db.get(Project, project_id)
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    await _get_project_file_or_404(db, project_id, file_id)
+    extraction_profile = await _resolve_project_extraction_profile(db, project_id, request)
+
+    ingest_job = Job(
+        project_id=project_id,
+        file_id=file_id,
+        extraction_profile_id=extraction_profile.id,
+        job_type="ingest",
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        cancel_requested=False,
+    )
+    db.add(ingest_job)
+    await db.commit()
+    await db.refresh(ingest_job)
+
+    try:
+        enqueue_ingest_job(ingest_job.id)
+    except Exception as exc:
+        await _mark_job_enqueue_failed(db, ingest_job, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code=ErrorCode.INTERNAL_ERROR,
+                message=_PUBLIC_ENQUEUE_FAILURE_MESSAGE,
+                details=_enqueue_failure_details(ingest_job),
+            ),
+        ) from exc
+
+    return ingest_job
 
 
 @files_router.get(
@@ -418,7 +568,10 @@ async def list_project_files(
         last_item = rows[-1]
         next_cursor = _encode_cursor(last_item.created_at, last_item.id)
 
-    items = [FileRead.model_validate(row) for row in rows]
+    items = [
+        FileRead.model_validate(row)
+        for row in await _attach_initial_upload_metadata_for_files(db, rows)
+    ]
     return FileListResponse(items=items, next_cursor=next_cursor)
 
 
@@ -432,11 +585,6 @@ async def get_project_file(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> FileModel:
     """Get a single file by id within a project scope."""
-    query = select(FileModel).where(
-        (FileModel.project_id == project_id) & (FileModel.id == file_id)
-    )
-    file_row = (await db.execute(query)).scalar_one_or_none()
-    if file_row is None:
-        raise_not_found("File", str(file_id))
-    assert file_row is not None
+    file_row = await _get_project_file_or_404(db, project_id, file_id)
+    await _attach_initial_upload_metadata_for_files(db, [file_row])
     return file_row

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -23,6 +23,8 @@ jobs_router = APIRouter()
 
 _DEFAULT_EVENTS_LIMIT = 50
 _MAX_EVENTS_LIMIT = 200
+_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH = 255
+_PUBLIC_ENQUEUE_FAILURE_MESSAGE = "Failed to enqueue ingest job"
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 
 
@@ -210,7 +212,7 @@ async def retry_job(
     except Exception as exc:
         job.status = "failed"
         job.error_code = ErrorCode.INTERNAL_ERROR.value
-        job.error_message = f"Failed to enqueue ingest job: {exc}"
+        job.error_message = _PUBLIC_ENQUEUE_FAILURE_MESSAGE[:_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH]
         job.finished_at = datetime.now(UTC)
         await db.commit()
         raise HTTPException(

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -25,6 +25,7 @@ _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
 _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
 _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
+_ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
 
 celery_app = Celery(
     "draupnir",
@@ -133,6 +134,17 @@ async def _mark_job_failed(
             session=session,
         )
         await session.commit()
+
+
+async def _mark_recovery_enqueue_failed(job_id: UUID) -> None:
+    """Persist and log a sanitized worker-recovery enqueue failure."""
+    await _mark_job_failed(job_id, error_message=_ENQUEUE_INGEST_JOB_ERROR_MESSAGE)
+    logger.error(
+        "ingest_job_recovery_enqueue_failed",
+        job_id=str(job_id),
+        error_code=ErrorCode.INTERNAL_ERROR.value,
+        recovery_action="mark_failed",
+    )
 
 
 def _finalize_job_cancelled(job: Job) -> None:
@@ -332,14 +344,8 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
     for job_id in recovered_job_ids:
         try:
             enqueue_ingest_job(job_id)
-        except Exception as exc:
-            await _mark_job_failed(job_id, error_message=f"Failed to enqueue ingest job: {exc}")
-            logger.error(
-                "ingest_job_recovery_enqueue_failed",
-                job_id=str(job_id),
-                error=str(exc),
-                exc_info=True,
-            )
+        except Exception:
+            await _mark_recovery_enqueue_failed(job_id)
         else:
             enqueued_job_ids.append(job_id)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ for Alembic autogenerate support. Example:
 
 """
 
+from . import extraction_profile as extraction_profile
 from . import file as file
 from . import job as job
 from . import job_event as job_event

--- a/app/models/extraction_profile.py
+++ b/app/models/extraction_profile.py
@@ -1,0 +1,103 @@
+"""Immutable extraction profile model for ingestion settings."""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ExtractionProfile(Base):
+    """SQLAlchemy ORM model for immutable extraction profiles."""
+
+    __tablename__ = "extraction_profiles"
+    __table_args__ = (
+        UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_extraction_profiles_id_project_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique extraction profile identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    profile_version: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Extraction profile schema version",
+    )
+    units_override: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Optional extraction units override",
+    )
+    layout_mode: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Layout extraction mode",
+    )
+    xref_handling: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="External reference handling mode",
+    )
+    block_handling: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Block extraction handling mode",
+    )
+    text_extraction: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        comment="Whether text extraction is enabled",
+    )
+    dimension_extraction: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        comment="Whether dimension extraction is enabled",
+    )
+    pdf_page_range: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="Optional PDF page range selector",
+    )
+    raster_calibration: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON,
+        nullable=True,
+        comment="Optional raster calibration payload",
+    )
+    confidence_threshold: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=0.6,
+        comment="Minimum confidence threshold for extracted results",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Extraction profile creation timestamp",
+    )

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -80,6 +80,14 @@ class File(Base):
         nullable=False,
         comment="Whether the original upload is immutable",
     )
+    initial_job_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Initial ingest job identifier created during upload",
+    )
+    initial_extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Initial extraction profile identifier created during upload",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=func.now(),

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -28,6 +28,12 @@ class Job(Base):
             ondelete="CASCADE",
             name="fk_jobs_file_id_project_id_files",
         ),
+        ForeignKeyConstraint(
+            ["extraction_profile_id", "project_id"],
+            ["extraction_profiles.id", "extraction_profiles.project_id"],
+            ondelete="CASCADE",
+            name="fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -45,6 +51,14 @@ class Job(Base):
         nullable=False,
         index=True,
         comment="Associated file identifier",
+    )
+    extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment=(
+            "Immutable extraction profile identifier. Nullable only during the "
+            "expand/rollback window; a future contract migration can enforce NOT NULL."
+        ),
     )
     job_type: Mapped[str] = mapped_column(
         String(64),

--- a/app/schemas/extraction_profile.py
+++ b/app/schemas/extraction_profile.py
@@ -1,0 +1,166 @@
+"""Pydantic schemas for immutable extraction profile payloads."""
+
+import math
+import uuid
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+AllowedUnitsOverride = Literal["metric", "imperial", "mm", "cm", "m", "inch", "foot", "feet"]
+LayoutMode = Literal["auto", "model_space", "paper_space"]
+XrefHandling = Literal["preserve", "inline", "detach"]
+BlockHandling = Literal["expand", "preserve"]
+
+class RasterCalibration(BaseModel):
+    """Strict raster calibration payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scale: int | float = Field(
+        ...,
+        description="Positive calibration scale factor",
+    )
+    unit: AllowedUnitsOverride = Field(
+        ...,
+        description="Calibration unit",
+    )
+
+    @field_validator("scale", mode="before")
+    @classmethod
+    def validate_scale(cls, value: Any) -> Any:
+        """Require a positive numeric scale without coercing strings/bools."""
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int | float)
+            or not math.isfinite(value)
+            or value <= 0
+        ):
+            raise ValueError("raster_calibration.scale must be a positive number.")
+        return value
+
+
+class ExtractionProfileCreate(BaseModel):
+    """Request payload for creating a new immutable extraction profile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    profile_version: Literal["v0.1"] = Field(
+        default="v0.1",
+        description="Extraction profile schema version",
+    )
+    units_override: AllowedUnitsOverride | None = Field(
+        default=None,
+        description="Optional extraction units override",
+    )
+    layout_mode: LayoutMode = Field(
+        default="auto",
+        description="Layout extraction mode",
+    )
+    xref_handling: XrefHandling = Field(
+        default="preserve",
+        description="External reference handling mode",
+    )
+    block_handling: BlockHandling = Field(
+        default="expand",
+        description="Block extraction handling mode",
+    )
+    text_extraction: bool = Field(
+        default=True,
+        description="Whether text extraction is enabled",
+    )
+    dimension_extraction: bool = Field(
+        default=True,
+        description="Whether dimension extraction is enabled",
+    )
+    pdf_page_range: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Optional PDF page range selector",
+    )
+    raster_calibration: RasterCalibration | None = Field(
+        default=None,
+        description="Optional raster calibration payload",
+    )
+    confidence_threshold: float = Field(
+        default=0.6,
+        ge=0.0,
+        le=1.0,
+        description="Minimum confidence threshold for extracted results",
+    )
+
+    @field_validator("pdf_page_range")
+    @classmethod
+    def validate_pdf_page_range(cls, value: str | None) -> str | None:
+        """Reject blank or malformed PDF page range selectors."""
+        if value is None:
+            return None
+
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("pdf_page_range must not be blank.")
+
+        normalized_tokens: list[str] = []
+        for raw_token in normalized.split(","):
+            token = raw_token.strip()
+            if not token:
+                raise ValueError(
+                    "pdf_page_range must use comma-separated positive pages or page ranges."
+                )
+
+            if "-" not in token:
+                if not token.isdigit() or int(token) <= 0:
+                    raise ValueError(
+                        "pdf_page_range must use comma-separated positive pages or page ranges."
+                    )
+                normalized_tokens.append(token)
+                continue
+
+            if token.count("-") != 1:
+                raise ValueError(
+                    "pdf_page_range must use comma-separated positive pages or page ranges."
+                )
+
+            start_raw, end_raw = token.split("-", maxsplit=1)
+            if not start_raw.isdigit() or not end_raw.isdigit():
+                raise ValueError(
+                    "pdf_page_range must use comma-separated positive pages or page ranges."
+                )
+
+            start = int(start_raw)
+            end = int(end_raw)
+            if start <= 0 or end <= 0 or start > end:
+                raise ValueError(
+                    "pdf_page_range must use comma-separated positive pages or page ranges."
+                )
+
+            normalized_tokens.append(f"{start}-{end}")
+
+        return ", ".join(normalized_tokens)
+
+
+class FileReprocessRequest(BaseModel):
+    """Request payload for reprocessing an existing file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    extraction_profile_id: uuid.UUID | None = Field(
+        default=None,
+        description="Existing immutable extraction profile identifier",
+    )
+    extraction_profile: ExtractionProfileCreate | None = Field(
+        default=None,
+        description="New immutable extraction profile payload",
+    )
+
+    @model_validator(mode="after")
+    def validate_profile_selection(self) -> "FileReprocessRequest":
+        """Require exactly one extraction profile selector."""
+        provided_values = (
+            int(self.extraction_profile_id is not None)
+            + int(self.extraction_profile is not None)
+        )
+        if provided_values != 1:
+            raise ValueError(
+                "Provide exactly one of extraction_profile_id or extraction_profile."
+            )
+        return self

--- a/app/schemas/file.py
+++ b/app/schemas/file.py
@@ -19,6 +19,14 @@ class FileRead(BaseModel):
     size_bytes: int = Field(..., ge=0, description="Uploaded file size in bytes")
     checksum_sha256: str = Field(..., min_length=64, max_length=64, description="SHA-256 checksum")
     immutable: bool = Field(..., description="Whether original upload is immutable")
+    initial_job_id: uuid.UUID | None = Field(
+        None,
+        description="Initial ingest job identifier created during upload",
+    )
+    initial_extraction_profile_id: uuid.UUID | None = Field(
+        None,
+        description="Initial extraction profile identifier created during upload",
+    )
     created_at: datetime = Field(..., description="File creation timestamp")
 
 

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -17,6 +17,14 @@ class JobRead(BaseModel):
     id: uuid.UUID = Field(..., description="Unique job identifier (UUID)")
     project_id: uuid.UUID = Field(..., description="Owning project identifier")
     file_id: uuid.UUID = Field(..., description="Associated file identifier")
+    extraction_profile_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Immutable extraction profile identifier. Nullable for historical jobs "
+            "during the migration rollback window; future contract migration can "
+            "enforce non-null."
+        ),
+    )
     job_type: str = Field(..., description="Job type")
     status: str = Field(..., description="Job status")
     attempts: int = Field(..., ge=0, description="Current attempt count")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,6 +132,7 @@ AI must not directly write CAD files or compute final quantities/prices.
 ```text
 Upload
   -> file record
+     (durable `initial_job_id` + `initial_extraction_profile_id` lineage)
   -> extraction profile selection/persistence
   -> ingestion job (file_id + extraction_profile_id)
   -> source adapter

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -594,7 +594,8 @@ Database ownership and append-only policy:
 
 - Original file rows are API-created metadata for immutable uploads; workers may
   read them, but never replace the original object or rewrite the row as a new
-  source.
+  source. Upload responses and file-read responses must expose the durable
+  initial lineage fields `initial_job_id` and `initial_extraction_profile_id`.
 - Drawing revisions, approved quantity takeoffs, finalized estimate versions,
   export artifacts, and `job_events` are append-only historical records.
 - Mutable workflow/state records include job status, attempt counters, progress,
@@ -626,6 +627,10 @@ prior one.
 - Ids are opaque ULIDs or UUIDs; clients must not parse them.
 - Idempotent mutating endpoints accept `Idempotency-Key` headers and return the
   prior response on replay within a documented retention window.
+- When job enqueue fails after durable records are created, the public error must
+  stay sanitized and may include only safe identifiers already assigned by the
+  system, such as `file_id`, `job_id`, or `extraction_profile_id` where
+  applicable.
 
 ## Error Taxonomy
 
@@ -914,15 +919,18 @@ Probe rules:
   for the run, and records the adapter name/version that produced the result.
 - The prior revision remains available for lineage, comparison, and audit even
   when the newer reprocessed revision supersedes it.
-- API direction for future `POST /v1/files/{file_id}/reprocess`:
-  - request body should accept either an existing `extraction_profile_id` or a
-    profile payload to persist as a new extraction profile before job creation
-  - the server creates a new ingestion/reprocessing job bound to `file_id` and
-    the resolved `extraction_profile_id`
+- Reprocess API contract: `POST /v1/projects/{project_id}/files/{file_id}/reprocess`
+  - request body accepts exactly one of an existing `extraction_profile_id` or a
+    new extraction profile payload to persist before job creation
+  - the server creates a new ingestion/reprocessing job bound to `project_id`,
+    `file_id`, and the resolved `extraction_profile_id`
   - successful completion creates a new drawing revision rather than mutating
     the previous revision in place
   - the resulting revision must expose adapter version, extraction profile, and
     predecessor/superseded lineage metadata
+  - during the expand/rollback window for this contract, `jobs.extraction_profile_id`
+    may remain nullable even though file initial lineage and resolved reprocess
+    lineage are durable
 - `provenance_json` is a structured object, not free text. Required keys:
   `origin`, `adapter`, `source_ref`, `source_identity`, `source_hash`,
   `extraction_path`, `notes`.

--- a/tests/test_extraction_profiles.py
+++ b/tests/test_extraction_profiles.py
@@ -1,0 +1,834 @@
+"""Integration tests for immutable extraction profiles and reprocessing."""
+
+import importlib.util
+import math
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from pydantic import ValidationError
+from sqlalchemy import select, text
+
+import app.api.v1.files as files_api
+import app.db.session as session_module
+from app.models.extraction_profile import ExtractionProfile
+from app.models.job import Job
+from app.schemas.extraction_profile import ExtractionProfileCreate
+from app.schemas.job import JobRead
+from tests.conftest import requires_database
+
+
+async def _create_project(async_client: httpx.AsyncClient) -> dict[str, Any]:
+    """Create a project and return its payload."""
+    response = await async_client.post(
+        "/v1/projects",
+        json={
+            "name": "Extraction Profile Test Project",
+            "description": "A project for extraction profile tests",
+        },
+    )
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json())
+
+
+async def _upload_file(
+    async_client: httpx.AsyncClient,
+    project_id: str,
+) -> dict[str, Any]:
+    """Upload a supported file and return its payload."""
+    response = await async_client.post(
+        f"/v1/projects/{project_id}/files",
+        files={"file": ("plan.pdf", b"%PDF-1.7\nprofile-test\n", "application/pdf")},
+    )
+    assert response.status_code == 201
+    return cast(dict[str, Any], response.json())
+
+
+async def _get_jobs_for_file(file_id: str) -> list[Job]:
+    """Load all jobs for a file ordered by creation time."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(Job)
+            .where(Job.file_id == uuid.UUID(file_id))
+            .order_by(Job.created_at.asc(), Job.id.asc())
+        )
+        return list(result.scalars())
+
+
+async def _get_extraction_profile(profile_id: uuid.UUID) -> ExtractionProfile:
+    """Load a profile by id."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        profile = await session.get(ExtractionProfile, profile_id)
+
+    assert profile is not None
+    return profile
+
+
+@pytest.fixture
+def stub_enqueue_ingest_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub enqueue publish so tests do not require RabbitMQ."""
+
+    def _fake_enqueue(job_id: uuid.UUID) -> None:
+        _ = job_id
+
+    monkeypatch.setattr(files_api, "enqueue_ingest_job", _fake_enqueue)
+
+
+@requires_database
+class TestExtractionProfiles:
+    """Tests for immutable extraction profile persistence and reprocessing."""
+
+    async def test_upload_creates_default_v0_1_profile(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Uploading should create a default immutable extraction profile."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        jobs = await _get_jobs_for_file(str(uploaded["id"]))
+
+        assert len(jobs) == 1
+        assert jobs[0].extraction_profile_id is not None
+        assert uploaded["initial_job_id"] == str(jobs[0].id)
+        assert uploaded["initial_extraction_profile_id"] == str(jobs[0].extraction_profile_id)
+
+        profile = await _get_extraction_profile(jobs[0].extraction_profile_id)
+        assert profile.project_id == uuid.UUID(project["id"])
+        assert profile.profile_version == "v0.1"
+        assert profile.units_override is None
+        assert profile.layout_mode == "auto"
+        assert profile.xref_handling == "preserve"
+        assert profile.block_handling == "expand"
+        assert profile.text_extraction is True
+        assert profile.dimension_extraction is True
+        assert profile.pdf_page_range is None
+        assert profile.raster_calibration is None
+        assert profile.confidence_threshold == pytest.approx(0.6)
+
+    async def test_reprocess_reuses_existing_profile_by_id(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Reprocessing should allow creating a new job from an existing profile id."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        original_jobs = await _get_jobs_for_file(str(uploaded["id"]))
+        original_job = original_jobs[0]
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(original_job.extraction_profile_id)},
+        )
+
+        assert response.status_code == 202
+        payload = response.json()
+        assert payload["file_id"] == uploaded["id"]
+        assert payload["project_id"] == project["id"]
+        assert payload["job_type"] == "ingest"
+        assert payload["status"] == "pending"
+        assert payload["extraction_profile_id"] == str(original_job.extraction_profile_id)
+
+        jobs = await _get_jobs_for_file(str(uploaded["id"]))
+        assert len(jobs) == 2
+        assert jobs[0].id == original_job.id
+        assert jobs[0].extraction_profile_id == original_job.extraction_profile_id
+        assert jobs[1].id != original_job.id
+        assert jobs[1].extraction_profile_id == original_job.extraction_profile_id
+
+    async def test_reprocess_creates_new_profile_from_payload(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Reprocessing should allow creating a new immutable profile from request payload."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        original_jobs = await _get_jobs_for_file(str(uploaded["id"]))
+        original_job = original_jobs[0]
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile": {
+                    "profile_version": "v0.1",
+                    "units_override": "imperial",
+                    "layout_mode": "paper_space",
+                    "xref_handling": "detach",
+                    "block_handling": "preserve",
+                    "text_extraction": False,
+                    "dimension_extraction": True,
+                    "pdf_page_range": "2-4",
+                    "raster_calibration": {"scale": 48, "unit": "inch"},
+                    "confidence_threshold": 0.95,
+                }
+            },
+        )
+
+        assert response.status_code == 202
+        payload = response.json()
+        assert payload["extraction_profile_id"] != str(original_job.extraction_profile_id)
+
+        jobs = await _get_jobs_for_file(str(uploaded["id"]))
+        assert len(jobs) == 2
+        assert jobs[0].extraction_profile_id == original_job.extraction_profile_id
+        assert jobs[1].extraction_profile_id != original_job.extraction_profile_id
+
+        assert jobs[1].extraction_profile_id is not None
+        profile = await _get_extraction_profile(jobs[1].extraction_profile_id)
+        assert profile.project_id == uuid.UUID(project["id"])
+        assert profile.profile_version == "v0.1"
+        assert profile.units_override == "imperial"
+        assert profile.layout_mode == "paper_space"
+        assert profile.xref_handling == "detach"
+        assert profile.block_handling == "preserve"
+        assert profile.text_extraction is False
+        assert profile.dimension_extraction is True
+        assert profile.pdf_page_range == "2-4"
+        assert profile.raster_calibration == {"scale": 48, "unit": "inch"}
+        assert profile.confidence_threshold == pytest.approx(0.95)
+
+    async def test_reprocess_rejects_profile_from_another_project(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Reprocessing should enforce project ownership for existing profiles."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        first_project = await _create_project(async_client)
+        second_project = await _create_project(async_client)
+
+        first_file = await _upload_file(async_client, first_project["id"])
+        second_file = await _upload_file(async_client, second_project["id"])
+
+        foreign_jobs = await _get_jobs_for_file(str(second_file["id"]))
+        foreign_job = foreign_jobs[0]
+        response = await async_client.post(
+            f"/v1/projects/{first_project['id']}/files/{first_file['id']}/reprocess",
+            json={"extraction_profile_id": str(foreign_job.extraction_profile_id)},
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": (
+                    "ExtractionProfile with identifier "
+                    f"'{foreign_job.extraction_profile_id}' not found"
+                ),
+                "details": None,
+            }
+        }
+
+    async def test_reprocess_rejects_unknown_extraction_profile_fields(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Reprocessing should reject unexpected extraction profile keys."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile": {
+                    "unexpected": True,
+                }
+            },
+        )
+
+        assert response.status_code == 422
+        assert "unexpected" in response.text
+        assert "extra_forbidden" in response.text
+
+    async def test_reprocess_rejects_unknown_top_level_fields(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Reprocessing should reject unexpected top-level request keys."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile_id": uploaded["initial_extraction_profile_id"],
+                "unexpected": True,
+            },
+        )
+
+        assert response.status_code == 422
+        assert "unexpected" in response.text
+        assert "extra_forbidden" in response.text
+
+    async def test_reprocess_rejects_invalid_extraction_profile_enum_values(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Reprocessing should reject unsupported profile enum values."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile": {
+                    "units_override": "yards",
+                }
+            },
+        )
+
+        assert response.status_code == 422
+        assert "units_override" in response.text
+        assert "yards" in response.text
+        assert "literal_error" in response.text
+
+    async def test_reprocess_enqueue_failure_returns_durable_failed_job_details(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reprocess enqueue failures should expose safe durable identifiers."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+
+        def _failing_enqueue(_: uuid.UUID) -> None:
+            raise RuntimeError("broker exploded: amqp://user:secret@mq.internal/vhost")
+
+        monkeypatch.setattr(files_api, "enqueue_ingest_job", _failing_enqueue)
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile": {
+                    "profile_version": "v0.1",
+                    "units_override": "metric",
+                    "layout_mode": "paper_space",
+                    "xref_handling": "detach",
+                    "block_handling": "preserve",
+                    "text_extraction": True,
+                    "dimension_extraction": False,
+                    "pdf_page_range": "1",
+                    "raster_calibration": None,
+                    "confidence_threshold": 0.75,
+                }
+            },
+        )
+
+        assert response.status_code == 500
+        payload = response.json()
+        assert payload["error"]["code"] == "INTERNAL_ERROR"
+        assert payload["error"]["message"] == "Failed to enqueue ingest job"
+        assert payload["error"]["details"] is not None
+        assert "broker exploded" not in response.text
+        assert "amqp://user:secret@mq.internal/vhost" not in response.text
+
+        details = cast(dict[str, str], payload["error"]["details"])
+        jobs = await _get_jobs_for_file(str(uploaded["id"]))
+        assert len(jobs) == 2
+
+        failed_job = jobs[1]
+        assert details == {
+            "job_id": str(failed_job.id),
+            "extraction_profile_id": str(failed_job.extraction_profile_id),
+        }
+        assert failed_job.status == "failed"
+        assert failed_job.error_code == "INTERNAL_ERROR"
+        assert failed_job.error_message == "Failed to enqueue ingest job"
+        assert "broker exploded" not in failed_job.error_message
+        assert failed_job.extraction_profile_id is not None
+
+        failed_profile = await _get_extraction_profile(failed_job.extraction_profile_id)
+        assert str(failed_profile.id) == details["extraction_profile_id"]
+        assert failed_profile.project_id == uuid.UUID(project["id"])
+        assert failed_profile.units_override == "metric"
+        assert failed_profile.layout_mode == "paper_space"
+
+    async def test_jobs_column_stays_nullable_for_expand_contract_rollback_window(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        stub_enqueue_ingest_job: None,
+    ) -> None:
+        """Head schema must still allow legacy inserts without extraction_profile_id."""
+        _ = self
+        _ = cleanup_projects
+        _ = stub_enqueue_ingest_job
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        legacy_job_id = uuid.uuid4()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO jobs (
+                        id,
+                        project_id,
+                        file_id,
+                        job_type,
+                        status,
+                        attempts,
+                        max_attempts,
+                        cancel_requested
+                    ) VALUES (
+                        :id,
+                        :project_id,
+                        :file_id,
+                        :job_type,
+                        :status,
+                        :attempts,
+                        :max_attempts,
+                        :cancel_requested
+                    )
+                    """
+                ),
+                {
+                    "id": legacy_job_id,
+                    "project_id": uuid.UUID(project["id"]),
+                    "file_id": uuid.UUID(uploaded["id"]),
+                    "job_type": "ingest",
+                    "status": "pending",
+                    "attempts": 0,
+                    "max_attempts": 3,
+                    "cancel_requested": False,
+                },
+            )
+            await session.commit()
+
+        jobs = await _get_jobs_for_file(str(uploaded["id"]))
+        legacy_job = next(job for job in jobs if job.id == legacy_job_id)
+        assert legacy_job.extraction_profile_id is None
+
+    async def test_migration_upgrade_backfills_profiles_and_initial_lineage(
+        self,
+    ) -> None:
+        """Upgrade should backfill profiles now while leaving NOT NULL for a later contract step."""
+        _ = self
+
+        engine = session_module.get_engine()
+        assert engine is not None
+
+        schema_name = f"test_extract_profiles_{uuid.uuid4().hex}"
+        migration = _load_extraction_profiles_migration()
+        project_id = uuid.uuid4()
+        file_id = uuid.uuid4()
+        first_ingest_job_id = uuid.uuid4()
+        second_ingest_job_id = uuid.uuid4()
+        export_job_id = uuid.uuid4()
+
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(_install_pre_0004_schema)
+
+                await conn.execute(
+                    text("INSERT INTO projects (id) VALUES (:id)"),
+                    {"id": project_id},
+                )
+                await conn.execute(
+                    text("INSERT INTO files (id, project_id) VALUES (:id, :project_id)"),
+                    {"id": file_id, "project_id": project_id},
+                )
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO jobs (
+                            id,
+                            project_id,
+                            file_id,
+                            job_type,
+                            status,
+                            attempts,
+                            max_attempts,
+                            cancel_requested,
+                            created_at
+                        ) VALUES (
+                            :id,
+                            :project_id,
+                            :file_id,
+                            :job_type,
+                            :status,
+                            0,
+                            3,
+                            false,
+                            :created_at
+                        )
+                        """
+                    ),
+                    [
+                        {
+                            "id": first_ingest_job_id,
+                            "project_id": project_id,
+                            "file_id": file_id,
+                            "job_type": "ingest",
+                            "status": "succeeded",
+                            "created_at": datetime(2026, 5, 1, tzinfo=UTC),
+                        },
+                        {
+                            "id": second_ingest_job_id,
+                            "project_id": project_id,
+                            "file_id": file_id,
+                            "job_type": "ingest",
+                            "status": "pending",
+                            "created_at": datetime(2026, 5, 2, tzinfo=UTC),
+                        },
+                        {
+                            "id": export_job_id,
+                            "project_id": project_id,
+                            "file_id": file_id,
+                            "job_type": "export",
+                            "status": "pending",
+                            "created_at": datetime(2026, 5, 3, tzinfo=UTC),
+                        },
+                    ],
+                )
+
+                await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+                jobs = (
+                    (
+                        await conn.execute(
+                            text(
+                                """
+                                SELECT id, extraction_profile_id
+                                FROM jobs
+                                ORDER BY created_at ASC, id ASC
+                                """
+                            )
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                assert len(jobs) == 3
+                profile_ids = {row["extraction_profile_id"] for row in jobs}
+                assert len(profile_ids) == 1
+                assert None not in profile_ids
+                profile_id = next(iter(profile_ids))
+
+                extraction_profiles = (
+                    (
+                        await conn.execute(
+                            text(
+                                """
+                                SELECT id, project_id, profile_version, layout_mode, xref_handling,
+                                       block_handling, text_extraction, dimension_extraction,
+                                       pdf_page_range, raster_calibration, confidence_threshold
+                                FROM extraction_profiles
+                                """
+                            )
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                assert len(extraction_profiles) == 1
+                assert extraction_profiles[0]["id"] == profile_id
+                assert extraction_profiles[0]["project_id"] == project_id
+                assert extraction_profiles[0]["profile_version"] == "v0.1"
+                assert extraction_profiles[0]["layout_mode"] == "auto"
+                assert extraction_profiles[0]["xref_handling"] == "preserve"
+                assert extraction_profiles[0]["block_handling"] == "expand"
+                assert extraction_profiles[0]["text_extraction"] is True
+                assert extraction_profiles[0]["dimension_extraction"] is True
+                assert extraction_profiles[0]["pdf_page_range"] is None
+                assert extraction_profiles[0]["raster_calibration"] is None
+                assert extraction_profiles[0]["confidence_threshold"] == pytest.approx(0.6)
+
+                file_row = (
+                    (
+                        await conn.execute(
+                            text(
+                                """
+                                SELECT initial_job_id, initial_extraction_profile_id
+                                FROM files
+                                WHERE id = :file_id
+                                """
+                            ),
+                            {"file_id": file_id},
+                        )
+                    )
+                    .mappings()
+                    .one()
+                )
+                assert file_row == {
+                    "initial_job_id": first_ingest_job_id,
+                    "initial_extraction_profile_id": profile_id,
+                }
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+def _load_extraction_profiles_migration() -> Any:
+    """Load the extraction profiles migration module directly from disk."""
+    migration_path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "2026_05_05_0004_add_extraction_profiles.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_05_0004_add_extraction_profiles",
+        migration_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_pre_0004_schema(sync_conn: sa.Connection) -> None:
+    """Create the minimal pre-0004 schema needed to exercise the migration."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "projects",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+    )
+    sa.Table(
+        "files",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+    )
+    sa.Table(
+        "jobs",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("file_id", sa.Uuid(), nullable=False),
+        sa.Column("job_type", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("max_attempts", sa.Integer(), nullable=False, server_default=sa.text("3")),
+        sa.Column(
+            "cancel_requested",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("error_code", sa.String(length=128), nullable=True),
+        sa.Column("error_message", sa.String(length=2048), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    metadata.create_all(sync_conn)
+
+
+def _run_migration_upgrade(sync_conn: sa.Connection, migration: Any) -> None:
+    """Run the extraction-profile upgrade against a live connection."""
+    migration_context = MigrationContext.configure(sync_conn)
+    migration.op = Operations(migration_context)
+    migration.upgrade()
+
+
+class _FakeScalarResult:
+    """Small scalar result stand-in for migration guard tests."""
+
+    def __init__(self, value: bool) -> None:
+        self._value = value
+
+    def scalar(self) -> bool:
+        """Return the configured scalar value."""
+        return self._value
+
+
+class _FakeBind:
+    """Minimal Alembic bind double for downgrade guard tests."""
+
+    def __init__(self, *, profile_rows_exist: bool) -> None:
+        self.profile_rows_exist = profile_rows_exist
+
+    def execute(self, *_: Any, **__: Any) -> _FakeScalarResult:
+        """Return the configured extraction-profile existence result."""
+        return _FakeScalarResult(self.profile_rows_exist)
+
+
+class _FakeOp:
+    """Minimal Alembic op double for downgrade guard tests."""
+
+    def __init__(self, *, profile_rows_exist: bool) -> None:
+        self._bind = _FakeBind(profile_rows_exist=profile_rows_exist)
+        self.drop_calls: list[tuple[str, str]] = []
+
+    def get_bind(self) -> _FakeBind:
+        """Return the fake bind used by the downgrade guard."""
+        return self._bind
+
+    def drop_constraint(self, name: str, table_name: str, *, type_: str) -> None:
+        """Record drop calls that would mutate schema state."""
+        _ = type_
+        self.drop_calls.append(("drop_constraint", f"{table_name}:{name}"))
+
+    def drop_index(self, name: str, *, table_name: str) -> None:
+        """Record drop index calls."""
+        self.drop_calls.append(("drop_index", f"{table_name}:{name}"))
+
+    def drop_column(self, table_name: str, column_name: str) -> None:
+        """Record drop column calls."""
+        self.drop_calls.append(("drop_column", f"{table_name}:{column_name}"))
+
+    def drop_table(self, table_name: str) -> None:
+        """Record drop table calls."""
+        self.drop_calls.append(("drop_table", table_name))
+
+    def f(self, name: str) -> str:
+        """Mimic Alembic naming helper passthrough."""
+        return name
+
+
+def test_extraction_profiles_migration_downgrade_raises_when_rows_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Downgrade should refuse to drop profile lineage when rows already exist."""
+    migration = _load_extraction_profiles_migration()
+    fake_op = _FakeOp(profile_rows_exist=True)
+    monkeypatch.setattr(migration, "op", fake_op)
+
+    with pytest.raises(RuntimeError, match="Manual data-preserving rollback is required"):
+        migration.downgrade()
+
+    assert fake_op.drop_calls == []
+
+
+def test_job_read_accepts_null_extraction_profile_id_during_rollback_window() -> None:
+    """Read schema should tolerate historical jobs until the contract migration lands."""
+    job = JobRead.model_validate(
+        {
+            "id": uuid.uuid4(),
+            "project_id": uuid.uuid4(),
+            "file_id": uuid.uuid4(),
+            "extraction_profile_id": None,
+            "job_type": "ingest",
+            "status": "pending",
+            "attempts": 0,
+            "max_attempts": 3,
+            "cancel_requested": False,
+            "error_code": None,
+            "error_message": None,
+            "started_at": None,
+            "finished_at": None,
+            "created_at": datetime(2026, 5, 5, tzinfo=UTC),
+        }
+    )
+
+    assert job.extraction_profile_id is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["1--3", "0", "-1", "1,", ",1", "1,,2", "3-1", "1-0"],
+)
+def test_extraction_profile_create_rejects_malformed_pdf_page_ranges(value: str) -> None:
+    """Schema should reject malformed page selectors before reprocess jobs are created."""
+    with pytest.raises(ValidationError, match="pdf_page_range"):
+        ExtractionProfileCreate(pdf_page_range=value)
+
+
+def test_extraction_profile_create_accepts_csv_page_ranges_and_strict_raster_calibration() -> None:
+    """Schema should accept valid page ranges and typed raster calibration payloads."""
+    profile = ExtractionProfileCreate.model_validate(
+        {
+            "pdf_page_range": "1, 2-4",
+            "raster_calibration": {"scale": 48, "unit": "inch"},
+        }
+    )
+
+    assert profile.pdf_page_range == "1, 2-4"
+    assert profile.raster_calibration is not None
+    assert profile.raster_calibration.model_dump() == {"scale": 48, "unit": "inch"}
+
+
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        ({"scale": 48, "unit": "inch", "extra": True}, "extra_forbidden"),
+        ({"scale": 0, "unit": "inch"}, "raster_calibration.scale"),
+        ({"scale": -1, "unit": "inch"}, "raster_calibration.scale"),
+        ({"scale": math.inf, "unit": "inch"}, "raster_calibration.scale"),
+        ({"scale": -math.inf, "unit": "inch"}, "raster_calibration.scale"),
+        ({"scale": math.nan, "unit": "inch"}, "raster_calibration.scale"),
+        ({"scale": "48", "unit": "inch"}, "raster_calibration.scale"),
+        ({"scale": 48, "unit": "yards"}, "literal_error"),
+    ],
+)
+def test_extraction_profile_create_rejects_invalid_raster_calibration(
+    value: dict[str, Any],
+    match: str,
+) -> None:
+    """Schema should enforce strict raster calibration shape and values."""
+    with pytest.raises(ValidationError, match=match):
+        ExtractionProfileCreate.model_validate({"raster_calibration": value})

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import uuid
 from collections.abc import AsyncGenerator, Callable
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -208,6 +209,8 @@ class TestProjectFiles:
         assert uploaded["size_bytes"] == len(payload)
         assert uploaded["checksum_sha256"] == hashlib.sha256(payload).hexdigest()
         assert uploaded["immutable"] is True
+        assert "initial_job_id" in uploaded
+        assert "initial_extraction_profile_id" in uploaded
         assert "created_at" in uploaded
         assert "storage_uri" not in uploaded
 
@@ -241,6 +244,11 @@ class TestProjectFiles:
         assert job is not None
         assert job.project_id == uuid.UUID(str(created_project["id"]))
         assert job.file_id == uuid.UUID(str(uploaded["id"]))
+        assert job.extraction_profile_id is not None
+        assert file_row.initial_job_id == job.id
+        assert file_row.initial_extraction_profile_id == job.extraction_profile_id
+        assert uploaded["initial_job_id"] == str(job.id)
+        assert uploaded["initial_extraction_profile_id"] == str(job.extraction_profile_id)
         assert job.job_type == "ingest"
         assert job.status == "pending"
         assert job.attempts == 0
@@ -406,6 +414,69 @@ class TestProjectFiles:
         returned_ids = {item["id"] for item in data["items"]}
         assert returned_ids == {first["id"], second["id"]}
 
+    async def test_list_project_files_includes_initial_upload_metadata_after_reprocess(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET list should read durable initial ingest identifiers from the file row."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="initial.pdf",
+            content=b"%PDF-1.7\ninitial",
+            media_type="application/pdf",
+        )
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile": {
+                    "profile_version": "v0.1",
+                    "units_override": "imperial",
+                    "layout_mode": "paper_space",
+                    "xref_handling": "detach",
+                    "block_handling": "preserve",
+                    "text_extraction": False,
+                    "dimension_extraction": True,
+                    "pdf_page_range": "2-4",
+                    "raster_calibration": {"scale": 48, "unit": "inch"},
+                    "confidence_threshold": 0.95,
+                }
+            },
+        )
+        assert response.status_code == 202
+        reprocess_job = response.json()
+        assert reprocess_job["id"] != uploaded["initial_job_id"]
+        assert reprocess_job["extraction_profile_id"] != uploaded["initial_extraction_profile_id"]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            initial_job = await session.get(Job, uuid.UUID(str(uploaded["initial_job_id"])))
+            latest_job = await session.get(Job, uuid.UUID(str(reprocess_job["id"])))
+            file_row = await session.get(FileModel, uuid.UUID(str(uploaded["id"])))
+
+            assert initial_job is not None
+            assert latest_job is not None
+            assert file_row is not None
+
+            latest_created_at = latest_job.created_at or datetime.now(UTC)
+            initial_job.created_at = latest_created_at + timedelta(seconds=1)
+            await session.commit()
+
+            assert file_row.initial_job_id == initial_job.id
+            assert file_row.initial_extraction_profile_id == initial_job.extraction_profile_id
+
+        list_response = await async_client.get(f"/v1/projects/{created_project['id']}/files")
+        assert list_response.status_code == 200
+
+        item = list_response.json()["items"][0]
+        assert item["id"] == uploaded["id"]
+        assert item["initial_job_id"] == uploaded["initial_job_id"]
+        assert item["initial_extraction_profile_id"] == uploaded["initial_extraction_profile_id"]
+
     async def test_list_project_files_pagination(
         self,
         async_client: httpx.AsyncClient,
@@ -503,6 +574,53 @@ class TestProjectFiles:
         assert data["id"] == uploaded["id"]
         assert data["project_id"] == created_project["id"]
         assert data["original_filename"] == "detail.ifc"
+
+    async def test_get_project_file_detail_includes_initial_upload_metadata_after_reprocess(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET detail should preserve earliest ingest identifiers after reprocessing."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="detail.pdf",
+            content=b"%PDF-1.7\ndetail",
+            media_type="application/pdf",
+        )
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}/reprocess",
+            json={
+                "extraction_profile": {
+                    "profile_version": "v0.1",
+                    "units_override": "metric",
+                    "layout_mode": "paper_space",
+                    "xref_handling": "detach",
+                    "block_handling": "preserve",
+                    "text_extraction": True,
+                    "dimension_extraction": False,
+                    "pdf_page_range": "1",
+                    "raster_calibration": None,
+                    "confidence_threshold": 0.75,
+                }
+            },
+        )
+        assert response.status_code == 202
+        reprocess_job = response.json()
+        assert reprocess_job["id"] != uploaded["initial_job_id"]
+        assert reprocess_job["extraction_profile_id"] != uploaded["initial_extraction_profile_id"]
+
+        detail_response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}"
+        )
+        assert detail_response.status_code == 200
+
+        data = detail_response.json()
+        assert data["id"] == uploaded["id"]
+        assert data["initial_job_id"] == uploaded["initial_job_id"]
+        assert data["initial_extraction_profile_id"] == uploaded["initial_extraction_profile_id"]
 
     async def test_get_project_file_not_found(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -145,6 +145,45 @@ def enqueued_job_ids(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     return recorded_job_ids
 
 
+async def test_mark_recovery_enqueue_failed_logs_only_safe_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recovery enqueue failure logging should exclude exception text and traceback."""
+    job_id = uuid.uuid4()
+    logger_error_calls: list[tuple[str, dict[str, Any]]] = []
+    marked_failed_job_ids: list[uuid.UUID] = []
+
+    async def _fake_mark_job_failed(
+        failed_job_id: uuid.UUID,
+        *,
+        error_message: str,
+        error_code: ErrorCode = ErrorCode.INTERNAL_ERROR,
+    ) -> None:
+        marked_failed_job_ids.append(failed_job_id)
+        assert error_message == "Failed to enqueue ingest job"
+        assert error_code == ErrorCode.INTERNAL_ERROR
+
+    def _capture_logger_error(event: str, **kwargs: Any) -> None:
+        logger_error_calls.append((event, kwargs))
+
+    monkeypatch.setattr(worker_module, "_mark_job_failed", _fake_mark_job_failed)
+    monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
+
+    await worker_module._mark_recovery_enqueue_failed(job_id)
+
+    assert marked_failed_job_ids == [job_id]
+    assert logger_error_calls == [
+        (
+            "ingest_job_recovery_enqueue_failed",
+            {
+                "job_id": str(job_id),
+                "error_code": ErrorCode.INTERNAL_ERROR.value,
+                "recovery_action": "mark_failed",
+            },
+        )
+    ]
+
+
 @requires_database
 class TestJobs:
     """Tests for job status retrieval and worker state transitions."""
@@ -189,7 +228,9 @@ class TestJobs:
         assert job.status == "failed"
         assert job.attempts == 0
         assert job.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert job.error_message == "Failed to enqueue ingest job: broker unavailable"
+        assert job.error_message == "Failed to enqueue ingest job"
+        assert "broker unavailable" not in job.error_message
+        assert len(job.error_message) <= 255
         assert job.started_at is None
         assert job.finished_at is not None
 
@@ -245,6 +286,7 @@ class TestJobs:
         assert data["id"] == str(job.id)
         assert data["project_id"] == project["id"]
         assert data["file_id"] == uploaded["id"]
+        assert data["extraction_profile_id"] == str(job.extraction_profile_id)
         assert data["job_type"] == "ingest"
         assert data["status"] == "pending"
         assert data["attempts"] == 0
@@ -683,6 +725,68 @@ class TestJobs:
         assert unchanged_job.attempts == 1
         assert unchanged_job.started_at is not None
 
+    async def test_recover_incomplete_ingest_jobs_sanitizes_enqueue_failure_details(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker startup recovery should not persist raw enqueue exception text."""
+        _ = self
+        _ = cleanup_projects
+
+        secret_broker_text = "amqp://user:super-secret-password@broker/vhost timed out"
+        logger_error_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _fail_recovery_enqueue(_: uuid.UUID) -> None:
+            raise RuntimeError(secret_broker_text)
+
+        def _capture_logger_error(event: str, **kwargs: Any) -> None:
+            logger_error_calls.append((event, kwargs))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fail_recovery_enqueue)
+        monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        enqueued_job_ids.clear()
+
+        requeued = await recover_incomplete_ingest_jobs()
+
+        assert requeued == []
+
+        failed_job = await _get_job(job.id)
+        assert failed_job.status == "failed"
+        assert failed_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert failed_job.error_message == "Failed to enqueue ingest job"
+        assert secret_broker_text not in failed_job.error_message
+        assert len(failed_job.error_message) <= 255
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == ["Job failed"]
+        assert data["items"][0]["data_json"] == {
+            "status": "failed",
+            "error_code": ErrorCode.INTERNAL_ERROR.value,
+            "error_message": "Failed to enqueue ingest job",
+        }
+        assert secret_broker_text not in str(data["items"][0]["data_json"])
+        assert data["next_cursor"] is None
+
+        assert logger_error_calls == [
+            (
+                "ingest_job_recovery_enqueue_failed",
+                {
+                    "job_id": str(job.id),
+                    "error_code": ErrorCode.INTERNAL_ERROR.value,
+                    "recovery_action": "mark_failed",
+                },
+            )
+        ]
+
     async def test_process_ingest_job_ignores_duplicate_delivery_after_success(
         self,
         async_client: httpx.AsyncClient,
@@ -871,7 +975,9 @@ class TestJobs:
         updated = await _get_job(job.id)
         assert updated.status == "failed"
         assert updated.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert updated.error_message == "Failed to enqueue ingest job: broker unavailable"
+        assert updated.error_message == "Failed to enqueue ingest job"
+        assert "broker unavailable" not in updated.error_message
+        assert len(updated.error_message) <= 255
         assert updated.finished_at is not None
 
     async def test_retry_job_noops_when_attempt_limit_reached(


### PR DESCRIPTION
Closes #90

## Summary
- add immutable extraction profiles and thread `extraction_profile_id` through upload, reprocess, retry, and worker recovery flows
- persist durable initial upload lineage on files, tighten extraction profile validation, and sanitize enqueue-failure persistence, responses, and logs
- add the migration backfill/expand-contract coverage plus API/docs updates for the project-scoped reprocess contract

## Test plan
- [x] `uv run ruff check app tests`
- [x] `uv run mypy app tests`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_issue90_expand_contract_final_validation uv run alembic upgrade head`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_issue90_expand_contract_final_validation uv run pytest`