### PR TITLE
feat: persist ingest output primitives

### DIFF
--- a/alembic/versions/2026_05_05_0005_add_ingest_output_primitives.py
+++ b/alembic/versions/2026_05_05_0005_add_ingest_output_primitives.py
@@ -1,0 +1,775 @@
+"""add ingest output primitives
+
+Revision ID: 2026_05_05_0005
+Revises: 2026_05_05_0004
+Create Date: 2026-05-05 19:55:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_05_0005"
+down_revision: str | None = "2026_05_05_0004"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def _raise_if_table_non_empty(table_name: str) -> None:
+    """Prevent destructive downgrade of append-only output tables with data."""
+    bind = op.get_bind()
+    has_rows = bool(bind.execute(sa.text(f"SELECT EXISTS (SELECT 1 FROM {table_name})")).scalar())
+    if has_rows:
+        raise RuntimeError(
+            "Cannot downgrade revision 2026_05_05_0005 while "
+            f"{table_name} contains rows. Manual data-preserving rollback is required."
+        )
+
+
+def upgrade() -> None:
+    """Create append-only ingest output persistence primitives."""
+    op.create_table(
+        "adapter_run_outputs",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique adapter run output identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "source_file_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Immutable source file identifier used for this adapter run",
+        ),
+        sa.Column(
+            "extraction_profile_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Immutable extraction profile identifier used for this adapter run",
+        ),
+        sa.Column(
+            "source_job_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Job identifier that produced this committed adapter output",
+        ),
+        sa.Column(
+            "adapter_key",
+            sa.String(length=128),
+            nullable=False,
+            comment="Stable adapter registry key used for this adapter run",
+        ),
+        sa.Column(
+            "adapter_version",
+            sa.String(length=64),
+            nullable=False,
+            comment="Adapter version recorded in adapter diagnostics",
+        ),
+        sa.Column(
+            "input_family",
+            sa.String(length=32),
+            nullable=False,
+            comment="Normalized input family processed by this adapter run",
+        ),
+        sa.Column(
+            "canonical_entity_schema_version",
+            sa.String(length=16),
+            nullable=False,
+            comment="Canonical entity schema version for the adapter output payload",
+        ),
+        sa.Column(
+            "canonical_json",
+            sa.JSON(),
+            nullable=False,
+            comment=(
+                "Canonical adapter output payload including layouts, layers, "
+                "blocks, and entities"
+            ),
+        ),
+        sa.Column(
+            "provenance_json",
+            sa.JSON(),
+            nullable=False,
+            comment="Structured adapter provenance payload",
+        ),
+        sa.Column(
+            "confidence_json",
+            sa.JSON(),
+            nullable=False,
+            comment="Structured confidence payload for adapter output review workflows",
+        ),
+        sa.Column(
+            "confidence_score",
+            sa.Float(),
+            nullable=False,
+            comment="Overall adapter confidence score for this committed output",
+        ),
+        sa.Column(
+            "warnings_json",
+            sa.JSON(),
+            nullable=False,
+            comment="Adapter-emitted warnings carried with the committed output envelope",
+        ),
+        sa.Column(
+            "diagnostics_json",
+            sa.JSON(),
+            nullable=False,
+            comment="Adapter diagnostics payload including timing metadata",
+        ),
+        sa.Column(
+            "result_checksum_sha256",
+            sa.String(length=64),
+            nullable=False,
+            comment="SHA-256 checksum of the committed adapter result envelope",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="Adapter output record creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(
+            ["extraction_profile_id", "project_id"],
+            ["extraction_profiles.id", "extraction_profiles.project_id"],
+            ondelete="CASCADE",
+            name="fk_adapter_run_outputs_extraction_profile_proj_profiles",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_adapter_run_outputs_source_file_id_project_id_files",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_job_id"],
+            ["jobs.id"],
+            ondelete="CASCADE",
+            name="fk_adapter_run_outputs_source_job_id_jobs",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("id", "project_id", name="uq_adapter_run_outputs_id_project_id"),
+        sa.UniqueConstraint("source_job_id", name="uq_adapter_run_outputs_source_job_id"),
+        sa.CheckConstraint(
+            "confidence_score >= 0.0 AND confidence_score <= 1.0",
+            name="ck_adapter_outputs_confidence_0_1",
+        ),
+        sa.CheckConstraint(
+            "length(result_checksum_sha256) = 64 "
+            "AND result_checksum_sha256 = lower(result_checksum_sha256)",
+            name="ck_adapter_outputs_checksum",
+        ),
+    )
+    op.create_index(
+        op.f("ix_adapter_run_outputs_extraction_profile_id"),
+        "adapter_run_outputs",
+        ["extraction_profile_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_adapter_run_outputs_project_id"),
+        "adapter_run_outputs",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_adapter_run_outputs_source_file_id"),
+        "adapter_run_outputs",
+        ["source_file_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "drawing_revisions",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique drawing revision identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "source_file_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Immutable source file identifier for this revision",
+        ),
+        sa.Column(
+            "extraction_profile_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Immutable extraction profile identifier used to derive this revision",
+        ),
+        sa.Column(
+            "source_job_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Job identifier that committed this drawing revision",
+        ),
+        sa.Column(
+            "adapter_run_output_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Committed adapter output envelope consumed by this drawing revision",
+        ),
+        sa.Column(
+            "predecessor_revision_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Immediate predecessor drawing revision identifier for append-only lineage",
+        ),
+        sa.Column(
+            "revision_sequence",
+            sa.Integer(),
+            nullable=False,
+            comment="Monotonic revision sequence per source file within a project",
+        ),
+        sa.Column(
+            "revision_kind",
+            sa.String(length=32),
+            nullable=False,
+            comment="Drawing revision kind recorded for this append-only revision",
+        ),
+        sa.Column(
+            "review_state",
+            sa.String(length=32),
+            nullable=False,
+            comment="Review state recorded for this drawing revision",
+        ),
+        sa.Column(
+            "canonical_entity_schema_version",
+            sa.String(length=16),
+            nullable=False,
+            comment="Canonical entity schema version stored on this drawing revision",
+        ),
+        sa.Column(
+            "confidence_score",
+            sa.Float(),
+            nullable=False,
+            comment="Overall drawing revision confidence score for review workflows",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="Drawing revision creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(
+            ["adapter_run_output_id", "project_id"],
+            ["adapter_run_outputs.id", "adapter_run_outputs.project_id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_adapter_run_output_id_project_id_outputs",
+        ),
+        sa.ForeignKeyConstraint(
+            ["extraction_profile_id", "project_id"],
+            ["extraction_profiles.id", "extraction_profiles.project_id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_extraction_profile_proj_profiles",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["predecessor_revision_id"],
+            ["drawing_revisions.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_source_file_id_project_id_files",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_job_id"],
+            ["jobs.id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_source_job_id_jobs",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "adapter_run_output_id",
+            name="uq_drawing_revisions_adapter_run_output_id",
+        ),
+        sa.UniqueConstraint("id", "project_id", name="uq_drawing_revisions_id_project_id"),
+        sa.UniqueConstraint(
+            "project_id",
+            "source_file_id",
+            "revision_sequence",
+            name="uq_drawing_revisions_project_file_revision_sequence",
+        ),
+        sa.UniqueConstraint("source_job_id", name="uq_drawing_revisions_source_job_id"),
+        sa.CheckConstraint(
+            "revision_sequence >= 1",
+            name="ck_drawing_revisions_seq_ge_1",
+        ),
+        sa.CheckConstraint(
+            "revision_kind IN ('ingest', 'reprocess')",
+            name="ck_drawing_revisions_kind",
+        ),
+        sa.CheckConstraint(
+            "review_state IN "
+            "('approved', 'provisional', 'review_required', 'rejected', 'superseded')",
+            name="ck_drawing_revisions_review_state",
+        ),
+        sa.CheckConstraint(
+            "confidence_score >= 0.0 AND confidence_score <= 1.0",
+            name="ck_drawing_revisions_conf_0_1",
+        ),
+    )
+    op.create_index(
+        op.f("ix_drawing_revisions_extraction_profile_id"),
+        "drawing_revisions",
+        ["extraction_profile_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_drawing_revisions_predecessor_revision_id"),
+        "drawing_revisions",
+        ["predecessor_revision_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_drawing_revisions_project_id"),
+        "drawing_revisions",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_drawing_revisions_source_file_id"),
+        "drawing_revisions",
+        ["source_file_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_drawing_revisions_source_job_id"),
+        "drawing_revisions",
+        ["source_job_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "validation_reports",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique validation report identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "drawing_revision_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Drawing revision identifier addressed by this canonical validation report",
+        ),
+        sa.Column(
+            "source_job_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Job identifier that produced this validation report",
+        ),
+        sa.Column(
+            "validation_report_schema_version",
+            sa.String(length=16),
+            nullable=False,
+            comment="Validation report schema version",
+        ),
+        sa.Column(
+            "canonical_entity_schema_version",
+            sa.String(length=16),
+            nullable=False,
+            comment="Canonical entity schema version validated by this report",
+        ),
+        sa.Column(
+            "validation_status",
+            sa.String(length=32),
+            nullable=False,
+            comment="Technical validation status for the drawing revision",
+        ),
+        sa.Column(
+            "review_state",
+            sa.String(length=32),
+            nullable=False,
+            comment="Inherited review state recorded on the validation report",
+        ),
+        sa.Column(
+            "quantity_gate",
+            sa.String(length=32),
+            nullable=False,
+            comment="Derived quantity gate outcome for the drawing revision",
+        ),
+        sa.Column(
+            "effective_confidence",
+            sa.Float(),
+            nullable=False,
+            comment="Conservative effective confidence used for quantity gate decisions",
+        ),
+        sa.Column(
+            "validator_name",
+            sa.String(length=128),
+            nullable=False,
+            comment="Validator implementation name",
+        ),
+        sa.Column(
+            "validator_version",
+            sa.String(length=64),
+            nullable=False,
+            comment="Validator implementation version",
+        ),
+        sa.Column(
+            "report_json",
+            sa.JSON(),
+            nullable=False,
+            comment=(
+                "Validation report payload containing summary, checks, findings, "
+                "and adapter warnings"
+            ),
+        ),
+        sa.Column(
+            "generated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            comment="Validation report generation timestamp",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="Validation report record creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id"],
+            ["drawing_revisions.id", "drawing_revisions.project_id"],
+            ondelete="CASCADE",
+            name="fk_validation_reports_drawing_revision_id_project_id_revisions",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["source_job_id"],
+            ["jobs.id"],
+            ondelete="CASCADE",
+            name="fk_validation_reports_source_job_id_jobs",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "drawing_revision_id",
+            name="uq_validation_reports_drawing_revision_id",
+        ),
+        sa.UniqueConstraint("id", "project_id", name="uq_validation_reports_id_project_id"),
+        sa.UniqueConstraint("source_job_id", name="uq_validation_reports_source_job_id"),
+        sa.CheckConstraint(
+            "validation_status IN "
+            "('valid', 'valid_with_warnings', 'invalid', 'needs_review')",
+            name="ck_validation_reports_status",
+        ),
+        sa.CheckConstraint(
+            "review_state IN "
+            "('approved', 'provisional', 'review_required', 'rejected', 'superseded')",
+            name="ck_validation_reports_review_state",
+        ),
+        sa.CheckConstraint(
+            "quantity_gate IN "
+            "('allowed', 'allowed_provisional', 'review_gated', 'blocked')",
+            name="ck_validation_reports_quantity_gate",
+        ),
+        sa.CheckConstraint(
+            "effective_confidence >= 0.0 AND effective_confidence <= 1.0",
+            name="ck_validation_reports_conf_0_1",
+        ),
+    )
+    op.create_index(
+        op.f("ix_validation_reports_project_id"),
+        "validation_reports",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_validation_reports_source_job_id"),
+        "validation_reports",
+        ["source_job_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "generated_artifacts",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Unique generated artifact identifier (UUID v4)",
+        ),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Owning project identifier",
+        ),
+        sa.Column(
+            "source_file_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Source file identifier for artifact lineage",
+        ),
+        sa.Column(
+            "job_id",
+            sa.Uuid(),
+            nullable=False,
+            comment="Job identifier that produced this generated artifact",
+        ),
+        sa.Column(
+            "drawing_revision_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Drawing revision identifier used to generate this artifact",
+        ),
+        sa.Column(
+            "adapter_run_output_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Adapter run output identifier used to generate this artifact",
+        ),
+        sa.Column(
+            "artifact_kind",
+            sa.String(length=64),
+            nullable=False,
+            comment="Generated artifact kind",
+        ),
+        sa.Column(
+            "name",
+            sa.String(length=255),
+            nullable=False,
+            comment="Human-readable generated artifact name",
+        ),
+        sa.Column(
+            "format",
+            sa.String(length=64),
+            nullable=False,
+            comment="Generated artifact format identifier",
+        ),
+        sa.Column(
+            "media_type",
+            sa.String(length=255),
+            nullable=False,
+            comment="Generated artifact media type",
+        ),
+        sa.Column(
+            "size_bytes",
+            sa.BigInteger(),
+            nullable=False,
+            comment="Generated artifact byte size",
+        ),
+        sa.Column(
+            "checksum_sha256",
+            sa.String(length=64),
+            nullable=False,
+            comment="SHA-256 checksum for generated artifact bytes",
+        ),
+        sa.Column(
+            "generator_name",
+            sa.String(length=128),
+            nullable=False,
+            comment="Artifact generator implementation name",
+        ),
+        sa.Column(
+            "generator_version",
+            sa.String(length=64),
+            nullable=False,
+            comment="Artifact generator implementation version",
+        ),
+        sa.Column(
+            "generator_config_json",
+            sa.JSON(),
+            nullable=False,
+            comment="Artifact generator configuration payload",
+        ),
+        sa.Column(
+            "storage_key",
+            sa.String(length=1024),
+            nullable=False,
+            comment="Immutable generated artifact storage key",
+        ),
+        sa.Column(
+            "storage_uri",
+            sa.String(length=1024),
+            nullable=False,
+            comment="Immutable generated artifact storage URI",
+        ),
+        sa.Column(
+            "lineage_json",
+            sa.JSON(),
+            nullable=False,
+            comment="Structured generated artifact lineage payload",
+        ),
+        sa.Column(
+            "predecessor_artifact_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Immediate predecessor artifact identifier for append-only lineage",
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Soft deletion timestamp for retention workflows",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            comment="Generated artifact creation timestamp",
+        ),
+        sa.ForeignKeyConstraint(
+            ["adapter_run_output_id", "project_id"],
+            ["adapter_run_outputs.id", "adapter_run_outputs.project_id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_adapter_run_output_id_project_id_outputs",
+        ),
+        sa.ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id"],
+            ["drawing_revisions.id", "drawing_revisions.project_id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_drawing_revision_id_project_id_revisions",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_source_file_id_project_id_files",
+        ),
+        sa.ForeignKeyConstraint(
+            ["job_id"],
+            ["jobs.id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_job_id_jobs",
+        ),
+        sa.ForeignKeyConstraint(
+            ["predecessor_artifact_id"],
+            ["generated_artifacts.id"],
+            ondelete="RESTRICT",
+            name="fk_generated_artifacts_predecessor_artifact_id_self",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("id", "project_id", name="uq_generated_artifacts_id_project_id"),
+        sa.UniqueConstraint("storage_key", name="uq_generated_artifacts_storage_key"),
+        sa.CheckConstraint(
+            "size_bytes >= 0",
+            name="ck_generated_artifacts_size_ge_0",
+        ),
+        sa.CheckConstraint(
+            "length(checksum_sha256) = 64 AND checksum_sha256 = lower(checksum_sha256)",
+            name="ck_generated_artifacts_checksum",
+        ),
+    )
+    op.create_index(
+        op.f("ix_generated_artifacts_adapter_run_output_id"),
+        "generated_artifacts",
+        ["adapter_run_output_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_generated_artifacts_drawing_revision_id"),
+        "generated_artifacts",
+        ["drawing_revision_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_generated_artifacts_project_id"),
+        "generated_artifacts",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_generated_artifacts_predecessor_artifact_id"),
+        "generated_artifacts",
+        ["predecessor_artifact_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_generated_artifacts_source_file_id"),
+        "generated_artifacts",
+        ["source_file_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_generated_artifacts_job_id"),
+        "generated_artifacts",
+        ["job_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop append-only ingest output persistence primitives."""
+    _raise_if_table_non_empty("generated_artifacts")
+    _raise_if_table_non_empty("validation_reports")
+    _raise_if_table_non_empty("drawing_revisions")
+    _raise_if_table_non_empty("adapter_run_outputs")
+
+    op.drop_index(op.f("ix_generated_artifacts_job_id"), table_name="generated_artifacts")
+    op.drop_index(op.f("ix_generated_artifacts_source_file_id"), table_name="generated_artifacts")
+    op.drop_index(op.f("ix_generated_artifacts_project_id"), table_name="generated_artifacts")
+    op.drop_index(
+        op.f("ix_generated_artifacts_predecessor_artifact_id"),
+        table_name="generated_artifacts",
+    )
+    op.drop_index(
+        op.f("ix_generated_artifacts_drawing_revision_id"),
+        table_name="generated_artifacts",
+    )
+    op.drop_index(
+        op.f("ix_generated_artifacts_adapter_run_output_id"),
+        table_name="generated_artifacts",
+    )
+    op.drop_table("generated_artifacts")
+
+    op.drop_index(op.f("ix_validation_reports_source_job_id"), table_name="validation_reports")
+    op.drop_index(op.f("ix_validation_reports_project_id"), table_name="validation_reports")
+    op.drop_table("validation_reports")
+
+    op.drop_index(op.f("ix_drawing_revisions_source_job_id"), table_name="drawing_revisions")
+    op.drop_index(op.f("ix_drawing_revisions_source_file_id"), table_name="drawing_revisions")
+    op.drop_index(op.f("ix_drawing_revisions_project_id"), table_name="drawing_revisions")
+    op.drop_index(
+        op.f("ix_drawing_revisions_predecessor_revision_id"),
+        table_name="drawing_revisions",
+    )
+    op.drop_index(
+        op.f("ix_drawing_revisions_extraction_profile_id"),
+        table_name="drawing_revisions",
+    )
+    op.drop_table("drawing_revisions")
+
+    op.drop_index(
+        op.f("ix_adapter_run_outputs_source_file_id"),
+        table_name="adapter_run_outputs",
+    )
+    op.drop_index(op.f("ix_adapter_run_outputs_project_id"), table_name="adapter_run_outputs")
+    op.drop_index(
+        op.f("ix_adapter_run_outputs_extraction_profile_id"),
+        table_name="adapter_run_outputs",
+    )
+    op.drop_table("adapter_run_outputs")

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1,6 +1,10 @@
 """Celery worker application and persisted job handlers."""
 
 import asyncio
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -14,8 +18,12 @@ from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.drawing_revision import DrawingRevision
+from app.models.file import File
 from app.models.job import Job
 from app.models.job_event import JobEvent
+from app.models.validation_report import ValidationReport
 
 logger = get_logger(__name__)
 
@@ -26,6 +34,19 @@ _DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
 _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
 _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
 _ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
+_FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
+_NOOP_ADAPTER_KEY = "noop.ingest"
+_NOOP_ADAPTER_VERSION = "0.1"
+_CANONICAL_ENTITY_SCHEMA_VERSION = "0.1"
+_VALIDATION_REPORT_SCHEMA_VERSION = "0.1"
+_NOOP_REVIEW_STATE = "review_required"
+_NOOP_VALIDATION_STATUS = "needs_review"
+_NOOP_QUANTITY_GATE = "review_gated"
+_NOOP_CONFIDENCE_SCORE = 0.0
+_INITIAL_INGEST_REVISION_KIND = "ingest"
+_REPROCESS_REVISION_KIND = "reprocess"
+_NOOP_VALIDATOR_NAME = "noop.ingest"
+_NOOP_VALIDATOR_VERSION = "0.1"
 
 celery_app = Celery(
     "draupnir",
@@ -49,6 +70,44 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+@dataclass(frozen=True, slots=True)
+class NoopIngestPayloadSource:
+    """Immutable source snapshot used to build no-op ingest payloads."""
+
+    file_id: UUID
+    extraction_profile_id: UUID | None
+    initial_job_id: UUID | None
+    detected_format: str | None
+    media_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class NoopIngestOutputPayload:
+    """Prepared no-op ingest payload inserted during finalization."""
+
+    revision_kind: str
+    adapter_key: str
+    adapter_version: str
+    input_family: str
+    canonical_entity_schema_version: str
+    canonical_json: dict[str, Any]
+    provenance_json: dict[str, Any]
+    confidence_json: dict[str, Any]
+    confidence_score: float
+    warnings_json: list[Any]
+    diagnostics_json: dict[str, Any]
+    result_checksum_sha256: str
+    validation_report_schema_version: str
+    validation_status: str
+    review_state: str
+    quantity_gate: str
+    effective_confidence: float
+    validator_name: str
+    validator_version: str
+    report_json: dict[str, Any]
+    generated_at: datetime
+
+
 def _is_stale_running_job(job: Job, *, now: datetime) -> bool:
     """Return whether a running job is old enough to treat as orphaned."""
     if job.started_at is None:
@@ -65,6 +124,428 @@ async def _get_job_for_update(session: AsyncSession, job_id: UUID) -> Job | None
     """Load and lock a persisted job row."""
     result = await session.execute(select(Job).where(Job.id == job_id).with_for_update())
     return result.scalar_one_or_none()
+
+
+async def _get_source_file(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    file_id: UUID,
+    for_update: bool = False,
+) -> File | None:
+    """Load a source file row, optionally under a row lock."""
+    statement = select(File).where((File.project_id == project_id) & (File.id == file_id))
+    if for_update:
+        statement = statement.with_for_update()
+
+    result = await session.execute(statement)
+    return result.scalar_one_or_none()
+
+
+async def _get_existing_adapter_run_output(
+    session: AsyncSession,
+    *,
+    source_job_id: UUID,
+) -> AdapterRunOutput | None:
+    """Load an existing committed adapter output for a job."""
+    result = await session.execute(
+        select(AdapterRunOutput).where(AdapterRunOutput.source_job_id == source_job_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_latest_drawing_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    source_file_id: UUID,
+) -> DrawingRevision | None:
+    """Load the latest drawing revision for a source file."""
+    result = await session.execute(
+        select(DrawingRevision)
+        .where(
+            (DrawingRevision.project_id == project_id)
+            & (DrawingRevision.source_file_id == source_file_id)
+        )
+        .order_by(DrawingRevision.revision_sequence.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+def _normalize_input_family(source: NoopIngestPayloadSource) -> str:
+    """Map immutable file metadata to a stable no-op input family."""
+    if source.detected_format is not None:
+        return source.detected_format.lower()
+
+    media_type = source.media_type.lower()
+    if media_type == "application/pdf":
+        return "pdf"
+
+    return "unknown"
+
+
+def _compute_adapter_result_checksum(result_envelope: dict[str, Any]) -> str:
+    """Return a stable SHA-256 checksum for a committed result envelope."""
+    payload = json.dumps(result_envelope, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _resolve_revision_kind(job_id: UUID, *, initial_job_id: UUID | None) -> str:
+    """Map file linkage to the correct ingest revision kind."""
+    if initial_job_id == job_id:
+        return _INITIAL_INGEST_REVISION_KIND
+
+    return _REPROCESS_REVISION_KIND
+
+
+def _resolve_noop_revision_kind(job_id: UUID, *, source: NoopIngestPayloadSource) -> str:
+    """Map the source file linkage to the correct ingest revision kind."""
+    return _resolve_revision_kind(job_id, initial_job_id=source.initial_job_id)
+
+
+def _build_noop_entity_counts() -> dict[str, int]:
+    """Return stable empty entity counts for no-op payloads."""
+    return {
+        "layouts": 0,
+        "layers": 0,
+        "blocks": 0,
+        "entities": 0,
+    }
+
+
+def _assert_revision_invariants(
+    job_id: UUID,
+    *,
+    source_file: File,
+    predecessor_revision: DrawingRevision | None,
+    payload_revision_kind: str,
+) -> None:
+    """Reject finalization when revision lineage invariants are violated."""
+    expected_revision_kind = _resolve_revision_kind(
+        job_id,
+        initial_job_id=source_file.initial_job_id,
+    )
+    if payload_revision_kind != expected_revision_kind:
+        raise ValueError("Ingest job revision kind changed before finalization")
+
+    if expected_revision_kind == _INITIAL_INGEST_REVISION_KIND:
+        if predecessor_revision is not None:
+            raise ValueError("Initial ingest cannot finalize after a predecessor revision exists")
+        return
+
+    if predecessor_revision is None:
+        raise ValueError(
+            "Reprocess ingest job cannot finalize before a predecessor revision exists"
+        )
+
+
+async def _load_noop_ingest_payload_source(job_id: UUID) -> NoopIngestPayloadSource:
+    """Load immutable file metadata needed for no-op payload construction."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        result = await session.execute(select(Job).where(Job.id == job_id))
+        job = result.scalar_one_or_none()
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        source_file = await _get_source_file(
+            session,
+            project_id=job.project_id,
+            file_id=job.file_id,
+        )
+        if source_file is None:
+            raise LookupError(
+                f"File with identifier '{job.file_id}' for job '{job_id}' not found"
+            )
+
+        return NoopIngestPayloadSource(
+            file_id=source_file.id,
+            extraction_profile_id=job.extraction_profile_id,
+            initial_job_id=source_file.initial_job_id,
+            detected_format=source_file.detected_format,
+            media_type=source_file.media_type,
+        )
+
+
+def _build_noop_ingest_output_payload(
+    job_id: UUID,
+    *,
+    source: NoopIngestPayloadSource,
+) -> NoopIngestOutputPayload:
+    """Construct the immutable no-op ingest payload outside finalization."""
+    generated_at = _utcnow()
+    input_family = _normalize_input_family(source)
+    revision_kind = _resolve_noop_revision_kind(job_id, source=source)
+    entity_counts = _build_noop_entity_counts()
+    canonical_json: dict[str, Any] = {
+        "canonical_entity_schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
+        "schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
+        "layouts": [],
+        "layers": [],
+        "blocks": [],
+        "entities": [],
+        "entity_counts": entity_counts,
+    }
+    provenance_json = {
+        "schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
+        "bridge": "noop_ingest",
+        "adapter": {
+            "key": _NOOP_ADAPTER_KEY,
+            "version": _NOOP_ADAPTER_VERSION,
+        },
+        "source": {
+            "file_id": str(source.file_id),
+            "job_id": str(job_id),
+            "extraction_profile_id": (
+                str(source.extraction_profile_id)
+                if source.extraction_profile_id is not None
+                else None
+            ),
+            "input_family": input_family,
+            "revision_kind": revision_kind,
+        },
+        "generated_at": generated_at.isoformat(),
+    }
+    noop_warning = {
+        "code": "NOOP_INGEST_BRIDGE",
+        "severity": "warning",
+        "message": "No real adapter executed; review is required.",
+    }
+    confidence_json = {
+        "score": _NOOP_CONFIDENCE_SCORE,
+        "effective_confidence": _NOOP_CONFIDENCE_SCORE,
+        "review_state": _NOOP_REVIEW_STATE,
+    }
+    warnings_json: list[Any] = [noop_warning]
+    diagnostics_json = {
+        "adapter": _NOOP_ADAPTER_KEY,
+        "adapter_version": _NOOP_ADAPTER_VERSION,
+        "bridge": "noop_ingest",
+        "timing": {"sleep_seconds": _INGEST_NOOP_DELAY_SECONDS},
+    }
+    report_json = {
+        "validation_report_schema_version": _VALIDATION_REPORT_SCHEMA_VERSION,
+        "canonical_entity_schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
+        "validator": {
+            "name": _NOOP_VALIDATOR_NAME,
+            "version": _NOOP_VALIDATOR_VERSION,
+        },
+        "summary": {
+            "validation_status": _NOOP_VALIDATION_STATUS,
+            "review_state": _NOOP_REVIEW_STATE,
+            "quantity_gate": _NOOP_QUANTITY_GATE,
+            "effective_confidence": _NOOP_CONFIDENCE_SCORE,
+            "entity_counts": entity_counts,
+        },
+        "checks": [],
+        "findings": [noop_warning],
+        "adapter_warnings": warnings_json,
+        "provenance": provenance_json,
+    }
+    result_envelope = {
+        "adapter_key": _NOOP_ADAPTER_KEY,
+        "adapter_version": _NOOP_ADAPTER_VERSION,
+        "input_family": input_family,
+        "canonical_entity_schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
+        "canonical_json": canonical_json,
+        "provenance_json": provenance_json,
+        "confidence_json": confidence_json,
+        "confidence_score": _NOOP_CONFIDENCE_SCORE,
+        "warnings_json": warnings_json,
+        "diagnostics_json": diagnostics_json,
+    }
+
+    return NoopIngestOutputPayload(
+        revision_kind=revision_kind,
+        adapter_key=_NOOP_ADAPTER_KEY,
+        adapter_version=_NOOP_ADAPTER_VERSION,
+        input_family=input_family,
+        canonical_entity_schema_version=_CANONICAL_ENTITY_SCHEMA_VERSION,
+        canonical_json=canonical_json,
+        provenance_json=provenance_json,
+        confidence_json=confidence_json,
+        confidence_score=_NOOP_CONFIDENCE_SCORE,
+        warnings_json=warnings_json,
+        diagnostics_json=diagnostics_json,
+        result_checksum_sha256=_compute_adapter_result_checksum(result_envelope),
+        validation_report_schema_version=_VALIDATION_REPORT_SCHEMA_VERSION,
+        validation_status=_NOOP_VALIDATION_STATUS,
+        review_state=_NOOP_REVIEW_STATE,
+        quantity_gate=_NOOP_QUANTITY_GATE,
+        effective_confidence=_NOOP_CONFIDENCE_SCORE,
+        validator_name=_NOOP_VALIDATOR_NAME,
+        validator_version=_NOOP_VALIDATOR_VERSION,
+        report_json=report_json,
+        generated_at=generated_at,
+    )
+
+
+async def _finalize_ingest_job(job_id: UUID, *, payload: NoopIngestOutputPayload) -> bool:
+    """Atomically publish durable no-op outputs and terminal job success."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "ingest_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
+            await session.commit()
+            logger.info("ingest_job_cancelled", job_id=str(job_id))
+            return False
+
+        if job.status != "running":
+            logger.info(
+                "ingest_job_completion_skipped_non_running_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        existing_output = await _get_existing_adapter_run_output(session, source_job_id=job.id)
+        if existing_output is not None:
+            logger.info(
+                "ingest_job_completion_skipped_existing_output",
+                job_id=str(job_id),
+                adapter_run_output_id=str(existing_output.id),
+            )
+            return False
+
+        if job.extraction_profile_id is None:
+            raise ValueError("Ingest job missing extraction profile during finalization")
+
+        source_file = await _get_source_file(
+            session,
+            project_id=job.project_id,
+            file_id=job.file_id,
+            for_update=True,
+        )
+        if source_file is None:
+            raise LookupError(
+                f"File with identifier '{job.file_id}' for job '{job_id}' not found"
+            )
+
+        predecessor_revision = await _get_latest_drawing_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+        )
+        _assert_revision_invariants(
+            job.id,
+            source_file=source_file,
+            predecessor_revision=predecessor_revision,
+            payload_revision_kind=payload.revision_kind,
+        )
+        revision_sequence = 1
+        predecessor_revision_id: UUID | None = None
+        if predecessor_revision is not None:
+            revision_sequence = predecessor_revision.revision_sequence + 1
+            predecessor_revision_id = predecessor_revision.id
+
+        adapter_run_output_id = uuid.uuid4()
+        drawing_revision_id = uuid.uuid4()
+        validation_report_id = uuid.uuid4()
+        finished_at = _utcnow()
+
+        session.add(
+            AdapterRunOutput(
+                id=adapter_run_output_id,
+                project_id=job.project_id,
+                source_file_id=source_file.id,
+                extraction_profile_id=job.extraction_profile_id,
+                source_job_id=job.id,
+                adapter_key=payload.adapter_key,
+                adapter_version=payload.adapter_version,
+                input_family=payload.input_family,
+                canonical_entity_schema_version=payload.canonical_entity_schema_version,
+                canonical_json=payload.canonical_json,
+                provenance_json=payload.provenance_json,
+                confidence_json=payload.confidence_json,
+                confidence_score=payload.confidence_score,
+                warnings_json=payload.warnings_json,
+                diagnostics_json=payload.diagnostics_json,
+                result_checksum_sha256=payload.result_checksum_sha256,
+            )
+        )
+        session.add(
+            DrawingRevision(
+                id=drawing_revision_id,
+                project_id=job.project_id,
+                source_file_id=source_file.id,
+                extraction_profile_id=job.extraction_profile_id,
+                source_job_id=job.id,
+                adapter_run_output_id=adapter_run_output_id,
+                predecessor_revision_id=predecessor_revision_id,
+                revision_sequence=revision_sequence,
+                revision_kind=payload.revision_kind,
+                review_state=payload.review_state,
+                canonical_entity_schema_version=payload.canonical_entity_schema_version,
+                confidence_score=payload.confidence_score,
+            )
+        )
+        session.add(
+            ValidationReport(
+                id=validation_report_id,
+                project_id=job.project_id,
+                drawing_revision_id=drawing_revision_id,
+                source_job_id=job.id,
+                validation_report_schema_version=payload.validation_report_schema_version,
+                canonical_entity_schema_version=payload.canonical_entity_schema_version,
+                validation_status=payload.validation_status,
+                review_state=payload.review_state,
+                quantity_gate=payload.quantity_gate,
+                effective_confidence=payload.effective_confidence,
+                validator_name=payload.validator_name,
+                validator_version=payload.validator_version,
+                report_json=payload.report_json,
+                generated_at=payload.generated_at,
+            )
+        )
+
+        job.status = "succeeded"
+        job.finished_at = finished_at
+        job.error_code = None
+        job.error_message = None
+        await emit_job_event(
+            job.id,
+            level="info",
+            message="Job succeeded",
+            data_json={
+                "status": "succeeded",
+                "attempts": job.attempts,
+                "adapter_run_output_id": str(adapter_run_output_id),
+                "drawing_revision_id": str(drawing_revision_id),
+                "validation_report_id": str(validation_report_id),
+            },
+            session=session,
+        )
+        await session.commit()
+
+    return True
 
 
 async def emit_job_event(
@@ -256,54 +737,22 @@ async def process_ingest_job(job_id: UUID) -> None:
         logger.error("ingest_job_failed", job_id=str(job_id), error=str(exc), exc_info=True)
         raise
 
-    async with session_maker() as session:
-        job = await _get_job_for_update(session, job_id)
-        if job is None:
-            raise LookupError(f"Job with identifier '{job_id}' not found")
-
-        if job.status in _TERMINAL_JOB_STATUSES:
-            logger.info(
-                "ingest_job_completion_skipped_terminal_status",
-                job_id=str(job_id),
-                status=job.status,
-            )
-            return
-
-        if job.cancel_requested:
-            _finalize_job_cancelled(job)
-            await emit_job_event(
-                job.id,
-                level="warning",
-                message="Job cancelled",
-                data_json={"status": "cancelled"},
-                session=session,
-            )
-            await session.commit()
-            logger.info("ingest_job_cancelled", job_id=str(job_id))
-            return
-
-        if job.status != "running":
-            logger.info(
-                "ingest_job_completion_skipped_non_running_status",
-                job_id=str(job_id),
-                status=job.status,
-            )
-            return
-
-        job.status = "succeeded"
-        job.finished_at = _utcnow()
-        job.error_code = None
-        job.error_message = None
-        await emit_job_event(
-            job.id,
-            level="info",
-            message="Job succeeded",
-            data_json={"status": "succeeded", "attempts": job.attempts},
-            session=session,
+    try:
+        payload_source = await _load_noop_ingest_payload_source(job_id)
+        payload = _build_noop_ingest_output_payload(job_id, source=payload_source)
+        finalized = await _finalize_ingest_job(job_id, payload=payload)
+    except Exception as exc:
+        await _mark_job_failed(job_id, error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE)
+        logger.error(
+            "ingest_job_finalization_failed",
+            job_id=str(job_id),
+            error=str(exc),
+            exc_info=True,
         )
-        await session.commit()
+        raise
 
-    logger.info("ingest_job_succeeded", job_id=str(job_id))
+    if finalized:
+        logger.info("ingest_job_succeeded", job_id=str(job_id))
 
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,8 +7,12 @@ for Alembic autogenerate support. Example:
 
 """
 
+from . import adapter_run_output as adapter_run_output
+from . import drawing_revision as drawing_revision
 from . import extraction_profile as extraction_profile
 from . import file as file
+from . import generated_artifact as generated_artifact
 from . import job as job
 from . import job_event as job_event
 from . import project as project
+from . import validation_report as validation_report

--- a/app/models/adapter_run_output.py
+++ b/app/models/adapter_run_output.py
@@ -1,0 +1,148 @@
+"""Immutable persisted adapter run output envelopes."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    ForeignKeyConstraint,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class AdapterRunOutput(Base):
+    """SQLAlchemy ORM model for committed adapter output envelopes."""
+
+    __tablename__ = "adapter_run_outputs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_adapter_run_outputs_source_file_id_project_id_files",
+        ),
+        ForeignKeyConstraint(
+            ["extraction_profile_id", "project_id"],
+            ["extraction_profiles.id", "extraction_profiles.project_id"],
+            ondelete="CASCADE",
+            name="fk_adapter_run_outputs_extraction_profile_proj_profiles",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_adapter_run_outputs_id_project_id",
+        ),
+        UniqueConstraint(
+            "source_job_id",
+            name="uq_adapter_run_outputs_source_job_id",
+        ),
+        CheckConstraint(
+            "confidence_score >= 0.0 AND confidence_score <= 1.0",
+            name="ck_adapter_outputs_confidence_0_1",
+        ),
+        CheckConstraint(
+            "length(result_checksum_sha256) = 64 "
+            "AND result_checksum_sha256 = lower(result_checksum_sha256)",
+            name="ck_adapter_outputs_checksum",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique adapter run output identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Immutable source file identifier used for this adapter run",
+    )
+    extraction_profile_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Immutable extraction profile identifier used for this adapter run",
+    )
+    source_job_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="Job identifier that produced this committed adapter output",
+    )
+    adapter_key: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Stable adapter registry key used for this adapter run",
+    )
+    adapter_version: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Adapter version recorded in adapter diagnostics",
+    )
+    input_family: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Normalized input family processed by this adapter run",
+    )
+    canonical_entity_schema_version: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Canonical entity schema version for the adapter output payload",
+    )
+    canonical_json: Mapped[dict[str, Any]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Canonical adapter output payload including layouts, layers, blocks, and entities",
+    )
+    provenance_json: Mapped[dict[str, Any]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Structured adapter provenance payload",
+    )
+    confidence_json: Mapped[dict[str, Any]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Structured confidence payload for adapter output review workflows",
+    )
+    confidence_score: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        comment="Overall adapter confidence score for this committed output",
+    )
+    warnings_json: Mapped[list[Any]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Adapter-emitted warnings carried with the committed output envelope",
+    )
+    diagnostics_json: Mapped[dict[str, Any]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Adapter diagnostics payload including timing metadata",
+    )
+    result_checksum_sha256: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="SHA-256 checksum of the committed adapter result envelope",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Adapter output record creation timestamp",
+    )

--- a/app/models/drawing_revision.py
+++ b/app/models/drawing_revision.py
@@ -1,0 +1,152 @@
+"""Append-only drawing revision aggregates."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class DrawingRevision(Base):
+    """SQLAlchemy ORM model for immutable drawing revisions."""
+
+    __tablename__ = "drawing_revisions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_source_file_id_project_id_files",
+        ),
+        ForeignKeyConstraint(
+            ["extraction_profile_id", "project_id"],
+            ["extraction_profiles.id", "extraction_profiles.project_id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_extraction_profile_proj_profiles",
+        ),
+        ForeignKeyConstraint(
+            ["adapter_run_output_id", "project_id"],
+            ["adapter_run_outputs.id", "adapter_run_outputs.project_id"],
+            ondelete="CASCADE",
+            name="fk_drawing_revisions_adapter_run_output_id_project_id_outputs",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_drawing_revisions_id_project_id",
+        ),
+        UniqueConstraint(
+            "adapter_run_output_id",
+            name="uq_drawing_revisions_adapter_run_output_id",
+        ),
+        UniqueConstraint(
+            "source_job_id",
+            name="uq_drawing_revisions_source_job_id",
+        ),
+        UniqueConstraint(
+            "project_id",
+            "source_file_id",
+            "revision_sequence",
+            name="uq_drawing_revisions_project_file_revision_sequence",
+        ),
+        CheckConstraint(
+            "revision_sequence >= 1",
+            name="ck_drawing_revisions_seq_ge_1",
+        ),
+        CheckConstraint(
+            "revision_kind IN ('ingest', 'reprocess')",
+            name="ck_drawing_revisions_kind",
+        ),
+        CheckConstraint(
+            "review_state IN "
+            "('approved', 'provisional', 'review_required', 'rejected', 'superseded')",
+            name="ck_drawing_revisions_review_state",
+        ),
+        CheckConstraint(
+            "confidence_score >= 0.0 AND confidence_score <= 1.0",
+            name="ck_drawing_revisions_conf_0_1",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique drawing revision identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Immutable source file identifier for this revision",
+    )
+    extraction_profile_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Immutable extraction profile identifier used to derive this revision",
+    )
+    source_job_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Job identifier that committed this drawing revision",
+    )
+    adapter_run_output_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Committed adapter output envelope consumed by this drawing revision",
+    )
+    predecessor_revision_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("drawing_revisions.id", ondelete="RESTRICT"),
+        nullable=True,
+        index=True,
+        comment="Immediate predecessor drawing revision identifier for append-only lineage",
+    )
+    revision_sequence: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Monotonic revision sequence per source file within a project",
+    )
+    revision_kind: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Drawing revision kind recorded for this append-only revision",
+    )
+    review_state: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Review state recorded for this drawing revision",
+    )
+    canonical_entity_schema_version: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Canonical entity schema version stored on this drawing revision",
+    )
+    confidence_score: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        comment="Overall drawing revision confidence score for review workflows",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Drawing revision creation timestamp",
+    )

--- a/app/models/generated_artifact.py
+++ b/app/models/generated_artifact.py
@@ -1,0 +1,179 @@
+"""Immutable generated artifact lineage records."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class GeneratedArtifact(Base):
+    """SQLAlchemy ORM model for append-only generated artifacts."""
+
+    __tablename__ = "generated_artifacts"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_source_file_id_project_id_files",
+        ),
+        ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id"],
+            ["drawing_revisions.id", "drawing_revisions.project_id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_drawing_revision_id_project_id_revisions",
+        ),
+        ForeignKeyConstraint(
+            ["adapter_run_output_id", "project_id"],
+            ["adapter_run_outputs.id", "adapter_run_outputs.project_id"],
+            ondelete="CASCADE",
+            name="fk_generated_artifacts_adapter_run_output_id_project_id_outputs",
+        ),
+        ForeignKeyConstraint(
+            ["predecessor_artifact_id"],
+            ["generated_artifacts.id"],
+            ondelete="RESTRICT",
+            name="fk_generated_artifacts_predecessor_artifact_id_self",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_generated_artifacts_id_project_id",
+        ),
+        UniqueConstraint(
+            "storage_key",
+            name="uq_generated_artifacts_storage_key",
+        ),
+        CheckConstraint(
+            "size_bytes >= 0",
+            name="ck_generated_artifacts_size_ge_0",
+        ),
+        CheckConstraint(
+            "length(checksum_sha256) = 64 AND checksum_sha256 = lower(checksum_sha256)",
+            name="ck_generated_artifacts_checksum",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique generated artifact identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Source file identifier for artifact lineage",
+    )
+    job_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Job identifier that produced this generated artifact",
+    )
+    drawing_revision_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment="Drawing revision identifier used to generate this artifact",
+    )
+    adapter_run_output_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment="Adapter run output identifier used to generate this artifact",
+    )
+    artifact_kind: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Generated artifact kind",
+    )
+    name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Human-readable generated artifact name",
+    )
+    format: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Generated artifact format identifier",
+    )
+    media_type: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Generated artifact media type",
+    )
+    size_bytes: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        comment="Generated artifact byte size",
+    )
+    checksum_sha256: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="SHA-256 checksum for generated artifact bytes",
+    )
+    generator_name: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Artifact generator implementation name",
+    )
+    generator_version: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Artifact generator implementation version",
+    )
+    generator_config_json: Mapped[dict[str, object]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Artifact generator configuration payload",
+    )
+    storage_key: Mapped[str] = mapped_column(
+        String(1024),
+        nullable=False,
+        comment="Immutable generated artifact storage key",
+    )
+    storage_uri: Mapped[str] = mapped_column(
+        String(1024),
+        nullable=False,
+        comment="Immutable generated artifact storage URI",
+    )
+    lineage_json: Mapped[dict[str, object]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment="Structured generated artifact lineage payload",
+    )
+    predecessor_artifact_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment="Immediate predecessor artifact identifier for append-only lineage",
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Soft deletion timestamp for retention workflows",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Generated artifact creation timestamp",
+    )

--- a/app/models/validation_report.py
+++ b/app/models/validation_report.py
@@ -1,0 +1,149 @@
+"""Canonical validation reports for drawing revisions."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    ForeignKeyConstraint,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ValidationReport(Base):
+    """SQLAlchemy ORM model for immutable validation reports."""
+
+    __tablename__ = "validation_reports"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id"],
+            ["drawing_revisions.id", "drawing_revisions.project_id"],
+            ondelete="CASCADE",
+            name="fk_validation_reports_drawing_revision_id_project_id_revisions",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_validation_reports_id_project_id",
+        ),
+        UniqueConstraint(
+            "drawing_revision_id",
+            name="uq_validation_reports_drawing_revision_id",
+        ),
+        UniqueConstraint(
+            "source_job_id",
+            name="uq_validation_reports_source_job_id",
+        ),
+        CheckConstraint(
+            "validation_status IN "
+            "('valid', 'valid_with_warnings', 'invalid', 'needs_review')",
+            name="ck_validation_reports_status",
+        ),
+        CheckConstraint(
+            "review_state IN "
+            "('approved', 'provisional', 'review_required', 'rejected', 'superseded')",
+            name="ck_validation_reports_review_state",
+        ),
+        CheckConstraint(
+            "quantity_gate IN "
+            "('allowed', 'allowed_provisional', 'review_gated', 'blocked')",
+            name="ck_validation_reports_quantity_gate",
+        ),
+        CheckConstraint(
+            "effective_confidence >= 0.0 AND effective_confidence <= 1.0",
+            name="ck_validation_reports_conf_0_1",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique validation report identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Drawing revision identifier addressed by this canonical validation report",
+    )
+    source_job_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Job identifier that produced this validation report",
+    )
+    validation_report_schema_version: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Validation report schema version",
+    )
+    canonical_entity_schema_version: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        comment="Canonical entity schema version validated by this report",
+    )
+    validation_status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Technical validation status for the drawing revision",
+    )
+    review_state: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Inherited review state recorded on the validation report",
+    )
+    quantity_gate: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Derived quantity gate outcome for the drawing revision",
+    )
+    effective_confidence: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        comment="Conservative effective confidence used for quantity gate decisions",
+    )
+    validator_name: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Validator implementation name",
+    )
+    validator_version: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Validator implementation version",
+    )
+    report_json: Mapped[dict[str, Any]] = mapped_column(
+        JSON,
+        nullable=False,
+        comment=(
+            "Validation report payload containing summary, checks, findings, "
+            "and adapter warnings"
+        ),
+    )
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Validation report generation timestamp",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Validation report record creation timestamp",
+    )

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -1,0 +1,616 @@
+"""Integration tests for persisted ingest output rows."""
+
+import asyncio
+import uuid
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+import app.db.session as session_module
+import app.jobs.worker as worker_module
+from app.core.errors import ErrorCode
+from app.jobs.worker import process_ingest_job
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.drawing_revision import DrawingRevision
+from app.models.generated_artifact import GeneratedArtifact
+from app.models.job import Job
+from app.models.job_event import JobEvent
+from app.models.validation_report import ValidationReport
+from tests.conftest import requires_database
+from tests.test_jobs import (
+    _create_project,
+    _get_job,
+    _get_job_for_file,
+    _update_job,
+    _upload_file,
+)
+
+pytest_plugins = ("tests.test_jobs",)
+
+
+def _as_uuid(value: str | uuid.UUID) -> uuid.UUID:
+    """Normalize string UUID inputs for direct model comparisons."""
+    if isinstance(value, uuid.UUID):
+        return value
+
+    return uuid.UUID(value)
+
+
+async def _load_project_outputs(
+    project_id: str | uuid.UUID,
+) -> tuple[
+    list[AdapterRunOutput],
+    list[DrawingRevision],
+    list[ValidationReport],
+    list[GeneratedArtifact],
+]:
+    """Load persisted ingest outputs for a single isolated project."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    normalized_project_id = _as_uuid(project_id)
+
+    async with session_maker() as session:
+        adapter_outputs = list(
+            (
+                await session.execute(
+                    select(AdapterRunOutput)
+                    .where(AdapterRunOutput.project_id == normalized_project_id)
+                    .order_by(AdapterRunOutput.created_at, AdapterRunOutput.id)
+                )
+            ).scalars()
+        )
+        drawing_revisions = list(
+            (
+                await session.execute(
+                    select(DrawingRevision)
+                    .where(DrawingRevision.project_id == normalized_project_id)
+                    .order_by(DrawingRevision.revision_sequence, DrawingRevision.id)
+                )
+            ).scalars()
+        )
+        validation_reports = list(
+            (
+                await session.execute(
+                    select(ValidationReport)
+                    .where(ValidationReport.project_id == normalized_project_id)
+                    .order_by(ValidationReport.created_at, ValidationReport.id)
+                )
+            ).scalars()
+        )
+        generated_artifacts = list(
+            (
+                await session.execute(
+                    select(GeneratedArtifact)
+                    .where(GeneratedArtifact.project_id == normalized_project_id)
+                    .order_by(GeneratedArtifact.created_at, GeneratedArtifact.id)
+                )
+            ).scalars()
+        )
+
+    return adapter_outputs, drawing_revisions, validation_reports, generated_artifacts
+
+
+async def _load_job_events(job_id: uuid.UUID) -> list[JobEvent]:
+    """Load persisted job events in chronological order."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        return list(
+            (
+                await session.execute(
+                    select(JobEvent)
+                    .where(JobEvent.job_id == job_id)
+                    .order_by(JobEvent.created_at, JobEvent.id)
+                )
+            ).scalars()
+        )
+
+
+async def _set_job_extraction_profile_id(
+    job_id: uuid.UUID,
+    extraction_profile_id: uuid.UUID | None,
+) -> Job:
+    """Update a job extraction profile for failure-path setup."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        assert job is not None
+        job.extraction_profile_id = extraction_profile_id
+        await session.commit()
+
+    return await _get_job(job_id)
+
+
+@requires_database
+class TestIngestOutputPersistence:
+    """Tests for durable ingest output persistence and finalization guards."""
+
+    async def test_process_ingest_job_persists_single_noop_output_set(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Successful ingest should atomically persist one no-op output set."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+
+        assert len(adapter_outputs) == 1
+        assert len(drawing_revisions) == 1
+        assert len(validation_reports) == 1
+        assert generated_artifacts == []
+
+        adapter_output = adapter_outputs[0]
+        drawing_revision = drawing_revisions[0]
+        validation_report = validation_reports[0]
+
+        assert adapter_output.project_id == job.project_id
+        assert adapter_output.source_file_id == job.file_id
+        assert adapter_output.source_job_id == job.id
+        assert adapter_output.extraction_profile_id == job.extraction_profile_id
+        assert adapter_output.adapter_key == "noop.ingest"
+        assert adapter_output.adapter_version == "0.1"
+        assert adapter_output.input_family == "pdf"
+        assert adapter_output.canonical_entity_schema_version == "0.1"
+        assert adapter_output.confidence_score == 0.0
+        assert adapter_output.canonical_json == {
+            "canonical_entity_schema_version": "0.1",
+            "schema_version": "0.1",
+            "layouts": [],
+            "layers": [],
+            "blocks": [],
+            "entities": [],
+            "entity_counts": {
+                "layouts": 0,
+                "layers": 0,
+                "blocks": 0,
+                "entities": 0,
+            },
+        }
+        assert adapter_output.provenance_json == {
+            "schema_version": "0.1",
+            "bridge": "noop_ingest",
+            "adapter": {"key": "noop.ingest", "version": "0.1"},
+            "source": {
+                "file_id": str(job.file_id),
+                "job_id": str(job.id),
+                "extraction_profile_id": str(job.extraction_profile_id),
+                "input_family": "pdf",
+                "revision_kind": "ingest",
+            },
+            "generated_at": adapter_output.provenance_json["generated_at"],
+        }
+
+        assert drawing_revision.project_id == job.project_id
+        assert drawing_revision.source_file_id == job.file_id
+        assert drawing_revision.source_job_id == job.id
+        assert drawing_revision.extraction_profile_id == job.extraction_profile_id
+        assert drawing_revision.adapter_run_output_id == adapter_output.id
+        assert drawing_revision.predecessor_revision_id is None
+        assert drawing_revision.revision_sequence == 1
+        assert drawing_revision.revision_kind == "ingest"
+        assert drawing_revision.review_state == "review_required"
+        assert drawing_revision.canonical_entity_schema_version == "0.1"
+        assert drawing_revision.confidence_score == 0.0
+
+        assert validation_report.project_id == job.project_id
+        assert validation_report.drawing_revision_id == drawing_revision.id
+        assert validation_report.source_job_id == job.id
+        assert validation_report.validation_report_schema_version == "0.1"
+        assert validation_report.canonical_entity_schema_version == "0.1"
+        assert validation_report.validation_status == "needs_review"
+        assert validation_report.review_state == "review_required"
+        assert validation_report.quantity_gate == "review_gated"
+        assert validation_report.effective_confidence == 0.0
+        assert validation_report.report_json == {
+            "validation_report_schema_version": "0.1",
+            "canonical_entity_schema_version": "0.1",
+            "validator": {"name": "noop.ingest", "version": "0.1"},
+            "summary": {
+                "validation_status": "needs_review",
+                "review_state": "review_required",
+                "quantity_gate": "review_gated",
+                "effective_confidence": 0.0,
+                "entity_counts": {
+                    "layouts": 0,
+                    "layers": 0,
+                    "blocks": 0,
+                    "entities": 0,
+                },
+            },
+            "checks": [],
+            "findings": [
+                {
+                    "code": "NOOP_INGEST_BRIDGE",
+                    "severity": "warning",
+                    "message": "No real adapter executed; review is required.",
+                }
+            ],
+            "adapter_warnings": [
+                {
+                    "code": "NOOP_INGEST_BRIDGE",
+                    "severity": "warning",
+                    "message": "No real adapter executed; review is required.",
+                }
+            ],
+            "provenance": adapter_output.provenance_json,
+        }
+
+    async def test_reprocess_creates_second_revision_with_predecessor(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Reprocess should append a second output set linked to the prior revision."""
+        _ = self
+        _ = cleanup_projects
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        first_job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(first_job.id)
+
+        reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(first_job.extraction_profile_id)},
+        )
+
+        assert reprocess_response.status_code == 202
+
+        second_job_id = _as_uuid(reprocess_response.json()["id"])
+        second_job = await _get_job(second_job_id)
+        assert enqueued_job_ids == [str(first_job.id), str(second_job.id)]
+
+        await process_ingest_job(second_job.id)
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+
+        assert len(adapter_outputs) == 2
+        assert len(drawing_revisions) == 2
+        assert len(validation_reports) == 2
+        assert generated_artifacts == []
+
+        first_revision, second_revision = drawing_revisions
+        first_adapter_output = next(
+            output for output in adapter_outputs if output.source_job_id == first_job.id
+        )
+        second_adapter_output = next(
+            output for output in adapter_outputs if output.source_job_id == second_job.id
+        )
+        first_validation_report = next(
+            report for report in validation_reports if report.source_job_id == first_job.id
+        )
+        second_validation_report = next(
+            report for report in validation_reports if report.source_job_id == second_job.id
+        )
+
+        assert first_revision.revision_sequence == 1
+        assert first_revision.revision_kind == "ingest"
+        assert first_revision.predecessor_revision_id is None
+        assert first_revision.adapter_run_output_id == first_adapter_output.id
+        assert first_validation_report.drawing_revision_id == first_revision.id
+
+        assert second_adapter_output.project_id == first_job.project_id
+        assert second_adapter_output.source_file_id == first_job.file_id
+        assert second_adapter_output.source_job_id == second_job.id
+        assert second_adapter_output.extraction_profile_id == second_job.extraction_profile_id
+        assert second_adapter_output.adapter_key == "noop.ingest"
+
+        assert second_revision.project_id == first_job.project_id
+        assert second_revision.source_file_id == first_job.file_id
+        assert second_revision.source_job_id == second_job.id
+        assert second_revision.extraction_profile_id == second_job.extraction_profile_id
+        assert second_revision.adapter_run_output_id == second_adapter_output.id
+        assert second_revision.revision_sequence == 2
+        assert second_revision.revision_kind == "reprocess"
+        assert second_revision.predecessor_revision_id == first_revision.id
+
+        assert second_validation_report.project_id == first_job.project_id
+        assert second_validation_report.source_job_id == second_job.id
+        assert second_validation_report.drawing_revision_id == second_revision.id
+        assert second_validation_report.validation_status == "needs_review"
+        assert second_validation_report.review_state == "review_required"
+        assert second_validation_report.quantity_gate == "review_gated"
+        assert second_validation_report.effective_confidence == 0.0
+
+    async def test_validation_report_allows_trd_status_and_gate_values(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Persisted validation reports should accept TRD v0.1 status and gate values."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, _drawing_revisions, validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        validation_report = validation_reports[0]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            persisted_validation_report = await session.get(ValidationReport, validation_report.id)
+            assert persisted_validation_report is not None
+            persisted_validation_report.validation_status = "valid_with_warnings"
+            persisted_validation_report.quantity_gate = "allowed_provisional"
+            await session.commit()
+
+        _adapter_outputs, _drawing_revisions, updated_validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        updated_validation_report = updated_validation_reports[0]
+
+        assert updated_validation_report.validation_status == "valid_with_warnings"
+        assert updated_validation_report.quantity_gate == "allowed_provisional"
+
+    async def test_concurrent_reprocess_creates_linear_three_revision_chain(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Concurrent reprocess runs should still persist a linear revision chain."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        first_job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(first_job.id)
+
+        second_reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(first_job.extraction_profile_id)},
+        )
+        assert second_reprocess_response.status_code == 202
+
+        third_reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(first_job.extraction_profile_id)},
+        )
+        assert third_reprocess_response.status_code == 202
+
+        second_job = await _get_job(_as_uuid(second_reprocess_response.json()["id"]))
+        third_job = await _get_job(_as_uuid(third_reprocess_response.json()["id"]))
+
+        await asyncio.gather(
+            process_ingest_job(second_job.id),
+            process_ingest_job(third_job.id),
+        )
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+
+        assert len(adapter_outputs) == 3
+        assert len(drawing_revisions) == 3
+        assert len(validation_reports) == 3
+        assert generated_artifacts == []
+
+        first_revision, second_revision, _third_revision = drawing_revisions
+        assert [revision.revision_sequence for revision in drawing_revisions] == [1, 2, 3]
+        assert [revision.predecessor_revision_id for revision in drawing_revisions] == [
+            None,
+            first_revision.id,
+            second_revision.id,
+        ]
+        assert [revision.revision_kind for revision in drawing_revisions] == [
+            "ingest",
+            "reprocess",
+            "reprocess",
+        ]
+
+        expected_job_ids = {first_job.id, second_job.id, third_job.id}
+        assert {output.source_job_id for output in adapter_outputs} == expected_job_ids
+        assert {report.source_job_id for report in validation_reports} == expected_job_ids
+
+    async def test_reprocess_before_initial_finalization_fails_without_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """A reprocess cannot finalize before the initial revision exists."""
+        _ = self
+        _ = cleanup_projects
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+
+        first_reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert first_reprocess_response.status_code == 202
+
+        second_reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert second_reprocess_response.status_code == 202
+
+        blocked_reprocess_job = await _get_job(_as_uuid(first_reprocess_response.json()["id"]))
+        _unused_reprocess_job = await _get_job(_as_uuid(second_reprocess_response.json()["id"]))
+        assert enqueued_job_ids == [
+            str(initial_job.id),
+            str(blocked_reprocess_job.id),
+            str(_unused_reprocess_job.id),
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match="Reprocess ingest job cannot finalize before a predecessor revision exists",
+        ):
+            await process_ingest_job(blocked_reprocess_job.id)
+
+        failed_reprocess_job = await _get_job(blocked_reprocess_job.id)
+        assert failed_reprocess_job.status == "failed"
+        assert failed_reprocess_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert (
+            failed_reprocess_job.error_message
+            == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
+        )
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        assert adapter_outputs == []
+        assert drawing_revisions == []
+        assert validation_reports == []
+        assert generated_artifacts == []
+
+        await process_ingest_job(initial_job.id)
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        assert len(adapter_outputs) == 1
+        assert len(drawing_revisions) == 1
+        assert len(validation_reports) == 1
+        assert generated_artifacts == []
+        assert adapter_outputs[0].source_job_id == initial_job.id
+        assert drawing_revisions[0].source_job_id == initial_job.id
+        assert drawing_revisions[0].revision_sequence == 1
+        assert drawing_revisions[0].predecessor_revision_id is None
+        assert drawing_revisions[0].revision_kind == "ingest"
+
+    async def test_process_ingest_job_cancelled_before_finalization_creates_no_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cancellation before finalization should publish no output rows."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _cancel_during_work(_: float) -> None:
+            await _update_job(job.id, cancel_requested=True)
+
+        monkeypatch.setattr(asyncio, "sleep", _cancel_during_work)
+
+        await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+
+        assert adapter_outputs == []
+        assert drawing_revisions == []
+        assert validation_reports == []
+        assert generated_artifacts == []
+
+    async def test_process_ingest_job_duplicate_delivery_after_success_keeps_single_output_set(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Duplicate success delivery should not append extra persisted outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+        first_outputs = await _load_project_outputs(project["id"])
+
+        await process_ingest_job(job.id)
+        second_outputs = await _load_project_outputs(project["id"])
+
+        assert len(second_outputs[0]) == 1
+        assert len(second_outputs[1]) == 1
+        assert len(second_outputs[2]) == 1
+        assert second_outputs[3] == []
+        assert [row.id for row in second_outputs[0]] == [row.id for row in first_outputs[0]]
+        assert [row.id for row in second_outputs[1]] == [row.id for row in first_outputs[1]]
+        assert [row.id for row in second_outputs[2]] == [row.id for row in first_outputs[2]]
+
+    async def test_process_ingest_job_missing_profile_fails_without_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Missing extraction profile should fail finalization without partial outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await _set_job_extraction_profile_id(job.id, None)
+
+        with pytest.raises(ValueError, match="Ingest job missing extraction profile"):
+            await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert updated_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
+
+        events = await _load_job_events(job.id)
+        assert events[-1].level == "error"
+        assert events[-1].message == "Job failed"
+        assert events[-1].data_json == {
+            "status": "failed",
+            "error_code": ErrorCode.INTERNAL_ERROR.value,
+            "error_message": worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE,
+        }
+
+        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+
+        assert adapter_outputs == []
+        assert drawing_revisions == []
+        assert validation_reports == []
+        assert generated_artifacts == []


### PR DESCRIPTION
Closes #91

## Summary
- Add durable persistence primitives for adapter run outputs, drawing revisions, validation reports, and generated artifact lineage so ingest results survive retries and reprocessing with deterministic history.
- Finalize no-op ingest outputs atomically under job and file locks, enforcing revision-order invariants and TRD-aligned validation/review gate contracts.
- Add DB-backed coverage for happy path persistence, cancellation, duplicate delivery, reprocess sequencing, concurrent finalization, and validation constraint acceptance.

## Test plan
- [x] `uv run ruff check app tests alembic`
- [x] `uv run mypy app tests`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_validation_91 uv run alembic upgrade head`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_validation_91 uv run pytest tests/test_ingest_output_persistence.py tests/test_jobs.py tests/test_files.py tests/test_extraction_profiles.py`

## Notes
- No breaking changes intended.
- The current worker persists a no-op bridge output; real adapter orchestration remains follow-on work.