### PR TITLE
feat: expose adapter capability and system health endpoints

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -4,5 +4,6 @@ from app.api.v1.files import files_router
 from app.api.v1.health import health_router
 from app.api.v1.jobs import jobs_router
 from app.api.v1.projects import project_router
+from app.api.v1.system import system_router
 
-__all__ = ["files_router", "health_router", "jobs_router", "project_router"]
+__all__ = ["files_router", "health_router", "jobs_router", "project_router", "system_router"]

--- a/app/api/v1/system.py
+++ b/app/api/v1/system.py
@@ -1,0 +1,630 @@
+"""System capability and bounded health endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import shutil
+import socket
+from collections.abc import Callable, Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException, Response, status
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response
+from app.core.logging import get_logger
+from app.db.session import get_engine
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDescriptor,
+    AdapterStatus,
+    AvailabilityReason,
+    LicenseState,
+    ProbeKind,
+    ProbeObservation,
+    ProbeRequirement,
+    ProbeStatus,
+)
+from app.ingestion.registry import evaluate_availability, list_descriptors
+from app.schemas.system import (
+    AdapterCapabilityRead,
+    AdapterHealthCheck,
+    ConfidenceRange,
+    DependencyHealthCheck,
+    SystemCapabilitiesResponse,
+    SystemCheckStatus,
+    SystemHealthChecks,
+    SystemHealthResponse,
+    SystemHealthStatus,
+)
+from app.storage import get_storage
+
+logger = get_logger(__name__)
+
+system_router = APIRouter()
+
+_DEPENDENCY_PROBE_TIMEOUT_SECONDS = 0.5
+_GENERIC_ADAPTER_PROBE_TIMEOUT_SECONDS = 0.5
+_LICENSE_APPROVAL_ENV = "DRAUPNIR_APPROVED_LICENSE_PROBES"
+_INFLIGHT_ADAPTER_PROBE_TASKS: dict[str, asyncio.Task[tuple[ProbeObservation, ...]]] = {}
+_INFLIGHT_ADAPTER_PROBE_TASKS_LOCK = asyncio.Lock()
+_ADAPTER_PROBE_CLEANUP_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _approved_license_probes() -> frozenset[str] | None:
+    """Return the optional set of explicitly approved license probe names."""
+
+    raw_value = os.environ.get(_LICENSE_APPROVAL_ENV)
+    if raw_value is None:
+        return None
+
+    approved = {item.strip() for item in raw_value.split(",") if item.strip()}
+    return frozenset(approved)
+
+
+def _probe_requirement(requirement: ProbeRequirement) -> ProbeObservation:
+    """Resolve a side-effect-free observation for a registry probe requirement."""
+
+    if requirement.kind is ProbeKind.BINARY:
+        return _probe_binary_requirement(requirement)
+    if requirement.kind is ProbeKind.PYTHON_PACKAGE:
+        return _probe_python_package_requirement(requirement)
+    if requirement.kind is ProbeKind.LICENSE:
+        return _probe_license_requirement(requirement)
+
+    return ProbeObservation(
+        kind=requirement.kind,
+        name=requirement.name,
+        status=ProbeStatus.UNKNOWN,
+        detail="Probe kind is not supported by the system endpoint.",
+    )
+
+
+def _probe_binary_requirement(requirement: ProbeRequirement) -> ProbeObservation:
+    """Check whether a required binary is present on PATH."""
+
+    binary_path = shutil.which(requirement.name)
+    return ProbeObservation(
+        kind=requirement.kind,
+        name=requirement.name,
+        status=ProbeStatus.AVAILABLE if binary_path is not None else ProbeStatus.MISSING,
+        detail=None if binary_path is not None else requirement.detail,
+    )
+
+
+def _probe_python_package_requirement(requirement: ProbeRequirement) -> ProbeObservation:
+    """Check whether a required Python package can be resolved without importing it."""
+
+    try:
+        package_spec = importlib.util.find_spec(requirement.name)
+    except (ImportError, ModuleNotFoundError, ValueError):
+        package_spec = None
+
+    return ProbeObservation(
+        kind=requirement.kind,
+        name=requirement.name,
+        status=ProbeStatus.AVAILABLE if package_spec is not None else ProbeStatus.MISSING,
+        detail=None if package_spec is not None else requirement.detail,
+    )
+
+
+def _probe_license_requirement(requirement: ProbeRequirement) -> ProbeObservation:
+    """Resolve runtime license approval without importing optional adapters."""
+
+    approved = _approved_license_probes()
+    if approved is None:
+        return ProbeObservation(
+            kind=requirement.kind,
+            name=requirement.name,
+            status=ProbeStatus.UNKNOWN,
+            detail="Runtime license approval signal is not configured.",
+        )
+
+    if requirement.name in approved:
+        return ProbeObservation(
+            kind=requirement.kind,
+            name=requirement.name,
+            status=ProbeStatus.AVAILABLE,
+            detail="Runtime license approval is configured.",
+        )
+
+    return ProbeObservation(
+        kind=requirement.kind,
+        name=requirement.name,
+        status=ProbeStatus.MISSING,
+        detail=requirement.detail,
+    )
+
+
+def _probe_observations_for_descriptor(
+    descriptor: AdapterDescriptor,
+) -> tuple[ProbeObservation, ...]:
+    """Collect bounded, side-effect-free observations for a descriptor."""
+
+    return tuple(_probe_requirement(requirement) for requirement in descriptor.probes)
+
+
+def _availability_timeout_seconds(descriptor: AdapterDescriptor) -> float:
+    """Return the effective probe timeout for a descriptor."""
+
+    return min(descriptor.bounded_probe_ms / 1000, _GENERIC_ADAPTER_PROBE_TIMEOUT_SECONDS)
+
+
+async def _run_descriptor_probe_task(
+    descriptor: AdapterDescriptor,
+) -> tuple[ProbeObservation, ...]:
+    """Run the descriptor probe in the threadpool."""
+
+    return await asyncio.to_thread(_probe_observations_for_descriptor, descriptor)
+
+
+async def _discard_inflight_adapter_probe_task(
+    adapter_key: str,
+    task: asyncio.Task[tuple[ProbeObservation, ...]],
+) -> None:
+    """Remove a completed shared probe task from the in-flight cache."""
+
+    async with _INFLIGHT_ADAPTER_PROBE_TASKS_LOCK:
+        if _INFLIGHT_ADAPTER_PROBE_TASKS.get(adapter_key) is task:
+            _INFLIGHT_ADAPTER_PROBE_TASKS.pop(adapter_key, None)
+
+
+def _schedule_inflight_adapter_probe_task_cleanup(
+    adapter_key: str,
+    task: asyncio.Task[tuple[ProbeObservation, ...]],
+) -> None:
+    """Schedule cleanup for a completed shared probe task."""
+
+    cleanup_task = asyncio.create_task(_discard_inflight_adapter_probe_task(adapter_key, task))
+    _ADAPTER_PROBE_CLEANUP_TASKS.add(cleanup_task)
+    cleanup_task.add_done_callback(_ADAPTER_PROBE_CLEANUP_TASKS.discard)
+
+
+def _inflight_adapter_probe_task_cleanup_callback(
+    adapter_key: str,
+) -> Callable[[asyncio.Task[tuple[ProbeObservation, ...]]], None]:
+    """Build a done callback that clears a shared probe task."""
+
+    def _callback(task: asyncio.Task[tuple[ProbeObservation, ...]]) -> None:
+        _schedule_inflight_adapter_probe_task_cleanup(adapter_key, task)
+
+    return _callback
+
+
+async def _get_or_create_inflight_adapter_probe_task(
+    descriptor: AdapterDescriptor,
+) -> asyncio.Task[tuple[ProbeObservation, ...]]:
+    """Reuse a single in-flight probe task per adapter descriptor."""
+
+    async with _INFLIGHT_ADAPTER_PROBE_TASKS_LOCK:
+        existing_task = _INFLIGHT_ADAPTER_PROBE_TASKS.get(descriptor.adapter_key)
+        if existing_task is not None and not existing_task.done():
+            return existing_task
+
+        probe_task = asyncio.create_task(_run_descriptor_probe_task(descriptor))
+        _INFLIGHT_ADAPTER_PROBE_TASKS[descriptor.adapter_key] = probe_task
+        probe_task.add_done_callback(
+            _inflight_adapter_probe_task_cleanup_callback(descriptor.adapter_key)
+        )
+        return probe_task
+
+
+async def _probe_descriptor_availability(descriptor: AdapterDescriptor) -> AdapterAvailability:
+    """Evaluate a descriptor's runtime availability within a bounded timeout."""
+
+    started_at = perf_counter()
+    checked_at = datetime.now(UTC)
+    probe_task = await _get_or_create_inflight_adapter_probe_task(descriptor)
+    try:
+        async with asyncio.timeout(_availability_timeout_seconds(descriptor)):
+            observations = await asyncio.shield(probe_task)
+    except TimeoutError:
+        return AdapterAvailability(
+            status=AdapterStatus.UNAVAILABLE,
+            availability_reason=AvailabilityReason.PROBE_FAILED,
+            license_state=LicenseState.UNKNOWN
+            if any(requirement.kind is ProbeKind.LICENSE for requirement in descriptor.probes)
+            else LicenseState.NOT_REQUIRED,
+            issues=(),
+            observed=(),
+            last_checked_at=checked_at,
+            details={
+                "probe_timed_out": True,
+                "required_probe_count": len(descriptor.probes),
+            },
+            probe_elapsed_ms=(perf_counter() - started_at) * 1000,
+        )
+
+    return evaluate_availability(
+        descriptor,
+        observations,
+        last_checked_at=checked_at,
+        probe_elapsed_ms=(perf_counter() - started_at) * 1000,
+    )
+
+
+def _confidence_range_from_descriptor(descriptor: AdapterDescriptor) -> ConfidenceRange | None:
+    """Convert a descriptor confidence range into the API response model."""
+
+    if descriptor.confidence_range is None:
+        return None
+
+    minimum, maximum = descriptor.confidence_range
+    return ConfidenceRange(min=minimum, max=maximum)
+
+
+def _availability_details(availability: AdapterAvailability) -> dict[str, object] | None:
+    """Return JSON-friendly adapter availability details."""
+
+    if availability.details is None:
+        return None
+    return dict(availability.details)
+
+
+def _capability_from_descriptor(
+    descriptor: AdapterDescriptor,
+    availability: AdapterAvailability,
+) -> AdapterCapabilityRead:
+    """Build a capability response entry from registry metadata and availability."""
+
+    capabilities = descriptor.capabilities
+    return AdapterCapabilityRead(
+        adapter_key=descriptor.adapter_key,
+        input_family=descriptor.family,
+        adapter_name=descriptor.display_name,
+        adapter_version=descriptor.adapter_version,
+        input_formats=list(descriptor.input_formats),
+        output_formats=list(descriptor.output_formats),
+        status=availability.status,
+        availability_reason=availability.availability_reason,
+        license_state=availability.license_state,
+        license_name=descriptor.license_name,
+        can_read=capabilities.can_read,
+        can_write=capabilities.can_write,
+        extracts_geometry=capabilities.extracts_geometry,
+        extracts_text=capabilities.extracts_text,
+        extracts_layers=capabilities.extracts_layers,
+        extracts_blocks=capabilities.extracts_blocks,
+        extracts_materials=capabilities.extracts_materials,
+        supports_exports=capabilities.supports_exports,
+        supports_quantity_hints=capabilities.supports_quantity_hints,
+        supports_layout_selection=capabilities.supports_layout_selection,
+        supports_xref_resolution=capabilities.supports_xref_resolution,
+        experimental=descriptor.experimental,
+        confidence_range=_confidence_range_from_descriptor(descriptor),
+        bounded_probe_ms=descriptor.bounded_probe_ms,
+        last_checked_at=availability.last_checked_at,
+        details=_availability_details(availability),
+    )
+
+
+def _status_from_adapter_availability(availability: AdapterAvailability) -> SystemCheckStatus:
+    """Map adapter availability states onto system health check states."""
+
+    if availability.status is AdapterStatus.AVAILABLE:
+        return SystemCheckStatus.OK
+    if availability.status is AdapterStatus.DEGRADED:
+        return SystemCheckStatus.DEGRADED
+    return SystemCheckStatus.DOWN
+
+
+def _error_code_from_adapter_availability(availability: AdapterAvailability) -> ErrorCode | None:
+    """Map adapter availability into the public operator error taxonomy."""
+
+    if availability.status is AdapterStatus.AVAILABLE:
+        return None
+
+    details = availability.details or {}
+    if details.get("probe_timed_out") is True:
+        return ErrorCode.ADAPTER_TIMEOUT
+    if availability.availability_reason is AvailabilityReason.PROBE_FAILED:
+        return ErrorCode.ADAPTER_FAILED
+    return ErrorCode.ADAPTER_UNAVAILABLE
+
+
+def _adapter_health_details(availability: AdapterAvailability) -> dict[str, object] | None:
+    """Return health-safe details for a probed adapter."""
+
+    details: dict[str, object] = {}
+    if availability.availability_reason is not None:
+        details["availability_reason"] = availability.availability_reason.value
+    details["license_state"] = availability.license_state.value
+    if availability.details is not None:
+        details.update(dict(availability.details))
+    return details or None
+
+
+def _adapter_health_from_availability(
+    descriptor: AdapterDescriptor,
+    availability: AdapterAvailability,
+) -> AdapterHealthCheck:
+    """Build an adapter health entry from availability state."""
+
+    return AdapterHealthCheck(
+        adapter_key=descriptor.adapter_key,
+        status=_status_from_adapter_availability(availability),
+        error_code=_error_code_from_adapter_availability(availability),
+        latency_ms=availability.probe_elapsed_ms,
+        details=_adapter_health_details(availability),
+    )
+
+
+def _aggregate_adapter_check_status(adapters: Iterable[AdapterHealthCheck]) -> SystemCheckStatus:
+    """Reduce individual adapter checks into a single adapter-group status."""
+
+    adapter_list = list(adapters)
+    if not adapter_list:
+        return SystemCheckStatus.UNKNOWN
+
+    statuses = {adapter.status for adapter in adapter_list}
+    if statuses == {SystemCheckStatus.OK}:
+        return SystemCheckStatus.OK
+    if statuses == {SystemCheckStatus.DOWN}:
+        return SystemCheckStatus.DOWN
+    if SystemCheckStatus.OK in statuses:
+        return SystemCheckStatus.DEGRADED
+    if SystemCheckStatus.DEGRADED in statuses:
+        return SystemCheckStatus.DEGRADED
+    return SystemCheckStatus.DOWN
+
+
+def _nearest_existing_ancestor(path: Path) -> Path | None:
+    """Return the nearest existing path at or above the given path."""
+
+    for candidate in (path, *path.parents):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+async def _probe_database_check() -> DependencyHealthCheck:
+    """Run a bounded liveness query against the configured database."""
+
+    engine = get_engine()
+    if engine is None:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            details={"configured": False},
+        )
+
+    started_at = perf_counter()
+    try:
+        async with asyncio.timeout(_DEPENDENCY_PROBE_TIMEOUT_SECONDS):
+            async with engine.connect() as connection:
+                await connection.execute(text("SELECT 1"))
+    except TimeoutError:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details={"timed_out": True},
+        )
+    except Exception:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details={"reachable": False},
+        )
+
+    return DependencyHealthCheck(
+        status=SystemCheckStatus.OK,
+        latency_ms=(perf_counter() - started_at) * 1000,
+    )
+
+
+def _probe_storage_root_sync(storage_root: Path) -> bool:
+    """Check whether the configured local storage root can be traversed or created."""
+
+    existing = _nearest_existing_ancestor(storage_root)
+    if existing is None or not existing.is_dir():
+        return False
+    return os.access(existing, os.R_OK | os.W_OK | os.X_OK)
+
+
+async def _probe_storage_check() -> DependencyHealthCheck:
+    """Run a bounded health check for the configured storage backend."""
+
+    storage = get_storage()
+    started_at = perf_counter()
+
+    storage_attributes = vars(storage) if hasattr(storage, "__dict__") else {}
+    raw_root = storage_attributes.get("root")
+    if isinstance(raw_root, Path):
+        try:
+            async with asyncio.timeout(_DEPENDENCY_PROBE_TIMEOUT_SECONDS):
+                healthy = await asyncio.to_thread(_probe_storage_root_sync, raw_root)
+        except TimeoutError:
+            return DependencyHealthCheck(
+                status=SystemCheckStatus.DOWN,
+                latency_ms=(perf_counter() - started_at) * 1000,
+                details={"timed_out": True},
+            )
+
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.OK if healthy else SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details=None if healthy else {"reachable": False},
+        )
+
+    try:
+        async with asyncio.timeout(_DEPENDENCY_PROBE_TIMEOUT_SECONDS):
+            await storage.exists("__draupnir_system_health__/nonexistent")
+    except TimeoutError:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details={"timed_out": True},
+        )
+    except Exception:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details={"reachable": False},
+        )
+
+    return DependencyHealthCheck(
+        status=SystemCheckStatus.OK,
+        latency_ms=(perf_counter() - started_at) * 1000,
+    )
+
+
+def _broker_endpoint() -> tuple[str, int]:
+    """Return the host and port for the configured message broker."""
+
+    parsed = urlparse(settings.broker_url)
+    host = parsed.hostname
+    if host is None:
+        raise ValueError("Broker host is not configured.")
+
+    if parsed.port is not None:
+        return host, parsed.port
+    if parsed.scheme in {"amqp", "pyamqp"}:
+        return host, 5672
+    if parsed.scheme == "amqps":
+        return host, 5671
+    raise ValueError("Broker URL scheme is not supported for health probing.")
+
+
+def _probe_broker_socket(timeout_seconds: float) -> None:
+    """Perform a bounded TCP handshake against the configured broker."""
+
+    host, port = _broker_endpoint()
+    with socket.create_connection((host, port), timeout=timeout_seconds):
+        pass
+
+
+async def _probe_broker_check() -> DependencyHealthCheck:
+    """Run a bounded broker reachability check."""
+
+    started_at = perf_counter()
+    try:
+        async with asyncio.timeout(_DEPENDENCY_PROBE_TIMEOUT_SECONDS):
+            await asyncio.to_thread(_probe_broker_socket, _DEPENDENCY_PROBE_TIMEOUT_SECONDS)
+    except TimeoutError:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details={"timed_out": True},
+        )
+    except (OSError, ValueError):
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=(perf_counter() - started_at) * 1000,
+            details={"reachable": False},
+        )
+
+    return DependencyHealthCheck(
+        status=SystemCheckStatus.OK,
+        latency_ms=(perf_counter() - started_at) * 1000,
+    )
+
+
+async def _build_adapter_health_checks() -> tuple[list[AdapterHealthCheck], SystemCheckStatus]:
+    """Build per-adapter health checks and the aggregate adapter-group status."""
+
+    descriptors = list_descriptors()
+    availabilities = await asyncio.gather(
+        *(_probe_descriptor_availability(descriptor) for descriptor in descriptors)
+    )
+    adapter_checks = [
+        _adapter_health_from_availability(descriptor, availability)
+        for descriptor, availability in zip(descriptors, availabilities, strict=True)
+    ]
+    return adapter_checks, _aggregate_adapter_check_status(adapter_checks)
+
+
+def _aggregate_system_health_status(
+    database: DependencyHealthCheck,
+    storage: DependencyHealthCheck,
+    broker: DependencyHealthCheck,
+    adapters: SystemCheckStatus,
+) -> SystemHealthStatus:
+    """Reduce dependency and adapter checks into the public top-level status."""
+
+    core_statuses = {database.status, storage.status, broker.status}
+    if SystemCheckStatus.DOWN in core_statuses:
+        return SystemHealthStatus.DOWN
+    if adapters is SystemCheckStatus.DOWN:
+        return SystemHealthStatus.DOWN
+    if SystemCheckStatus.DEGRADED in core_statuses or SystemCheckStatus.UNKNOWN in core_statuses:
+        return SystemHealthStatus.DEGRADED
+    if adapters in {SystemCheckStatus.DEGRADED, SystemCheckStatus.UNKNOWN}:
+        return SystemHealthStatus.DEGRADED
+    return SystemHealthStatus.OK
+
+
+@system_router.get("/system/capabilities", response_model=SystemCapabilitiesResponse)
+async def get_system_capabilities() -> SystemCapabilitiesResponse:
+    """Return the bounded runtime capability registry for configured adapters."""
+
+    try:
+        descriptors = list_descriptors()
+        availabilities = await asyncio.gather(
+            *(_probe_descriptor_availability(descriptor) for descriptor in descriptors)
+        )
+    except Exception:
+        logger.error("system_capabilities_failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code=ErrorCode.INTERNAL_ERROR,
+                message="Failed to build system capability registry",
+                details=None,
+            ),
+        ) from None
+
+    return SystemCapabilitiesResponse(
+        adapters=[
+            _capability_from_descriptor(descriptor, availability)
+            for descriptor, availability in zip(descriptors, availabilities, strict=True)
+        ]
+    )
+
+
+@system_router.get("/system/health", response_model=SystemHealthResponse)
+async def get_system_health(response: Response) -> SystemHealthResponse:
+    """Return bounded dependency and adapter health for operators."""
+
+    try:
+        database_check, storage_check, broker_check, adapter_bundle = await asyncio.gather(
+            _probe_database_check(),
+            _probe_storage_check(),
+            _probe_broker_check(),
+            _build_adapter_health_checks(),
+        )
+    except Exception:
+        logger.error("system_health_failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code=ErrorCode.INTERNAL_ERROR,
+                message="Failed to build system health response",
+                details=None,
+            ),
+        ) from None
+
+    adapter_checks, adapter_status = adapter_bundle
+    overall_status = _aggregate_system_health_status(
+        database_check,
+        storage_check,
+        broker_check,
+        adapter_status,
+    )
+    if overall_status is not SystemHealthStatus.OK:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+    return SystemHealthResponse(
+        status=overall_status,
+        checks=SystemHealthChecks(
+            database=database_check,
+            storage=storage_check,
+            broker=broker_check,
+            adapters=adapter_checks,
+        ),
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from app.api.v1 import files_router, health_router, jobs_router, project_router
+from app.api.v1 import files_router, health_router, jobs_router, project_router, system_router
 from app.core.config import settings
 from app.core.exceptions import custom_http_exception_handler, request_validation_exception_handler
 from app.core.logging import configure_logging, get_logger
@@ -35,6 +35,7 @@ def create_app() -> FastAPI:
     app.add_middleware(RequestIdMiddleware)
 
     app.include_router(health_router, prefix=settings.api_prefix)
+    app.include_router(system_router, prefix=settings.api_prefix)
     app.include_router(project_router, prefix=f"{settings.api_prefix}/projects")
     app.include_router(files_router, prefix=settings.api_prefix)
     app.include_router(jobs_router, prefix=settings.api_prefix)

--- a/app/schemas/system.py
+++ b/app/schemas/system.py
@@ -1,0 +1,169 @@
+"""Pydantic schemas for system capability and health endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from app.core.errors import ErrorCode
+from app.ingestion.contracts import (
+    AdapterStatus,
+    AvailabilityReason,
+    InputFamily,
+    LicenseState,
+    UploadFormat,
+)
+
+
+class SystemHealthStatus(StrEnum):
+    """Top-level system health states."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    DOWN = "down"
+
+
+class SystemCheckStatus(StrEnum):
+    """Dependency and adapter health states."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    DOWN = "down"
+    UNKNOWN = "unknown"
+
+
+class ConfidenceRange(BaseModel):
+    """Expected extraction confidence range for an adapter."""
+
+    min: float = Field(..., ge=0, le=1, description="Lower bound of expected confidence")
+    max: float = Field(..., ge=0, le=1, description="Upper bound of expected confidence")
+
+
+class AdapterCapabilityRead(BaseModel):
+    """Capability registry entry exposed by the system API."""
+
+    adapter_key: str = Field(..., description="Stable adapter registry key")
+    input_family: InputFamily = Field(..., description="Normalized input family")
+    adapter_name: str = Field(..., description="Operator-facing adapter name")
+    adapter_version: str | None = Field(None, description="Resolved adapter version if known")
+    input_formats: list[UploadFormat] = Field(
+        ...,
+        description="Concrete source formats accepted",
+    )
+    output_formats: list[str] = Field(
+        ...,
+        description="Concrete normalized or export formats emitted",
+    )
+    status: AdapterStatus = Field(..., description="Resolved adapter availability")
+    availability_reason: AvailabilityReason | None = Field(
+        None,
+        description="Primary availability reason when not fully available",
+    )
+    license_state: LicenseState = Field(..., description="Resolved runtime license posture")
+    license_name: str | None = Field(
+        None,
+        description="Short license identifier for the adapter",
+    )
+    can_read: bool = Field(..., description="Whether the adapter can read inputs")
+    can_write: bool = Field(..., description="Whether the adapter can write outputs")
+    extracts_geometry: bool = Field(..., description="Whether the adapter extracts geometry")
+    extracts_text: bool = Field(..., description="Whether the adapter extracts text")
+    extracts_layers: bool = Field(..., description="Whether the adapter extracts layers")
+    extracts_blocks: bool = Field(..., description="Whether the adapter extracts blocks")
+    extracts_materials: bool = Field(..., description="Whether the adapter extracts materials")
+    supports_exports: bool = Field(..., description="Whether the adapter supports exports")
+    supports_quantity_hints: bool = Field(
+        ...,
+        description="Whether the adapter emits quantity hints",
+    )
+    supports_layout_selection: bool = Field(
+        ...,
+        description="Whether the adapter supports layout selection",
+    )
+    supports_xref_resolution: bool = Field(
+        ...,
+        description="Whether the adapter supports xref resolution",
+    )
+    experimental: bool = Field(
+        ...,
+        description="Whether the adapter is experimental or review-first",
+    )
+    confidence_range: ConfidenceRange | None = Field(
+        None,
+        description="Expected extraction confidence range",
+    )
+    bounded_probe_ms: int = Field(
+        ...,
+        ge=1,
+        description="Maximum bounded probe budget in milliseconds",
+    )
+    last_checked_at: datetime | None = Field(
+        None,
+        description="Timestamp of the latest availability probe",
+    )
+    details: dict[str, object] | None = Field(
+        None,
+        description="Safe structured diagnostic metadata for operators",
+    )
+
+
+class SystemCapabilitiesResponse(BaseModel):
+    """Response model for the system capabilities endpoint."""
+
+    adapters: list[AdapterCapabilityRead] = Field(
+        ...,
+        description="Registered ingestion adapters",
+    )
+
+
+class DependencyHealthCheck(BaseModel):
+    """Health check payload for a core dependency."""
+
+    status: SystemCheckStatus = Field(..., description="Resolved dependency health")
+    latency_ms: float | None = Field(
+        default=None,
+        ge=0,
+        description="Probe latency in milliseconds",
+    )
+    details: dict[str, object] | None = Field(
+        default=None,
+        description="Safe structured dependency diagnostics",
+    )
+
+
+class AdapterHealthCheck(BaseModel):
+    """Health check payload for a single adapter."""
+
+    adapter_key: str = Field(..., description="Stable adapter registry key")
+    status: SystemCheckStatus = Field(..., description="Resolved adapter health")
+    error_code: ErrorCode | None = Field(
+        default=None,
+        description="Operator-safe adapter error code when the adapter is not healthy",
+    )
+    latency_ms: float | None = Field(
+        default=None,
+        ge=0,
+        description="Probe latency in milliseconds",
+    )
+    details: dict[str, object] | None = Field(
+        default=None,
+        description="Safe structured adapter diagnostics",
+    )
+
+
+class SystemHealthChecks(BaseModel):
+    """Grouped dependency and adapter health checks."""
+
+    database: DependencyHealthCheck
+    storage: DependencyHealthCheck
+    broker: DependencyHealthCheck
+    adapters: list[AdapterHealthCheck]
+
+
+class SystemHealthResponse(BaseModel):
+    """Response model for the system health endpoint."""
+
+    status: SystemHealthStatus
+    checks: SystemHealthChecks

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -1,0 +1,418 @@
+"""Tests for system capability and health endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from app.api.v1 import system as system_api
+from app.core.errors import ErrorCode
+from app.ingestion.contracts import (
+    AdapterDescriptor,
+    ProbeKind,
+    ProbeObservation,
+    ProbeRequirement,
+    ProbeStatus,
+)
+from app.ingestion.registry import evaluate_availability, list_descriptors
+from app.main import app as fastapi_app
+from app.schemas.system import (
+    AdapterHealthCheck,
+    DependencyHealthCheck,
+    SystemCheckStatus,
+)
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Provide the FastAPI application instance for testing."""
+
+    return fastapi_app
+
+
+@pytest.fixture
+async def async_client(app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Provide an async HTTP client for system endpoint tests."""
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+def _fake_probe_observation(requirement: ProbeRequirement) -> ProbeObservation:
+    """Return deterministic probe observations for adapter endpoint tests."""
+
+    if requirement.kind is ProbeKind.LICENSE:
+        return ProbeObservation(
+            kind=requirement.kind,
+            name=requirement.name,
+            status=ProbeStatus.AVAILABLE,
+        )
+    if requirement.kind is ProbeKind.PYTHON_PACKAGE:
+        return ProbeObservation(
+            kind=requirement.kind,
+            name=requirement.name,
+            status=ProbeStatus.AVAILABLE,
+        )
+    if requirement.kind is ProbeKind.BINARY and requirement.name == "tesseract":
+        return ProbeObservation(
+            kind=requirement.kind,
+            name=requirement.name,
+            status=ProbeStatus.MISSING,
+            detail=requirement.detail,
+        )
+    return ProbeObservation(
+        kind=requirement.kind,
+        name=requirement.name,
+        status=ProbeStatus.AVAILABLE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_system_capabilities_reflect_registry_availability_consistently(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capabilities should expose registry metadata plus evaluated availability."""
+
+    monkeypatch.setattr(system_api, "_probe_requirement", _fake_probe_observation)
+
+    response = await async_client.get("/v1/system/capabilities")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {"adapters"}
+
+    adapters_by_key = {adapter["adapter_key"]: adapter for adapter in payload["adapters"]}
+    expected_keys = {descriptor.adapter_key for descriptor in list_descriptors()}
+    assert set(adapters_by_key) == expected_keys
+
+    for descriptor in list_descriptors():
+        expected_availability = evaluate_availability(
+            descriptor,
+            tuple(_fake_probe_observation(requirement) for requirement in descriptor.probes),
+        )
+        adapter_payload = adapters_by_key[descriptor.adapter_key]
+
+        assert set(adapter_payload) == {
+            "adapter_key",
+            "input_family",
+            "adapter_name",
+            "adapter_version",
+            "input_formats",
+            "output_formats",
+            "status",
+            "availability_reason",
+            "license_state",
+            "license_name",
+            "can_read",
+            "can_write",
+            "extracts_geometry",
+            "extracts_text",
+            "extracts_layers",
+            "extracts_blocks",
+            "extracts_materials",
+            "supports_exports",
+            "supports_quantity_hints",
+            "supports_layout_selection",
+            "supports_xref_resolution",
+            "experimental",
+            "confidence_range",
+            "bounded_probe_ms",
+            "last_checked_at",
+            "details",
+        }
+        assert adapter_payload["adapter_name"] == descriptor.display_name
+        assert adapter_payload["status"] == expected_availability.status.value
+        expected_reason = (
+            expected_availability.availability_reason.value
+            if expected_availability.availability_reason is not None
+            else None
+        )
+        assert adapter_payload["availability_reason"] == expected_reason
+        assert adapter_payload["license_state"] == expected_availability.license_state.value
+        assert adapter_payload["can_read"] is descriptor.capabilities.can_read
+        assert adapter_payload["can_write"] is descriptor.capabilities.can_write
+        assert adapter_payload["extracts_geometry"] is descriptor.capabilities.extracts_geometry
+        assert (
+            adapter_payload["supports_quantity_hints"]
+            is descriptor.capabilities.supports_quantity_hints
+        )
+        assert adapter_payload["bounded_probe_ms"] == descriptor.bounded_probe_ms
+        assert adapter_payload["last_checked_at"] is not None
+
+    assert adapters_by_key["vtracer_tesseract"]["status"] == "degraded"
+    assert adapters_by_key["vtracer_tesseract"]["availability_reason"] == "missing_binary"
+
+
+@pytest.mark.asyncio
+async def test_system_health_returns_ok_and_200_when_all_checks_are_healthy(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Healthy dependencies and adapters should yield a 200 ok response."""
+
+    async def _ok_dependency() -> DependencyHealthCheck:
+        return DependencyHealthCheck(status=SystemCheckStatus.OK, latency_ms=1.0)
+
+    async def _ok_adapters() -> tuple[list[AdapterHealthCheck], SystemCheckStatus]:
+        return (
+            [
+                AdapterHealthCheck(
+                    adapter_key="ezdxf",
+                    status=SystemCheckStatus.OK,
+                    latency_ms=2.0,
+                )
+            ],
+            SystemCheckStatus.OK,
+        )
+
+    monkeypatch.setattr(system_api, "_probe_database_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_storage_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_broker_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_build_adapter_health_checks", _ok_adapters)
+
+    response = await async_client.get("/v1/system/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "checks": {
+            "database": {"status": "ok", "latency_ms": 1.0, "details": None},
+            "storage": {"status": "ok", "latency_ms": 1.0, "details": None},
+            "broker": {"status": "ok", "latency_ms": 1.0, "details": None},
+            "adapters": [
+                {
+                    "adapter_key": "ezdxf",
+                    "status": "ok",
+                    "error_code": None,
+                    "latency_ms": 2.0,
+                    "details": None,
+                }
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_system_health_returns_503_and_degraded_when_some_adapters_are_unavailable(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unavailable optional adapters should degrade overall system health."""
+
+    async def _ok_dependency() -> DependencyHealthCheck:
+        return DependencyHealthCheck(status=SystemCheckStatus.OK, latency_ms=1.0)
+
+    monkeypatch.setattr(system_api, "_probe_database_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_storage_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_broker_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_requirement", _fake_probe_observation)
+
+    response = await async_client.get("/v1/system/health")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "degraded"
+
+    adapter_payloads = {item["adapter_key"]: item for item in payload["checks"]["adapters"]}
+    assert adapter_payloads["vtracer_tesseract"]["status"] == "degraded"
+    assert adapter_payloads["vtracer_tesseract"]["error_code"] == "ADAPTER_UNAVAILABLE"
+    assert (
+        adapter_payloads["vtracer_tesseract"]["details"]["availability_reason"]
+        == "missing_binary"
+    )
+    assert adapter_payloads["libredwg"]["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_system_health_returns_503_and_down_when_core_dependency_is_down(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A down core dependency should force top-level system status down."""
+
+    async def _ok_dependency() -> DependencyHealthCheck:
+        return DependencyHealthCheck(status=SystemCheckStatus.OK, latency_ms=1.0)
+
+    async def _down_database() -> DependencyHealthCheck:
+        return DependencyHealthCheck(
+            status=SystemCheckStatus.DOWN,
+            latency_ms=3.0,
+            details={"reachable": False},
+        )
+
+    async def _ok_adapters() -> tuple[list[AdapterHealthCheck], SystemCheckStatus]:
+        return (
+            [
+                AdapterHealthCheck(
+                    adapter_key="ezdxf",
+                    status=SystemCheckStatus.OK,
+                    latency_ms=2.0,
+                )
+            ],
+            SystemCheckStatus.OK,
+        )
+
+    monkeypatch.setattr(system_api, "_probe_database_check", _down_database)
+    monkeypatch.setattr(system_api, "_probe_storage_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_broker_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_build_adapter_health_checks", _ok_adapters)
+
+    response = await async_client.get("/v1/system/health")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "down"
+
+
+@pytest.mark.asyncio
+async def test_v1_health_remains_shallow_when_system_probes_fail(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shallow health should stay independent from system probe failures."""
+
+    async def _failing_dependency() -> DependencyHealthCheck:
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(system_api, "_probe_database_check", _failing_dependency)
+    monkeypatch.setattr(system_api, "_probe_storage_check", _failing_dependency)
+    monkeypatch.setattr(system_api, "_probe_broker_check", _failing_dependency)
+
+    response = await async_client.get("/v1/health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {"status", "version"}
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_system_capabilities_hides_raw_probe_observation_shape(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Capabilities should expose contract fields, not raw probe observation payloads."""
+
+    monkeypatch.setattr(system_api, "_probe_requirement", _fake_probe_observation)
+
+    response = await async_client.get("/v1/system/capabilities")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    for adapter in payload["adapters"]:
+        assert "probes" not in adapter
+        assert "requirements" not in adapter
+        assert "observations" not in adapter
+
+        details = adapter["details"]
+        if details is not None:
+            assert "probe_observations" not in details
+            assert "raw_observations" not in details
+
+
+@pytest.mark.asyncio
+async def test_system_health_mixed_adapter_statuses_report_degraded_not_down_when_core_ok(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mixed adapter failures should degrade health without forcing overall down."""
+
+    async def _ok_dependency() -> DependencyHealthCheck:
+        return DependencyHealthCheck(status=SystemCheckStatus.OK, latency_ms=1.0)
+
+    async def _mixed_adapters() -> tuple[list[AdapterHealthCheck], SystemCheckStatus]:
+        return (
+            [
+                AdapterHealthCheck(
+                    adapter_key="ezdxf",
+                    status=SystemCheckStatus.OK,
+                    latency_ms=2.0,
+                ),
+                AdapterHealthCheck(
+                    adapter_key="vtracer_tesseract",
+                    status=SystemCheckStatus.DEGRADED,
+                    error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+                    latency_ms=2.0,
+                    details={"availability_reason": "missing_binary"},
+                ),
+                AdapterHealthCheck(
+                    adapter_key="ifcopenshell",
+                    status=SystemCheckStatus.DOWN,
+                    error_code=ErrorCode.ADAPTER_FAILED,
+                    latency_ms=2.0,
+                    details={"availability_reason": "probe_failed"},
+                ),
+            ],
+            SystemCheckStatus.DEGRADED,
+        )
+
+    monkeypatch.setattr(system_api, "_probe_database_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_storage_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_probe_broker_check", _ok_dependency)
+    monkeypatch.setattr(system_api, "_build_adapter_health_checks", _mixed_adapters)
+
+    response = await async_client.get("/v1/system/health")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "degraded"
+
+    adapters = {adapter["adapter_key"]: adapter for adapter in payload["checks"]["adapters"]}
+    assert adapters["ezdxf"]["status"] == "ok"
+    assert adapters["vtracer_tesseract"]["status"] == "degraded"
+    assert adapters["ifcopenshell"]["status"] == "down"
+
+
+@pytest.mark.asyncio
+async def test_probe_descriptor_availability_reuses_inflight_thread_probe_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent timeouts should share one background descriptor probe."""
+
+    descriptor = list_descriptors()[0]
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    call_count = 0
+
+    def _blocking_probe(_: AdapterDescriptor) -> tuple[ProbeObservation, ...]:
+        nonlocal call_count
+        call_count += 1
+        probe_started.set()
+        release_probe.wait(timeout=1.0)
+        return ()
+
+    monkeypatch.setattr(system_api, "_probe_observations_for_descriptor", _blocking_probe)
+    monkeypatch.setattr(system_api, "_availability_timeout_seconds", lambda _: 0.01)
+    system_api._INFLIGHT_ADAPTER_PROBE_TASKS.clear()
+
+    try:
+        first_probe = asyncio.create_task(system_api._probe_descriptor_availability(descriptor))
+        await asyncio.to_thread(probe_started.wait, 1.0)
+        second_probe = asyncio.create_task(system_api._probe_descriptor_availability(descriptor))
+
+        first_result, second_result = await asyncio.gather(first_probe, second_probe)
+
+        expected_details = {
+            "probe_timed_out": True,
+            "required_probe_count": len(descriptor.probes),
+        }
+        assert first_result.details == expected_details
+        assert second_result.details == expected_details
+        assert call_count == 1
+    finally:
+        release_probe.set()
+
+    for _ in range(100):
+        if descriptor.adapter_key not in system_api._INFLIGHT_ADAPTER_PROBE_TASKS:
+            break
+        await asyncio.sleep(0.01)
+
+    assert descriptor.adapter_key not in system_api._INFLIGHT_ADAPTER_PROBE_TASKS


### PR DESCRIPTION
Closes #93

## Summary
- Add `/v1/system/capabilities` and `/v1/system/health` so clients can inspect adapter readiness and system dependency health
- Surface adapter availability, dependency probe results, and license state while preserving the existing shallow `/v1/health` contract
- Bound repeated slow adapter probes by reusing in-flight probe tasks and add endpoint contract/regression coverage

## Test plan
- [x] `uv run ruff check`
- [x] `uv run mypy app tests`
- [x] `uv run pytest`

## Notes
- No breaking changes