### PR TITLE
feat: replace noop ingest worker with adapter runner

### DIFF
--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -30,6 +30,7 @@ from app.schemas.extraction_profile import ExtractionProfileCreate, FileReproces
 from app.schemas.file import FileListResponse, FileRead
 from app.schemas.job import JobRead
 from app.storage import Storage, get_storage
+from app.storage.keys import build_original_storage_key
 
 files_router = APIRouter()
 _UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
@@ -142,11 +143,6 @@ def _staging_path(file_id: UUID) -> Path:
 def _upload_root() -> Path:
     """Return the canonical local storage root for uploads and artifacts."""
     return Path(settings.storage_local_root).resolve()
-
-
-def _storage_key(file_id: UUID, checksum: str) -> str:
-    """Build the server-derived immutable storage key for an uploaded file."""
-    return f"originals/{file_id}/{checksum}"
 
 
 def _cleanup_uploaded_path(storage_path: Path) -> None:
@@ -387,7 +383,7 @@ async def upload_project_file(
                 total_bytes = next_total
 
         checksum = checksum_builder.hexdigest()
-        storage_key = _storage_key(file_id, checksum)
+        storage_key = build_original_storage_key(file_id, checksum)
 
         try:
             stored_object = await storage.put(storage_key, staging_path, immutable=True)

--- a/app/ingestion/finalization.py
+++ b/app/ingestion/finalization.py
@@ -1,0 +1,272 @@
+"""Helpers for normalizing adapter results into finalization payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from app.ingestion.contracts import AdapterResult, InputFamily
+
+_CANONICAL_ENTITY_SCHEMA_VERSION = "0.1"
+_VALIDATION_REPORT_SCHEMA_VERSION = "0.1"
+_INITIAL_INGEST_REVISION_KIND = "ingest"
+_REPROCESS_REVISION_KIND = "reprocess"
+_RUNNER_VALIDATOR_NAME = "ingestion.runner"
+_RUNNER_VALIDATOR_VERSION = "0.1"
+
+
+@dataclass(frozen=True, slots=True)
+class IngestFinalizationPayload:
+    """Prepared ingest payload inserted during finalization."""
+
+    revision_kind: str
+    adapter_key: str
+    adapter_version: str
+    input_family: str
+    canonical_entity_schema_version: str
+    canonical_json: dict[str, Any]
+    provenance_json: dict[str, Any]
+    confidence_json: dict[str, Any]
+    confidence_score: float
+    warnings_json: list[Any]
+    diagnostics_json: dict[str, Any]
+    result_checksum_sha256: str
+    validation_report_schema_version: str
+    validation_status: str
+    review_state: str
+    quantity_gate: str
+    effective_confidence: float
+    validator_name: str
+    validator_version: str
+    report_json: dict[str, Any]
+    generated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class IngestFinalizationContext:
+    """Immutable context required to build a finalization payload."""
+
+    job_id: UUID
+    file_id: UUID
+    extraction_profile_id: UUID | None
+    initial_job_id: UUID | None
+    input_family: InputFamily
+    adapter_key: str
+    adapter_version: str
+
+
+def utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(UTC)
+
+
+def resolve_revision_kind(job_id: UUID, *, initial_job_id: UUID | None) -> str:
+    """Map file linkage to the correct ingest revision kind."""
+    if initial_job_id == job_id:
+        return _INITIAL_INGEST_REVISION_KIND
+
+    return _REPROCESS_REVISION_KIND
+
+
+def compute_adapter_result_checksum(result_envelope: Mapping[str, Any]) -> str:
+    """Return a stable SHA-256 checksum for a committed result envelope."""
+    payload = json.dumps(
+        _json_compatible(result_envelope),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def build_ingest_finalization_payload(
+    context: IngestFinalizationContext,
+    *,
+    result: AdapterResult,
+    generated_at: datetime | None = None,
+) -> IngestFinalizationPayload:
+    """Build a deterministic finalization payload from an adapter result."""
+    emitted_at = generated_at or utcnow()
+    canonical_json = _coerce_dict(result.canonical)
+    canonical_entity_schema_version = _resolve_canonical_schema_version(canonical_json)
+    revision_kind = resolve_revision_kind(context.job_id, initial_job_id=context.initial_job_id)
+    provenance_records = [_json_compatible(record) for record in result.provenance]
+    warnings_json = [_json_compatible(warning) for warning in result.warnings]
+    diagnostics = [_json_compatible(diagnostic) for diagnostic in result.diagnostics]
+    confidence_score = _confidence_score(result)
+    review_state, validation_status, quantity_gate = _derive_review_outcome(
+        confidence_score=confidence_score,
+        review_required=(
+            result.confidence.review_required if result.confidence is not None else True
+        ),
+        has_warnings=bool(warnings_json),
+    )
+    confidence_json = {
+        "score": result.confidence.score if result.confidence is not None else None,
+        "effective_confidence": confidence_score,
+        "review_state": review_state,
+        "review_required": review_state == "review_required",
+        "basis": result.confidence.basis if result.confidence is not None else None,
+    }
+    provenance_json = {
+        "schema_version": canonical_entity_schema_version,
+        "adapter": {
+            "key": context.adapter_key,
+            "version": context.adapter_version,
+        },
+        "source": {
+            "file_id": str(context.file_id),
+            "job_id": str(context.job_id),
+            "extraction_profile_id": (
+                str(context.extraction_profile_id)
+                if context.extraction_profile_id is not None
+                else None
+            ),
+            "input_family": context.input_family.value,
+            "revision_kind": revision_kind,
+        },
+        "records": provenance_records,
+        "generated_at": emitted_at.isoformat(),
+    }
+    diagnostics_json = {
+        "adapter": context.adapter_key,
+        "adapter_version": context.adapter_version,
+        "diagnostics": diagnostics,
+    }
+    report_json = {
+        "validation_report_schema_version": _VALIDATION_REPORT_SCHEMA_VERSION,
+        "canonical_entity_schema_version": canonical_entity_schema_version,
+        "validator": {
+            "name": _RUNNER_VALIDATOR_NAME,
+            "version": _RUNNER_VALIDATOR_VERSION,
+        },
+        "summary": {
+            "validation_status": validation_status,
+            "review_state": review_state,
+            "quantity_gate": quantity_gate,
+            "effective_confidence": confidence_score,
+            "entity_counts": _entity_counts(canonical_json),
+        },
+        "checks": [],
+        "findings": warnings_json,
+        "adapter_warnings": warnings_json,
+        "provenance": provenance_json,
+    }
+    result_envelope = {
+        "adapter_key": context.adapter_key,
+        "adapter_version": context.adapter_version,
+        "input_family": context.input_family.value,
+        "canonical_entity_schema_version": canonical_entity_schema_version,
+        "canonical_json": canonical_json,
+        "provenance_json": provenance_json,
+        "confidence_json": confidence_json,
+        "confidence_score": confidence_score,
+        "warnings_json": warnings_json,
+        "diagnostics_json": diagnostics_json,
+    }
+
+    return IngestFinalizationPayload(
+        revision_kind=revision_kind,
+        adapter_key=context.adapter_key,
+        adapter_version=context.adapter_version,
+        input_family=context.input_family.value,
+        canonical_entity_schema_version=canonical_entity_schema_version,
+        canonical_json=canonical_json,
+        provenance_json=provenance_json,
+        confidence_json=confidence_json,
+        confidence_score=confidence_score,
+        warnings_json=warnings_json,
+        diagnostics_json=diagnostics_json,
+        result_checksum_sha256=compute_adapter_result_checksum(result_envelope),
+        validation_report_schema_version=_VALIDATION_REPORT_SCHEMA_VERSION,
+        validation_status=validation_status,
+        review_state=review_state,
+        quantity_gate=quantity_gate,
+        effective_confidence=confidence_score,
+        validator_name=_RUNNER_VALIDATOR_NAME,
+        validator_version=_RUNNER_VALIDATOR_VERSION,
+        report_json=report_json,
+        generated_at=emitted_at,
+    )
+
+
+def _coerce_dict(value: Mapping[str, Any]) -> dict[str, Any]:
+    payload = _json_compatible(value)
+    if not isinstance(payload, dict):
+        raise TypeError("Adapter canonical payload must serialize to an object.")
+
+    return payload
+
+
+def _resolve_canonical_schema_version(canonical_json: dict[str, Any]) -> str:
+    if "canonical_entity_schema_version" in canonical_json:
+        return str(canonical_json["canonical_entity_schema_version"])
+
+    if "schema_version" in canonical_json:
+        schema_version = str(canonical_json["schema_version"])
+        canonical_json.setdefault("canonical_entity_schema_version", schema_version)
+        return schema_version
+
+    canonical_json["canonical_entity_schema_version"] = _CANONICAL_ENTITY_SCHEMA_VERSION
+    canonical_json.setdefault("schema_version", _CANONICAL_ENTITY_SCHEMA_VERSION)
+    return _CANONICAL_ENTITY_SCHEMA_VERSION
+
+
+def _confidence_score(result: AdapterResult) -> float:
+    if result.confidence is None or result.confidence.score is None:
+        return 0.0
+
+    return float(result.confidence.score)
+
+
+def _derive_review_outcome(
+    *,
+    confidence_score: float,
+    review_required: bool,
+    has_warnings: bool,
+) -> tuple[str, str, str]:
+    if review_required or confidence_score < 0.60:
+        return ("review_required", "needs_review", "review_gated")
+
+    if confidence_score < 0.95:
+        validation_status = "valid_with_warnings" if has_warnings else "valid"
+        return ("provisional", validation_status, "allowed_provisional")
+
+    validation_status = "valid_with_warnings" if has_warnings else "valid"
+    return ("approved", validation_status, "allowed")
+
+
+def _entity_counts(canonical_json: Mapping[str, Any]) -> dict[str, int]:
+    return {
+        "layouts": _sequence_length(canonical_json.get("layouts")),
+        "layers": _sequence_length(canonical_json.get("layers")),
+        "blocks": _sequence_length(canonical_json.get("blocks")),
+        "entities": _sequence_length(canonical_json.get("entities")),
+    }
+
+
+def _sequence_length(value: Any) -> int:
+    if isinstance(value, (list, tuple)):
+        return len(value)
+
+    return 0
+
+
+def _json_compatible(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return _json_compatible(asdict(value))
+
+    if isinstance(value, Mapping):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_compatible(item) for item in value]
+
+    if isinstance(value, UUID):
+        return str(value)
+
+    return value

--- a/app/ingestion/loader.py
+++ b/app/ingestion/loader.py
@@ -1,0 +1,31 @@
+"""Dynamic adapter loader for ingestion runners."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from typing import cast
+
+from app.ingestion.contracts import AdapterDescriptor, IngestionAdapter
+
+_FACTORY_NAME = "create_adapter"
+
+
+def load_adapter(descriptor: AdapterDescriptor) -> IngestionAdapter:
+    """Import an adapter module and call its standard factory."""
+    module = importlib.import_module(descriptor.module)
+
+    try:
+        factory = getattr(module, _FACTORY_NAME)
+    except AttributeError as exc:
+        raise AttributeError(
+            f"Adapter module '{descriptor.module}' does not define '{_FACTORY_NAME}'."
+        ) from exc
+
+    if not callable(factory):
+        raise TypeError(
+            f"Adapter module '{descriptor.module}' exposes non-callable '{_FACTORY_NAME}'."
+        )
+
+    adapter_factory = cast(Callable[[], IngestionAdapter], factory)
+    return adapter_factory()

--- a/app/ingestion/runner.py
+++ b/app/ingestion/runner.py
@@ -1,0 +1,369 @@
+"""Scaffolding for adapter-backed ingestion runner execution."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from app.core.errors import ErrorCode
+from app.ingestion.contracts import (
+    AdapterExecutionOptions,
+    AdapterFailureKind,
+    AdapterResult,
+    AdapterSource,
+    AdapterTimeout,
+    CancellationHandle,
+    IngestionAdapter,
+    ProgressCallback,
+)
+from app.ingestion.finalization import (
+    IngestFinalizationContext,
+    IngestFinalizationPayload,
+    build_ingest_finalization_payload,
+)
+from app.ingestion.loader import load_adapter
+from app.ingestion.selection import AdapterCandidate, select_adapter_candidates
+from app.ingestion.source import (
+    OriginalSourceMaterialization,
+    OriginalSourceReadError,
+    OriginalSourceStageError,
+    materialize_original_source,
+)
+from app.storage import Storage
+
+_DEFAULT_ADAPTER_TIMEOUT = AdapterTimeout(seconds=300)
+
+
+@dataclass(frozen=True, slots=True)
+class IngestionRunRequest:
+    """Immutable inputs required to run an adapter-backed ingest attempt."""
+
+    job_id: UUID
+    file_id: UUID
+    checksum_sha256: str
+    detected_format: str | None
+    media_type: str | None
+    original_name: str | None = None
+    extraction_profile_id: UUID | None = None
+    initial_job_id: UUID | None = None
+
+
+class IngestionRunnerError(Exception):
+    """Sanitized typed failure surfaced by ingestion runner scaffolding."""
+
+    def __init__(
+        self,
+        *,
+        error_code: ErrorCode,
+        failure_kind: AdapterFailureKind,
+        message: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+        self.failure_kind = failure_kind
+        self.message = message
+        self.details = details or {}
+
+
+@dataclass(frozen=True, slots=True)
+class _ExecutionPolicy:
+    """Shared timeout/cancellation budget for a single ingestion attempt."""
+
+    timeout: AdapterTimeout | None
+    cancellation: CancellationHandle | None
+    started_at: float
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        timeout: AdapterTimeout | None,
+        cancellation: CancellationHandle | None,
+    ) -> _ExecutionPolicy:
+        return cls(timeout=timeout, cancellation=cancellation, started_at=time.monotonic())
+
+    def checkpoint(self, *, stage: str, adapter_key: str | None = None) -> AdapterTimeout | None:
+        if self.cancellation is not None and self.cancellation.is_cancelled():
+            raise _cancelled_error(stage=stage, adapter_key=adapter_key)
+
+        if self.timeout is None:
+            return None
+
+        remaining_seconds = self.timeout.seconds - (time.monotonic() - self.started_at)
+        if remaining_seconds <= 0:
+            raise _timeout_error(stage=stage, adapter_key=adapter_key)
+
+        return AdapterTimeout(seconds=remaining_seconds)
+
+
+async def run_ingestion(
+    request: IngestionRunRequest,
+    *,
+    storage: Storage | None = None,
+    temp_root: Path | None = None,
+    timeout: AdapterTimeout | None = None,
+    cancellation: CancellationHandle | None = None,
+    on_progress: ProgressCallback | None = None,
+    generated_at: datetime | None = None,
+) -> IngestFinalizationPayload:
+    """Run the first loadable adapter candidate and build a payload."""
+    policy = _ExecutionPolicy.start(
+        timeout=timeout or _DEFAULT_ADAPTER_TIMEOUT,
+        cancellation=cancellation,
+    )
+
+    try:
+        candidates = select_adapter_candidates(
+            request.detected_format,
+            media_type=request.media_type,
+        )
+    except ValueError as exc:
+        raise IngestionRunnerError(
+            error_code=ErrorCode.INPUT_UNSUPPORTED_FORMAT,
+            failure_kind=AdapterFailureKind.UNSUPPORTED_FORMAT,
+            message="Input format is not supported for ingestion.",
+            details={
+                "detected_format": request.detected_format,
+                "media_type": request.media_type,
+            },
+        ) from exc
+
+    last_unavailable_error: IngestionRunnerError | None = None
+    for candidate in candidates:
+        policy.checkpoint(stage="load", adapter_key=candidate.descriptor.key)
+        try:
+            adapter = load_adapter(candidate.descriptor)
+        except ModuleNotFoundError as exc:
+            last_unavailable_error = _adapter_load_error(
+                candidate,
+                reason=(
+                    "module_missing"
+                    if exc.name in {None, candidate.descriptor.module}
+                    else "dependency_missing"
+                ),
+            )
+            continue
+        except AttributeError:
+            reason = "factory_missing"
+            last_unavailable_error = _adapter_load_error(candidate, reason=reason)
+            continue
+        except TypeError:
+            reason = "factory_invalid"
+            last_unavailable_error = _adapter_load_error(candidate, reason=reason)
+            continue
+
+        materialization = OriginalSourceMaterialization(
+            file_id=request.file_id,
+            checksum_sha256=request.checksum_sha256,
+            upload_format=candidate.upload_format,
+            input_family=candidate.input_family,
+            media_type=request.media_type,
+            original_name=request.original_name,
+        )
+        source_context = materialize_original_source(
+            materialization,
+            storage=storage,
+            temp_root=temp_root,
+        )
+        source: AdapterSource | None = None
+        try:
+            source = await _enter_materialized_source(
+                source_context,
+                timeout=policy.checkpoint(stage="source", adapter_key=candidate.descriptor.key),
+                adapter_key=candidate.descriptor.key,
+            )
+            policy.checkpoint(stage="source", adapter_key=candidate.descriptor.key)
+            remaining_timeout = policy.checkpoint(
+                stage="execute",
+                adapter_key=candidate.descriptor.key,
+            )
+            result = await _execute_adapter(
+                adapter,
+                source,
+                timeout=remaining_timeout,
+                cancellation=cancellation,
+                on_progress=on_progress,
+                adapter_key=candidate.descriptor.key,
+            )
+            policy.checkpoint(stage="execute", adapter_key=candidate.descriptor.key)
+        except OriginalSourceReadError as exc:
+            raise _storage_error(candidate, exc) from exc
+        except OriginalSourceStageError as exc:
+            raise _staging_error(candidate, exc) from exc
+        except asyncio.CancelledError as exc:
+            raise _cancelled_error(stage="source", adapter_key=candidate.descriptor.key) from exc
+        finally:
+            if source is not None:
+                await source_context.__aexit__(None, None, None)
+
+        return build_ingest_finalization_payload(
+            IngestFinalizationContext(
+                job_id=request.job_id,
+                file_id=request.file_id,
+                extraction_profile_id=request.extraction_profile_id,
+                initial_job_id=request.initial_job_id,
+                input_family=candidate.input_family,
+                adapter_key=candidate.descriptor.key,
+                adapter_version=_adapter_version(candidate, adapter),
+            ),
+            result=result,
+            generated_at=generated_at,
+        )
+
+    if last_unavailable_error is not None:
+        raise last_unavailable_error
+
+    raise IngestionRunnerError(
+        error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+        failure_kind=AdapterFailureKind.UNAVAILABLE,
+        message="No ingestion adapter candidates were available.",
+    )
+
+
+async def _execute_adapter(
+    adapter: IngestionAdapter,
+    source: AdapterSource,
+    *,
+    timeout: AdapterTimeout | None,
+    cancellation: CancellationHandle | None,
+    on_progress: ProgressCallback | None,
+    adapter_key: str,
+) -> AdapterResult:
+    options = AdapterExecutionOptions(
+        timeout=timeout,
+        cancellation=cancellation,
+        on_progress=on_progress,
+    )
+
+    try:
+        ingestion = adapter.ingest(source, options)
+        if timeout is None:
+            return await ingestion
+        return await asyncio.wait_for(ingestion, timeout=timeout.seconds)
+    except TimeoutError as exc:
+        raise IngestionRunnerError(
+            error_code=ErrorCode.ADAPTER_TIMEOUT,
+            failure_kind=AdapterFailureKind.TIMEOUT,
+            message="Adapter execution timed out.",
+            details={"adapter_key": adapter_key, "stage": "execute"},
+        ) from exc
+    except asyncio.CancelledError as exc:
+        raise IngestionRunnerError(
+            error_code=ErrorCode.JOB_CANCELLED,
+            failure_kind=AdapterFailureKind.CANCELLED,
+            message="Adapter execution was cancelled.",
+            details={"adapter_key": adapter_key, "stage": "execute"},
+        ) from exc
+    except Exception as exc:
+        raise IngestionRunnerError(
+            error_code=ErrorCode.ADAPTER_FAILED,
+            failure_kind=AdapterFailureKind.FAILED,
+            message="Adapter execution failed.",
+            details={"adapter_key": adapter_key},
+        ) from exc
+
+
+def _adapter_load_error(candidate: AdapterCandidate, *, reason: str) -> IngestionRunnerError:
+    return IngestionRunnerError(
+        error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+        failure_kind=AdapterFailureKind.UNAVAILABLE,
+        message="Adapter could not be loaded.",
+        details={
+            "adapter_key": candidate.descriptor.key,
+            "input_family": candidate.input_family.value,
+            "reason": reason,
+        },
+    )
+
+
+def _storage_error(
+    candidate: AdapterCandidate,
+    exc: OriginalSourceReadError,
+) -> IngestionRunnerError:
+    return IngestionRunnerError(
+        error_code=ErrorCode.STORAGE_FAILED,
+        failure_kind=AdapterFailureKind.FAILED,
+        message="Failed to read original source from storage.",
+        details={
+            "adapter_key": candidate.descriptor.key,
+            "input_family": candidate.input_family.value,
+            "reason": exc.reason,
+        },
+    )
+
+
+def _staging_error(
+    candidate: AdapterCandidate,
+    exc: OriginalSourceStageError,
+) -> IngestionRunnerError:
+    return IngestionRunnerError(
+        error_code=ErrorCode.STORAGE_FAILED,
+        failure_kind=AdapterFailureKind.FAILED,
+        message="Failed to stage original source.",
+        details={
+            "adapter_key": candidate.descriptor.key,
+            "input_family": candidate.input_family.value,
+            "reason": exc.reason,
+        },
+    )
+
+
+async def _enter_materialized_source(
+    source_context: AbstractAsyncContextManager[AdapterSource],
+    *,
+    timeout: AdapterTimeout | None,
+    adapter_key: str,
+) -> AdapterSource:
+    try:
+        if timeout is None:
+            return await source_context.__aenter__()
+        return await asyncio.wait_for(source_context.__aenter__(), timeout=timeout.seconds)
+    except TimeoutError as exc:
+        raise _timeout_error(stage="source", adapter_key=adapter_key) from exc
+    except asyncio.CancelledError as exc:
+        raise _cancelled_error(stage="source", adapter_key=adapter_key) from exc
+
+
+def _timeout_error(*, stage: str, adapter_key: str | None) -> IngestionRunnerError:
+    details: dict[str, Any] = {"stage": stage}
+    if adapter_key is not None:
+        details["adapter_key"] = adapter_key
+
+    return IngestionRunnerError(
+        error_code=ErrorCode.ADAPTER_TIMEOUT,
+        failure_kind=AdapterFailureKind.TIMEOUT,
+        message="Adapter execution timed out.",
+        details=details,
+    )
+
+
+def _cancelled_error(*, stage: str, adapter_key: str | None) -> IngestionRunnerError:
+    details: dict[str, Any] = {"stage": stage}
+    if adapter_key is not None:
+        details["adapter_key"] = adapter_key
+
+    return IngestionRunnerError(
+        error_code=ErrorCode.JOB_CANCELLED,
+        failure_kind=AdapterFailureKind.CANCELLED,
+        message="Adapter execution was cancelled.",
+        details=details,
+    )
+
+
+def _adapter_version(candidate: AdapterCandidate, adapter: IngestionAdapter) -> str:
+    declared_version = candidate.descriptor.adapter_version
+    if declared_version is not None:
+        return declared_version
+
+    runtime_version = getattr(adapter, "version", None)
+    if isinstance(runtime_version, str) and runtime_version:
+        return runtime_version
+
+    return "unknown"

--- a/app/ingestion/selection.py
+++ b/app/ingestion/selection.py
@@ -1,0 +1,82 @@
+"""Candidate selection helpers for ingestion runners."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.ingestion.contracts import AdapterDescriptor, InputFamily, UploadFormat
+from app.ingestion.registry import descriptors_for_upload_format, get_descriptor
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterCandidate:
+    """A concrete adapter candidate for a source upload."""
+
+    upload_format: UploadFormat
+    input_family: InputFamily
+    descriptor: AdapterDescriptor
+
+
+def select_adapter_candidates(
+    detected_format: str | UploadFormat | InputFamily | None,
+    *,
+    media_type: str | None,
+) -> tuple[AdapterCandidate, ...]:
+    """Resolve ordered adapter candidates for a detected upload."""
+    input_family = resolve_input_family(detected_format)
+    if input_family is not None:
+        descriptor = get_descriptor(input_family)
+        descriptor_upload_format = descriptor.upload_formats[0]
+        return (AdapterCandidate(descriptor_upload_format, input_family, descriptor),)
+
+    upload_format = resolve_upload_format(detected_format, media_type=media_type)
+    if upload_format is None:
+        raise ValueError("Unsupported upload format for ingestion.")
+
+    return tuple(
+        AdapterCandidate(upload_format, descriptor.family, descriptor)
+        for descriptor in descriptors_for_upload_format(upload_format)
+    )
+
+
+def resolve_input_family(
+    detected_format: str | UploadFormat | InputFamily | None,
+) -> InputFamily | None:
+    """Resolve a concrete input family when already known."""
+    if isinstance(detected_format, InputFamily):
+        return detected_format
+
+    if isinstance(detected_format, UploadFormat) or detected_format is None:
+        return None
+
+    normalized = detected_format.strip().lower()
+    try:
+        return InputFamily(normalized)
+    except ValueError:
+        return None
+
+
+def resolve_upload_format(
+    detected_format: str | UploadFormat | InputFamily | None,
+    *,
+    media_type: str | None,
+) -> UploadFormat | None:
+    """Resolve an upload format from immutable file metadata."""
+    if isinstance(detected_format, UploadFormat):
+        return detected_format
+
+    if isinstance(detected_format, InputFamily):
+        descriptor = get_descriptor(detected_format)
+        return descriptor.upload_formats[0]
+
+    if detected_format is not None:
+        normalized = detected_format.strip().lower()
+        try:
+            return UploadFormat(normalized)
+        except ValueError:
+            pass
+
+    if media_type is not None and media_type.lower() == "application/pdf":
+        return UploadFormat.PDF
+
+    return None

--- a/app/ingestion/source.py
+++ b/app/ingestion/source.py
@@ -1,0 +1,95 @@
+"""Source materialization helpers for ingestion runners."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from uuid import UUID
+
+from app.ingestion.contracts import AdapterSource, InputFamily, UploadFormat
+from app.storage import Storage, get_storage
+from app.storage.base import StorageChecksumMismatchError
+from app.storage.keys import build_original_storage_key
+
+
+@dataclass(frozen=True, slots=True)
+class OriginalSourceMaterialization:
+    """Immutable source metadata required to stage an original upload."""
+
+    file_id: UUID
+    checksum_sha256: str
+    upload_format: UploadFormat
+    input_family: InputFamily
+    media_type: str | None
+    original_name: str | None = None
+
+
+class OriginalSourceReadError(Exception):
+    """Sanitized original-source read failure."""
+
+    def __init__(self, *, storage_key: str, reason: str) -> None:
+        super().__init__("Failed to read original source from storage.")
+        self.storage_key = storage_key
+        self.reason = reason
+
+
+class OriginalSourceStageError(Exception):
+    """Sanitized original-source staging failure."""
+
+    def __init__(self, *, reason: str) -> None:
+        super().__init__("Failed to stage original source.")
+        self.reason = reason
+
+
+@asynccontextmanager
+async def materialize_original_source(
+    source: OriginalSourceMaterialization,
+    *,
+    storage: Storage | None = None,
+    temp_root: Path | None = None,
+) -> AsyncIterator[AdapterSource]:
+    """Fetch an immutable original and stage it into an attempt-local tempdir."""
+    resolved_storage = storage or get_storage()
+    storage_key = build_original_storage_key(source.file_id, source.checksum_sha256)
+    try:
+        stored_object = await resolved_storage.get(
+            storage_key,
+            expected_checksum_sha256=source.checksum_sha256,
+        )
+    except StorageChecksumMismatchError as exc:
+        raise OriginalSourceReadError(
+            storage_key=storage_key,
+            reason="checksum_mismatch",
+        ) from exc
+    except (FileNotFoundError, KeyError) as exc:
+        raise OriginalSourceReadError(
+            storage_key=storage_key,
+            reason="not_found",
+        ) from exc
+    except OSError as exc:
+        raise OriginalSourceReadError(
+            storage_key=storage_key,
+            reason="read_failed",
+        ) from exc
+
+    temp_dir_root = str(temp_root) if temp_root is not None else None
+    with TemporaryDirectory(prefix="ingestion-source-", dir=temp_dir_root) as temp_dir:
+        file_path = Path(temp_dir) / _materialized_name(source)
+        try:
+            file_path.write_bytes(stored_object.body)
+        except OSError as exc:
+            raise OriginalSourceStageError(reason="stage_failed") from exc
+        yield AdapterSource(
+            file_path=file_path,
+            upload_format=source.upload_format,
+            input_family=source.input_family,
+            media_type=source.media_type,
+            original_name=source.original_name,
+        )
+
+
+def _materialized_name(source: OriginalSourceMaterialization) -> str:
+    return f"source.{source.upload_format.value}"

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1,8 +1,7 @@
 """Celery worker application and persisted job handlers."""
 
 import asyncio
-import hashlib
-import json
+import inspect
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -18,6 +17,9 @@ from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
+from app.ingestion.contracts import AdapterTimeout, ProgressUpdate
+from app.ingestion.finalization import IngestFinalizationPayload
+from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.file import File
@@ -27,26 +29,97 @@ from app.models.validation_report import ValidationReport
 
 logger = get_logger(__name__)
 
-_INGEST_NOOP_DELAY_SECONDS = 0.01
 _INCOMPLETE_JOB_STATUSES = ("pending", "running")
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
 _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
+_JOB_CANCELLATION_POLL_INTERVAL_SECONDS = 0.1
 _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
 _ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
 _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
-_NOOP_ADAPTER_KEY = "noop.ingest"
-_NOOP_ADAPTER_VERSION = "0.1"
-_CANONICAL_ENTITY_SCHEMA_VERSION = "0.1"
-_VALIDATION_REPORT_SCHEMA_VERSION = "0.1"
-_NOOP_REVIEW_STATE = "review_required"
-_NOOP_VALIDATION_STATUS = "needs_review"
-_NOOP_QUANTITY_GATE = "review_gated"
-_NOOP_CONFIDENCE_SCORE = 0.0
+_PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
-_NOOP_VALIDATOR_NAME = "noop.ingest"
-_NOOP_VALIDATOR_VERSION = "0.1"
+_SAFE_RUNNER_ERROR_DETAIL_KEYS = (
+    "adapter_key",
+    "input_family",
+    "reason",
+    "stage",
+    "detected_format",
+    "media_type",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _QueuedJobEvent:
+    """Buffered job event persisted by the progress drain."""
+
+    level: str
+    message: str
+    data_json: dict[str, Any]
+
+
+class _PersistedJobCancellationHandle:
+    """Cancellation handle backed by worker polling."""
+
+    def __init__(self) -> None:
+        self._cancel_requested = False
+
+    def is_cancelled(self) -> bool:
+        return self._cancel_requested
+
+    def mark_cancelled(self) -> None:
+        self._cancel_requested = True
+
+
+class _JobProgressEventBridge:
+    """Synchronous progress callback with async DB draining."""
+
+    _STOP = object()
+
+    def __init__(self, job_id: UUID) -> None:
+        self._job_id = job_id
+        self._queue: asyncio.Queue[_QueuedJobEvent | object] = asyncio.Queue()
+        self._drain_task = asyncio.create_task(self._drain())
+        self._closed = False
+
+    def callback(self, update: ProgressUpdate) -> None:
+        if self._closed:
+            raise RuntimeError("Progress callback received update after bridge closed.")
+
+        self._queue.put_nowait(
+            _QueuedJobEvent(
+                level="info",
+                message=update.message or f"Job progress: {update.stage}",
+                data_json=_progress_event_data(update),
+            )
+        )
+
+    async def flush(self) -> None:
+        if self._closed:
+            await self._drain_task
+            return
+
+        self._closed = True
+        self._queue.put_nowait(self._STOP)
+        await self._drain_task
+
+    async def _drain(self) -> None:
+        while True:
+            queued = await self._queue.get()
+            try:
+                if queued is self._STOP:
+                    return
+
+                assert isinstance(queued, _QueuedJobEvent)
+                await emit_job_event(
+                    self._job_id,
+                    level=queued.level,
+                    message=queued.message,
+                    data_json=queued.data_json,
+                )
+            finally:
+                self._queue.task_done()
 
 celery_app = Celery(
     "draupnir",
@@ -68,44 +141,6 @@ celery_app.autodiscover_tasks(["app.jobs"], force=True)
 def _utcnow() -> datetime:
     """Return a timezone-aware UTC timestamp."""
     return datetime.now(UTC)
-
-
-@dataclass(frozen=True, slots=True)
-class NoopIngestPayloadSource:
-    """Immutable source snapshot used to build no-op ingest payloads."""
-
-    file_id: UUID
-    extraction_profile_id: UUID | None
-    initial_job_id: UUID | None
-    detected_format: str | None
-    media_type: str
-
-
-@dataclass(frozen=True, slots=True)
-class NoopIngestOutputPayload:
-    """Prepared no-op ingest payload inserted during finalization."""
-
-    revision_kind: str
-    adapter_key: str
-    adapter_version: str
-    input_family: str
-    canonical_entity_schema_version: str
-    canonical_json: dict[str, Any]
-    provenance_json: dict[str, Any]
-    confidence_json: dict[str, Any]
-    confidence_score: float
-    warnings_json: list[Any]
-    diagnostics_json: dict[str, Any]
-    result_checksum_sha256: str
-    validation_report_schema_version: str
-    validation_status: str
-    review_state: str
-    quantity_gate: str
-    effective_confidence: float
-    validator_name: str
-    validator_version: str
-    report_json: dict[str, Any]
-    generated_at: datetime
 
 
 def _is_stale_running_job(job: Job, *, now: datetime) -> bool:
@@ -173,47 +208,12 @@ async def _get_latest_drawing_revision(
     return result.scalar_one_or_none()
 
 
-def _normalize_input_family(source: NoopIngestPayloadSource) -> str:
-    """Map immutable file metadata to a stable no-op input family."""
-    if source.detected_format is not None:
-        return source.detected_format.lower()
-
-    media_type = source.media_type.lower()
-    if media_type == "application/pdf":
-        return "pdf"
-
-    return "unknown"
-
-
-def _compute_adapter_result_checksum(result_envelope: dict[str, Any]) -> str:
-    """Return a stable SHA-256 checksum for a committed result envelope."""
-    payload = json.dumps(result_envelope, sort_keys=True, separators=(",", ":")).encode(
-        "utf-8"
-    )
-    return hashlib.sha256(payload).hexdigest()
-
-
 def _resolve_revision_kind(job_id: UUID, *, initial_job_id: UUID | None) -> str:
     """Map file linkage to the correct ingest revision kind."""
     if initial_job_id == job_id:
         return _INITIAL_INGEST_REVISION_KIND
 
     return _REPROCESS_REVISION_KIND
-
-
-def _resolve_noop_revision_kind(job_id: UUID, *, source: NoopIngestPayloadSource) -> str:
-    """Map the source file linkage to the correct ingest revision kind."""
-    return _resolve_revision_kind(job_id, initial_job_id=source.initial_job_id)
-
-
-def _build_noop_entity_counts() -> dict[str, int]:
-    """Return stable empty entity counts for no-op payloads."""
-    return {
-        "layouts": 0,
-        "layers": 0,
-        "blocks": 0,
-        "entities": 0,
-    }
 
 
 def _assert_revision_invariants(
@@ -242,8 +242,8 @@ def _assert_revision_invariants(
         )
 
 
-async def _load_noop_ingest_payload_source(job_id: UUID) -> NoopIngestPayloadSource:
-    """Load immutable file metadata needed for no-op payload construction."""
+async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
+    """Load persisted job and file metadata for the ingestion runner."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -264,130 +264,20 @@ async def _load_noop_ingest_payload_source(job_id: UUID) -> NoopIngestPayloadSou
                 f"File with identifier '{job.file_id}' for job '{job_id}' not found"
             )
 
-        return NoopIngestPayloadSource(
+        return IngestionRunRequest(
+            job_id=job.id,
             file_id=source_file.id,
-            extraction_profile_id=job.extraction_profile_id,
-            initial_job_id=source_file.initial_job_id,
+            checksum_sha256=source_file.checksum_sha256,
             detected_format=source_file.detected_format,
             media_type=source_file.media_type,
+            original_name=source_file.original_filename,
+            extraction_profile_id=job.extraction_profile_id,
+            initial_job_id=source_file.initial_job_id,
         )
 
 
-def _build_noop_ingest_output_payload(
-    job_id: UUID,
-    *,
-    source: NoopIngestPayloadSource,
-) -> NoopIngestOutputPayload:
-    """Construct the immutable no-op ingest payload outside finalization."""
-    generated_at = _utcnow()
-    input_family = _normalize_input_family(source)
-    revision_kind = _resolve_noop_revision_kind(job_id, source=source)
-    entity_counts = _build_noop_entity_counts()
-    canonical_json: dict[str, Any] = {
-        "canonical_entity_schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
-        "schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
-        "layouts": [],
-        "layers": [],
-        "blocks": [],
-        "entities": [],
-        "entity_counts": entity_counts,
-    }
-    provenance_json = {
-        "schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
-        "bridge": "noop_ingest",
-        "adapter": {
-            "key": _NOOP_ADAPTER_KEY,
-            "version": _NOOP_ADAPTER_VERSION,
-        },
-        "source": {
-            "file_id": str(source.file_id),
-            "job_id": str(job_id),
-            "extraction_profile_id": (
-                str(source.extraction_profile_id)
-                if source.extraction_profile_id is not None
-                else None
-            ),
-            "input_family": input_family,
-            "revision_kind": revision_kind,
-        },
-        "generated_at": generated_at.isoformat(),
-    }
-    noop_warning = {
-        "code": "NOOP_INGEST_BRIDGE",
-        "severity": "warning",
-        "message": "No real adapter executed; review is required.",
-    }
-    confidence_json = {
-        "score": _NOOP_CONFIDENCE_SCORE,
-        "effective_confidence": _NOOP_CONFIDENCE_SCORE,
-        "review_state": _NOOP_REVIEW_STATE,
-    }
-    warnings_json: list[Any] = [noop_warning]
-    diagnostics_json = {
-        "adapter": _NOOP_ADAPTER_KEY,
-        "adapter_version": _NOOP_ADAPTER_VERSION,
-        "bridge": "noop_ingest",
-        "timing": {"sleep_seconds": _INGEST_NOOP_DELAY_SECONDS},
-    }
-    report_json = {
-        "validation_report_schema_version": _VALIDATION_REPORT_SCHEMA_VERSION,
-        "canonical_entity_schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
-        "validator": {
-            "name": _NOOP_VALIDATOR_NAME,
-            "version": _NOOP_VALIDATOR_VERSION,
-        },
-        "summary": {
-            "validation_status": _NOOP_VALIDATION_STATUS,
-            "review_state": _NOOP_REVIEW_STATE,
-            "quantity_gate": _NOOP_QUANTITY_GATE,
-            "effective_confidence": _NOOP_CONFIDENCE_SCORE,
-            "entity_counts": entity_counts,
-        },
-        "checks": [],
-        "findings": [noop_warning],
-        "adapter_warnings": warnings_json,
-        "provenance": provenance_json,
-    }
-    result_envelope = {
-        "adapter_key": _NOOP_ADAPTER_KEY,
-        "adapter_version": _NOOP_ADAPTER_VERSION,
-        "input_family": input_family,
-        "canonical_entity_schema_version": _CANONICAL_ENTITY_SCHEMA_VERSION,
-        "canonical_json": canonical_json,
-        "provenance_json": provenance_json,
-        "confidence_json": confidence_json,
-        "confidence_score": _NOOP_CONFIDENCE_SCORE,
-        "warnings_json": warnings_json,
-        "diagnostics_json": diagnostics_json,
-    }
-
-    return NoopIngestOutputPayload(
-        revision_kind=revision_kind,
-        adapter_key=_NOOP_ADAPTER_KEY,
-        adapter_version=_NOOP_ADAPTER_VERSION,
-        input_family=input_family,
-        canonical_entity_schema_version=_CANONICAL_ENTITY_SCHEMA_VERSION,
-        canonical_json=canonical_json,
-        provenance_json=provenance_json,
-        confidence_json=confidence_json,
-        confidence_score=_NOOP_CONFIDENCE_SCORE,
-        warnings_json=warnings_json,
-        diagnostics_json=diagnostics_json,
-        result_checksum_sha256=_compute_adapter_result_checksum(result_envelope),
-        validation_report_schema_version=_VALIDATION_REPORT_SCHEMA_VERSION,
-        validation_status=_NOOP_VALIDATION_STATUS,
-        review_state=_NOOP_REVIEW_STATE,
-        quantity_gate=_NOOP_QUANTITY_GATE,
-        effective_confidence=_NOOP_CONFIDENCE_SCORE,
-        validator_name=_NOOP_VALIDATOR_NAME,
-        validator_version=_NOOP_VALIDATOR_VERSION,
-        report_json=report_json,
-        generated_at=generated_at,
-    )
-
-
-async def _finalize_ingest_job(job_id: UUID, *, payload: NoopIngestOutputPayload) -> bool:
-    """Atomically publish durable no-op outputs and terminal job success."""
+async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPayload) -> bool:
+    """Atomically publish durable ingest outputs and terminal job success."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -576,6 +466,113 @@ async def emit_job_event(
         await managed_session.commit()
 
 
+def _progress_event_data(update: ProgressUpdate) -> dict[str, Any]:
+    """Build a stable persisted progress event payload."""
+    data_json: dict[str, Any] = {
+        "status": "running",
+        "event": "progress",
+        "stage": update.stage,
+    }
+    if update.message is not None:
+        data_json["detail"] = update.message
+    if update.completed is not None:
+        data_json["completed"] = update.completed
+    if update.total is not None:
+        data_json["total"] = update.total
+    if update.percent is not None:
+        data_json["percent"] = update.percent
+    return data_json
+
+
+def _runner_error_log_fields(exc: IngestionRunnerError) -> dict[str, Any]:
+    """Return whitelisted structured fields for expected runner failures."""
+    data_json: dict[str, Any] = {
+        "error_code": exc.error_code.value,
+        "failure_kind": exc.failure_kind.value,
+        "error_message": exc.message,
+    }
+    for key in _SAFE_RUNNER_ERROR_DETAIL_KEYS:
+        value = exc.details.get(key)
+        if value is not None:
+            data_json[key] = value
+    return data_json
+
+
+def _runner_supports_keyword(runner: Any, keyword: str) -> bool:
+    """Return whether a runner callable accepts a given keyword."""
+    signature = inspect.signature(runner)
+    parameters = signature.parameters.values()
+    if any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters):
+        return True
+    return keyword in signature.parameters
+
+
+async def _invoke_ingestion_runner(
+    request: IngestionRunRequest,
+    *,
+    timeout: AdapterTimeout,
+    cancellation: _PersistedJobCancellationHandle,
+    on_progress: Any,
+) -> IngestFinalizationPayload:
+    """Call the runner while remaining compatible with patched test doubles."""
+    kwargs: dict[str, Any] = {}
+    if _runner_supports_keyword(run_ingestion, "timeout"):
+        kwargs["timeout"] = timeout
+    if _runner_supports_keyword(run_ingestion, "cancellation"):
+        kwargs["cancellation"] = cancellation
+    if _runner_supports_keyword(run_ingestion, "on_progress"):
+        kwargs["on_progress"] = on_progress
+    return await run_ingestion(request, **kwargs)
+
+
+async def _poll_job_cancellation(
+    job_id: UUID,
+    *,
+    cancellation: _PersistedJobCancellationHandle,
+    run_task: asyncio.Task[IngestFinalizationPayload],
+    stop_event: asyncio.Event,
+) -> None:
+    """Poll persisted cancellation without holding DB locks during execution."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    while not stop_event.is_set() and not cancellation.is_cancelled():
+        async with session_maker() as session:
+            result = await session.execute(select(Job.cancel_requested).where(Job.id == job_id))
+            cancel_requested = result.scalar_one_or_none()
+
+        if cancel_requested is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if cancel_requested:
+            cancellation.mark_cancelled()
+            run_task.cancel()
+            return
+
+        try:
+            await asyncio.wait_for(
+                stop_event.wait(),
+                timeout=_JOB_CANCELLATION_POLL_INTERVAL_SECONDS,
+            )
+        except TimeoutError:
+            continue
+
+
+async def _stop_job_execution_monitor(
+    *,
+    progress_bridge: _JobProgressEventBridge,
+    stop_event: asyncio.Event,
+    cancellation_task: asyncio.Task[None],
+) -> None:
+    """Flush queued progress and stop background execution monitors."""
+    stop_event.set()
+    try:
+        await cancellation_task
+    finally:
+        await progress_bridge.flush()
+
+
 async def _mark_job_failed(
     job_id: UUID,
     *,
@@ -612,6 +609,36 @@ async def _mark_job_failed(
                 "error_code": error_code.value,
                 "error_message": error_message,
             },
+            session=session,
+        )
+        await session.commit()
+
+
+async def _mark_job_cancelled(job_id: UUID) -> None:
+    """Persist a cancelled job state."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "ingest_job_cancel_mark_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return
+
+        _finalize_job_cancelled(job)
+        await emit_job_event(
+            job_id,
+            level="warning",
+            message="Job cancelled",
+            data_json={"status": "cancelled"},
             session=session,
         )
         await session.commit()
@@ -722,7 +749,7 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
 
 
 async def process_ingest_job(job_id: UUID) -> None:
-    """Load a persisted ingest job, perform a no-op, and persist state transitions."""
+    """Load a persisted ingest job, run ingestion, and persist state transitions."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -731,15 +758,62 @@ async def process_ingest_job(job_id: UUID) -> None:
         return
 
     try:
-        await asyncio.sleep(_INGEST_NOOP_DELAY_SECONDS)
-    except Exception as exc:
-        await _mark_job_failed(job_id, error_message=str(exc))
-        logger.error("ingest_job_failed", job_id=str(job_id), error=str(exc), exc_info=True)
+        request = await _build_ingestion_run_request(job_id)
+        progress_bridge = _JobProgressEventBridge(job_id)
+        cancellation = _PersistedJobCancellationHandle()
+        stop_event = asyncio.Event()
+        run_task = asyncio.create_task(
+            _invoke_ingestion_runner(
+                request,
+                timeout=AdapterTimeout(seconds=_DEFAULT_ADAPTER_TIMEOUT.total_seconds()),
+                cancellation=cancellation,
+                on_progress=progress_bridge.callback,
+            )
+        )
+        cancellation_task = asyncio.create_task(
+            _poll_job_cancellation(
+                job_id,
+                cancellation=cancellation,
+                run_task=run_task,
+                stop_event=stop_event,
+            )
+        )
+        try:
+            payload = await run_task
+        finally:
+            await _stop_job_execution_monitor(
+                progress_bridge=progress_bridge,
+                stop_event=stop_event,
+                cancellation_task=cancellation_task,
+            )
+    except IngestionRunnerError as exc:
+        if exc.error_code is ErrorCode.JOB_CANCELLED:
+            await _mark_job_cancelled(job_id)
+            logger.info(
+                "ingest_job_cancelled_during_execution",
+                job_id=str(job_id),
+                error_code=exc.error_code.value,
+            )
+        else:
+            await _mark_job_failed(job_id, error_message=exc.message, error_code=exc.error_code)
+            logger.error("ingest_job_failed", job_id=str(job_id), **_runner_error_log_fields(exc))
+        raise
+    except asyncio.CancelledError:
+        await _mark_job_cancelled(job_id)
+        logger.info("ingest_job_cancelled_during_execution", job_id=str(job_id))
+        raise
+    except Exception:
+        await _mark_job_failed(job_id, error_message=_PROCESS_INGEST_JOB_ERROR_MESSAGE)
+        logger.error(
+            "ingest_job_failed",
+            job_id=str(job_id),
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message=_PROCESS_INGEST_JOB_ERROR_MESSAGE,
+            exc_info=True,
+        )
         raise
 
     try:
-        payload_source = await _load_noop_ingest_payload_source(job_id)
-        payload = _build_noop_ingest_output_payload(job_id, source=payload_source)
         finalized = await _finalize_ingest_job(job_id, payload=payload)
     except Exception as exc:
         await _mark_job_failed(job_id, error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE)

--- a/app/storage/keys.py
+++ b/app/storage/keys.py
@@ -1,0 +1,8 @@
+"""Shared helpers for immutable storage object keys."""
+
+from uuid import UUID
+
+
+def build_original_storage_key(file_id: UUID, checksum: str) -> str:
+    """Build the immutable storage key for an uploaded source file."""
+    return f"originals/{file_id}/{checksum}"

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -19,6 +19,17 @@ from app.models.job_event import JobEvent
 from app.models.validation_report import ValidationReport
 from tests.conftest import requires_database
 from tests.test_jobs import (
+    _FAKE_RUNNER_ADAPTER_KEY,
+    _FAKE_RUNNER_ADAPTER_VERSION,
+    _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+    _FAKE_RUNNER_CONFIDENCE_SCORE,
+    _FAKE_RUNNER_QUANTITY_GATE,
+    _FAKE_RUNNER_REVIEW_STATE,
+    _FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION,
+    _FAKE_RUNNER_VALIDATION_STATUS,
+    _FAKE_RUNNER_VALIDATOR_NAME,
+    _FAKE_RUNNER_VALIDATOR_VERSION,
+    _build_fake_ingest_payload,
     _create_project,
     _get_job,
     _get_job_for_file,
@@ -130,13 +141,13 @@ async def _set_job_extraction_profile_id(
 class TestIngestOutputPersistence:
     """Tests for durable ingest output persistence and finalization guards."""
 
-    async def test_process_ingest_job_persists_single_noop_output_set(
+    async def test_process_ingest_job_persists_single_runner_output_set(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
     ) -> None:
-        """Successful ingest should atomically persist one no-op output set."""
+        """Successful ingest should atomically persist one runner output set."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
@@ -164,35 +175,42 @@ class TestIngestOutputPersistence:
         assert adapter_output.source_file_id == job.file_id
         assert adapter_output.source_job_id == job.id
         assert adapter_output.extraction_profile_id == job.extraction_profile_id
-        assert adapter_output.adapter_key == "noop.ingest"
-        assert adapter_output.adapter_version == "0.1"
-        assert adapter_output.input_family == "pdf"
-        assert adapter_output.canonical_entity_schema_version == "0.1"
-        assert adapter_output.confidence_score == 0.0
+        assert adapter_output.adapter_key == _FAKE_RUNNER_ADAPTER_KEY
+        assert adapter_output.adapter_version == _FAKE_RUNNER_ADAPTER_VERSION
+        assert adapter_output.input_family == "pdf_vector"
+        assert (
+            adapter_output.canonical_entity_schema_version
+            == _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION
+        )
+        assert adapter_output.confidence_score == _FAKE_RUNNER_CONFIDENCE_SCORE
         assert adapter_output.canonical_json == {
-            "canonical_entity_schema_version": "0.1",
-            "schema_version": "0.1",
-            "layouts": [],
-            "layers": [],
+            "canonical_entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+            "schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+            "layouts": [{"name": "Model"}],
+            "layers": [{"name": "A-WALL"}],
             "blocks": [],
-            "entities": [],
+            "entities": [{"kind": "line", "layer": "A-WALL"}],
             "entity_counts": {
-                "layouts": 0,
-                "layers": 0,
+                "layouts": 1,
+                "layers": 1,
                 "blocks": 0,
-                "entities": 0,
+                "entities": 1,
             },
         }
         assert adapter_output.provenance_json == {
-            "schema_version": "0.1",
-            "bridge": "noop_ingest",
-            "adapter": {"key": "noop.ingest", "version": "0.1"},
+            "schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+            "bridge": "tests.fake_ingestion_runner",
+            "adapter": {
+                "key": _FAKE_RUNNER_ADAPTER_KEY,
+                "version": _FAKE_RUNNER_ADAPTER_VERSION,
+            },
             "source": {
                 "file_id": str(job.file_id),
                 "job_id": str(job.id),
                 "extraction_profile_id": str(job.extraction_profile_id),
-                "input_family": "pdf",
+                "input_family": "pdf_vector",
                 "revision_kind": "ingest",
+                "original_name": "plan.pdf",
             },
             "generated_at": adapter_output.provenance_json["generated_at"],
         }
@@ -205,50 +223,50 @@ class TestIngestOutputPersistence:
         assert drawing_revision.predecessor_revision_id is None
         assert drawing_revision.revision_sequence == 1
         assert drawing_revision.revision_kind == "ingest"
-        assert drawing_revision.review_state == "review_required"
-        assert drawing_revision.canonical_entity_schema_version == "0.1"
-        assert drawing_revision.confidence_score == 0.0
+        assert drawing_revision.review_state == _FAKE_RUNNER_REVIEW_STATE
+        assert (
+            drawing_revision.canonical_entity_schema_version
+            == _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION
+        )
+        assert drawing_revision.confidence_score == _FAKE_RUNNER_CONFIDENCE_SCORE
 
         assert validation_report.project_id == job.project_id
         assert validation_report.drawing_revision_id == drawing_revision.id
         assert validation_report.source_job_id == job.id
-        assert validation_report.validation_report_schema_version == "0.1"
-        assert validation_report.canonical_entity_schema_version == "0.1"
-        assert validation_report.validation_status == "needs_review"
-        assert validation_report.review_state == "review_required"
-        assert validation_report.quantity_gate == "review_gated"
-        assert validation_report.effective_confidence == 0.0
+        assert (
+            validation_report.validation_report_schema_version
+            == _FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION
+        )
+        assert (
+            validation_report.canonical_entity_schema_version
+            == _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION
+        )
+        assert validation_report.validation_status == _FAKE_RUNNER_VALIDATION_STATUS
+        assert validation_report.review_state == _FAKE_RUNNER_REVIEW_STATE
+        assert validation_report.quantity_gate == _FAKE_RUNNER_QUANTITY_GATE
+        assert validation_report.effective_confidence == _FAKE_RUNNER_CONFIDENCE_SCORE
         assert validation_report.report_json == {
-            "validation_report_schema_version": "0.1",
-            "canonical_entity_schema_version": "0.1",
-            "validator": {"name": "noop.ingest", "version": "0.1"},
+            "validation_report_schema_version": _FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION,
+            "canonical_entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+            "validator": {
+                "name": _FAKE_RUNNER_VALIDATOR_NAME,
+                "version": _FAKE_RUNNER_VALIDATOR_VERSION,
+            },
             "summary": {
-                "validation_status": "needs_review",
-                "review_state": "review_required",
-                "quantity_gate": "review_gated",
-                "effective_confidence": 0.0,
+                "validation_status": _FAKE_RUNNER_VALIDATION_STATUS,
+                "review_state": _FAKE_RUNNER_REVIEW_STATE,
+                "quantity_gate": _FAKE_RUNNER_QUANTITY_GATE,
+                "effective_confidence": _FAKE_RUNNER_CONFIDENCE_SCORE,
                 "entity_counts": {
-                    "layouts": 0,
-                    "layers": 0,
+                    "layouts": 1,
+                    "layers": 1,
                     "blocks": 0,
-                    "entities": 0,
+                    "entities": 1,
                 },
             },
             "checks": [],
-            "findings": [
-                {
-                    "code": "NOOP_INGEST_BRIDGE",
-                    "severity": "warning",
-                    "message": "No real adapter executed; review is required.",
-                }
-            ],
-            "adapter_warnings": [
-                {
-                    "code": "NOOP_INGEST_BRIDGE",
-                    "severity": "warning",
-                    "message": "No real adapter executed; review is required.",
-                }
-            ],
+            "findings": [],
+            "adapter_warnings": [],
             "provenance": adapter_output.provenance_json,
         }
 
@@ -314,7 +332,7 @@ class TestIngestOutputPersistence:
         assert second_adapter_output.source_file_id == first_job.file_id
         assert second_adapter_output.source_job_id == second_job.id
         assert second_adapter_output.extraction_profile_id == second_job.extraction_profile_id
-        assert second_adapter_output.adapter_key == "noop.ingest"
+        assert second_adapter_output.adapter_key == _FAKE_RUNNER_ADAPTER_KEY
 
         assert second_revision.project_id == first_job.project_id
         assert second_revision.source_file_id == first_job.file_id
@@ -328,10 +346,10 @@ class TestIngestOutputPersistence:
         assert second_validation_report.project_id == first_job.project_id
         assert second_validation_report.source_job_id == second_job.id
         assert second_validation_report.drawing_revision_id == second_revision.id
-        assert second_validation_report.validation_status == "needs_review"
-        assert second_validation_report.review_state == "review_required"
-        assert second_validation_report.quantity_gate == "review_gated"
-        assert second_validation_report.effective_confidence == 0.0
+        assert second_validation_report.validation_status == _FAKE_RUNNER_VALIDATION_STATUS
+        assert second_validation_report.review_state == _FAKE_RUNNER_REVIEW_STATE
+        assert second_validation_report.quantity_gate == _FAKE_RUNNER_QUANTITY_GATE
+        assert second_validation_report.effective_confidence == _FAKE_RUNNER_CONFIDENCE_SCORE
 
     async def test_validation_report_allows_trd_status_and_gate_values(
         self,
@@ -523,10 +541,11 @@ class TestIngestOutputPersistence:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        async def _cancel_during_work(_: float) -> None:
+        async def _cancel_during_work(request) -> object:
             await _update_job(job.id, cancel_requested=True)
+            return _build_fake_ingest_payload(request)
 
-        monkeypatch.setattr(asyncio, "sleep", _cancel_during_work)
+        monkeypatch.setattr(worker_module, "run_ingestion", _cancel_during_work)
 
         await process_ingest_job(job.id)
 

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -10,6 +10,8 @@ from sqlalchemy import select
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
+from app.ingestion.finalization import IngestFinalizationPayload
+from app.ingestion.runner import IngestionRunRequest
 from app.jobs.worker import process_ingest_job
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
@@ -541,7 +543,9 @@ class TestIngestOutputPersistence:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        async def _cancel_during_work(request) -> object:
+        async def _cancel_during_work(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
             await _update_job(job.id, cancel_requested=True)
             return _build_fake_ingest_payload(request)
 

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import types
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -55,6 +56,14 @@ class _FakeAdapter:
             ),
             confidence=ConfidenceSummary(score=0.61, review_required=False, basis="raster"),
         )
+
+
+class _AdapterModule(types.ModuleType):
+    create_adapter: Callable[[], object]
+
+    def __init__(self, name: str, create_adapter: Callable[[], object]) -> None:
+        super().__init__(name)
+        self.create_adapter = create_adapter
 
 
 @pytest.mark.asyncio
@@ -113,8 +122,10 @@ async def test_run_ingestion_falls_back_to_next_candidate_and_is_deterministic(
     await storage.put(key, body, immutable=True)
     seen_paths: list[Path] = []
 
-    raster_module = types.ModuleType("fake_raster_module")
-    raster_module.create_adapter = lambda: _FakeAdapter(seen_paths=seen_paths)
+    raster_module = _AdapterModule(
+        "fake_raster_module",
+        lambda: _FakeAdapter(seen_paths=seen_paths),
+    )
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.pymupdf":
@@ -298,8 +309,7 @@ async def test_run_ingestion_passes_progress_and_cancellation_to_adapter(
                 confidence=ConfidenceSummary(score=0.98, review_required=False, basis="vector"),
             )
 
-    module = types.ModuleType("recording_adapter_module")
-    module.create_adapter = lambda: _RecordingAdapter()
+    module = _AdapterModule("recording_adapter_module", lambda: _RecordingAdapter())
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.ezdxf":
@@ -342,8 +352,10 @@ async def test_run_ingestion_passes_progress_and_cancellation_to_adapter(
 async def test_run_ingestion_maps_storage_read_errors_to_storage_failed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = types.ModuleType("storage_failure_adapter_module")
-    module.create_adapter = lambda: _FakeAdapter(seen_paths=[])
+    module = _AdapterModule(
+        "storage_failure_adapter_module",
+        lambda: _FakeAdapter(seen_paths=[]),
+    )
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.ezdxf":
@@ -383,8 +395,10 @@ async def test_run_ingestion_maps_storage_checksum_mismatch_to_storage_failed(
     key = build_original_storage_key(file_id, expected_checksum)
     await storage.put(key, actual_body, immutable=True)
 
-    module = types.ModuleType("storage_checksum_mismatch_adapter_module")
-    module.create_adapter = lambda: _FakeAdapter(seen_paths=[])
+    module = _AdapterModule(
+        "storage_checksum_mismatch_adapter_module",
+        lambda: _FakeAdapter(seen_paths=[]),
+    )
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.ezdxf":
@@ -445,10 +459,14 @@ async def test_run_ingestion_does_not_fall_through_after_runtime_failure(
             _ = (source, options)
             raise AssertionError("Runner should not fall through after runtime failure")
 
-    vector_module = types.ModuleType("failing_vector_adapter_module")
-    vector_module.create_adapter = lambda: _FailingVectorAdapter()
-    raster_module = types.ModuleType("unexpected_raster_adapter_module")
-    raster_module.create_adapter = lambda: _UnexpectedRasterAdapter()
+    vector_module = _AdapterModule(
+        "failing_vector_adapter_module",
+        lambda: _FailingVectorAdapter(),
+    )
+    raster_module = _AdapterModule(
+        "unexpected_raster_adapter_module",
+        lambda: _UnexpectedRasterAdapter(),
+    )
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.pymupdf":
@@ -511,10 +529,14 @@ async def test_run_ingestion_maps_vector_execute_timeout_without_importing_raste
             _ = (source, options)
             raise AssertionError("Runner should not import or run raster fallback after timeout")
 
-    vector_module = types.ModuleType("slow_vector_adapter_module")
-    vector_module.create_adapter = lambda: _SlowVectorAdapter()
-    raster_module = types.ModuleType("unexpected_raster_timeout_adapter_module")
-    raster_module.create_adapter = lambda: _UnexpectedRasterAdapter()
+    vector_module = _AdapterModule(
+        "slow_vector_adapter_module",
+        lambda: _SlowVectorAdapter(),
+    )
+    raster_module = _AdapterModule(
+        "unexpected_raster_timeout_adapter_module",
+        lambda: _UnexpectedRasterAdapter(),
+    )
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         imported_modules.append(module_name)
@@ -555,8 +577,7 @@ async def test_run_ingestion_maps_vector_execute_timeout_without_importing_raste
 async def test_run_ingestion_enforces_source_timeout_checkpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    module = types.ModuleType("timeout_adapter_module")
-    module.create_adapter = lambda: _FakeAdapter(seen_paths=[])
+    module = _AdapterModule("timeout_adapter_module", lambda: _FakeAdapter(seen_paths=[]))
 
     class _SlowMemoryStorage(MemoryStorage):
         async def get(self, *args, **kwargs):  # type: ignore[no-untyped-def]
@@ -616,8 +637,7 @@ async def test_run_ingestion_cleans_up_staged_source_after_adapter_execution_fai
             _ = options
             raise RuntimeError("adapter exploded")
 
-    module = types.ModuleType("failing_cleanup_adapter_module")
-    module.create_adapter = lambda: _FailingAdapter()
+    module = _AdapterModule("failing_cleanup_adapter_module", lambda: _FailingAdapter())
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.ezdxf":
@@ -675,8 +695,7 @@ async def test_run_ingestion_enforces_cancellation_checkpoint_before_execute(
             _ = (source, options)
             raise AssertionError("Adapter ingest should not start after cancellation checkpoint")
 
-    module = types.ModuleType("cancelled_adapter_module")
-    module.create_adapter = lambda: _UnexpectedAdapter()
+    module = _AdapterModule("cancelled_adapter_module", lambda: _UnexpectedAdapter())
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.ezdxf":

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -1,0 +1,706 @@
+"""Tests for ingestion runner scaffolding and source staging."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.core.errors import ErrorCode
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterResult,
+    AdapterStatus,
+    AdapterTimeout,
+    ConfidenceSummary,
+    InputFamily,
+    ProgressUpdate,
+    ProvenanceRecord,
+    UploadFormat,
+)
+from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
+from app.ingestion.selection import select_adapter_candidates
+from app.ingestion.source import OriginalSourceMaterialization, materialize_original_source
+from app.storage.keys import build_original_storage_key
+from app.storage.memory import MemoryStorage
+
+
+class _FakeAdapter:
+    version = "test-1.0"
+
+    def __init__(self, *, seen_paths: list[Path]) -> None:
+        self._seen_paths = seen_paths
+
+    def probe(self) -> AdapterAvailability:
+        return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+    async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+        self._seen_paths.append(source.file_path)
+        assert source.file_path.exists()
+        assert options.timeout is not None
+        assert 0 < options.timeout.seconds <= 300
+        return AdapterResult(
+            canonical={"entities": ({"kind": "line"},)},
+            provenance=(
+                ProvenanceRecord(
+                    stage="extract",
+                    adapter_key="fake-raster",
+                    source_ref="originals/source.pdf",
+                ),
+            ),
+            confidence=ConfidenceSummary(score=0.61, review_required=False, basis="raster"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_materialize_original_source_stages_and_cleans_up(tmp_path: Path) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    materialization = OriginalSourceMaterialization(
+        file_id=file_id,
+        checksum_sha256=checksum,
+        upload_format=UploadFormat.PDF,
+        input_family=InputFamily.PDF_VECTOR,
+        media_type="application/pdf",
+        original_name="../drawing.pdf",
+    )
+
+    async with materialize_original_source(
+        materialization,
+        storage=storage,
+        temp_root=tmp_path,
+    ) as source:
+        staged_path = source.file_path
+        assert staged_path.exists()
+        assert staged_path.name == "source.pdf"
+        assert staged_path.read_bytes() == body
+        assert source.original_name == "../drawing.pdf"
+
+    assert not staged_path.exists()
+
+
+def test_select_adapter_candidates_keeps_pdf_vector_then_raster_order() -> None:
+    candidates = select_adapter_candidates("pdf", media_type="application/pdf")
+
+    assert [(candidate.upload_format, candidate.input_family) for candidate in candidates] == [
+        (UploadFormat.PDF, InputFamily.PDF_VECTOR),
+        (UploadFormat.PDF, InputFamily.PDF_RASTER),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_falls_back_to_next_candidate_and_is_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    job_id = uuid4()
+    extraction_profile_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    seen_paths: list[Path] = []
+
+    raster_module = types.ModuleType("fake_raster_module")
+    raster_module.create_adapter = lambda: _FakeAdapter(seen_paths=seen_paths)
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.pymupdf":
+            raise ModuleNotFoundError(name=module_name)
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            return raster_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=job_id,
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+        extraction_profile_id=extraction_profile_id,
+        initial_job_id=job_id,
+    )
+    generated_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+
+    payload_one = await run_ingestion(
+        request,
+        storage=storage,
+        temp_root=tmp_path,
+        generated_at=generated_at,
+    )
+    payload_two = await run_ingestion(
+        request,
+        storage=storage,
+        temp_root=tmp_path,
+        generated_at=generated_at,
+    )
+
+    assert payload_one.adapter_key == "vtracer_tesseract"
+    assert payload_one.adapter_version == "test-1.0"
+    assert payload_one.input_family == InputFamily.PDF_RASTER.value
+    assert payload_one.revision_kind == "ingest"
+    assert payload_one.review_state == "provisional"
+    assert payload_one.validation_status == "valid"
+    assert payload_one.quantity_gate == "allowed_provisional"
+    assert payload_one.confidence_score == 0.61
+    assert payload_one.result_checksum_sha256 == payload_two.result_checksum_sha256
+    assert payload_one.canonical_json["canonical_entity_schema_version"] == "0.1"
+    assert payload_one.report_json["summary"]["entity_counts"] == {
+        "layouts": 0,
+        "layers": 0,
+        "blocks": 0,
+        "entities": 1,
+    }
+    assert seen_paths
+    assert all(not path.exists() for path in seen_paths)
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_missing_factory_to_sanitized_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broken_module = types.ModuleType("broken_adapter_module")
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return broken_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=uuid4(),
+        checksum_sha256="deadbeef",
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=MemoryStorage())
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter could not be loaded."
+    assert error.details["reason"] == "factory_missing"
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_missing_dependency_to_sanitized_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            raise ModuleNotFoundError(name="ezdxf")
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=uuid4(),
+        checksum_sha256="deadbeef",
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=MemoryStorage())
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter could not be loaded."
+    assert error.details["reason"] == "dependency_missing"
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_unsupported_format_to_typed_error() -> None:
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=uuid4(),
+        checksum_sha256="deadbeef",
+        detected_format="txt",
+        media_type="text/plain",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=MemoryStorage())
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.INPUT_UNSUPPORTED_FORMAT
+    assert error.failure_kind.value == "unsupported_format"
+    assert error.message == "Input format is not supported for ingestion."
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_passes_progress_and_cancellation_to_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    job_id = uuid4()
+    body = b"0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    progress_updates: list[ProgressUpdate] = []
+
+    class _CancellationHandle:
+        def is_cancelled(self) -> bool:
+            return False
+
+    cancellation = _CancellationHandle()
+
+    class _RecordingAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            assert source.file_path.exists()
+            assert options.cancellation is cancellation
+            assert options.on_progress is not None
+            update = ProgressUpdate(
+                stage="extract",
+                message="Reading entities",
+                completed=1,
+                total=2,
+                percent=0.5,
+            )
+            options.on_progress(update)
+            return AdapterResult(
+                canonical={"entities": ({"kind": "line"},)},
+                provenance=(
+                    ProvenanceRecord(
+                        stage="extract",
+                        adapter_key="fake-dxf",
+                        source_ref="originals/source.dxf",
+                    ),
+                ),
+                confidence=ConfidenceSummary(score=0.98, review_required=False, basis="vector"),
+            )
+
+    module = types.ModuleType("recording_adapter_module")
+    module.create_adapter = lambda: _RecordingAdapter()
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=job_id,
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+        original_name="drawing.dxf",
+        initial_job_id=job_id,
+    )
+
+    payload = await run_ingestion(
+        request,
+        storage=storage,
+        temp_root=tmp_path,
+        cancellation=cancellation,
+        on_progress=progress_updates.append,
+    )
+
+    assert payload.adapter_key == "ezdxf"
+    assert progress_updates == [
+        ProgressUpdate(
+            stage="extract",
+            message="Reading entities",
+            completed=1,
+            total=2,
+            percent=0.5,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_storage_read_errors_to_storage_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = types.ModuleType("storage_failure_adapter_module")
+    module.create_adapter = lambda: _FakeAdapter(seen_paths=[])
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=uuid4(),
+        checksum_sha256="deadbeef",
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=MemoryStorage())
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.STORAGE_FAILED
+    assert error.failure_kind.value == "failed"
+    assert error.message == "Failed to read original source from storage."
+    assert error.details["reason"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_storage_checksum_mismatch_to_storage_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    expected_body = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+    actual_body = b"0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n"
+    expected_checksum = hashlib.sha256(expected_body).hexdigest()
+    actual_checksum = hashlib.sha256(actual_body).hexdigest()
+    key = build_original_storage_key(file_id, expected_checksum)
+    await storage.put(key, actual_body, immutable=True)
+
+    module = types.ModuleType("storage_checksum_mismatch_adapter_module")
+    module.create_adapter = lambda: _FakeAdapter(seen_paths=[])
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=expected_checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.STORAGE_FAILED
+    assert error.failure_kind.value == "failed"
+    assert error.message == "Failed to read original source from storage."
+    assert error.details["reason"] == "checksum_mismatch"
+    assert expected_checksum not in str(error.details)
+    assert actual_checksum not in str(error.details)
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_does_not_fall_through_after_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    attempted_adapters: list[str] = []
+
+    class _FailingVectorAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("pymupdf")
+            assert source.file_path.exists()
+            _ = options
+            raise RuntimeError("vector parse failed")
+
+    class _UnexpectedRasterAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("vtracer_tesseract")
+            _ = (source, options)
+            raise AssertionError("Runner should not fall through after runtime failure")
+
+    vector_module = types.ModuleType("failing_vector_adapter_module")
+    vector_module.create_adapter = lambda: _FailingVectorAdapter()
+    raster_module = types.ModuleType("unexpected_raster_adapter_module")
+    raster_module.create_adapter = lambda: _UnexpectedRasterAdapter()
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return vector_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            return raster_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_FAILED
+    assert error.failure_kind.value == "failed"
+    assert attempted_adapters == ["pymupdf"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_vector_execute_timeout_without_importing_raster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    attempted_adapters: list[str] = []
+    imported_modules: list[str] = []
+
+    class _SlowVectorAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("pymupdf")
+            assert source.file_path.exists()
+            _ = options
+            await asyncio.sleep(0.02)
+            raise AssertionError("Runner should time out before returning from vector adapter")
+
+    class _UnexpectedRasterAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("vtracer_tesseract")
+            _ = (source, options)
+            raise AssertionError("Runner should not import or run raster fallback after timeout")
+
+    vector_module = types.ModuleType("slow_vector_adapter_module")
+    vector_module.create_adapter = lambda: _SlowVectorAdapter()
+    raster_module = types.ModuleType("unexpected_raster_timeout_adapter_module")
+    raster_module.create_adapter = lambda: _UnexpectedRasterAdapter()
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        imported_modules.append(module_name)
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return vector_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            return raster_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(
+            request,
+            storage=storage,
+            temp_root=tmp_path,
+            timeout=AdapterTimeout(seconds=0.01),
+        )
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_TIMEOUT
+    assert error.failure_kind.value == "timeout"
+    assert error.details["stage"] == "execute"
+    assert imported_modules == ["app.ingestion.adapters.pymupdf"]
+    assert attempted_adapters == ["pymupdf"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_enforces_source_timeout_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = types.ModuleType("timeout_adapter_module")
+    module.create_adapter = lambda: _FakeAdapter(seen_paths=[])
+
+    class _SlowMemoryStorage(MemoryStorage):
+        async def get(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            await asyncio.sleep(0.02)
+            return await super().get(*args, **kwargs)
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    storage = _SlowMemoryStorage()
+    file_id = uuid4()
+    body = b"0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, timeout=AdapterTimeout(seconds=0.01))
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_TIMEOUT
+    assert error.details["stage"] == "source"
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_cleans_up_staged_source_after_adapter_execution_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    seen_paths: list[Path] = []
+
+    class _FailingAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            seen_paths.append(source.file_path)
+            assert source.file_path.exists()
+            _ = options
+            raise RuntimeError("adapter exploded")
+
+    module = types.ModuleType("failing_cleanup_adapter_module")
+    module.create_adapter = lambda: _FailingAdapter()
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+        original_name="drawing.dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_FAILED
+    assert error.failure_kind.value == "failed"
+    assert seen_paths
+    assert all(not path.exists() for path in seen_paths)
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_enforces_cancellation_checkpoint_before_execute(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    class _CheckpointCancellationHandle:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        def is_cancelled(self) -> bool:
+            self._calls += 1
+            return self._calls >= 4
+
+    cancellation = _CheckpointCancellationHandle()
+
+    class _UnexpectedAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            _ = (source, options)
+            raise AssertionError("Adapter ingest should not start after cancellation checkpoint")
+
+    module = types.ModuleType("cancelled_adapter_module")
+    module.create_adapter = lambda: _UnexpectedAdapter()
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(
+            request,
+            storage=storage,
+            temp_root=tmp_path,
+            cancellation=cancellation,
+        )
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.JOB_CANCELLED
+    assert error.details["stage"] == "execute"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import types
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -16,13 +17,14 @@ import app.api.v1.jobs as jobs_api
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
-from app.ingestion.contracts import ProgressUpdate
-from app.ingestion.finalization import IngestFinalizationPayload, compute_adapter_result_checksum
-from app.ingestion.runner import (
+from app.ingestion.contracts import (
     AdapterFailureKind,
-    IngestionRunnerError,
-    IngestionRunRequest,
+    CancellationHandle,
+    ProgressCallback,
+    ProgressUpdate,
 )
+from app.ingestion.finalization import IngestFinalizationPayload, compute_adapter_result_checksum
+from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest
 from app.ingestion.runner import (
     run_ingestion as real_run_ingestion,
 )
@@ -42,6 +44,14 @@ _FAKE_RUNNER_QUANTITY_GATE = "allowed_provisional"
 _FAKE_RUNNER_VALIDATOR_NAME = "tests.fake_ingestion_runner"
 _FAKE_RUNNER_VALIDATOR_VERSION = "1.0"
 _TEST_UPLOAD_BODY = b"%PDF-1.7\njob-test\n"
+
+
+class _AdapterModule(types.ModuleType):
+    create_adapter: Callable[[], object]
+
+    def __init__(self, name: str, create_adapter: Callable[[], object]) -> None:
+        super().__init__(name)
+        self.create_adapter = create_adapter
 
 
 async def _create_project(async_client: httpx.AsyncClient) -> dict[str, Any]:
@@ -539,8 +549,7 @@ class TestJobs:
         def _capture_logger_error(event: str, **kwargs: Any) -> None:
             logger_error_calls.append((event, kwargs))
 
-        module = types.ModuleType("available_vector_adapter_module")
-        module.create_adapter = lambda: object()
+        module = _AdapterModule("available_vector_adapter_module", lambda: object())
 
         def fake_import_module(module_name: str) -> types.ModuleType:
             if module_name == "app.ingestion.adapters.pymupdf":
@@ -614,8 +623,7 @@ class TestJobs:
         def _fail_write_bytes(self: Any, _: bytes) -> int:
             raise OSError(f"{secret_temp_marker}: {self}")
 
-        module = types.ModuleType("available_stage_vector_adapter_module")
-        module.create_adapter = lambda: object()
+        module = _AdapterModule("available_stage_vector_adapter_module", lambda: object())
 
         def fake_import_module(module_name: str) -> types.ModuleType:
             if module_name == "app.ingestion.adapters.pymupdf":
@@ -959,7 +967,7 @@ class TestJobs:
         async def _run_with_progress(
             request: IngestionRunRequest,
             *,
-            on_progress=None,
+            on_progress: ProgressCallback | None = None,
             **_: Any,
         ) -> IngestFinalizationPayload:
             assert on_progress is not None
@@ -1078,7 +1086,7 @@ class TestJobs:
         async def _run_with_progress_then_fail(
             _: IngestionRunRequest,
             *,
-            on_progress=None,
+            on_progress: ProgressCallback | None = None,
             **__: Any,
         ) -> IngestFinalizationPayload:
             assert on_progress is not None
@@ -1178,30 +1186,26 @@ class TestJobs:
         async def _cancel_run(
             _: IngestionRunRequest,
             *,
-            cancellation=None,
-            on_progress=None,
+            cancellation: CancellationHandle | None = None,
+            on_progress: ProgressCallback | None = None,
             **__: Any,
         ) -> IngestFinalizationPayload:
             assert cancellation is not None
             assert on_progress is not None
             on_progress(ProgressUpdate(stage="source", message="Staged original"))
             await _update_job(job.id, cancel_requested=True)
-            for _attempt in range(50):
-                if cancellation.is_cancelled():
-                    break
+            cancellation_deadline = asyncio.get_running_loop().time() + 1
+            while not cancellation.is_cancelled():
+                if asyncio.get_running_loop().time() >= cancellation_deadline:
+                    raise AssertionError("Expected cancellation flag within 1 second")
                 await asyncio.sleep(0.01)
-            else:
-                raise AssertionError("Worker cancellation handle was not updated")
 
-            raise IngestionRunnerError(
-                error_code=ErrorCode.JOB_CANCELLED,
-                failure_kind=AdapterFailureKind.CANCELLED,
-                message="Adapter execution was cancelled.",
-            )
+            await asyncio.sleep(1)
+            raise AssertionError("Worker cancellation should interrupt the runner task")
 
         monkeypatch.setattr(worker_module, "run_ingestion", _cancel_run)
 
-        with pytest.raises(IngestionRunnerError, match="Adapter execution was cancelled"):
+        with pytest.raises(asyncio.CancelledError):
             await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,6 +1,8 @@
 """Integration tests for persisted job status and worker transitions."""
 
 import asyncio
+import hashlib
+import types
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -14,10 +16,32 @@ import app.api.v1.jobs as jobs_api
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
-from app.jobs.worker import process_ingest_job, recover_incomplete_ingest_jobs
+from app.ingestion.contracts import ProgressUpdate
+from app.ingestion.finalization import IngestFinalizationPayload, compute_adapter_result_checksum
+from app.ingestion.runner import (
+    AdapterFailureKind,
+    IngestionRunnerError,
+    IngestionRunRequest,
+)
+from app.ingestion.runner import (
+    run_ingestion as real_run_ingestion,
+)
+from app.models.file import File
 from app.models.job import Job
 from app.models.job_event import JobEvent
 from tests.conftest import requires_database
+
+_FAKE_RUNNER_ADAPTER_KEY = "tests.fake_ingestion_runner"
+_FAKE_RUNNER_ADAPTER_VERSION = "1.0"
+_FAKE_RUNNER_CANONICAL_SCHEMA_VERSION = "0.1"
+_FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION = "0.1"
+_FAKE_RUNNER_CONFIDENCE_SCORE = 0.75
+_FAKE_RUNNER_REVIEW_STATE = "provisional"
+_FAKE_RUNNER_VALIDATION_STATUS = "valid"
+_FAKE_RUNNER_QUANTITY_GATE = "allowed_provisional"
+_FAKE_RUNNER_VALIDATOR_NAME = "tests.fake_ingestion_runner"
+_FAKE_RUNNER_VALIDATOR_VERSION = "1.0"
+_TEST_UPLOAD_BODY = b"%PDF-1.7\njob-test\n"
 
 
 async def _create_project(async_client: httpx.AsyncClient) -> dict[str, Any]:
@@ -40,10 +64,141 @@ async def _upload_file(
     """Upload a supported file and return its payload."""
     response = await async_client.post(
         f"/v1/projects/{project_id}/files",
-        files={"file": ("plan.pdf", b"%PDF-1.7\njob-test\n", "application/pdf")},
+        files={"file": ("plan.pdf", _TEST_UPLOAD_BODY, "application/pdf")},
     )
     assert response.status_code == 201
     return cast(dict[str, Any], response.json())
+
+
+def _resolve_fake_revision_kind(request: IngestionRunRequest) -> str:
+    """Match ingest vs reprocess semantics for fake runner payloads."""
+    if request.initial_job_id == request.job_id:
+        return "ingest"
+
+    return "reprocess"
+
+
+def _resolve_fake_input_family(request: IngestionRunRequest) -> str:
+    """Return a stable runner-like input family for tests."""
+    if request.detected_format == "pdf" and request.media_type == "application/pdf":
+        return "pdf_vector"
+
+    if request.detected_format is not None:
+        return request.detected_format
+
+    return "unknown"
+
+
+def _build_fake_ingest_payload(
+    request: IngestionRunRequest,
+    *,
+    generated_at: datetime | None = None,
+) -> IngestFinalizationPayload:
+    """Build a deterministic fake finalization payload for worker tests."""
+    normalized_generated_at = generated_at or datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    revision_kind = _resolve_fake_revision_kind(request)
+    input_family = _resolve_fake_input_family(request)
+    entity_counts = {
+        "layouts": 1,
+        "layers": 1,
+        "blocks": 0,
+        "entities": 1,
+    }
+    canonical_json = {
+        "canonical_entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        "schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        "layouts": [{"name": "Model"}],
+        "layers": [{"name": "A-WALL"}],
+        "blocks": [],
+        "entities": [{"kind": "line", "layer": "A-WALL"}],
+        "entity_counts": entity_counts,
+    }
+    provenance_json = {
+        "schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        "bridge": "tests.fake_ingestion_runner",
+        "adapter": {
+            "key": _FAKE_RUNNER_ADAPTER_KEY,
+            "version": _FAKE_RUNNER_ADAPTER_VERSION,
+        },
+        "source": {
+            "file_id": str(request.file_id),
+            "job_id": str(request.job_id),
+            "extraction_profile_id": (
+                str(request.extraction_profile_id)
+                if request.extraction_profile_id is not None
+                else None
+            ),
+            "input_family": input_family,
+            "revision_kind": revision_kind,
+            "original_name": request.original_name,
+        },
+        "generated_at": normalized_generated_at.isoformat(),
+    }
+    confidence_json = {
+        "score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+        "effective_confidence": _FAKE_RUNNER_CONFIDENCE_SCORE,
+        "review_state": _FAKE_RUNNER_REVIEW_STATE,
+    }
+    warnings_json: list[Any] = []
+    diagnostics_json = {
+        "runner": "tests.fake_ingestion_runner",
+        "detected_format": request.detected_format,
+    }
+    report_json = {
+        "validation_report_schema_version": _FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION,
+        "canonical_entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        "validator": {
+            "name": _FAKE_RUNNER_VALIDATOR_NAME,
+            "version": _FAKE_RUNNER_VALIDATOR_VERSION,
+        },
+        "summary": {
+            "validation_status": _FAKE_RUNNER_VALIDATION_STATUS,
+            "review_state": _FAKE_RUNNER_REVIEW_STATE,
+            "quantity_gate": _FAKE_RUNNER_QUANTITY_GATE,
+            "effective_confidence": _FAKE_RUNNER_CONFIDENCE_SCORE,
+            "entity_counts": entity_counts,
+        },
+        "checks": [],
+        "findings": [],
+        "adapter_warnings": warnings_json,
+        "provenance": provenance_json,
+    }
+    result_envelope = {
+        "adapter_key": _FAKE_RUNNER_ADAPTER_KEY,
+        "adapter_version": _FAKE_RUNNER_ADAPTER_VERSION,
+        "input_family": input_family,
+        "canonical_entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        "canonical_json": canonical_json,
+        "provenance_json": provenance_json,
+        "confidence_json": confidence_json,
+        "confidence_score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+        "warnings_json": warnings_json,
+        "diagnostics_json": diagnostics_json,
+    }
+
+    return IngestFinalizationPayload(
+        revision_kind=revision_kind,
+        adapter_key=_FAKE_RUNNER_ADAPTER_KEY,
+        adapter_version=_FAKE_RUNNER_ADAPTER_VERSION,
+        input_family=input_family,
+        canonical_entity_schema_version=_FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        canonical_json=canonical_json,
+        provenance_json=provenance_json,
+        confidence_json=confidence_json,
+        confidence_score=_FAKE_RUNNER_CONFIDENCE_SCORE,
+        warnings_json=warnings_json,
+        diagnostics_json=diagnostics_json,
+        result_checksum_sha256=compute_adapter_result_checksum(result_envelope),
+        validation_report_schema_version=_FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION,
+        validation_status=_FAKE_RUNNER_VALIDATION_STATUS,
+        review_state=_FAKE_RUNNER_REVIEW_STATE,
+        quantity_gate=_FAKE_RUNNER_QUANTITY_GATE,
+        effective_confidence=_FAKE_RUNNER_CONFIDENCE_SCORE,
+        validator_name=_FAKE_RUNNER_VALIDATOR_NAME,
+        validator_version=_FAKE_RUNNER_VALIDATOR_VERSION,
+        report_json=report_json,
+        generated_at=normalized_generated_at,
+    )
 
 
 async def _get_job_for_file(file_id: str) -> Job:
@@ -105,6 +260,30 @@ async def _update_job(
     return await _get_job(job_id)
 
 
+async def _update_source_file(
+    file_id: uuid.UUID,
+    *,
+    checksum_sha256: str | None = None,
+    original_filename: str | None = None,
+) -> File:
+    """Update and return a persisted source file for test setup."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        source_file = await session.get(File, file_id)
+        assert source_file is not None
+
+        if checksum_sha256 is not None:
+            source_file.checksum_sha256 = checksum_sha256
+        if original_filename is not None:
+            source_file.original_filename = original_filename
+
+        await session.commit()
+
+    return source_file
+
+
 async def _create_job_event(
     job_id: uuid.UUID,
     *,
@@ -143,6 +322,21 @@ def enqueued_job_ids(monkeypatch: pytest.MonkeyPatch) -> list[str]:
 
     monkeypatch.setattr(files_api, "enqueue_ingest_job", _fake_enqueue)
     return recorded_job_ids
+
+
+@pytest.fixture(autouse=True)
+def fake_ingestion_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[IngestionRunRequest]:
+    """Patch worker ingestion with a deterministic fake runner payload."""
+    recorded_requests: list[IngestionRunRequest] = []
+
+    async def _fake_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+        recorded_requests.append(request)
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+    return recorded_requests
 
 
 async def test_mark_recovery_enqueue_failed_logs_only_safe_fields(
@@ -250,19 +444,227 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        async def _fail_sleep(_: float) -> None:
+        async def _fail_run_ingestion(_: IngestionRunRequest) -> IngestFinalizationPayload:
             raise RuntimeError("adapter exploded")
 
-        monkeypatch.setattr(asyncio, "sleep", _fail_sleep)
+        monkeypatch.setattr(worker_module, "run_ingestion", _fail_run_ingestion)
 
         with pytest.raises(RuntimeError, match="adapter exploded"):
-            await process_ingest_job(job.id)
+            await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
         assert updated_job.status == "failed"
         assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert updated_job.error_message == "adapter exploded"
+        assert updated_job.error_message == "Ingest job failed unexpectedly."
+        assert "adapter exploded" not in updated_job.error_message
         assert updated_job.finished_at is not None
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"][-1]["data_json"] == {
+            "status": "failed",
+            "error_code": ErrorCode.INTERNAL_ERROR.value,
+            "error_message": "Ingest job failed unexpectedly.",
+        }
+        assert "adapter exploded" not in str(data["items"][-1]["data_json"])
+
+    async def test_process_ingest_job_marks_expected_runner_failure_with_sanitized_code(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Expected runner failures should persist their sanitized code and message."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+        logger_error_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _capture_logger_error(event: str, **kwargs: Any) -> None:
+            logger_error_calls.append((event, kwargs))
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _fail_run_ingestion(_: IngestionRunRequest) -> IngestFinalizationPayload:
+            raise IngestionRunnerError(
+                error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+                failure_kind=AdapterFailureKind.UNAVAILABLE,
+                message="Adapter could not be loaded.",
+                details={"stderr": "super-secret adapter detail"},
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _fail_run_ingestion)
+        monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
+
+        with pytest.raises(IngestionRunnerError, match="Adapter could not be loaded"):
+            await worker_module.process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.ADAPTER_UNAVAILABLE.value
+        assert updated_job.error_message == "Adapter could not be loaded."
+        assert "super-secret adapter detail" not in updated_job.error_message
+        assert updated_job.finished_at is not None
+        assert logger_error_calls == [
+            (
+                "ingest_job_failed",
+                {
+                    "job_id": str(job.id),
+                    "error_code": ErrorCode.ADAPTER_UNAVAILABLE.value,
+                    "failure_kind": AdapterFailureKind.UNAVAILABLE.value,
+                    "error_message": "Adapter could not be loaded.",
+                },
+            )
+        ]
+
+    async def test_process_ingest_job_persists_sanitized_real_runner_storage_failure(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Real runner storage failures should persist and log only sanitized fields."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        secret_checksum = "f" * 64
+        logger_error_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _capture_logger_error(event: str, **kwargs: Any) -> None:
+            logger_error_calls.append((event, kwargs))
+
+        module = types.ModuleType("available_vector_adapter_module")
+        module.create_adapter = lambda: object()
+
+        def fake_import_module(module_name: str) -> types.ModuleType:
+            if module_name == "app.ingestion.adapters.pymupdf":
+                return module
+            raise AssertionError(f"Unexpected module import: {module_name}")
+
+        monkeypatch.setattr(worker_module, "run_ingestion", real_run_ingestion)
+        monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+        monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_source_file(uuid.UUID(uploaded["id"]), checksum_sha256=secret_checksum)
+
+        with pytest.raises(
+            IngestionRunnerError,
+            match="Failed to read original source from storage",
+        ):
+            await worker_module.process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.STORAGE_FAILED.value
+        assert updated_job.error_message == "Failed to read original source from storage."
+        assert secret_checksum not in updated_job.error_message
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"][-1]["data_json"] == {
+            "status": "failed",
+            "error_code": ErrorCode.STORAGE_FAILED.value,
+            "error_message": "Failed to read original source from storage.",
+        }
+        assert secret_checksum not in str(data["items"][-1]["data_json"])
+        assert secret_checksum not in str(logger_error_calls)
+        assert logger_error_calls == [
+            (
+                "ingest_job_failed",
+                {
+                    "job_id": str(job.id),
+                    "error_code": ErrorCode.STORAGE_FAILED.value,
+                    "failure_kind": AdapterFailureKind.FAILED.value,
+                    "error_message": "Failed to read original source from storage.",
+                    "adapter_key": "pymupdf",
+                    "input_family": "pdf_vector",
+                    "reason": "not_found",
+                },
+            )
+        ]
+
+    async def test_process_ingest_job_persists_sanitized_real_runner_staging_failure(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Real runner staging failures should not leak temp paths or exception text."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        secret_temp_marker = "temp-path-leak"
+        logger_error_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _capture_logger_error(event: str, **kwargs: Any) -> None:
+            logger_error_calls.append((event, kwargs))
+
+        def _fail_write_bytes(self: Any, _: bytes) -> int:
+            raise OSError(f"{secret_temp_marker}: {self}")
+
+        module = types.ModuleType("available_stage_vector_adapter_module")
+        module.create_adapter = lambda: object()
+
+        def fake_import_module(module_name: str) -> types.ModuleType:
+            if module_name == "app.ingestion.adapters.pymupdf":
+                return module
+            raise AssertionError(f"Unexpected module import: {module_name}")
+
+        monkeypatch.setattr(worker_module, "run_ingestion", real_run_ingestion)
+        monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+        monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_source_file(uuid.UUID(uploaded["id"]), original_filename="..")
+        monkeypatch.setattr("app.ingestion.source.Path.write_bytes", _fail_write_bytes)
+
+        with pytest.raises(IngestionRunnerError, match="Failed to stage original source"):
+            await worker_module.process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.STORAGE_FAILED.value
+        assert updated_job.error_message == "Failed to stage original source."
+        assert secret_temp_marker not in updated_job.error_message
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"][-1]["data_json"] == {
+            "status": "failed",
+            "error_code": ErrorCode.STORAGE_FAILED.value,
+            "error_message": "Failed to stage original source.",
+        }
+        assert secret_temp_marker not in str(data["items"][-1]["data_json"])
+        assert secret_temp_marker not in str(logger_error_calls)
+        assert logger_error_calls == [
+            (
+                "ingest_job_failed",
+                {
+                    "job_id": str(job.id),
+                    "error_code": ErrorCode.STORAGE_FAILED.value,
+                    "failure_kind": AdapterFailureKind.FAILED.value,
+                    "error_message": "Failed to stage original source.",
+                    "adapter_key": "pymupdf",
+                    "input_family": "pdf_vector",
+                    "reason": "stage_failed",
+                },
+            )
+        ]
 
     async def test_get_job_returns_persisted_state(
         self,
@@ -522,7 +924,7 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         response = await async_client.get(f"/v1/jobs/{job.id}/events")
         assert response.status_code == 200
@@ -538,11 +940,94 @@ class TestJobs:
         ]
         assert data["next_cursor"] is None
 
+    async def test_process_ingest_job_flushes_progress_events_before_success(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker should persist queued progress updates before terminal success."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _run_with_progress(
+            request: IngestionRunRequest,
+            *,
+            on_progress=None,
+            **_: Any,
+        ) -> IngestFinalizationPayload:
+            assert on_progress is not None
+            on_progress(
+                ProgressUpdate(
+                    stage="source",
+                    message="Staged original",
+                    completed=1,
+                    total=3,
+                    percent=1 / 3,
+                )
+            )
+            on_progress(
+                ProgressUpdate(
+                    stage="extract",
+                    message="Extracted entities",
+                    completed=2,
+                    total=3,
+                    percent=2 / 3,
+                )
+            )
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_with_progress)
+
+        await worker_module.process_ingest_job(job.id)
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == [
+            "Job started",
+            "Staged original",
+            "Extracted entities",
+            "Job succeeded",
+        ]
+        assert [event["data_json"]["status"] for event in data["items"]] == [
+            "running",
+            "running",
+            "running",
+            "succeeded",
+        ]
+        assert data["items"][1]["data_json"] == {
+            "status": "running",
+            "event": "progress",
+            "stage": "source",
+            "detail": "Staged original",
+            "completed": 1,
+            "total": 3,
+            "percent": 1 / 3,
+        }
+        assert data["items"][2]["data_json"] == {
+            "status": "running",
+            "event": "progress",
+            "stage": "extract",
+            "detail": "Extracted entities",
+            "completed": 2,
+            "total": 3,
+            "percent": 2 / 3,
+        }
+        assert data["next_cursor"] is None
+
     async def test_process_ingest_job_transitions_to_succeeded(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
+        fake_ingestion_runner: list[IngestionRunRequest],
     ) -> None:
         """Worker processing should persist running and succeeded state transitions."""
         _ = self
@@ -553,9 +1038,11 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job_for_file(str(uploaded["id"]))
+        assert len(fake_ingestion_runner) == 1
+        request = fake_ingestion_runner[0]
         assert updated_job.status == "succeeded"
         assert updated_job.attempts == 1
         assert updated_job.started_at is not None
@@ -563,6 +1050,180 @@ class TestJobs:
         assert updated_job.finished_at >= updated_job.started_at
         assert updated_job.error_code is None
         assert updated_job.error_message is None
+        assert request.job_id == job.id
+        assert request.file_id == job.file_id
+        assert request.checksum_sha256 == hashlib.sha256(_TEST_UPLOAD_BODY).hexdigest()
+        assert request.detected_format == "pdf"
+        assert request.media_type == "application/pdf"
+        assert request.original_name == "plan.pdf"
+        assert request.extraction_profile_id == job.extraction_profile_id
+        assert request.initial_job_id == job.id
+
+    async def test_process_ingest_job_flushes_progress_events_before_failure(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker should persist queued progress updates before terminal failure."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _run_with_progress_then_fail(
+            _: IngestionRunRequest,
+            *,
+            on_progress=None,
+            **__: Any,
+        ) -> IngestFinalizationPayload:
+            assert on_progress is not None
+            on_progress(
+                ProgressUpdate(
+                    stage="source",
+                    message="Staged original",
+                    completed=1,
+                    total=3,
+                    percent=1 / 3,
+                )
+            )
+            on_progress(
+                ProgressUpdate(
+                    stage="extract",
+                    message="Extracted entities",
+                    completed=2,
+                    total=3,
+                    percent=2 / 3,
+                )
+            )
+            raise IngestionRunnerError(
+                error_code=ErrorCode.ADAPTER_FAILED,
+                failure_kind=AdapterFailureKind.FAILED,
+                message="Adapter execution failed.",
+                details={"stderr": "super-secret adapter detail"},
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_with_progress_then_fail)
+
+        with pytest.raises(IngestionRunnerError, match="Adapter execution failed"):
+            await worker_module.process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.ADAPTER_FAILED.value
+        assert updated_job.error_message == "Adapter execution failed."
+        assert "super-secret adapter detail" not in updated_job.error_message
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == [
+            "Job started",
+            "Staged original",
+            "Extracted entities",
+            "Job failed",
+        ]
+        assert [event["data_json"]["status"] for event in data["items"]] == [
+            "running",
+            "running",
+            "running",
+            "failed",
+        ]
+        assert data["items"][1]["data_json"] == {
+            "status": "running",
+            "event": "progress",
+            "stage": "source",
+            "detail": "Staged original",
+            "completed": 1,
+            "total": 3,
+            "percent": 1 / 3,
+        }
+        assert data["items"][2]["data_json"] == {
+            "status": "running",
+            "event": "progress",
+            "stage": "extract",
+            "detail": "Extracted entities",
+            "completed": 2,
+            "total": 3,
+            "percent": 2 / 3,
+        }
+        assert data["items"][3]["data_json"] == {
+            "status": "failed",
+            "error_code": ErrorCode.ADAPTER_FAILED.value,
+            "error_message": "Adapter execution failed.",
+        }
+        assert "super-secret adapter detail" not in str(data["items"][3]["data_json"])
+        assert data["next_cursor"] is None
+
+    async def test_process_ingest_job_marks_runner_cancellation_as_cancelled(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Runner cancellation should flush progress and persist a cancelled terminal state."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _cancel_run(
+            _: IngestionRunRequest,
+            *,
+            cancellation=None,
+            on_progress=None,
+            **__: Any,
+        ) -> IngestFinalizationPayload:
+            assert cancellation is not None
+            assert on_progress is not None
+            on_progress(ProgressUpdate(stage="source", message="Staged original"))
+            await _update_job(job.id, cancel_requested=True)
+            for _attempt in range(50):
+                if cancellation.is_cancelled():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("Worker cancellation handle was not updated")
+
+            raise IngestionRunnerError(
+                error_code=ErrorCode.JOB_CANCELLED,
+                failure_kind=AdapterFailureKind.CANCELLED,
+                message="Adapter execution was cancelled.",
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _cancel_run)
+
+        with pytest.raises(IngestionRunnerError, match="Adapter execution was cancelled"):
+            await worker_module.process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.cancel_requested is True
+        assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated_job.error_message is None
+        assert updated_job.finished_at is not None
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == [
+            "Job started",
+            "Staged original",
+            "Job cancelled",
+        ]
+        assert [event["data_json"]["status"] for event in data["items"]] == [
+            "running",
+            "running",
+            "cancelled",
+        ]
 
     async def test_process_ingest_job_continues_redelivered_running_job(
         self,
@@ -589,7 +1250,7 @@ class TestJobs:
             persisted_job.started_at = datetime.now(UTC)
             await session.commit()
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
         assert updated_job.status == "succeeded"
@@ -620,7 +1281,7 @@ class TestJobs:
         job = await _get_job_for_file(str(uploaded["id"]))
         enqueued_job_ids.clear()
 
-        requeued = await recover_incomplete_ingest_jobs()
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
 
         assert recovered_job_ids == [str(job.id)]
         assert requeued == [job.id]
@@ -665,7 +1326,7 @@ class TestJobs:
             )
             await session.commit()
 
-        requeued = await recover_incomplete_ingest_jobs()
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
 
         assert recovered_job_ids == [str(job.id)]
         assert requeued == [job.id]
@@ -676,7 +1337,7 @@ class TestJobs:
         assert recovered_job.started_at is None
         assert recovered_job.finished_at is None
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
         assert updated_job.status == "succeeded"
@@ -715,7 +1376,7 @@ class TestJobs:
             persisted_job.started_at = datetime.now(UTC)
             await session.commit()
 
-        requeued = await recover_incomplete_ingest_jobs()
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
 
         assert recovered_job_ids == []
         assert requeued == []
@@ -753,7 +1414,7 @@ class TestJobs:
         job = await _get_job_for_file(str(uploaded["id"]))
         enqueued_job_ids.clear()
 
-        requeued = await recover_incomplete_ingest_jobs()
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
 
         assert requeued == []
 
@@ -802,12 +1463,12 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
         first_completion = await _get_job(job.id)
         assert first_completion.status == "succeeded"
         assert first_completion.attempts == 1
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
         assert updated_job.status == "succeeded"
@@ -872,7 +1533,7 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
         completed = await _get_job(job.id)
         assert completed.status == "succeeded"
         assert completed.cancel_requested is False
@@ -1099,7 +1760,7 @@ class TestJobs:
         job = await _get_job_for_file(str(uploaded["id"]))
         await _update_job(job.id, status="pending", cancel_requested=True)
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         updated = await _get_job(job.id)
         assert updated.status == "cancelled"
@@ -1124,12 +1785,13 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        async def _cancel_during_work(_: float) -> None:
+        async def _cancel_during_work(request: IngestionRunRequest) -> IngestFinalizationPayload:
             await _update_job(job.id, cancel_requested=True)
+            return _build_fake_ingest_payload(request)
 
-        monkeypatch.setattr(asyncio, "sleep", _cancel_during_work)
+        monkeypatch.setattr(worker_module, "run_ingestion", _cancel_during_work)
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         updated = await _get_job(job.id)
         assert updated.status == "cancelled"
@@ -1157,7 +1819,7 @@ class TestJobs:
         before = await _get_job(job.id)
         before_finished_at = before.finished_at
 
-        await process_ingest_job(job.id)
+        await worker_module.process_ingest_job(job.id)
 
         after = await _get_job(job.id)
         assert after.status == "cancelled"


### PR DESCRIPTION
Closes #94

## Summary
- replace the production noop ingest path with real adapter-runner orchestration so persisted ingest jobs execute format-aware adapter selection and finalization
- keep the worker focused on durable job state transitions while adding sanitized timeout, cancellation, progress, and storage-failure handling around runner execution
- add regression coverage for fallback boundaries, staged-source cleanup, progress ordering, cancellation, and public error sanitization

## Test plan
- [x] `uv run ruff check app/ingestion app/jobs/worker.py app/api/v1/files.py app/storage tests/test_ingestion_runner.py tests/test_jobs.py tests/test_ingest_output_persistence.py`
- [x] `uv run mypy app`
- [x] `uv run python3 -m compileall app`
- [x] `uv run pytest tests/test_ingestion_runner.py tests/test_jobs.py tests/test_ingest_output_persistence.py`
- [x] `uv run pytest`

## Notes
- no breaking changes
- known follow-ups: sanitize expected runner exception chains at the Celery/task boundary, and make local staging writes timeout/cancellation-aware if the filesystem hangs