### PR TITLE
feat: add canonical validation reports and gates

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -4,6 +4,14 @@ from app.api.v1.files import files_router
 from app.api.v1.health import health_router
 from app.api.v1.jobs import jobs_router
 from app.api.v1.projects import project_router
+from app.api.v1.revisions import revisions_router
 from app.api.v1.system import system_router
 
-__all__ = ["files_router", "health_router", "jobs_router", "project_router", "system_router"]
+__all__ = [
+    "files_router",
+    "health_router",
+    "jobs_router",
+    "project_router",
+    "revisions_router",
+    "system_router",
+]

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -1,0 +1,43 @@
+"""Revision API routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.drawing_revision import DrawingRevision
+from app.models.validation_report import ValidationReport
+from app.schemas.validation_report import (
+    ValidationReportResponse,
+    build_validation_report_response,
+)
+
+revisions_router = APIRouter()
+
+
+@revisions_router.get(
+    "/revisions/{revision_id}/validation-report",
+    response_model=ValidationReportResponse,
+)
+async def get_validation_report(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ValidationReportResponse:
+    """Return the persisted canonical validation report for a drawing revision."""
+    result = await db.execute(
+        select(ValidationReport).where(ValidationReport.drawing_revision_id == revision_id)
+    )
+    report = result.scalar_one_or_none()
+    if report is None:
+        revision = await db.get(DrawingRevision, revision_id)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+        raise_not_found("Validation report", str(revision_id))
+
+    assert report is not None
+
+    return build_validation_report_response(report)

--- a/app/ingestion/finalization.py
+++ b/app/ingestion/finalization.py
@@ -11,13 +11,14 @@ from typing import Any
 from uuid import UUID
 
 from app.ingestion.contracts import AdapterResult, InputFamily
+from app.ingestion.validation import (
+    VALIDATION_REPORT_SCHEMA_VERSION,
+    build_validation_outcome,
+)
 
 _CANONICAL_ENTITY_SCHEMA_VERSION = "0.1"
-_VALIDATION_REPORT_SCHEMA_VERSION = "0.1"
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
-_RUNNER_VALIDATOR_NAME = "ingestion.runner"
-_RUNNER_VALIDATOR_VERSION = "0.1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,23 +96,16 @@ def build_ingest_finalization_payload(
     canonical_entity_schema_version = _resolve_canonical_schema_version(canonical_json)
     revision_kind = resolve_revision_kind(context.job_id, initial_job_id=context.initial_job_id)
     provenance_records = [_json_compatible(record) for record in result.provenance]
-    warnings_json = [_json_compatible(warning) for warning in result.warnings]
     diagnostics = [_json_compatible(diagnostic) for diagnostic in result.diagnostics]
-    confidence_score = _confidence_score(result)
-    review_state, validation_status, quantity_gate = _derive_review_outcome(
-        confidence_score=confidence_score,
-        review_required=(
-            result.confidence.review_required if result.confidence is not None else True
-        ),
-        has_warnings=bool(warnings_json),
+    validation_outcome = build_validation_outcome(
+        input_family=context.input_family,
+        canonical_json=canonical_json,
+        canonical_entity_schema_version=canonical_entity_schema_version,
+        result=result,
+        generated_at=emitted_at,
     )
-    confidence_json = {
-        "score": result.confidence.score if result.confidence is not None else None,
-        "effective_confidence": confidence_score,
-        "review_state": review_state,
-        "review_required": review_state == "review_required",
-        "basis": result.confidence.basis if result.confidence is not None else None,
-    }
+    warnings_json = validation_outcome.adapter_warnings_json
+    confidence_json = validation_outcome.confidence_json
     provenance_json = {
         "schema_version": canonical_entity_schema_version,
         "adapter": {
@@ -137,25 +131,7 @@ def build_ingest_finalization_payload(
         "adapter_version": context.adapter_version,
         "diagnostics": diagnostics,
     }
-    report_json = {
-        "validation_report_schema_version": _VALIDATION_REPORT_SCHEMA_VERSION,
-        "canonical_entity_schema_version": canonical_entity_schema_version,
-        "validator": {
-            "name": _RUNNER_VALIDATOR_NAME,
-            "version": _RUNNER_VALIDATOR_VERSION,
-        },
-        "summary": {
-            "validation_status": validation_status,
-            "review_state": review_state,
-            "quantity_gate": quantity_gate,
-            "effective_confidence": confidence_score,
-            "entity_counts": _entity_counts(canonical_json),
-        },
-        "checks": [],
-        "findings": warnings_json,
-        "adapter_warnings": warnings_json,
-        "provenance": provenance_json,
-    }
+    report_json = validation_outcome.report_json
     result_envelope = {
         "adapter_key": context.adapter_key,
         "adapter_version": context.adapter_version,
@@ -164,7 +140,7 @@ def build_ingest_finalization_payload(
         "canonical_json": canonical_json,
         "provenance_json": provenance_json,
         "confidence_json": confidence_json,
-        "confidence_score": confidence_score,
+        "confidence_score": validation_outcome.confidence_score,
         "warnings_json": warnings_json,
         "diagnostics_json": diagnostics_json,
     }
@@ -178,17 +154,17 @@ def build_ingest_finalization_payload(
         canonical_json=canonical_json,
         provenance_json=provenance_json,
         confidence_json=confidence_json,
-        confidence_score=confidence_score,
+        confidence_score=validation_outcome.confidence_score,
         warnings_json=warnings_json,
         diagnostics_json=diagnostics_json,
         result_checksum_sha256=compute_adapter_result_checksum(result_envelope),
-        validation_report_schema_version=_VALIDATION_REPORT_SCHEMA_VERSION,
-        validation_status=validation_status,
-        review_state=review_state,
-        quantity_gate=quantity_gate,
-        effective_confidence=confidence_score,
-        validator_name=_RUNNER_VALIDATOR_NAME,
-        validator_version=_RUNNER_VALIDATOR_VERSION,
+        validation_report_schema_version=VALIDATION_REPORT_SCHEMA_VERSION,
+        validation_status=validation_outcome.validation_status,
+        review_state=validation_outcome.review_state,
+        quantity_gate=validation_outcome.quantity_gate,
+        effective_confidence=validation_outcome.effective_confidence,
+        validator_name=validation_outcome.validator_name,
+        validator_version=validation_outcome.validator_version,
         report_json=report_json,
         generated_at=emitted_at,
     )
@@ -214,48 +190,6 @@ def _resolve_canonical_schema_version(canonical_json: dict[str, Any]) -> str:
     canonical_json["canonical_entity_schema_version"] = _CANONICAL_ENTITY_SCHEMA_VERSION
     canonical_json.setdefault("schema_version", _CANONICAL_ENTITY_SCHEMA_VERSION)
     return _CANONICAL_ENTITY_SCHEMA_VERSION
-
-
-def _confidence_score(result: AdapterResult) -> float:
-    if result.confidence is None or result.confidence.score is None:
-        return 0.0
-
-    return float(result.confidence.score)
-
-
-def _derive_review_outcome(
-    *,
-    confidence_score: float,
-    review_required: bool,
-    has_warnings: bool,
-) -> tuple[str, str, str]:
-    if review_required or confidence_score < 0.60:
-        return ("review_required", "needs_review", "review_gated")
-
-    if confidence_score < 0.95:
-        validation_status = "valid_with_warnings" if has_warnings else "valid"
-        return ("provisional", validation_status, "allowed_provisional")
-
-    validation_status = "valid_with_warnings" if has_warnings else "valid"
-    return ("approved", validation_status, "allowed")
-
-
-def _entity_counts(canonical_json: Mapping[str, Any]) -> dict[str, int]:
-    return {
-        "layouts": _sequence_length(canonical_json.get("layouts")),
-        "layers": _sequence_length(canonical_json.get("layers")),
-        "blocks": _sequence_length(canonical_json.get("blocks")),
-        "entities": _sequence_length(canonical_json.get("entities")),
-    }
-
-
-def _sequence_length(value: Any) -> int:
-    if isinstance(value, (list, tuple)):
-        return len(value)
-
-    return 0
-
-
 def _json_compatible(value: Any) -> Any:
     if is_dataclass(value) and not isinstance(value, type):
         return _json_compatible(asdict(value))

--- a/app/ingestion/validation.py
+++ b/app/ingestion/validation.py
@@ -1,0 +1,1680 @@
+"""Validation policy helpers for ingest finalization payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime
+from math import isfinite
+from typing import Any, Final
+from uuid import UUID
+
+from app.ingestion.contracts import AdapterResult, InputFamily
+
+VALIDATION_REPORT_SCHEMA_VERSION: Final[str] = "0.1"
+RUNNER_VALIDATOR_NAME: Final[str] = "ingestion.runner"
+RUNNER_VALIDATOR_VERSION: Final[str] = "0.1"
+
+_REVIEW_THRESHOLD: Final[float] = 0.60
+_APPROVED_THRESHOLD: Final[float] = 0.95
+_REVIEW_CAPPED_CONFIDENCE: Final[float] = 0.59
+_SUPPORTED_IFC_SCHEMAS: Final[frozenset[str]] = frozenset({"IFC2X3", "IFC4", "IFC4X3"})
+_SOURCE_DOCUMENT_REF: Final[str] = "source-document"
+_REVIEW_STATUS_VALUES: Final[frozenset[str]] = frozenset(
+    {
+        "incomplete",
+        "manual_required",
+        "missing",
+        "pending",
+        "review_required",
+        "unconfirmed",
+        "unknown",
+        "unresolved",
+    }
+)
+_FAIL_STATUS_VALUES: Final[frozenset[str]] = frozenset(
+    {"error", "fail", "failed", "false", "invalid", "rejected", "unsupported"}
+)
+_PASS_STATUS_VALUES: Final[frozenset[str]] = frozenset(
+    {
+        "captured",
+        "complete",
+        "confirmed",
+        "normalized",
+        "ok",
+        "pass",
+        "passed",
+        "present",
+        "resolved",
+        "supported",
+        "true",
+        "valid",
+    }
+)
+_PDF_SCALE_UNCONFIRMED_VALUES: Final[frozenset[str]] = frozenset(
+    {"manual_required", "pending", "placeholder", "tbd", "unconfirmed", "unknown"}
+)
+_CENTER_RADIUS_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"arc", "circle"})
+_LINE_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"line"})
+_POINT_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"point"})
+_POLYGON_ENTITY_KINDS: Final[frozenset[str]] = frozenset(
+    {"hatch", "lwpolyline", "polygon", "polyline", "solid"}
+)
+_BLOCK_REFERENCE_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"block_reference", "insert"})
+_REQUIRED_CHECK_KEYS: Final[tuple[str, ...]] = (
+    "units_presence_normalization",
+    "coordinate_system_capture",
+    "geometry_validity",
+    "closed_polygon_eligibility_for_area_quantities",
+    "block_transform_validity",
+    "layer_mapping_completeness",
+    "xref_resolution_status",
+    "pdf_scale_presence_calibration_status",
+    "ifc_schema_support",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationOutcome:
+    """Typed validation policy result for ingest finalization."""
+
+    confidence_score: float
+    effective_confidence: float
+    validation_status: str
+    review_state: str
+    quantity_gate: str
+    validator_name: str
+    validator_version: str
+    confidence_json: dict[str, Any]
+    adapter_warnings_json: list[Any]
+    report_json: dict[str, Any]
+
+
+def build_validation_outcome(
+    *,
+    input_family: InputFamily,
+    canonical_json: Mapping[str, Any],
+    canonical_entity_schema_version: str,
+    result: AdapterResult,
+    generated_at: datetime,
+) -> ValidationOutcome:
+    """Build the canonical v0.1 validation report and review policy outcome."""
+
+    confidence_score = _confidence_score(result)
+    effective_confidence = confidence_score
+    adapter_review_required = bool(
+        result.confidence.review_required if result.confidence is not None else True
+    )
+    confidence_basis = result.confidence.basis if result.confidence is not None else None
+    adapter_warnings_json = [_json_compatible(warning) for warning in result.warnings]
+    findings: list[dict[str, Any]] = []
+
+    def add_finding(
+        *,
+        check_key: str,
+        severity: str,
+        message: str,
+        target_type: str,
+        target_ref: str,
+        quantity_effect: str,
+        source: str,
+        details: Mapping[str, Any] | None = None,
+    ) -> str:
+        finding_id = f"finding-{len(findings) + 1:03d}"
+        finding: dict[str, Any] = {
+            "finding_id": finding_id,
+            "check_key": check_key,
+            "severity": severity,
+            "message": message,
+            "target_type": target_type,
+            "target_ref": target_ref,
+            "quantity_effect": quantity_effect,
+            "source": source,
+        }
+        if details is not None:
+            finding["details"] = _json_compatible(dict(details))
+        findings.append(finding)
+        return finding_id
+
+    if input_family == InputFamily.PDF_RASTER:
+        effective_confidence = min(effective_confidence, _REVIEW_CAPPED_CONFIDENCE)
+        add_finding(
+            check_key="raster_review_policy",
+            severity="warning",
+            message="Raster inputs remain review-first regardless of confidence score.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"input_family": input_family.value},
+        )
+
+    if confidence_score < _REVIEW_THRESHOLD:
+        effective_confidence = min(effective_confidence, confidence_score)
+        add_finding(
+            check_key="confidence_threshold",
+            severity="warning",
+            message="Confidence is below the review threshold.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={
+                "reported_confidence": confidence_score,
+                "review_threshold": _REVIEW_THRESHOLD,
+            },
+        )
+
+    if adapter_review_required:
+        effective_confidence = min(effective_confidence, _REVIEW_CAPPED_CONFIDENCE)
+        add_finding(
+            check_key="adapter_review_required",
+            severity="warning",
+            message="Adapter marked the result as requiring review.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"reported_confidence": confidence_score},
+        )
+
+    checks, required_checks_require_review, required_checks_invalid = _build_required_checks(
+        canonical_json=canonical_json,
+        add_finding=add_finding,
+    )
+    if required_checks_require_review:
+        effective_confidence = min(effective_confidence, _REVIEW_CAPPED_CONFIDENCE)
+    if required_checks_invalid:
+        effective_confidence = 0.0
+
+    pdf_scale_check, pdf_scale_requires_review = _build_pdf_scale_check(
+        input_family=input_family,
+        canonical_json=canonical_json,
+        add_finding=add_finding,
+    )
+    if pdf_scale_requires_review:
+        effective_confidence = min(effective_confidence, _REVIEW_CAPPED_CONFIDENCE)
+    if pdf_scale_check["status"] == "fail":
+        effective_confidence = 0.0
+    checks.append(pdf_scale_check)
+
+    ifc_schema_check, ifc_schema_invalid = _build_ifc_schema_check(
+        input_family=input_family,
+        canonical_json=canonical_json,
+        add_finding=add_finding,
+    )
+    if ifc_schema_invalid:
+        effective_confidence = 0.0
+    checks.append(ifc_schema_check)
+
+    for index, warning in enumerate(adapter_warnings_json, start=1):
+        normalized_warning = warning if isinstance(warning, Mapping) else {"value": warning}
+        add_finding(
+            check_key="adapter_warning",
+            severity="warning",
+            message=_adapter_warning_message(normalized_warning, index=index),
+            target_type="adapter_warning",
+            target_ref=_adapter_warning_target_ref(normalized_warning, index=index),
+            quantity_effect="warning_only",
+            source="adapter_warning",
+            details={"warning": normalized_warning},
+        )
+
+    validation_status = _derive_validation_status(
+        checks=checks,
+        findings=findings,
+        review_required=(
+            input_family == InputFamily.PDF_RASTER
+            or confidence_score < _REVIEW_THRESHOLD
+            or adapter_review_required
+            or required_checks_require_review
+            or pdf_scale_requires_review
+        ),
+    )
+    review_state = _derive_review_state(
+        validation_status=validation_status,
+        effective_confidence=effective_confidence,
+        review_required=(
+            input_family == InputFamily.PDF_RASTER
+            or confidence_score < _REVIEW_THRESHOLD
+            or adapter_review_required
+            or required_checks_require_review
+            or pdf_scale_requires_review
+        ),
+    )
+    quantity_gate = _derive_quantity_gate(
+        validation_status=validation_status,
+        review_state=review_state,
+    )
+    confidence_json = {
+        "score": result.confidence.score if result.confidence is not None else None,
+        "effective_confidence": effective_confidence,
+        "review_state": review_state,
+        "review_required": review_state == "review_required",
+        "basis": confidence_basis,
+    }
+    report_json = {
+        "validation_report_schema_version": VALIDATION_REPORT_SCHEMA_VERSION,
+        "canonical_entity_schema_version": canonical_entity_schema_version,
+        "validation_status": validation_status,
+        "review_state": review_state,
+        "quantity_gate": quantity_gate,
+        "effective_confidence": effective_confidence,
+        "validator_name": RUNNER_VALIDATOR_NAME,
+        "validator_version": RUNNER_VALIDATOR_VERSION,
+        "confidence": confidence_json,
+        "provenance": _json_compatible(result.provenance),
+        "summary": _build_summary(canonical_json=canonical_json, checks=checks, findings=findings),
+        "checks": checks,
+        "findings": findings,
+        "adapter_warnings": adapter_warnings_json,
+        "generated_at": generated_at.isoformat(),
+    }
+
+    return ValidationOutcome(
+        confidence_score=confidence_score,
+        effective_confidence=effective_confidence,
+        validation_status=validation_status,
+        review_state=review_state,
+        quantity_gate=quantity_gate,
+        validator_name=RUNNER_VALIDATOR_NAME,
+        validator_version=RUNNER_VALIDATOR_VERSION,
+        confidence_json=confidence_json,
+        adapter_warnings_json=adapter_warnings_json,
+        report_json=report_json,
+    )
+
+
+def _pass_check(check_key: str, summary_message: str) -> dict[str, Any]:
+    return _check(
+        check_key=check_key,
+        status="pass",
+        summary_message=summary_message,
+        details={"applicable": True},
+    )
+
+
+def _check(
+    *,
+    check_key: str,
+    status: str,
+    summary_message: str,
+    finding_refs: list[str] | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "check_key": check_key,
+        "status": status,
+        "summary_message": summary_message,
+        "finding_refs": [] if finding_refs is None else finding_refs,
+        "details": {"applicable": True} if details is None else _json_compatible(dict(details)),
+    }
+
+
+def _not_applicable_check(check_key: str, summary_message: str) -> dict[str, Any]:
+    return _check(
+        check_key=check_key,
+        status="pass",
+        summary_message=summary_message,
+        details={"applicable": False},
+    )
+
+
+def _build_required_checks(
+    *,
+    canonical_json: Mapping[str, Any],
+    add_finding: Any,
+) -> tuple[list[dict[str, Any]], bool, bool]:
+    checks: list[dict[str, Any]] = []
+    requires_review = False
+    invalid = False
+
+    for builder in (
+        _build_units_check,
+        _build_coordinate_system_check,
+        _build_geometry_validity_check,
+        _build_closed_polygon_check,
+        _build_block_transform_check,
+        _build_layer_mapping_check,
+        _build_xref_check,
+    ):
+        check, check_requires_review, check_invalid = builder(
+            canonical_json=canonical_json,
+            add_finding=add_finding,
+        )
+        checks.append(check)
+        requires_review = requires_review or check_requires_review
+        invalid = invalid or check_invalid
+
+    return checks, requires_review, invalid
+
+
+def _build_units_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "units_presence_normalization"
+    units = _extract_meaningful_metadata(
+        canonical_json,
+        "units",
+        "normalized_units",
+        "unit",
+        "unit_system",
+        "measurement_unit",
+    )
+    if units is not None:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Units metadata is present and normalized.",
+                details={"applicable": True, "units": units},
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message=(
+            "Units metadata is missing or unnormalized and requires review before "
+            "quantities run."
+        ),
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={"units_present": False},
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Units metadata is missing or unnormalized.",
+            finding_refs=[finding_ref],
+            details={"applicable": True, "units_present": False},
+        ),
+        True,
+        False,
+    )
+
+
+def _build_coordinate_system_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "coordinate_system_capture"
+    coordinate_system = _extract_meaningful_metadata(
+        canonical_json,
+        "coordinate_system",
+        "coordinate_reference_system",
+        "crs",
+        "spatial_reference",
+    )
+    if coordinate_system is not None:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Coordinate system metadata is present.",
+                details={"applicable": True, "coordinate_system": coordinate_system},
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message="Coordinate system metadata is missing and requires review before quantities run.",
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={"coordinate_system_present": False},
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Coordinate system metadata is missing.",
+            finding_refs=[finding_ref],
+            details={"applicable": True, "coordinate_system_present": False},
+        ),
+        True,
+        False,
+    )
+
+
+def _build_geometry_validity_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "geometry_validity"
+    entities = _entity_mappings(canonical_json)
+    geometry_hint = _normalize_status_hint(
+        _metadata_candidate(canonical_json, "geometry_validity"),
+        _metadata_candidate(canonical_json, "geometry_validation"),
+        _metadata_candidate(canonical_json, "geometry_status"),
+        _metadata_candidate(canonical_json, "geometry_valid"),
+    )
+    if geometry_hint is False:
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="error",
+            message="Geometry validity check reported invalid geometry.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"entity_count": len(entities)},
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="fail",
+                summary_message="Geometry validity check failed.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "entity_count": len(entities),
+                    "geometry_valid": False,
+                },
+            ),
+            False,
+            True,
+        )
+
+    geometry_states = [_entity_has_valid_geometry(entity) for entity in entities]
+    validated_entity_count = sum(state is True for state in geometry_states)
+
+    if geometry_hint is True or (
+        geometry_states and validated_entity_count == len(geometry_states)
+    ):
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Geometry validity reported no blocking issues.",
+                details={
+                    "applicable": True,
+                    "entity_count": len(entities),
+                    "validated_entity_count": validated_entity_count,
+                    "geometry_valid": True,
+                },
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message=(
+            "Geometry validity could not be confirmed and requires review before "
+            "quantities run."
+        ),
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={
+            "entity_count": len(entities),
+            "validated_entity_count": validated_entity_count,
+        },
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Geometry validity could not be confirmed.",
+            finding_refs=[finding_ref],
+            details={
+                "applicable": True,
+                "entity_count": len(entities),
+                "validated_entity_count": validated_entity_count,
+                "geometry_valid": None,
+            },
+        ),
+        True,
+        False,
+    )
+
+
+def _build_closed_polygon_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "closed_polygon_eligibility_for_area_quantities"
+    polygon_entities = _polygon_entities(canonical_json)
+    polygon_hint = _normalize_status_hint(
+        _metadata_candidate(canonical_json, "closed_polygon_eligibility_for_area_quantities"),
+        _metadata_candidate(canonical_json, "polygon_closure"),
+        _metadata_candidate(canonical_json, "area_quantity_eligibility"),
+    )
+    if not polygon_entities and polygon_hint is None:
+        return (
+            _not_applicable_check(
+                check_key,
+                "Closed polygon eligibility is not applicable because no area-bearing "
+                "polygons were reported.",
+            ),
+            False,
+            False,
+        )
+
+    if polygon_hint is False or any(
+        _polygon_closed_state(entity) is False for entity in polygon_entities
+    ):
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="error",
+            message=(
+                "Area-bearing polygons are not closed and cannot drive deterministic "
+                "quantities."
+            ),
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"polygon_count": len(polygon_entities)},
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="fail",
+                summary_message="Closed polygon eligibility failed.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "polygon_count": len(polygon_entities),
+                    "eligible": False,
+                },
+            ),
+            False,
+            True,
+        )
+
+    polygon_states = [_polygon_closed_state(entity) for entity in polygon_entities]
+    if polygon_hint is True or (
+        polygon_entities and all(state is True for state in polygon_states)
+    ):
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Closed polygon eligibility reported no blocking issues.",
+                details={
+                    "applicable": True,
+                    "polygon_count": len(polygon_entities),
+                    "eligible": True,
+                },
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message=(
+            "Polygon closure eligibility is incomplete and requires review before area "
+            "quantities run."
+        ),
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={"polygon_count": len(polygon_entities)},
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Polygon closure eligibility could not be confirmed.",
+            finding_refs=[finding_ref],
+            details={"applicable": True, "polygon_count": len(polygon_entities), "eligible": None},
+        ),
+        True,
+        False,
+    )
+
+
+def _build_block_transform_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "block_transform_validity"
+    has_block_transforms = _has_block_transform_content(canonical_json)
+    transform_hint = _normalize_status_hint(
+        _metadata_candidate(canonical_json, "block_transform_validity"),
+        _metadata_candidate(canonical_json, "transform_validity"),
+        _metadata_candidate(canonical_json, "transforms_valid"),
+    )
+    if not has_block_transforms and transform_hint is None:
+        return (
+            _not_applicable_check(
+                check_key,
+                "Block transform validity is not applicable because no block references "
+                "were reported.",
+            ),
+            False,
+            False,
+        )
+
+    if transform_hint is False:
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="error",
+            message="Block transform validation reported invalid transforms.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"block_references_present": has_block_transforms},
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="fail",
+                summary_message="Block transform validity failed.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "block_references_present": has_block_transforms,
+                    "transforms_valid": False,
+                },
+            ),
+            False,
+            True,
+        )
+
+    if transform_hint is True:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Block transform validity reported no blocking issues.",
+                details={
+                    "applicable": True,
+                    "block_references_present": has_block_transforms,
+                    "transforms_valid": True,
+                },
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message=(
+            "Block transform validity could not be confirmed and requires review before "
+            "quantities run."
+        ),
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={"block_references_present": has_block_transforms},
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Block transform validity could not be confirmed.",
+            finding_refs=[finding_ref],
+            details={
+                "applicable": True,
+                "block_references_present": has_block_transforms,
+                "transforms_valid": None,
+            },
+        ),
+        True,
+        False,
+    )
+
+
+def _build_layer_mapping_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "layer_mapping_completeness"
+    entities = _entity_mappings(canonical_json)
+    layer_mapping_hint = _normalize_status_hint(
+        _metadata_candidate(canonical_json, "layer_mapping_completeness"),
+        _metadata_candidate(canonical_json, "layer_mapping"),
+        _metadata_candidate(canonical_json, "layer_map"),
+    )
+    used_layers = {
+        str(layer).strip()
+        for entity in entities
+        for layer in [entity.get("layer")]
+        if isinstance(layer, str) and layer.strip()
+    }
+    declared_layers = {
+        str(name).strip()
+        for layer in _sequence_mappings(canonical_json.get("layers"))
+        for name in [layer.get("name")]
+        if isinstance(name, str) and name.strip()
+    }
+    missing_layers = (
+        sorted(used_layers - declared_layers) if declared_layers else sorted(used_layers)
+    )
+
+    if layer_mapping_hint is True:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Layer mapping completeness reported no blocking issues.",
+                details={
+                    "applicable": True,
+                    "used_layers": sorted(used_layers),
+                    "declared_layers": sorted(declared_layers),
+                },
+            ),
+            False,
+            False,
+        )
+
+    if layer_mapping_hint is False:
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="warning",
+            message=(
+                "Layer mapping completeness reported incomplete mappings and requires "
+                "review before quantities run."
+            ),
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={
+                "used_layers": sorted(used_layers),
+                "declared_layers": sorted(declared_layers),
+            },
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="review_required",
+                summary_message="Layer mapping completeness reported incomplete mappings.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "used_layers": sorted(used_layers),
+                    "declared_layers": sorted(declared_layers),
+                },
+            ),
+            True,
+            False,
+        )
+
+    if entities and declared_layers and used_layers and not missing_layers:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Layer mapping completeness reported no blocking issues.",
+                details={
+                    "applicable": True,
+                    "used_layers": sorted(used_layers),
+                    "declared_layers": sorted(declared_layers),
+                },
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message=(
+            "Layer mapping completeness is missing or incomplete and requires review "
+            "before quantities run."
+        ),
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={
+            "used_layers": sorted(used_layers),
+            "declared_layers": sorted(declared_layers),
+            "missing_layers": missing_layers,
+        },
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Layer mapping completeness is missing or incomplete.",
+            finding_refs=[finding_ref],
+            details={
+                "applicable": True,
+                "used_layers": sorted(used_layers),
+                "declared_layers": sorted(declared_layers),
+                "missing_layers": missing_layers,
+            },
+        ),
+        True,
+        False,
+    )
+
+
+def _build_xref_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "xref_resolution_status"
+    xref_value = _metadata_candidate(
+        canonical_json,
+        "xref_resolution_status",
+        "xrefs",
+        "external_references",
+    )
+    xref_hint = _normalize_status_hint(xref_value)
+    xrefs = _sequence_mappings(xref_value)
+    if xref_hint is True:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Xref resolution reported no blocking issues.",
+                details={"applicable": True, "xref_count": len(xrefs)},
+            ),
+            False,
+            False,
+        )
+
+    if isinstance(xref_value, (list, tuple)) and not xrefs:
+        return (
+            _not_applicable_check(
+                check_key,
+                "Xref resolution is not applicable because no xrefs were reported.",
+            ),
+            False,
+            False,
+        )
+
+    if xrefs:
+        unresolved_refs = [
+            _xref_ref(xref, index=index)
+            for index, xref in enumerate(xrefs, start=1)
+            if _normalize_status_hint(
+                xref.get("resolved"),
+                xref.get("status"),
+                xref.get("resolution_status"),
+            )
+            is not True
+        ]
+        if not unresolved_refs:
+            return (
+                _check(
+                    check_key=check_key,
+                    status="pass",
+                    summary_message="Xref resolution reported no blocking issues.",
+                    details={"applicable": True, "xref_count": len(xrefs), "unresolved_refs": []},
+                ),
+                False,
+                False,
+            )
+
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="warning",
+            message="One or more xrefs are unresolved and require review before quantities run.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"xref_count": len(xrefs), "unresolved_refs": unresolved_refs},
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="review_required",
+                summary_message="Xref resolution is incomplete.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "xref_count": len(xrefs),
+                    "unresolved_refs": unresolved_refs,
+                },
+            ),
+            True,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message="Xref resolution status is missing and requires review before quantities run.",
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={"xref_present": False},
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="Xref resolution status is missing.",
+            finding_refs=[finding_ref],
+            details={"applicable": True, "xref_present": False},
+        ),
+        True,
+        False,
+    )
+
+
+def _build_pdf_scale_check(
+    *,
+    input_family: InputFamily,
+    canonical_json: Mapping[str, Any],
+    add_finding: Any,
+) -> tuple[dict[str, Any], bool]:
+    check_key = "pdf_scale_presence_calibration_status"
+    if input_family not in {InputFamily.PDF_VECTOR, InputFamily.PDF_RASTER}:
+        return (
+            _not_applicable_check(
+                check_key,
+                "PDF scale calibration is not applicable for this input family.",
+            ),
+            False,
+        )
+
+    scale_status, scale_value = _extract_pdf_scale(canonical_json)
+    if scale_status == "present" and scale_value is not None:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="PDF scale metadata is present.",
+                details={"applicable": True, "scale_present": True, "scale": scale_value},
+            ),
+            False,
+        )
+
+    if scale_status == "invalid":
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="error",
+            message="PDF scale metadata is invalid and blocks deterministic quantities.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"input_family": input_family.value, "scale_present": True},
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="fail",
+                summary_message="PDF scale metadata is invalid.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "scale_present": True,
+                    "calibration_status": "invalid",
+                },
+            ),
+            False,
+        )
+
+    if scale_status == "unconfirmed":
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="warning",
+            message="PDF scale metadata is unconfirmed and requires review before quantities run.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"input_family": input_family.value, "scale_present": True},
+        )
+        return (
+            _check(
+                check_key=check_key,
+                status="review_required",
+                summary_message="PDF scale metadata is unconfirmed.",
+                finding_refs=[finding_ref],
+                details={
+                    "applicable": True,
+                    "scale_present": True,
+                    "calibration_status": "unconfirmed",
+                },
+            ),
+            True,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="warning",
+        message="PDF scale metadata is missing and requires review before quantities run.",
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={"input_family": input_family.value, "scale_present": False},
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="review_required",
+            summary_message="PDF scale metadata is missing.",
+            finding_refs=[finding_ref],
+            details={"applicable": True, "scale_present": False, "calibration_status": "missing"},
+        ),
+        True,
+    )
+
+
+def _build_ifc_schema_check(
+    *,
+    input_family: InputFamily,
+    canonical_json: Mapping[str, Any],
+    add_finding: Any,
+) -> tuple[dict[str, Any], bool]:
+    check_key = "ifc_schema_support"
+    if input_family != InputFamily.IFC:
+        return (
+            _not_applicable_check(
+                check_key,
+                "IFC schema support is not applicable for this input family.",
+            ),
+            False,
+        )
+
+    schema = _extract_ifc_schema(canonical_json)
+    if schema is None:
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="error",
+            message="IFC schema metadata is missing.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={"schema_present": False, "supported_schemas": sorted(_SUPPORTED_IFC_SCHEMAS)},
+        )
+        return (
+            {
+                "check_key": check_key,
+                "status": "fail",
+                "summary_message": "IFC schema metadata is missing.",
+                "finding_refs": [finding_ref],
+                "details": {
+                    "applicable": True,
+                    "schema_present": False,
+                    "supported": False,
+                },
+            },
+            True,
+        )
+
+    normalized_schema = schema.upper()
+    if normalized_schema not in _SUPPORTED_IFC_SCHEMAS:
+        finding_ref = add_finding(
+            check_key=check_key,
+            severity="error",
+            message="IFC schema is not supported for deterministic quantity generation.",
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={
+                "schema_present": True,
+                "schema": schema,
+                "supported_schemas": sorted(_SUPPORTED_IFC_SCHEMAS),
+            },
+        )
+        return (
+            {
+                "check_key": check_key,
+                "status": "fail",
+                "summary_message": "IFC schema is not supported.",
+                "finding_refs": [finding_ref],
+                "details": {
+                    "applicable": True,
+                    "schema_present": True,
+                    "schema": schema,
+                    "supported": False,
+                },
+            },
+            True,
+        )
+
+    return (
+        {
+            "check_key": check_key,
+            "status": "pass",
+            "summary_message": "IFC schema is supported.",
+            "finding_refs": [],
+            "details": {
+                "applicable": True,
+                "schema_present": True,
+                "schema": schema,
+                "supported": True,
+            },
+        },
+        False,
+    )
+
+
+def _extract_pdf_scale(canonical_json: Mapping[str, Any]) -> tuple[str, Any | None]:
+    candidates: tuple[Any | None, ...] = (
+        canonical_json.get("pdf_scale"),
+        canonical_json.get("document_scale"),
+        canonical_json.get("scale"),
+        _mapping_value(canonical_json.get("metadata"), "pdf_scale"),
+        _mapping_value(canonical_json.get("metadata"), "document_scale"),
+        _mapping_value(canonical_json.get("metadata"), "scale"),
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        explicit_status = _explicit_pdf_scale_status(candidate)
+        if explicit_status is not None:
+            return explicit_status, None
+        if _is_valid_pdf_scale(candidate):
+            return "present", _json_compatible(candidate)
+        if _is_unconfirmed_pdf_scale(candidate):
+            return "unconfirmed", None
+        return "invalid", None
+
+    return "missing", None
+
+
+def _extract_ifc_schema(canonical_json: Mapping[str, Any]) -> str | None:
+    candidates = (
+        canonical_json.get("ifc_schema"),
+        canonical_json.get("ifc_schema_version"),
+        _mapping_value(canonical_json.get("metadata"), "ifc_schema"),
+        _mapping_value(canonical_json.get("metadata"), "ifc_schema_version"),
+    )
+    for candidate in candidates:
+        if candidate is not None:
+            return str(candidate)
+
+    return None
+
+
+def _mapping_value(value: Any, key: str) -> Any | None:
+    if isinstance(value, Mapping):
+        return value.get(key)
+
+    return None
+
+
+def _metadata_candidate(canonical_json: Mapping[str, Any], *keys: str) -> Any | None:
+    metadata = canonical_json.get("metadata")
+    for key in keys:
+        value = canonical_json.get(key)
+        if value is not None:
+            return value
+        mapped_value = _mapping_value(metadata, key)
+        if mapped_value is not None:
+            return mapped_value
+
+    return None
+
+
+def _extract_meaningful_metadata(canonical_json: Mapping[str, Any], *keys: str) -> Any | None:
+    for key in keys:
+        candidate = _metadata_candidate(canonical_json, key)
+        if _is_meaningful_value(candidate):
+            return _json_compatible(candidate)
+
+    return None
+
+
+def _normalize_status_hint(*candidates: Any) -> bool | None:
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        normalized = _normalize_status_value(candidate)
+        if normalized is not None:
+            return normalized
+        if isinstance(candidate, Mapping):
+            for key in (
+                "status",
+                "state",
+                "validation_status",
+                "resolution_status",
+                "calibration_status",
+                "review_state",
+                "supported",
+                "valid",
+                "complete",
+                "captured",
+                "normalized",
+                "resolved",
+                "confirmed",
+            ):
+                nested = _normalize_status_value(candidate.get(key))
+                if nested is not None:
+                    return nested
+
+    return None
+
+
+def _normalize_status_value(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _PASS_STATUS_VALUES:
+            return True
+        if normalized in _FAIL_STATUS_VALUES:
+            return False
+
+    return None
+
+
+def _is_meaningful_value(value: Any) -> bool:
+    if value is None or value is False:
+        return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return (
+            bool(normalized)
+            and normalized not in _REVIEW_STATUS_VALUES
+            and normalized not in _FAIL_STATUS_VALUES
+        )
+    if isinstance(value, (int, float)):
+        return value > 0
+    if isinstance(value, Mapping):
+        return bool(value) and any(_is_meaningful_value(item) for item in value.values())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return any(_is_meaningful_value(item) for item in value)
+
+    return True
+
+
+def _sequence_mappings(value: Any) -> list[Mapping[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+
+    return [item for item in value if isinstance(item, Mapping)]
+
+
+def _entity_mappings(canonical_json: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return _sequence_mappings(canonical_json.get("entities"))
+
+
+def _entity_has_valid_geometry(entity: Mapping[str, Any]) -> bool | None:
+    kind = str(entity.get("kind", "")).strip().lower()
+    if kind in _LINE_ENTITY_KINDS:
+        return (
+            (
+                _has_coordinate_value(entity.get("start"))
+                and _has_coordinate_value(entity.get("end"))
+            )
+            or _has_coordinate_sequence(entity.get("points"), minimum_points=2)
+            or _has_coordinate_sequence(entity.get("vertices"), minimum_points=2)
+            or _has_numeric_fields(entity, ("x1", "y1", "x2", "y2"))
+        )
+    if kind in _POLYGON_ENTITY_KINDS:
+        return _has_valid_polygon_area_geometry(
+            entity.get("points")
+        ) or _has_valid_polygon_area_geometry(
+            entity.get("vertices")
+        )
+    if kind in _POINT_ENTITY_KINDS:
+        return (
+            _has_coordinate_value(entity.get("point"))
+            or _has_coordinate_value(entity.get("position"))
+            or _has_coordinate_value(entity.get("location"))
+            or _has_numeric_fields(entity, ("x", "y"))
+        )
+    if kind in _CENTER_RADIUS_ENTITY_KINDS:
+        return (
+            (
+                _has_coordinate_value(entity.get("center"))
+                or _has_coordinate_value(entity.get("origin"))
+            )
+            and (
+                _is_positive_number(entity.get("radius"))
+                or _is_positive_number(entity.get("diameter"))
+            )
+        )
+    if kind in _BLOCK_REFERENCE_ENTITY_KINDS:
+        return (
+            _has_coordinate_value(entity.get("insert"))
+            or _has_coordinate_value(entity.get("position"))
+            or _has_coordinate_value(entity.get("location"))
+            or _has_numeric_fields(entity, ("x", "y"))
+        )
+
+    return None
+
+
+def _has_coordinate_sequence(candidate: Any, *, minimum_points: int) -> bool:
+    if not isinstance(candidate, (list, tuple)):
+        return False
+
+    points = sum(_has_coordinate_value(item) for item in candidate)
+    return points >= minimum_points
+
+
+def _has_valid_polygon_area_geometry(candidate: Any) -> bool:
+    if not isinstance(candidate, (list, tuple)):
+        return False
+
+    points = [point for item in candidate if (point := _coordinate_xy(item)) is not None]
+    if len(points) < 3:
+        return False
+
+    distinct_points = list(dict.fromkeys(points))
+    if len(distinct_points) < 3:
+        return False
+
+    ring_points = points[:-1] if points[0] == points[-1] else points
+    if len(ring_points) < 3:
+        return False
+
+    area_twice = _polygon_signed_area_twice(ring_points)
+    return isfinite(area_twice) and area_twice != 0.0
+
+
+def _coordinate_xy(candidate: Any) -> tuple[float, float] | None:
+    if isinstance(candidate, Mapping):
+        x_value = _finite_float(candidate.get("x"))
+        y_value = _finite_float(candidate.get("y"))
+        if x_value is not None and y_value is not None:
+            return x_value, y_value
+        return None
+    if not isinstance(candidate, (list, tuple)) or len(candidate) < 2:
+        return None
+
+    x_value = _finite_float(candidate[0])
+    y_value = _finite_float(candidate[1])
+    if x_value is not None and y_value is not None:
+        return x_value, y_value
+
+    return None
+
+
+def _polygon_signed_area_twice(points: list[tuple[float, float]]) -> float:
+    signed_area_twice = 0.0
+    for index, (x_value, y_value) in enumerate(points):
+        next_x, next_y = points[(index + 1) % len(points)]
+        signed_area_twice += (x_value * next_y) - (next_x * y_value)
+
+    return signed_area_twice
+
+
+def _has_coordinate_value(candidate: Any) -> bool:
+    if isinstance(candidate, Mapping):
+        return _has_numeric_fields(candidate, ("x", "y"))
+    if not isinstance(candidate, (list, tuple)):
+        return False
+
+    numeric_components = sum(_is_number(component) for component in candidate)
+    return numeric_components >= 2
+
+
+def _has_numeric_fields(candidate: Mapping[str, Any], fields: tuple[str, ...]) -> bool:
+    return all(_is_number(candidate.get(field)) for field in fields)
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _finite_float(value: Any) -> float | None:
+    if not _is_finite_number(value):
+        return None
+
+    return float(value)
+
+
+def _is_finite_number(value: Any) -> bool:
+    return _is_number(value) and isfinite(value)
+
+
+def _is_positive_number(value: Any) -> bool:
+    return _is_number(value) and value > 0
+
+
+def _polygon_entities(canonical_json: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    polygon_entities: list[Mapping[str, Any]] = []
+    for entity in _entity_mappings(canonical_json):
+        kind = str(entity.get("kind", "")).strip().lower()
+        if kind in _POLYGON_ENTITY_KINDS:
+            polygon_entities.append(entity)
+
+    return polygon_entities
+
+
+def _polygon_closed_state(entity: Mapping[str, Any]) -> bool | None:
+    return _normalize_status_hint(
+        entity.get("closed"),
+        entity.get("is_closed"),
+        entity.get("area_quantity_eligible"),
+    )
+
+
+def _has_block_transform_content(canonical_json: Mapping[str, Any]) -> bool:
+    blocks = canonical_json.get("blocks")
+    if isinstance(blocks, (list, tuple)) and bool(blocks):
+        return True
+    for entity in _entity_mappings(canonical_json):
+        kind = str(entity.get("kind", "")).strip().lower()
+        if kind in _BLOCK_REFERENCE_ENTITY_KINDS:
+            return True
+        if entity.get("transform") is not None or entity.get("block_name") is not None:
+            return True
+
+    return False
+
+
+def _xref_ref(xref: Mapping[str, Any], *, index: int) -> str:
+    for key in ("ref", "name", "path", "source_ref"):
+        value = xref.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    return f"xref-{index}"
+
+
+def _is_valid_pdf_scale(candidate: Any) -> bool:
+    if isinstance(candidate, bool):
+        return False
+    if isinstance(candidate, (int, float)):
+        return candidate > 0
+    if isinstance(candidate, str):
+        return (
+            bool(candidate.strip())
+            and candidate.strip().lower() not in _PDF_SCALE_UNCONFIRMED_VALUES
+        )
+    if isinstance(candidate, Mapping):
+        if not candidate:
+            return False
+        if _normalize_status_hint(candidate.get("confirmed"), candidate.get("calibrated")) is False:
+            return False
+        return any(
+            _is_meaningful_value(candidate.get(key))
+            for key in ("scale", "ratio", "value", "factor", "numerator", "denominator")
+        )
+    if isinstance(candidate, (list, tuple)):
+        return bool(candidate)
+
+    return False
+
+
+def _explicit_pdf_scale_status(candidate: Any) -> str | None:
+    if not isinstance(candidate, Mapping):
+        return None
+
+    explicit_status = _normalize_status_hint(
+        candidate.get("status"),
+        candidate.get("calibration_status"),
+    )
+    if explicit_status is False:
+        return "invalid"
+    for value in (candidate.get("status"), candidate.get("calibration_status")):
+        if isinstance(value, str) and value.strip().lower() in _PDF_SCALE_UNCONFIRMED_VALUES:
+            return "unconfirmed"
+    if _normalize_status_hint(candidate.get("confirmed"), candidate.get("calibrated")) is False:
+        return "unconfirmed"
+
+    return None
+
+
+def _is_unconfirmed_pdf_scale(candidate: Any) -> bool:
+    if isinstance(candidate, str):
+        return candidate.strip().lower() in _PDF_SCALE_UNCONFIRMED_VALUES
+    if isinstance(candidate, Mapping):
+        status = candidate.get("status") or candidate.get("calibration_status")
+        if isinstance(status, str) and status.strip().lower() in _PDF_SCALE_UNCONFIRMED_VALUES:
+            return True
+        return (
+            _normalize_status_hint(candidate.get("confirmed"), candidate.get("calibrated")) is False
+        )
+
+    return False
+
+
+def _adapter_warning_message(warning: Mapping[str, Any], *, index: int) -> str:
+    for key in ("message", "summary", "warning"):
+        value = warning.get(key)
+        if value is not None:
+            return str(value)
+
+    return f"Adapter warning {index} was reported."
+
+
+def _adapter_warning_target_ref(warning: Mapping[str, Any], *, index: int) -> str:
+    for key in ("target_ref", "source_ref", "entity_ref", "ref", "code"):
+        value = warning.get(key)
+        if value is not None:
+            return str(value)
+
+    return f"adapter-warning-{index}"
+
+
+def _derive_validation_status(
+    *,
+    checks: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+    review_required: bool,
+) -> str:
+    check_statuses = {str(check["status"]) for check in checks}
+    if "fail" in check_statuses:
+        return "invalid"
+
+    if review_required or "review_required" in check_statuses:
+        return "needs_review"
+
+    if "warning" in check_statuses or any(finding["severity"] == "warning" for finding in findings):
+        return "valid_with_warnings"
+
+    return "valid"
+
+
+def _derive_review_state(
+    *,
+    validation_status: str,
+    effective_confidence: float,
+    review_required: bool,
+) -> str:
+    if validation_status == "invalid":
+        return "rejected"
+
+    if review_required or validation_status == "needs_review":
+        return "review_required"
+
+    if effective_confidence < _APPROVED_THRESHOLD:
+        return "provisional"
+
+    return "approved"
+
+
+def _derive_quantity_gate(*, validation_status: str, review_state: str) -> str:
+    if validation_status == "invalid" or review_state in {"rejected", "superseded"}:
+        return "blocked"
+
+    if review_state == "approved" and validation_status in {"valid", "valid_with_warnings"}:
+        return "allowed"
+
+    if review_state == "provisional" and validation_status in {
+        "valid",
+        "valid_with_warnings",
+        "needs_review",
+    }:
+        return "allowed_provisional"
+
+    if review_state == "review_required":
+        return "review_gated"
+
+    return "blocked"
+
+
+def _build_summary(
+    *,
+    canonical_json: Mapping[str, Any],
+    checks: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+) -> dict[str, Any]:
+    check_status_totals = {
+        "pass": 0,
+        "warning": 0,
+        "review_required": 0,
+        "fail": 0,
+    }
+    for check in checks:
+        status = str(check["status"])
+        check_status_totals[status] = check_status_totals.get(status, 0) + 1
+
+    severity_totals = {"info": 0, "warning": 0, "error": 0, "critical": 0}
+    for finding in findings:
+        severity = str(finding["severity"])
+        severity_totals[severity] = severity_totals.get(severity, 0) + 1
+
+    return {
+        "checks_total": len(checks),
+        "findings_total": len(findings),
+        "warnings_total": severity_totals["warning"],
+        "errors_total": severity_totals["error"],
+        "critical_total": severity_totals["critical"],
+        "check_status_totals": check_status_totals,
+        "entity_counts": _entity_counts(canonical_json),
+    }
+
+
+def _entity_counts(canonical_json: Mapping[str, Any]) -> dict[str, int]:
+    return {
+        "layouts": _sequence_length(canonical_json.get("layouts")),
+        "layers": _sequence_length(canonical_json.get("layers")),
+        "blocks": _sequence_length(canonical_json.get("blocks")),
+        "entities": _sequence_length(canonical_json.get("entities")),
+    }
+
+
+def _sequence_length(value: Any) -> int:
+    if isinstance(value, (list, tuple)):
+        return len(value)
+
+    return 0
+
+
+def _confidence_score(result: AdapterResult) -> float:
+    if result.confidence is None or result.confidence.score is None:
+        return 0.0
+
+    return float(result.confidence.score)
+
+
+def _json_compatible(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return _json_compatible(asdict(value))
+
+    if isinstance(value, Mapping):
+        return {str(key): _json_compatible(item) for key, item in value.items()}
+
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_compatible(item) for item in value]
+
+    if isinstance(value, UUID):
+        return str(value)
+
+    return value

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import uuid
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -242,6 +243,66 @@ def _assert_revision_invariants(
         )
 
 
+def _build_persisted_validation_report_json(
+    payload: IngestFinalizationPayload,
+    *,
+    drawing_revision_id: UUID,
+    source_job_id: UUID,
+    validation_report_id: UUID,
+) -> dict[str, Any]:
+    """Copy the canonical report JSON and enrich it with persisted identities."""
+    report_json = deepcopy(payload.report_json)
+
+    validator_json = report_json.get("validator")
+    validator = dict(validator_json) if isinstance(validator_json, dict) else {}
+    validator["name"] = payload.validator_name
+    validator["version"] = payload.validator_version
+
+    confidence = dict(payload.confidence_json)
+    confidence["effective_confidence"] = payload.effective_confidence
+    confidence["review_state"] = payload.review_state
+    confidence["review_required"] = payload.review_state == "review_required"
+
+    summary_json = report_json.get("summary")
+    summary = dict(summary_json) if isinstance(summary_json, dict) else {}
+    summary["validation_status"] = payload.validation_status
+    summary["review_state"] = payload.review_state
+    summary["quantity_gate"] = payload.quantity_gate
+    summary["effective_confidence"] = payload.effective_confidence
+
+    checks_json = report_json.get("checks")
+    checks = list(checks_json) if isinstance(checks_json, list) else []
+    if not checks:
+        checks.append(
+            {
+                "code": "validation_report_persisted",
+                "status": "passed",
+                "message": (
+                    "Persisted validation report columns are attached to the "
+                    "canonical payload."
+                ),
+            }
+        )
+
+    report_json["validation_report_id"] = str(validation_report_id)
+    report_json["drawing_revision_id"] = str(drawing_revision_id)
+    report_json["source_job_id"] = str(source_job_id)
+    report_json["validation_report_schema_version"] = payload.validation_report_schema_version
+    report_json["canonical_entity_schema_version"] = payload.canonical_entity_schema_version
+    report_json["validation_status"] = payload.validation_status
+    report_json["review_state"] = payload.review_state
+    report_json["quantity_gate"] = payload.quantity_gate
+    report_json["effective_confidence"] = payload.effective_confidence
+    report_json["validator"] = validator
+    report_json["confidence"] = confidence
+    report_json["provenance"] = deepcopy(payload.provenance_json)
+    report_json["generated_at"] = payload.generated_at.isoformat()
+    report_json["summary"] = summary
+    report_json["checks"] = checks
+
+    return report_json
+
+
 async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
     """Load persisted job and file metadata for the ingestion runner."""
     session_maker = get_session_maker()
@@ -411,7 +472,12 @@ async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPaylo
                 effective_confidence=payload.effective_confidence,
                 validator_name=payload.validator_name,
                 validator_version=payload.validator_version,
-                report_json=payload.report_json,
+                report_json=_build_persisted_validation_report_json(
+                    payload,
+                    drawing_revision_id=drawing_revision_id,
+                    source_job_id=job.id,
+                    validation_report_id=validation_report_id,
+                ),
                 generated_at=payload.generated_at,
             )
         )

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,14 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from app.api.v1 import files_router, health_router, jobs_router, project_router, system_router
+from app.api.v1 import (
+    files_router,
+    health_router,
+    jobs_router,
+    project_router,
+    revisions_router,
+    system_router,
+)
 from app.core.config import settings
 from app.core.exceptions import custom_http_exception_handler, request_validation_exception_handler
 from app.core.logging import configure_logging, get_logger
@@ -39,6 +46,7 @@ def create_app() -> FastAPI:
     app.include_router(project_router, prefix=f"{settings.api_prefix}/projects")
     app.include_router(files_router, prefix=settings.api_prefix)
     app.include_router(jobs_router, prefix=settings.api_prefix)
+    app.include_router(revisions_router, prefix=settings.api_prefix)
 
     logger.info("app_started", version=settings.app_version)
 

--- a/app/schemas/validation_report.py
+++ b/app/schemas/validation_report.py
@@ -1,0 +1,93 @@
+"""Validation report response schemas."""
+
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.validation_report import ValidationReport
+
+
+class ValidationReportValidator(BaseModel):
+    """Validator metadata for a persisted validation report."""
+
+    name: str
+    version: str
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ValidationReportSummary(BaseModel):
+    """Authoritative validation summary details."""
+
+    validation_status: str
+    review_state: str
+    quantity_gate: str
+    effective_confidence: float
+    entity_counts: dict[str, int] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ValidationReportResponse(BaseModel):
+    """Canonical validation report returned by the API."""
+
+    validation_report_id: UUID
+    drawing_revision_id: UUID
+    source_job_id: UUID
+    validation_report_schema_version: str
+    canonical_entity_schema_version: str
+    validation_status: str
+    review_state: str
+    quantity_gate: str
+    effective_confidence: float
+    validator: ValidationReportValidator
+    generated_at: datetime
+    summary: ValidationReportSummary
+    checks: list[Any] = Field(default_factory=list)
+    findings: list[Any] = Field(default_factory=list)
+    adapter_warnings: list[Any] = Field(default_factory=list)
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+def build_validation_report_response(report: ValidationReport) -> ValidationReportResponse:
+    """Merge persisted JSON with authoritative database columns for API output."""
+    report_json = deepcopy(report.report_json)
+
+    validator_json = report_json.get("validator")
+    validator = dict(validator_json) if isinstance(validator_json, dict) else {}
+    validator["name"] = report.validator_name
+    validator["version"] = report.validator_version
+
+    summary_json = report_json.get("summary")
+    summary = dict(summary_json) if isinstance(summary_json, dict) else {}
+    summary["validation_status"] = report.validation_status
+    summary["review_state"] = report.review_state
+    summary["quantity_gate"] = report.quantity_gate
+    summary["effective_confidence"] = report.effective_confidence
+
+    confidence_json = report_json.get("confidence")
+    confidence = dict(confidence_json) if isinstance(confidence_json, dict) else {}
+    confidence["effective_confidence"] = report.effective_confidence
+    confidence["review_state"] = report.review_state
+    confidence["review_required"] = report.review_state == "review_required"
+
+    report_json["validation_report_id"] = report.id
+    report_json["drawing_revision_id"] = report.drawing_revision_id
+    report_json["source_job_id"] = report.source_job_id
+    report_json["validation_report_schema_version"] = report.validation_report_schema_version
+    report_json["canonical_entity_schema_version"] = report.canonical_entity_schema_version
+    report_json["validation_status"] = report.validation_status
+    report_json["review_state"] = report.review_state
+    report_json["quantity_gate"] = report.quantity_gate
+    report_json["effective_confidence"] = report.effective_confidence
+    report_json["validator"] = validator
+    report_json["confidence"] = confidence
+    report_json["generated_at"] = report.generated_at
+    report_json["summary"] = summary
+
+    return ValidationReportResponse.model_validate(report_json)

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import uuid
+from contextlib import suppress
 
 import httpx
 import pytest
@@ -29,8 +30,6 @@ from tests.test_jobs import (
     _FAKE_RUNNER_REVIEW_STATE,
     _FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION,
     _FAKE_RUNNER_VALIDATION_STATUS,
-    _FAKE_RUNNER_VALIDATOR_NAME,
-    _FAKE_RUNNER_VALIDATOR_VERSION,
     _build_fake_ingest_payload,
     _create_project,
     _get_job,
@@ -48,6 +47,38 @@ def _as_uuid(value: str | uuid.UUID) -> uuid.UUID:
         return value
 
     return uuid.UUID(value)
+
+
+def _assert_validation_report_json_matches_columns(report: ValidationReport) -> None:
+    """Assert canonical report JSON matches authoritative validation columns."""
+    report_json = report.report_json
+
+    assert report_json["validation_report_id"] == str(report.id)
+    assert report_json["drawing_revision_id"] == str(report.drawing_revision_id)
+    assert report_json["source_job_id"] == str(report.source_job_id)
+    assert (
+        report_json["validation_report_schema_version"] == report.validation_report_schema_version
+    )
+    assert report_json["canonical_entity_schema_version"] == report.canonical_entity_schema_version
+    assert report_json["validation_status"] == report.validation_status
+    assert report_json["review_state"] == report.review_state
+    assert report_json["quantity_gate"] == report.quantity_gate
+    assert report_json["effective_confidence"] == report.effective_confidence
+    assert report_json["validator"] == {
+        "name": report.validator_name,
+        "version": report.validator_version,
+    }
+    assert report_json["confidence"]["effective_confidence"] == report.effective_confidence
+    assert report_json["confidence"]["review_state"] == report.review_state
+    assert report_json["confidence"]["review_required"] == (
+        report.review_state == "review_required"
+    )
+    assert report_json["generated_at"] == report.generated_at.isoformat()
+    assert report_json["summary"]["validation_status"] == report.validation_status
+    assert report_json["summary"]["review_state"] == report.review_state
+    assert report_json["summary"]["quantity_gate"] == report.quantity_gate
+    assert report_json["summary"]["effective_confidence"] == report.effective_confidence
+    assert report_json["checks"]
 
 
 async def _load_project_outputs(
@@ -160,9 +191,12 @@ class TestIngestOutputPersistence:
 
         await process_ingest_job(job.id)
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
 
         assert len(adapter_outputs) == 1
         assert len(drawing_revisions) == 1
@@ -181,8 +215,7 @@ class TestIngestOutputPersistence:
         assert adapter_output.adapter_version == _FAKE_RUNNER_ADAPTER_VERSION
         assert adapter_output.input_family == "pdf_vector"
         assert (
-            adapter_output.canonical_entity_schema_version
-            == _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION
+            adapter_output.canonical_entity_schema_version == _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION
         )
         assert adapter_output.confidence_score == _FAKE_RUNNER_CONFIDENCE_SCORE
         assert adapter_output.canonical_json == {
@@ -247,30 +280,81 @@ class TestIngestOutputPersistence:
         assert validation_report.review_state == _FAKE_RUNNER_REVIEW_STATE
         assert validation_report.quantity_gate == _FAKE_RUNNER_QUANTITY_GATE
         assert validation_report.effective_confidence == _FAKE_RUNNER_CONFIDENCE_SCORE
-        assert validation_report.report_json == {
-            "validation_report_schema_version": _FAKE_RUNNER_VALIDATION_REPORT_SCHEMA_VERSION,
-            "canonical_entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
-            "validator": {
-                "name": _FAKE_RUNNER_VALIDATOR_NAME,
-                "version": _FAKE_RUNNER_VALIDATOR_VERSION,
-            },
-            "summary": {
-                "validation_status": _FAKE_RUNNER_VALIDATION_STATUS,
-                "review_state": _FAKE_RUNNER_REVIEW_STATE,
-                "quantity_gate": _FAKE_RUNNER_QUANTITY_GATE,
-                "effective_confidence": _FAKE_RUNNER_CONFIDENCE_SCORE,
-                "entity_counts": {
-                    "layouts": 1,
-                    "layers": 1,
-                    "blocks": 0,
-                    "entities": 1,
-                },
-            },
-            "checks": [],
-            "findings": [],
-            "adapter_warnings": [],
-            "provenance": adapter_output.provenance_json,
+        _assert_validation_report_json_matches_columns(validation_report)
+        assert validation_report.report_json["summary"]["entity_counts"] == {
+            "layouts": 1,
+            "layers": 1,
+            "blocks": 0,
+            "entities": 1,
         }
+        assert validation_report.report_json["findings"] == []
+        assert validation_report.report_json["adapter_warnings"] == []
+        assert validation_report.report_json["provenance"] == adapter_output.provenance_json
+
+    async def test_process_ingest_job_persists_payload_provenance_and_confidence_precedence(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Finalization should persist payload provenance and authoritative confidence fields."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        captured_payloads: list[IngestFinalizationPayload] = []
+
+        async def _run_ingestion_with_stale_report(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            payload.report_json.pop("provenance", None)
+            payload.report_json["confidence"] = {
+                "score": payload.confidence_score,
+                "effective_confidence": 0.01,
+                "review_state": "approved",
+                "review_required": False,
+                "basis": "stale",
+            }
+            captured_payloads.append(payload)
+            return payload
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_ingestion_with_stale_report)
+
+        await process_ingest_job(job.id)
+
+        (
+            adapter_outputs,
+            _drawing_revisions,
+            validation_reports,
+            _generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+        adapter_output = adapter_outputs[0]
+        validation_report = validation_reports[0]
+
+        assert captured_payloads[0].provenance_json == adapter_output.provenance_json
+        assert validation_report.report_json["provenance"] == adapter_output.provenance_json
+        assert validation_report.report_json["confidence"]["score"] == captured_payloads[
+            0
+        ].confidence_json.get("score")
+        assert (
+            validation_report.report_json["confidence"]["effective_confidence"]
+            == validation_report.effective_confidence
+        )
+        assert (
+            validation_report.report_json["confidence"]["review_state"]
+            == validation_report.review_state
+        )
+        assert validation_report.report_json["confidence"]["review_required"] == (
+            validation_report.review_state == "review_required"
+        )
+        assert validation_report.report_json["confidence"].get("basis") == captured_payloads[
+            0
+        ].confidence_json.get("basis")
 
     async def test_reprocess_creates_second_revision_with_predecessor(
         self,
@@ -301,9 +385,12 @@ class TestIngestOutputPersistence:
 
         await process_ingest_job(second_job.id)
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
 
         assert len(adapter_outputs) == 2
         assert len(drawing_revisions) == 2
@@ -370,9 +457,12 @@ class TestIngestOutputPersistence:
 
         await process_ingest_job(job.id)
 
-        _adapter_outputs, _drawing_revisions, validation_reports, _generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            _adapter_outputs,
+            _drawing_revisions,
+            validation_reports,
+            _generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
         validation_report = validation_reports[0]
 
         session_maker = session_module.AsyncSessionLocal
@@ -385,9 +475,12 @@ class TestIngestOutputPersistence:
             persisted_validation_report.quantity_gate = "allowed_provisional"
             await session.commit()
 
-        _adapter_outputs, _drawing_revisions, updated_validation_reports, _generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            _adapter_outputs,
+            _drawing_revisions,
+            updated_validation_reports,
+            _generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
         updated_validation_report = updated_validation_reports[0]
 
         assert updated_validation_report.validation_status == "valid_with_warnings"
@@ -430,9 +523,12 @@ class TestIngestOutputPersistence:
             process_ingest_job(third_job.id),
         )
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
 
         assert len(adapter_outputs) == 3
         assert len(drawing_revisions) == 3
@@ -500,13 +596,15 @@ class TestIngestOutputPersistence:
         assert failed_reprocess_job.status == "failed"
         assert failed_reprocess_job.error_code == ErrorCode.INTERNAL_ERROR.value
         assert (
-            failed_reprocess_job.error_message
-            == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
+            failed_reprocess_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
         )
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
         assert adapter_outputs == []
         assert drawing_revisions == []
         assert validation_reports == []
@@ -514,9 +612,12 @@ class TestIngestOutputPersistence:
 
         await process_ingest_job(initial_job.id)
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
         assert len(adapter_outputs) == 1
         assert len(drawing_revisions) == 1
         assert len(validation_reports) == 1
@@ -551,15 +652,19 @@ class TestIngestOutputPersistence:
 
         monkeypatch.setattr(worker_module, "run_ingestion", _cancel_during_work)
 
-        await process_ingest_job(job.id)
+        with suppress(asyncio.CancelledError):
+            await process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
         assert updated_job.status == "cancelled"
         assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
 
         assert adapter_outputs == []
         assert drawing_revisions == []
@@ -629,9 +734,12 @@ class TestIngestOutputPersistence:
             "error_message": worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE,
         }
 
-        adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
 
         assert adapter_outputs == []
         assert drawing_revisions == []

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -165,10 +165,11 @@ async def test_run_ingestion_falls_back_to_next_candidate_and_is_deterministic(
     assert payload_one.adapter_version == "test-1.0"
     assert payload_one.input_family == InputFamily.PDF_RASTER.value
     assert payload_one.revision_kind == "ingest"
-    assert payload_one.review_state == "provisional"
-    assert payload_one.validation_status == "valid"
-    assert payload_one.quantity_gate == "allowed_provisional"
+    assert payload_one.review_state == "review_required"
+    assert payload_one.validation_status == "needs_review"
+    assert payload_one.quantity_gate == "review_gated"
     assert payload_one.confidence_score == 0.61
+    assert payload_one.report_json["checks"]
     assert payload_one.result_checksum_sha256 == payload_two.result_checksum_sha256
     assert payload_one.canonical_json["canonical_entity_schema_version"] == "0.1"
     assert payload_one.report_json["summary"]["entity_counts"] == {

--- a/tests/test_ingestion_validation.py
+++ b/tests/test_ingestion_validation.py
@@ -1,0 +1,690 @@
+"""Tests for ingest validation policy and report construction."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from app.ingestion.contracts import (
+    AdapterResult,
+    AdapterWarning,
+    ConfidenceSummary,
+    InputFamily,
+    JSONValue,
+    ProvenanceRecord,
+)
+from app.ingestion.finalization import (
+    IngestFinalizationContext,
+    build_ingest_finalization_payload,
+)
+from app.ingestion.validation import (
+    ValidationOutcome,
+    _has_valid_polygon_area_geometry,
+    build_validation_outcome,
+)
+
+_GENERATED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+_EXPECTED_CHECK_KEYS = [
+    "units_presence_normalization",
+    "coordinate_system_capture",
+    "geometry_validity",
+    "closed_polygon_eligibility_for_area_quantities",
+    "block_transform_validity",
+    "layer_mapping_completeness",
+    "xref_resolution_status",
+    "pdf_scale_presence_calibration_status",
+    "ifc_schema_support",
+]
+
+
+def _build_complete_canonical(
+    *,
+    entities: tuple[Mapping[str, JSONValue], ...] | None = None,
+    geometry_validity: JSONValue | None = None,
+    pdf_scale: JSONValue | None = None,
+    ifc_schema: str | None = None,
+    xrefs: tuple[Mapping[str, JSONValue], ...] | None = (),
+) -> dict[str, JSONValue]:
+    canonical_entities = entities or (
+        {
+            "kind": "line",
+            "layer": "A-WALL",
+            "start": {"x": 0.0, "y": 0.0},
+            "end": {"x": 1.0, "y": 0.0},
+        },
+    )
+    canonical: dict[str, JSONValue] = {
+        "units": {"normalized": "meter"},
+        "coordinate_system": {"name": "local"},
+        "layouts": ({"name": "Model"},),
+        "layers": ({"name": "A-WALL"},),
+        "blocks": (),
+        "entities": canonical_entities,
+        "xrefs": xrefs,
+    }
+    if geometry_validity is not None:
+        canonical["geometry_validity"] = geometry_validity
+    if pdf_scale is not None:
+        canonical["pdf_scale"] = pdf_scale
+    if ifc_schema is not None:
+        canonical["ifc_schema"] = ifc_schema
+
+    return canonical
+
+
+def _build_result(
+    *,
+    score: float = 0.95,
+    input_family: InputFamily = InputFamily.DXF,
+    canonical: Mapping[str, JSONValue] | None = None,
+    review_required: bool = False,
+    warnings: tuple[AdapterWarning, ...] = (),
+) -> AdapterResult:
+    if canonical is None:
+        canonical = {"entities": ({"kind": "line"},)}
+
+    return AdapterResult(
+        canonical=canonical,
+        provenance=(
+            ProvenanceRecord(
+                stage="extract",
+                adapter_key=input_family.value,
+                source_ref="originals/source.dat",
+            ),
+        ),
+        confidence=ConfidenceSummary(
+            score=score,
+            review_required=review_required,
+            basis=input_family.value,
+        ),
+        warnings=warnings,
+    )
+
+
+@pytest.mark.parametrize(
+    ("score", "validation_status", "review_state", "quantity_gate"),
+    [
+        (0.59, "needs_review", "review_required", "review_gated"),
+        (0.60, "valid", "provisional", "allowed_provisional"),
+        (0.949, "valid", "provisional", "allowed_provisional"),
+        (0.95, "valid", "approved", "allowed"),
+    ],
+)
+def test_build_validation_outcome_applies_confidence_thresholds(
+    score: float,
+    validation_status: str,
+    review_state: str,
+    quantity_gate: str,
+) -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=score),
+        generated_at=_GENERATED_AT,
+    )
+
+    assert outcome.validation_status == validation_status
+    assert outcome.review_state == review_state
+    assert outcome.quantity_gate == quantity_gate
+
+
+def test_build_validation_outcome_raster_is_review_first() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.PDF_RASTER,
+        canonical_json=_build_complete_canonical(pdf_scale={"ratio": "1:100"}),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99, input_family=InputFamily.PDF_RASTER),
+        generated_at=_GENERATED_AT,
+    )
+
+    assert outcome.confidence_score == 0.99
+    assert outcome.effective_confidence == 0.59
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+    assert outcome.report_json["findings"][0]["check_key"] == "raster_review_policy"
+
+
+def test_build_validation_outcome_missing_pdf_scale_requires_review() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.PDF_VECTOR,
+        canonical_json=_build_complete_canonical(),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99, input_family=InputFamily.PDF_VECTOR),
+        generated_at=_GENERATED_AT,
+    )
+
+    pdf_scale_check = outcome.report_json["checks"][7]
+
+    assert pdf_scale_check["check_key"] == "pdf_scale_presence_calibration_status"
+    assert pdf_scale_check["status"] == "review_required"
+    assert pdf_scale_check["details"] == {
+        "applicable": True,
+        "scale_present": False,
+        "calibration_status": "missing",
+    }
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+
+
+def test_build_validation_outcome_missing_ifc_schema_blocks_quantities() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.IFC,
+        canonical_json=_build_complete_canonical(
+            entities=({"kind": "product", "layer": "A-WALL"},),
+            geometry_validity="valid",
+        ),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99, input_family=InputFamily.IFC),
+        generated_at=_GENERATED_AT,
+    )
+
+    ifc_schema_check = outcome.report_json["checks"][8]
+
+    assert ifc_schema_check["check_key"] == "ifc_schema_support"
+    assert ifc_schema_check["status"] == "fail"
+    assert ifc_schema_check["details"] == {
+        "applicable": True,
+        "schema_present": False,
+        "supported": False,
+    }
+    assert outcome.effective_confidence == 0.0
+    assert outcome.validation_status == "invalid"
+    assert outcome.review_state == "rejected"
+    assert outcome.quantity_gate == "blocked"
+
+
+def test_build_validation_outcome_aggregates_adapter_warnings() -> None:
+    warnings = (
+        AdapterWarning(code="layer-map", message="Layer map incomplete"),
+        AdapterWarning(code="xref", message="Xref unresolved", details={"source_ref": "xref:A"}),
+    )
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.95, warnings=warnings),
+        generated_at=_GENERATED_AT,
+    )
+
+    assert outcome.validation_status == "valid_with_warnings"
+    assert outcome.review_state == "approved"
+    assert outcome.report_json["adapter_warnings"] == [
+        {"code": "layer-map", "message": "Layer map incomplete", "details": None},
+        {
+            "code": "xref",
+            "message": "Xref unresolved",
+            "details": {"source_ref": "xref:A"},
+        },
+    ]
+    assert [finding["source"] for finding in outcome.report_json["findings"]] == [
+        "adapter_warning",
+        "adapter_warning",
+    ]
+    assert outcome.report_json["summary"]["warnings_total"] == 2
+
+
+def test_build_validation_outcome_finding_ids_are_deterministic_for_mixed_findings() -> None:
+    warnings = (
+        AdapterWarning(code="layer-map", message="Layer map incomplete"),
+        AdapterWarning(code="xref", message="Xref unresolved", details={"source_ref": "xref:A"}),
+    )
+    canonical_json = _build_complete_canonical(
+        entities=({"kind": "product", "layer": "A-WALL"},),
+        geometry_validity="valid",
+    )
+
+    first_outcome = build_validation_outcome(
+        input_family=InputFamily.IFC,
+        canonical_json=canonical_json,
+        canonical_entity_schema_version="0.1",
+        result=_build_result(
+            score=0.42,
+            input_family=InputFamily.IFC,
+            review_required=True,
+            warnings=warnings,
+        ),
+        generated_at=_GENERATED_AT,
+    )
+    second_outcome = build_validation_outcome(
+        input_family=InputFamily.IFC,
+        canonical_json=canonical_json,
+        canonical_entity_schema_version="0.1",
+        result=_build_result(
+            score=0.42,
+            input_family=InputFamily.IFC,
+            review_required=True,
+            warnings=warnings,
+        ),
+        generated_at=_GENERATED_AT,
+    )
+
+    first_findings = first_outcome.report_json["findings"]
+    second_findings = second_outcome.report_json["findings"]
+
+    assert [finding["finding_id"] for finding in first_findings] == [
+        f"finding-{index:03d}" for index in range(1, len(first_findings) + 1)
+    ]
+    assert [finding["check_key"] for finding in first_findings] == [
+        "confidence_threshold",
+        "adapter_review_required",
+        "ifc_schema_support",
+        "adapter_warning",
+        "adapter_warning",
+    ]
+    assert [finding["severity"] for finding in first_findings] == [
+        "warning",
+        "warning",
+        "error",
+        "warning",
+        "warning",
+    ]
+    assert first_findings == second_findings
+
+
+def test_build_validation_outcome_emits_required_checks_in_deterministic_order() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.95),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks = outcome.report_json["checks"]
+
+    assert [check["check_key"] for check in checks] == _EXPECTED_CHECK_KEYS
+    assert [check["status"] for check in checks[:7]] == ["pass"] * 7
+    assert checks[3]["details"] == {"applicable": False}
+    assert checks[4]["details"] == {"applicable": False}
+    assert checks[6]["details"] == {"applicable": False}
+    assert checks[7]["details"] == {"applicable": False}
+    assert checks[8]["details"] == {"applicable": False}
+
+
+def test_build_validation_outcome_minimal_dxf_requires_review_for_missing_mvp_checks() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json={"entities": ({"kind": "line"},)},
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+    assert checks_by_key["units_presence_normalization"]["status"] == "review_required"
+    assert checks_by_key["coordinate_system_capture"]["status"] == "review_required"
+    assert checks_by_key["geometry_validity"]["status"] == "review_required"
+    assert checks_by_key["layer_mapping_completeness"]["status"] == "review_required"
+    assert checks_by_key["xref_resolution_status"]["status"] == "review_required"
+
+
+def test_build_validation_outcome_requires_geometry_evidence_for_line_entities() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(
+            entities=({"kind": "line", "layer": "A-WALL"},),
+        ),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99),
+        generated_at=_GENERATED_AT,
+    )
+
+    geometry_check = outcome.report_json["checks"][2]
+
+    assert geometry_check["check_key"] == "geometry_validity"
+    assert geometry_check["status"] == "review_required"
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+
+
+@pytest.mark.parametrize(
+    ("kind", "coordinate_field"),
+    [("polygon", "points"), ("hatch", "points"), ("solid", "vertices")],
+)
+def test_build_validation_outcome_review_gates_two_point_closed_area_entities(
+    kind: str,
+    coordinate_field: str,
+) -> None:
+    entity: dict[str, JSONValue] = {
+        "kind": kind,
+        "layer": "A-WALL",
+        coordinate_field: (
+            {"x": 0.0, "y": 0.0},
+            {"x": 1.0, "y": 0.0},
+        ),
+        "closed": True,
+    }
+
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(entities=(entity,)),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+
+    assert checks_by_key["geometry_validity"]["status"] == "review_required"
+    assert (
+        checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"]
+        == "pass"
+    )
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+
+
+def test_build_validation_outcome_review_gates_degenerate_closed_polygon() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(
+            entities=(
+                {
+                    "kind": "polygon",
+                    "layer": "A-WALL",
+                    "points": (
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.0},
+                        {"x": 2.0, "y": 0.0},
+                    ),
+                    "closed": True,
+                },
+            ),
+        ),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+
+    assert checks_by_key["geometry_validity"]["status"] == "review_required"
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        (
+            {"x": 1e308, "y": 1e308},
+            {"x": -1e308, "y": -1e308},
+            {"x": 5e307, "y": 5e307},
+        ),
+        (
+            {"x": 1e308, "y": 0.0},
+            {"x": 0.0, "y": 1e308},
+            {"x": 0.0, "y": 0.0},
+        ),
+    ],
+)
+def test_has_valid_polygon_area_geometry_rejects_nan_and_infinite_area(
+    points: tuple[dict[str, float], ...],
+) -> None:
+    assert _has_valid_polygon_area_geometry(points) is False
+
+
+def test_build_validation_outcome_review_gates_high_magnitude_collinear_polygon() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(
+            entities=(
+                {
+                    "kind": "polygon",
+                    "layer": "A-WALL",
+                    "points": (
+                        {"x": 1e308, "y": 1e308},
+                        {"x": -1e308, "y": -1e308},
+                        {"x": 5e307, "y": 5e307},
+                    ),
+                    "closed": True,
+                },
+            ),
+        ),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+
+    assert checks_by_key["geometry_validity"]["status"] == "review_required"
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+
+
+def test_build_validation_outcome_accepts_non_degenerate_closed_polygon() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(
+            entities=(
+                {
+                    "kind": "polygon",
+                    "layer": "A-WALL",
+                    "points": (
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.0},
+                        {"x": 0.0, "y": 1.0},
+                    ),
+                    "closed": True,
+                },
+            ),
+        ),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.95),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+
+    assert checks_by_key["geometry_validity"]["status"] == "pass"
+    assert (
+        checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"]
+        == "pass"
+    )
+    assert outcome.validation_status == "valid"
+    assert outcome.review_state == "approved"
+    assert outcome.quantity_gate == "allowed"
+
+
+def test_build_validation_outcome_keeps_explicit_geometry_validity_override() -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(
+            entities=(
+                {
+                    "kind": "polygon",
+                    "layer": "A-WALL",
+                    "points": (
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.0},
+                    ),
+                    "closed": True,
+                },
+            ),
+            geometry_validity="valid",
+        ),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+
+    assert checks_by_key["geometry_validity"]["status"] == "pass"
+    assert (
+        checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"]
+        == "pass"
+    )
+    assert outcome.validation_status == "valid"
+    assert outcome.review_state == "approved"
+    assert outcome.quantity_gate == "allowed"
+
+
+@pytest.mark.parametrize(
+    ("pdf_scale", "check_status", "validation_status", "review_state", "quantity_gate"),
+    [
+        ("", "fail", "invalid", "rejected", "blocked"),
+        ({}, "fail", "invalid", "rejected", "blocked"),
+        (False, "fail", "invalid", "rejected", "blocked"),
+        ("placeholder", "review_required", "needs_review", "review_required", "review_gated"),
+        (
+            {"calibration_status": "unconfirmed", "ratio": "1:100"},
+            "review_required",
+            "needs_review",
+            "review_required",
+            "review_gated",
+        ),
+        ({"status": "invalid", "ratio": "1:100"}, "fail", "invalid", "rejected", "blocked"),
+    ],
+)
+def test_build_validation_outcome_rejects_invalid_or_unconfirmed_pdf_scale_values(
+    pdf_scale: JSONValue,
+    check_status: str,
+    validation_status: str,
+    review_state: str,
+    quantity_gate: str,
+) -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.PDF_VECTOR,
+        canonical_json=_build_complete_canonical(pdf_scale=pdf_scale),
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99, input_family=InputFamily.PDF_VECTOR),
+        generated_at=_GENERATED_AT,
+    )
+
+    pdf_scale_check = outcome.report_json["checks"][7]
+
+    assert pdf_scale_check["status"] == check_status
+    assert outcome.validation_status == validation_status
+    assert outcome.review_state == review_state
+    assert outcome.quantity_gate == quantity_gate
+
+
+def test_build_validation_outcome_includes_raw_provenance_in_report_json() -> None:
+    result = _build_result(score=0.95)
+
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=_build_complete_canonical(),
+        canonical_entity_schema_version="0.1",
+        result=result,
+        generated_at=_GENERATED_AT,
+    )
+
+    assert outcome.report_json["provenance"] == [
+        {
+            "stage": "extract",
+            "adapter_key": "dxf",
+            "source_ref": "originals/source.dat",
+            "details": None,
+        }
+    ]
+
+
+def test_build_ingest_finalization_payload_calls_validation_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[InputFamily, str]] = []
+    fake_outcome = ValidationOutcome(
+        confidence_score=0.95,
+        effective_confidence=0.95,
+        validation_status="valid",
+        review_state="approved",
+        quantity_gate="allowed",
+        validator_name="ingestion.runner",
+        validator_version="0.1",
+        confidence_json={
+            "score": 0.95,
+            "effective_confidence": 0.95,
+            "review_state": "approved",
+            "review_required": False,
+            "basis": "dxf",
+        },
+        adapter_warnings_json=[],
+        report_json={
+            "validation_report_schema_version": "0.1",
+            "canonical_entity_schema_version": "0.1",
+            "validation_status": "valid",
+            "review_state": "approved",
+            "quantity_gate": "allowed",
+            "effective_confidence": 0.95,
+            "validator_name": "ingestion.runner",
+            "validator_version": "0.1",
+            "confidence": {},
+            "summary": {
+                "checks_total": 9,
+                "findings_total": 0,
+                "warnings_total": 0,
+                "errors_total": 0,
+                "critical_total": 0,
+                "check_status_totals": {
+                    "pass": 9,
+                    "warning": 0,
+                    "review_required": 0,
+                    "fail": 0,
+                },
+                "entity_counts": {
+                    "layouts": 0,
+                    "layers": 0,
+                    "blocks": 0,
+                    "entities": 1,
+                },
+            },
+            "checks": [],
+            "findings": [],
+            "adapter_warnings": [],
+            "generated_at": _GENERATED_AT.isoformat(),
+        },
+    )
+
+    def fake_build_validation_outcome(
+        *,
+        input_family: InputFamily,
+        canonical_json: Mapping[str, JSONValue],
+        canonical_entity_schema_version: str,
+        result: AdapterResult,
+        generated_at: datetime,
+    ) -> ValidationOutcome:
+        _ = canonical_json
+        _ = result
+        _ = generated_at
+        calls.append((input_family, canonical_entity_schema_version))
+        return fake_outcome
+
+    monkeypatch.setattr(
+        "app.ingestion.finalization.build_validation_outcome",
+        fake_build_validation_outcome,
+    )
+
+    payload = build_ingest_finalization_payload(
+        IngestFinalizationContext(
+            job_id=uuid4(),
+            file_id=uuid4(),
+            extraction_profile_id=None,
+            initial_job_id=None,
+            input_family=InputFamily.DXF,
+            adapter_key="ezdxf",
+            adapter_version="test-1.0",
+        ),
+        result=_build_result(score=0.95),
+        generated_at=_GENERATED_AT,
+    )
+
+    assert calls == [(InputFamily.DXF, "0.1")]
+    assert payload.validation_status == "valid"
+    assert payload.review_state == "approved"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,6 +5,7 @@ import hashlib
 import types
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -1795,7 +1796,8 @@ class TestJobs:
 
         monkeypatch.setattr(worker_module, "run_ingestion", _cancel_during_work)
 
-        await worker_module.process_ingest_job(job.id)
+        with suppress(asyncio.CancelledError):
+            await worker_module.process_ingest_job(job.id)
 
         updated = await _get_job(job.id)
         assert updated.status == "cancelled"

--- a/tests/test_validation_report_api.py
+++ b/tests/test_validation_report_api.py
@@ -1,0 +1,272 @@
+"""Integration tests for validation report API responses."""
+
+import uuid
+from datetime import UTC, datetime
+
+import httpx
+
+import app.db.session as session_module
+from app.core.errors import ErrorCode
+from app.jobs.worker import process_ingest_job
+from app.models.validation_report import ValidationReport
+from tests.conftest import requires_database
+from tests.test_ingest_output_persistence import (
+    _assert_validation_report_json_matches_columns,
+    _load_project_outputs,
+)
+from tests.test_jobs import _create_project, _get_job_for_file, _upload_file
+
+pytest_plugins = ("tests.test_jobs",)
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """Parse API timestamps while accepting UTC Z suffix serialization."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+@requires_database
+class TestValidationReportApi:
+    """Tests for revision validation report retrieval."""
+
+    async def test_get_validation_report_returns_canonical_response(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """The API should return the persisted canonical validation report."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+        validation_report = validation_reports[0]
+
+        response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/validation-report"
+        )
+
+        assert response.status_code == 200
+
+        body = response.json()
+        _assert_validation_report_json_matches_columns(validation_report)
+        assert body["validation_report_id"] == str(validation_report.id)
+        assert body["drawing_revision_id"] == str(drawing_revision.id)
+        assert body["source_job_id"] == str(validation_report.source_job_id)
+        assert (
+            body["validation_report_schema_version"]
+            == validation_report.validation_report_schema_version
+        )
+        assert (
+            body["canonical_entity_schema_version"]
+            == validation_report.canonical_entity_schema_version
+        )
+        assert body["validation_status"] == validation_report.validation_status
+        assert body["review_state"] == validation_report.review_state
+        assert body["quantity_gate"] == validation_report.quantity_gate
+        assert body["effective_confidence"] == validation_report.effective_confidence
+        assert body["validator"] == {
+            "name": validation_report.validator_name,
+            "version": validation_report.validator_version,
+        }
+        assert body["confidence"]["effective_confidence"] == validation_report.effective_confidence
+        assert body["confidence"]["review_state"] == validation_report.review_state
+        assert body["confidence"]["review_required"] == (
+            validation_report.review_state == "review_required"
+        )
+        assert _parse_timestamp(body["generated_at"]) == (
+            validation_report.generated_at.astimezone(UTC)
+        )
+        assert body["summary"]["validation_status"] == validation_report.validation_status
+        assert body["summary"]["review_state"] == validation_report.review_state
+        assert body["summary"]["quantity_gate"] == validation_report.quantity_gate
+        assert (
+            body["summary"]["effective_confidence"]
+            == validation_report.effective_confidence
+        )
+        assert body["checks"]
+        assert body["findings"] == validation_report.report_json["findings"]
+        assert (
+            body["adapter_warnings"] == validation_report.report_json["adapter_warnings"]
+        )
+        assert body["provenance"] == validation_report.report_json["provenance"]
+
+    async def test_get_validation_report_rewrites_nested_confidence_from_db_columns(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """API output should prefer persisted columns over stale nested confidence JSON."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+        validation_report = validation_reports[0]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            persisted_report = await session.get(ValidationReport, validation_report.id)
+            assert persisted_report is not None
+            persisted_report.validation_status = "needs_review"
+            persisted_report.review_state = "review_required"
+            persisted_report.quantity_gate = "review_gated"
+            persisted_report.effective_confidence = 0.59
+            persisted_report.report_json = {
+                **persisted_report.report_json,
+                "confidence": {
+                    "score": 0.95,
+                    "effective_confidence": 0.95,
+                    "review_state": "approved",
+                    "review_required": False,
+                    "basis": "stale",
+                },
+                "summary": {
+                    **persisted_report.report_json["summary"],
+                    "validation_status": "valid",
+                    "review_state": "approved",
+                    "quantity_gate": "allowed",
+                    "effective_confidence": 0.95,
+                },
+            }
+            await session.commit()
+
+        response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/validation-report"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["validation_status"] == "needs_review"
+        assert body["review_state"] == "review_required"
+        assert body["quantity_gate"] == "review_gated"
+        assert body["effective_confidence"] == 0.59
+        assert body["summary"]["validation_status"] == "needs_review"
+        assert body["summary"]["review_state"] == "review_required"
+        assert body["summary"]["quantity_gate"] == "review_gated"
+        assert body["summary"]["effective_confidence"] == 0.59
+        assert body["confidence"] == {
+            "score": 0.95,
+            "effective_confidence": 0.59,
+            "review_state": "review_required",
+            "review_required": True,
+            "basis": "stale",
+        }
+
+    async def test_get_validation_report_returns_404_for_missing_revision(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Unknown revisions should return the standardized not found error."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, _drawing_revisions, validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        assert len(validation_reports) == 1
+
+        revision_id = uuid.uuid4()
+        response = await async_client.get(f"/v1/revisions/{revision_id}/validation-report")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": f"Drawing revision with identifier '{revision_id}' not found",
+                "details": None,
+            }
+        }
+
+        (
+            _adapter_outputs,
+            _drawing_revisions,
+            validation_reports_after,
+            _generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+        assert len(validation_reports_after) == 1
+
+    async def test_get_validation_report_returns_404_when_report_missing(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Existing revisions without persisted reports should return 404."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+        validation_report = validation_reports[0]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            persisted_report = await session.get(ValidationReport, validation_report.id)
+            assert persisted_report is not None
+            await session.delete(persisted_report)
+            await session.commit()
+
+        response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/validation-report"
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": (
+                    f"Validation report with identifier '{drawing_revision.id}' not found"
+                ),
+                "details": None,
+            }
+        }
+
+        (
+            _adapter_outputs,
+            _drawing_revisions,
+            validation_reports_after,
+            _generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+        assert validation_reports_after == []


### PR DESCRIPTION
Closes #95

## Summary
- add canonical validation report generation with explicit validation, review, and quantity-gate policy for ingest revisions
- persist authoritative report payloads with provenance and expose them via `GET /v1/revisions/{revision_id}/validation-report`
- expand validation, persistence, API, and cancellation-race coverage for geometry, PDF scale, and deterministic report behavior

## Test plan
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_issue95_1778095602 uv run pytest
- [x] uv run ruff check .
- [x] uv run mypy app tests