### PR TITLE
test: add adapter contract harness

### DIFF
--- a/tests/fixtures/dwg/libredwg-wrapper-smoke.txt
+++ b/tests/fixtures/dwg/libredwg-wrapper-smoke.txt
@@ -1,0 +1,3 @@
+This fixture is a synthetic placeholder for DWG adapter-wrapper smoke coverage.
+It intentionally does not contain proprietary DWG geometry.
+Use this metadata fixture to validate registry/contract wiring only.

--- a/tests/fixtures/ifc/smoke-minimal.ifc
+++ b/tests/fixtures/ifc/smoke-minimal.ifc
@@ -1,0 +1,14 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView_V2.0]'),'2;1');
+FILE_NAME('smoke-minimal.ifc','2026-01-02T03:04:05',('Draupnir'),('Draupnir'),'opencode','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0vL7Q$8f95x9M5fCB5M7qf',$,'SmokeProject',$,$,$,$,(#2),#3);
+#2=IFCUNITASSIGNMENT(());
+#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#4,$);
+#4=IFCAXIS2PLACEMENT3D(#5,$,$);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+ENDSEC;
+END-ISO-10303-21;

--- a/tests/fixtures/manifest.yaml
+++ b/tests/fixtures/manifest.yaml
@@ -44,3 +44,115 @@ fixtures:
       notes: |
         This fixture is a deterministic geometry smoke test.
         Future global tolerance values may be defined in #61.
+
+  - filename: ifc/smoke-minimal.ifc
+    format: IFC
+    tier: tiny_synthetic
+    source: generated
+    license: CC0-1.0
+    allowed_in_git: true
+    units: meters
+    expected_extraction_notes: |
+      Minimal IFC STEP header + IfcProject shell for adapter wiring smoke checks.
+      Uses IFC4 schema metadata and should preserve schema provenance in canonical output.
+    expected_review_state: review_required
+    expected_validation_status: needs_review
+    expected_quantities:
+      entity_count: 0
+    acceptance_checks:
+      format:
+        expected_schema: IFC4
+        object_scope:
+          - IfcProject
+      quantities:
+        entity_count:
+          expected: 0
+          comparison: review_gated
+          provenance_required: true
+          expected_review_state: review_required
+      notes: |
+        This is a contract smoke fixture, not a semantic BIM completeness fixture.
+
+  - filename: pdf/vector-smoke.pdf
+    format: PDF
+    tier: tiny_synthetic
+    source: generated
+    license: CC0-1.0
+    allowed_in_git: true
+    units: unknown
+    expected_extraction_notes: |
+      Single-page vector PDF with simple stroke geometry and inline text marker.
+      Intended for vector-adapter smoke coverage with explicit scale metadata expected.
+    expected_review_state: provisional
+    expected_validation_status: valid
+    expected_quantities:
+      page_count: 1
+      linework_hint_count: 1
+    acceptance_checks:
+      format:
+        page_count: 1
+        geometry_mode: vector
+        text_expected: true
+      quantities:
+        linework_hint_count:
+          expected: 1
+          comparison: review_gated
+          provenance_required: true
+          expected_review_state: provisional
+      notes: |
+        Vector PDF extraction should not be forced into raster review policy.
+
+  - filename: pdf/raster-smoke.pdf
+    format: PDF
+    tier: tiny_synthetic
+    source: generated
+    license: CC0-1.0
+    allowed_in_git: true
+    units: unknown
+    expected_extraction_notes: |
+      Single-page PDF placeholder used for raster adapter wiring and review-first checks.
+      Outputs are expected to remain review-gated even when confidence is high.
+    expected_review_state: review_required
+    expected_validation_status: needs_review
+    expected_quantities:
+      page_count: 1
+    acceptance_checks:
+      format:
+        page_count: 1
+        geometry_mode: raster
+        ocr_expected: true
+      quantities:
+        page_count:
+          expected: 1
+          comparison: review_gated
+          provenance_required: true
+          expected_review_state: review_required
+      notes: |
+        Raster ingestion is review-first by policy and should keep quantity gates closed.
+
+  - filename: dwg/libredwg-wrapper-smoke.txt
+    format: DWG
+    tier: tiny_synthetic
+    source: generated
+    license: CC0-1.0
+    allowed_in_git: true
+    units: unknown
+    expected_extraction_notes: |
+      Text placeholder for DWG adapter-wrapper contract metadata smoke checks.
+      This fixture intentionally avoids committing real/proprietary DWG binaries.
+    expected_review_state: review_required
+    expected_validation_status: needs_review
+    expected_quantities:
+      entity_count: 0
+    acceptance_checks:
+      format:
+        wrapper_smoke_only: true
+        binary_in_repo: false
+      quantities:
+        entity_count:
+          expected: 0
+          comparison: review_gated
+          provenance_required: true
+          expected_review_state: review_required
+      notes: |
+        Maintains phase coverage beyond DXF while keeping fixture licensing risk low.

--- a/tests/fixtures/pdf/raster-smoke.pdf
+++ b/tests/fixtures/pdf/raster-smoke.pdf
@@ -1,0 +1,11 @@
+%PDF-1.1
+1 0 obj<<>>endobj
+2 0 obj<< /Type /Page /Parent 3 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>endobj
+3 0 obj<< /Type /Pages /Kids [2 0 R] /Count 1 >>endobj
+4 0 obj<< /Length 32 >>stream
+BT /F1 12 Tf 20 50 Td (Raster placeholder) Tj ET
+endstream
+endobj
+5 0 obj<< /Type /Catalog /Pages 3 0 R >>endobj
+trailer<< /Root 5 0 R >>
+%%EOF

--- a/tests/fixtures/pdf/vector-smoke.pdf
+++ b/tests/fixtures/pdf/vector-smoke.pdf
@@ -1,0 +1,16 @@
+%PDF-1.1
+1 0 obj<<>>endobj
+2 0 obj<< /Type /Page /Parent 3 0 R /MediaBox [0 0 100 100] /Contents 4 0 R >>endobj
+3 0 obj<< /Type /Pages /Kids [2 0 R] /Count 1 >>endobj
+4 0 obj<< /Length 44 >>stream
+0.5 w
+10 10 m
+90 10 l
+90 90 l
+S
+BT /F1 12 Tf 12 12 Td (V) Tj ET
+endstream
+endobj
+5 0 obj<< /Type /Catalog /Pages 3 0 R >>endobj
+trailer<< /Root 5 0 R >>
+%%EOF

--- a/tests/ingestion_contract_harness.py
+++ b/tests/ingestion_contract_harness.py
@@ -1,0 +1,286 @@
+"""Reusable contract harness for ingestion adapter tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDescriptor,
+    AdapterDiagnostic,
+    AdapterExecutionOptions,
+    AdapterResult,
+    AdapterSource,
+    AdapterStatus,
+    AdapterTimeout,
+    AdapterWarning,
+    ConfidenceSummary,
+    IngestionAdapter,
+    InputFamily,
+    JSONValue,
+    ProvenanceRecord,
+    UploadFormat,
+)
+from app.ingestion.finalization import (
+    IngestFinalizationContext,
+    IngestFinalizationPayload,
+    build_ingest_finalization_payload,
+)
+
+_DEFAULT_CONTRACT_TIMEOUT = AdapterTimeout(seconds=0.5)
+_DEFAULT_FAILURE_TIMEOUT = AdapterTimeout(seconds=0.01)
+
+
+@dataclass(frozen=True, slots=True)
+class ContractFinalizationExpectation:
+    """Expected finalization posture produced from an adapter run."""
+
+    validation_status: str
+    review_state: str
+    quantity_gate: str
+    warning_codes: tuple[str, ...] = ()
+    diagnostic_codes: tuple[str, ...] = ()
+
+
+class AdapterContractFailureKind(StrEnum):
+    """Normalized failure classes for adapter contract tests."""
+
+    UNSUPPORTED = "unsupported"
+    DEPENDENCY_MISSING = "dependency_missing"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterContractFailure:
+    """Captured failure from adapter execution in harness tests."""
+
+    kind: AdapterContractFailureKind
+    error: BaseException
+
+
+def build_contract_source(
+    *,
+    file_path: Path,
+    upload_format: UploadFormat = UploadFormat.DXF,
+    input_family: InputFamily = InputFamily.DXF,
+    media_type: str | None = None,
+    original_name: str = "fixture.dat",
+) -> AdapterSource:
+    """Build a typed adapter source for harness execution."""
+
+    return AdapterSource(
+        file_path=file_path,
+        upload_format=upload_format,
+        input_family=input_family,
+        media_type=media_type,
+        original_name=original_name,
+    )
+
+
+def build_complete_canonical(*, include_pdf_scale: bool = False) -> dict[str, JSONValue]:
+    """Return a canonical payload that satisfies baseline validator checks."""
+
+    canonical: dict[str, JSONValue] = {
+        "units": {"normalized": "meter"},
+        "coordinate_system": {"name": "local"},
+        "layouts": ({"name": "Model"},),
+        "layers": ({"name": "A-WALL"},),
+        "blocks": (),
+        "entities": (
+            {
+                "kind": "line",
+                "layer": "A-WALL",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 10.0, "y": 0.0},
+            },
+        ),
+        "xrefs": (),
+    }
+    if include_pdf_scale:
+        canonical["pdf_scale"] = {"ratio": "1:100", "status": "confirmed"}
+
+    return canonical
+
+
+def build_result(
+    *,
+    adapter_key: str,
+    score: float,
+    canonical: dict[str, JSONValue],
+    review_required: bool = False,
+    warnings: tuple[AdapterWarning, ...] = (),
+    diagnostics: tuple[AdapterDiagnostic, ...] = (),
+) -> AdapterResult:
+    """Build a well-typed adapter result for contract tests."""
+
+    return AdapterResult(
+        canonical=canonical,
+        provenance=(
+            ProvenanceRecord(
+                stage="extract",
+                adapter_key=adapter_key,
+                source_ref="originals/source.dat",
+            ),
+        ),
+        confidence=ConfidenceSummary(
+            score=score,
+            review_required=review_required,
+            basis="contract",
+        ),
+        warnings=warnings,
+        diagnostics=diagnostics,
+    )
+
+
+def assert_adapter_result_contract(
+    result: AdapterResult,
+    *,
+    expected_adapter_key: str,
+    expected_warning_codes: tuple[str, ...],
+    expected_diagnostic_codes: tuple[str, ...],
+) -> None:
+    """Assert canonical adapter result payload shape and diagnostic metadata."""
+
+    if "entities" not in result.canonical:
+        raise AssertionError("Adapter canonical payload must include an entities collection.")
+    if not result.provenance:
+        raise AssertionError("Adapter result must include provenance records.")
+    if result.confidence is None:
+        raise AssertionError("Adapter result must include confidence metadata.")
+
+    for record in result.provenance:
+        if not record.stage or not record.source_ref:
+            raise AssertionError("Provenance records must include stage and source reference.")
+        if record.adapter_key != expected_adapter_key:
+            raise AssertionError("Provenance adapter key must match the descriptor key.")
+
+    warning_codes = tuple(warning.code for warning in result.warnings)
+    diagnostic_codes = tuple(diagnostic.code for diagnostic in result.diagnostics)
+    if Counter(warning_codes) != Counter(expected_warning_codes):
+        raise AssertionError("Adapter warning codes did not match expected contract output.")
+    if Counter(diagnostic_codes) != Counter(expected_diagnostic_codes):
+        raise AssertionError("Adapter diagnostic codes did not match expected contract output.")
+
+
+async def exercise_adapter_contract(
+    adapter: IngestionAdapter,
+    *,
+    source: AdapterSource,
+    input_family: InputFamily,
+    expectation: ContractFinalizationExpectation,
+    adapter_key: str,
+    adapter_version: str = "contract-test-1.0",
+    timeout: AdapterTimeout = _DEFAULT_CONTRACT_TIMEOUT,
+    generated_at: datetime | None = None,
+    job_id: UUID | None = None,
+    file_id: UUID | None = None,
+) -> IngestFinalizationPayload:
+    """Execute an adapter and assert the shared ingestion/finalization contract."""
+
+    availability = adapter.probe()
+    if availability.status is AdapterStatus.UNAVAILABLE:
+        raise AssertionError("Contract harness requires a probeable adapter.")
+
+    options = AdapterExecutionOptions(timeout=timeout)
+    result = await asyncio.wait_for(adapter.ingest(source, options), timeout=timeout.seconds)
+    assert_adapter_result_contract(
+        result,
+        expected_adapter_key=adapter_key,
+        expected_warning_codes=expectation.warning_codes,
+        expected_diagnostic_codes=expectation.diagnostic_codes,
+    )
+
+    payload = build_ingest_finalization_payload(
+        IngestFinalizationContext(
+            job_id=job_id or uuid4(),
+            file_id=file_id or uuid4(),
+            extraction_profile_id=None,
+            initial_job_id=None,
+            input_family=input_family,
+            adapter_key=adapter_key,
+            adapter_version=adapter_version,
+        ),
+        result=result,
+        generated_at=generated_at or datetime.now(UTC),
+    )
+
+    if payload.validation_status != expectation.validation_status:
+        raise AssertionError("Validation status did not match expected contract output.")
+    if payload.review_state != expectation.review_state:
+        raise AssertionError("Review state did not match expected contract output.")
+    if payload.quantity_gate != expectation.quantity_gate:
+        raise AssertionError("Quantity gate did not match expected contract output.")
+
+    return payload
+
+
+async def exercise_adapter_failure(
+    adapter: IngestionAdapter,
+    *,
+    source: AdapterSource,
+    timeout: AdapterTimeout = _DEFAULT_FAILURE_TIMEOUT,
+    options: AdapterExecutionOptions | None = None,
+) -> AdapterContractFailure:
+    """Execute a failing adapter and classify the failure kind."""
+
+    execution_options = options or AdapterExecutionOptions(timeout=timeout)
+    timeout_seconds = (
+        execution_options.timeout.seconds
+        if execution_options.timeout is not None
+        else timeout.seconds
+    )
+    try:
+        await asyncio.wait_for(
+            adapter.ingest(source, execution_options),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError as error:
+        return AdapterContractFailure(kind=AdapterContractFailureKind.TIMEOUT, error=error)
+    except asyncio.CancelledError as error:
+        return AdapterContractFailure(kind=AdapterContractFailureKind.CANCELLED, error=error)
+    except ModuleNotFoundError as error:
+        return AdapterContractFailure(
+            kind=AdapterContractFailureKind.DEPENDENCY_MISSING,
+            error=error,
+        )
+    except NotImplementedError as error:
+        return AdapterContractFailure(kind=AdapterContractFailureKind.UNSUPPORTED, error=error)
+    except Exception as error:
+        return AdapterContractFailure(kind=AdapterContractFailureKind.FAILED, error=error)
+
+    raise AssertionError("Expected adapter execution to fail in contract failure harness.")
+
+
+def build_descriptor(*, key: str, family: InputFamily) -> AdapterDescriptor:
+    """Create a minimal descriptor for fake contract adapters."""
+
+    upload_format = {
+        InputFamily.DWG: UploadFormat.DWG,
+        InputFamily.DXF: UploadFormat.DXF,
+        InputFamily.IFC: UploadFormat.IFC,
+        InputFamily.PDF_VECTOR: UploadFormat.PDF,
+        InputFamily.PDF_RASTER: UploadFormat.PDF,
+    }[family]
+    return AdapterDescriptor(
+        key=key,
+        family=family,
+        upload_formats=(upload_format,),
+        display_name=f"{key} adapter",
+        module="tests.fake.adapter",
+        license_name="MIT",
+        adapter_version="contract-test-1.0",
+    )
+
+
+def available_probe() -> AdapterAvailability:
+    """Return a standard available probe result for fake adapters."""
+
+    return AdapterAvailability(status=AdapterStatus.AVAILABLE)

--- a/tests/test_adapter_contract_harness.py
+++ b/tests/test_adapter_contract_harness.py
@@ -1,0 +1,321 @@
+"""Tests for reusable ingestion adapter contract harness helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDiagnostic,
+    AdapterExecutionOptions,
+    AdapterResult,
+    AdapterSource,
+    AdapterWarning,
+    IngestionAdapter,
+    InputFamily,
+)
+from tests.ingestion_contract_harness import (
+    AdapterContractFailureKind,
+    ContractFinalizationExpectation,
+    available_probe,
+    build_complete_canonical,
+    build_contract_source,
+    build_descriptor,
+    build_result,
+    exercise_adapter_contract,
+    exercise_adapter_failure,
+)
+
+
+def _load_fixture_manifest() -> dict[str, Any]:
+    manifest_path = Path(__file__).parent / "fixtures" / "manifest.yaml"
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("Fixture manifest must parse to a mapping.")
+    return payload
+
+
+class _ResultAdapter(IngestionAdapter):
+    def __init__(self, *, result: AdapterResult, family: InputFamily, key: str) -> None:
+        self._result = result
+        self.descriptor = build_descriptor(key=key, family=family)
+
+    def probe(self) -> AdapterAvailability:
+        return available_probe()
+
+    async def ingest(
+        self,
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> AdapterResult:
+        _ = (source, options)
+        return self._result
+
+
+class _FailingAdapter(IngestionAdapter):
+    def __init__(self, *, family: InputFamily, key: str, mode: str) -> None:
+        self.descriptor = build_descriptor(key=key, family=family)
+        self._mode = mode
+
+    def probe(self) -> AdapterAvailability:
+        return available_probe()
+
+    async def ingest(
+        self,
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> AdapterResult:
+        _ = source
+        if self._mode == "unsupported":
+            raise NotImplementedError("unsupported")
+        if self._mode == "dependency":
+            raise ModuleNotFoundError(name="ifcopenshell")
+        if self._mode == "timeout":
+            await asyncio.sleep(0.05)
+            raise AssertionError("timeout guard should trigger before this line")
+        if self._mode == "cancelled":
+            if options.cancellation is not None and options.cancellation.is_cancelled():
+                raise asyncio.CancelledError
+            raise AssertionError("cancelled mode requires cancellation handle")
+        raise RuntimeError("unexpected")
+
+
+class _AlwaysCancelled:
+    def is_cancelled(self) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("score", "validation_status", "review_state", "quantity_gate"),
+    [
+        (0.97, "valid", "approved", "allowed"),
+        (0.70, "valid", "provisional", "allowed_provisional"),
+        (0.40, "needs_review", "review_required", "review_gated"),
+    ],
+)
+async def test_contract_harness_applies_review_thresholds(
+    tmp_path: Path,
+    score: float,
+    validation_status: str,
+    review_state: str,
+    quantity_gate: str,
+) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter_key = "fake-dxf"
+    adapter = _ResultAdapter(
+        result=build_result(
+            adapter_key=adapter_key,
+            score=score,
+            canonical=build_complete_canonical(),
+        ),
+        family=InputFamily.DXF,
+        key=adapter_key,
+    )
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=InputFamily.DXF,
+        adapter_key=adapter_key,
+        expectation=ContractFinalizationExpectation(
+            validation_status=validation_status,
+            review_state=review_state,
+            quantity_gate=quantity_gate,
+        ),
+    )
+
+    assert payload.input_family == InputFamily.DXF.value
+    assert payload.provenance_json["records"][0]["adapter_key"] == adapter_key
+
+
+@pytest.mark.asyncio
+async def test_contract_harness_asserts_warnings_and_diagnostics_shape(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter_key = "fake-dxf"
+    warnings = (
+        AdapterWarning(code="layer-map", message="Layer map incomplete"),
+        AdapterWarning(code="xref", message="Xref unresolved"),
+    )
+    diagnostics = (
+        AdapterDiagnostic(code="probe.elapsed", message="Probe completed", elapsed_ms=5.0),
+    )
+    adapter = _ResultAdapter(
+        result=build_result(
+            adapter_key=adapter_key,
+            score=0.97,
+            canonical=build_complete_canonical(),
+            warnings=warnings,
+            diagnostics=diagnostics,
+        ),
+        family=InputFamily.DXF,
+        key=adapter_key,
+    )
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=InputFamily.DXF,
+        adapter_key=adapter_key,
+        expectation=ContractFinalizationExpectation(
+            validation_status="valid_with_warnings",
+            review_state="approved",
+            quantity_gate="allowed",
+            warning_codes=("layer-map", "xref"),
+            diagnostic_codes=("probe.elapsed",),
+        ),
+    )
+
+    assert payload.report_json["adapter_warnings"][0]["code"] == "layer-map"
+    assert payload.diagnostics_json["diagnostics"][0]["code"] == "probe.elapsed"
+
+
+@pytest.mark.asyncio
+async def test_contract_harness_rejects_missing_entities_key(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter_key = "fake-dxf"
+    adapter = _ResultAdapter(
+        result=build_result(
+            adapter_key=adapter_key,
+            score=0.97,
+            canonical={"units": {"normalized": "meter"}},
+        ),
+        family=InputFamily.DXF,
+        key=adapter_key,
+    )
+
+    with pytest.raises(AssertionError):
+        await exercise_adapter_contract(
+            adapter,
+            source=source,
+            input_family=InputFamily.DXF,
+            adapter_key=adapter_key,
+            expectation=ContractFinalizationExpectation(
+                validation_status="valid",
+                review_state="approved",
+                quantity_gate="allowed",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_kind"),
+    [
+        ("unsupported", AdapterContractFailureKind.UNSUPPORTED),
+        ("dependency", AdapterContractFailureKind.DEPENDENCY_MISSING),
+        ("timeout", AdapterContractFailureKind.TIMEOUT),
+    ],
+)
+async def test_contract_harness_classifies_common_failure_modes(
+    tmp_path: Path,
+    mode: str,
+    expected_kind: AdapterContractFailureKind,
+) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter = _FailingAdapter(family=InputFamily.DXF, key="failing-dxf", mode=mode)
+
+    failure = await exercise_adapter_failure(adapter, source=source)
+
+    assert failure.kind is expected_kind
+
+
+@pytest.mark.asyncio
+async def test_contract_harness_classifies_cancellation(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter = _FailingAdapter(family=InputFamily.DXF, key="failing-dxf", mode="cancelled")
+
+    failure = await exercise_adapter_failure(
+        adapter,
+        source=source,
+        options=AdapterExecutionOptions(cancellation=_AlwaysCancelled()),
+    )
+
+    assert failure.kind is AdapterContractFailureKind.CANCELLED
+
+
+def test_fixture_manifest_has_multi_format_smoke_contract_coverage() -> None:
+    manifest = _load_fixture_manifest()
+    fixtures_payload = manifest.get("fixtures")
+    if not isinstance(fixtures_payload, list):
+        raise AssertionError("Fixture manifest fixtures list is missing.")
+
+    fixtures_by_filename: dict[str, dict[str, Any]] = {
+        fixture["filename"]: fixture
+        for fixture in fixtures_payload
+        if isinstance(fixture, dict) and isinstance(fixture.get("filename"), str)
+    }
+
+    expected = {
+        "dxf/simple-line.dxf": ("approved", "valid", "total_length"),
+        "ifc/smoke-minimal.ifc": ("review_required", "needs_review", "entity_count"),
+        "pdf/vector-smoke.pdf": ("provisional", "valid", "linework_hint_count"),
+        "pdf/raster-smoke.pdf": ("review_required", "needs_review", "page_count"),
+        "dwg/libredwg-wrapper-smoke.txt": (
+            "review_required",
+            "needs_review",
+            "entity_count",
+        ),
+    }
+
+    for filename, (review_state, validation_status, quantity_key) in expected.items():
+        fixture = fixtures_by_filename.get(filename)
+        if fixture is None:
+            raise AssertionError(f"Missing fixture manifest entry: {filename}")
+
+        if not filename.startswith("dxf/"):
+            license_value = fixture.get("license")
+            if not isinstance(license_value, str) or not license_value.strip():
+                raise AssertionError(f"Fixture {filename} missing non-empty license metadata.")
+
+            allowed_in_git = fixture.get("allowed_in_git")
+            if not isinstance(allowed_in_git, bool):
+                raise AssertionError(f"Fixture {filename} missing boolean allowed_in_git flag.")
+
+            if filename.endswith(".txt"):
+                placeholder_intent = fixture.get("placeholder_intent")
+                has_placeholder_intent = (
+                    isinstance(placeholder_intent, str) and bool(placeholder_intent.strip())
+                )
+                has_fallback_intent = any(
+                    isinstance(fixture.get(key), str) and fixture.get(key, "").strip()
+                    for key in ("description", "notes", "source")
+                )
+                if not (has_placeholder_intent or has_fallback_intent):
+                    raise AssertionError(
+                        f"Placeholder fixture {filename} missing intent metadata fields."
+                    )
+
+        assert fixture.get("expected_review_state") == review_state
+        assert fixture.get("expected_validation_status") == validation_status
+
+        acceptance_checks = fixture.get("acceptance_checks")
+        if not isinstance(acceptance_checks, dict):
+            raise AssertionError(f"Fixture {filename} missing acceptance_checks mapping.")
+
+        quantities = acceptance_checks.get("quantities")
+        if not isinstance(quantities, dict):
+            raise AssertionError(f"Fixture {filename} missing quantities acceptance checks.")
+
+        quantity_check = quantities.get(quantity_key)
+        if not isinstance(quantity_check, dict):
+            raise AssertionError(
+                f"Fixture {filename} missing quantity check for {quantity_key}."
+            )
+
+        assert quantity_check.get("expected_review_state") == review_state


### PR DESCRIPTION
Closes #96

## Summary
- add a reusable ingestion adapter contract harness so Phase 4 adapters can be validated against the same canonical shape, review-state, warning, diagnostic, and failure-mode expectations
- expand fixture coverage beyond the single DXF sample with safe synthetic IFC, PDF, and DWG-wrapper smoke fixtures plus manifest assertions for fixture-policy metadata
- keep contract coverage independent of live adapter implementations so adapter work can land against stable tests first

## Test plan
- [x] `uv run pytest tests/test_adapter_contract_harness.py tests/test_ingestion_contracts.py tests/test_ingestion_runner.py`
- [x] `uv run ruff check tests/ingestion_contract_harness.py tests/test_adapter_contract_harness.py`
- [x] `uv run mypy tests/ingestion_contract_harness.py tests/test_adapter_contract_harness.py`
- [x] `ruby -e 'require "yaml"; YAML.load_file("tests/fixtures/manifest.yaml"); puts "ok"'`

## Notes
- no breaking changes