### PR TITLE
feat: add ezdxf DXF ingestion adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           version: "0.11.8"
 
       - name: Install dependencies
-        run: uv sync --locked --extra db --extra jobs --extra dev --extra test
+        run: uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
 
       - name: Run ruff
         run: uv run ruff check app tests
@@ -51,7 +51,7 @@ jobs:
           version: "0.11.8"
 
       - name: Install dependencies
-        run: uv sync --locked --extra db --extra jobs --extra dev --extra test
+        run: uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
 
       - name: Run mypy
         run: uv run mypy app tests
@@ -89,7 +89,7 @@ jobs:
           version: "0.11.8"
 
       - name: Install dependencies
-        run: uv sync --locked --extra db --extra jobs --extra dev --extra test
+        run: uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
 
       - name: Run Alembic migrations
         run: uv run alembic upgrade head

--- a/app/ingestion/adapters/__init__.py
+++ b/app/ingestion/adapters/__init__.py
@@ -1,0 +1,3 @@
+"""Concrete ingestion adapter implementations."""
+
+__all__ = ["ezdxf"]

--- a/app/ingestion/adapters/ezdxf.py
+++ b/app/ingestion/adapters/ezdxf.py
@@ -1,0 +1,882 @@
+"""Concrete DXF ingestion adapter backed by ezdxf."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from math import isfinite, sqrt
+from pathlib import Path
+from typing import Any
+
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDescriptor,
+    AdapterDiagnostic,
+    AdapterExecutionOptions,
+    AdapterResult,
+    AdapterSource,
+    AdapterTimeout,
+    AdapterWarning,
+    CancellationHandle,
+    ConfidenceSummary,
+    InputFamily,
+    JSONValue,
+    ProbeKind,
+    ProbeObservation,
+    ProbeStatus,
+    ProgressCallback,
+    ProgressUpdate,
+    ProvenanceRecord,
+)
+from app.ingestion.registry import evaluate_availability, get_descriptor
+
+_DESCRIPTOR = get_descriptor(InputFamily.DXF)
+_CANONICAL_SCHEMA_VERSION = "0.1"
+_METER_UNITS = 6
+_MODEL_LAYOUT_NAME = "Model"
+_UNIT_NAMES: dict[int, str] = {
+    0: "unitless",
+    1: "inch",
+    2: "foot",
+    3: "mile",
+    4: "millimeter",
+    5: "centimeter",
+    6: "meter",
+    7: "kilometer",
+    8: "microinch",
+    9: "mil",
+    10: "yard",
+    11: "angstrom",
+    12: "nanometer",
+    13: "micron",
+    14: "decimeter",
+    15: "decameter",
+    16: "hectometer",
+    17: "gigameter",
+    18: "astronomical_unit",
+    19: "light_year",
+    20: "parsec",
+    21: "us_survey_foot",
+    22: "us_survey_inch",
+    23: "us_survey_yard",
+    24: "us_survey_mile",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimeBindings:
+    ezdxf: Any
+    units: Any
+    dxf_structure_error: type[Exception]
+
+
+@dataclass(frozen=True, slots=True)
+class _CheckpointBudget:
+    timeout: AdapterTimeout | None
+    cancellation: CancellationHandle | None
+    started_at: float
+
+    @classmethod
+    def start(cls, options: AdapterExecutionOptions) -> _CheckpointBudget:
+        return cls(
+            timeout=options.timeout,
+            cancellation=options.cancellation,
+            started_at=time.monotonic(),
+        )
+
+    def check(self) -> None:
+        if self.cancellation is not None and self.cancellation.is_cancelled():
+            raise asyncio.CancelledError()
+
+        if self.timeout is None:
+            return
+
+        elapsed_seconds = time.monotonic() - self.started_at
+        if elapsed_seconds >= self.timeout.seconds:
+            raise TimeoutError("DXF ingestion exceeded the adapter timeout budget.")
+
+
+class EzdxfAdapter:
+    """DXF adapter implementation that emits canonical v0.1 payloads."""
+
+    descriptor: AdapterDescriptor = _DESCRIPTOR
+
+    def __init__(self, runtime: _RuntimeBindings) -> None:
+        self._runtime = runtime
+        self.version = str(runtime.ezdxf.__version__)
+
+    def probe(self) -> AdapterAvailability:
+        started_at = time.monotonic()
+        observation = ProbeObservation(
+            kind=ProbeKind.PYTHON_PACKAGE,
+            name="ezdxf",
+            status=ProbeStatus.AVAILABLE,
+            detail=f"ezdxf {self.version} is installed.",
+        )
+        return evaluate_availability(
+            self.descriptor,
+            observations=(observation,),
+            details={
+                "package": "ezdxf",
+                "package_version": self.version,
+            },
+            probe_elapsed_ms=(time.monotonic() - started_at) * 1000,
+        )
+
+    async def ingest(
+        self,
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> AdapterResult:
+        budget = _CheckpointBudget.start(options)
+        budget.check()
+        _emit_progress(options.on_progress, stage="load", message="Opening DXF document.")
+
+        load_started_at = time.monotonic()
+        document = self._read_document(source.file_path)
+        load_elapsed_ms = (time.monotonic() - load_started_at) * 1000
+        budget.check()
+        units_payload = _units_payload(document, self._runtime.units)
+
+        modelspace_entities = list(document.modelspace())
+        total_entities = len(modelspace_entities)
+        _emit_progress(
+            options.on_progress,
+            stage="extract",
+            message="Extracting DXF entities.",
+            completed=0,
+            total=total_entities,
+            percent=0.0 if total_entities else 1.0,
+        )
+
+        warnings: list[AdapterWarning] = []
+        canonical_entities: list[dict[str, JSONValue]] = []
+        used_layers: set[str] = set()
+        supported_entities = 0
+        unsupported_entities = 0
+        invalid_geometry_entities = 0
+        units_review_required = not _units_are_normalized_to_meter(units_payload)
+        if units_review_required:
+            warnings.append(
+                AdapterWarning(
+                    code="units_unconfirmed",
+                    message=(
+                        "DXF units could not be normalized to meters; "
+                        "geometry-derived quantities require review."
+                    ),
+                    details={
+                        "source_value": units_payload["source_value"],
+                        "normalized": units_payload["normalized"],
+                    },
+                )
+            )
+
+        extract_started_at = time.monotonic()
+        for index, entity in enumerate(modelspace_entities, start=1):
+            budget.check()
+            layout_name = _layout_name(entity)
+            entity_type = str(entity.dxftype()).upper()
+            if entity_type == "LINE":
+                try:
+                    canonical_entity = _line_entity_payload(
+                        entity,
+                        layout_name=layout_name,
+                        units=units_payload,
+                    )
+                except ValueError as exc:
+                    canonical_entity = _unknown_entity_payload(
+                        entity,
+                        layout_name=layout_name,
+                        units=units_payload,
+                    )
+                    warnings.append(
+                        AdapterWarning(
+                            code="malformed_coordinates",
+                            message=(
+                                "DXF entity coordinates were invalid and the entity "
+                                "was retained as unknown."
+                            ),
+                            details={
+                                "entity_type": entity_type,
+                                "handle": _entity_handle(entity),
+                                "layer": _entity_layer(entity),
+                                "layout": layout_name,
+                                "reason": str(exc),
+                            },
+                        )
+                    )
+                    invalid_geometry_entities += 1
+                else:
+                    supported_entities += 1
+            else:
+                canonical_entity = _unknown_entity_payload(
+                    entity,
+                    layout_name=layout_name,
+                    units=units_payload,
+                )
+                warnings.append(
+                    AdapterWarning(
+                        code="unsupported_entity",
+                        message=(
+                            f"Unsupported DXF entity type '{entity_type}' was retained as unknown."
+                        ),
+                        details={
+                            "entity_type": entity_type,
+                            "handle": _entity_handle(entity),
+                            "layer": _entity_layer(entity),
+                            "layout": layout_name,
+                        },
+                    )
+                )
+                unsupported_entities += 1
+
+            layer_name = canonical_entity.get("layer")
+            if isinstance(layer_name, str) and layer_name:
+                used_layers.add(layer_name)
+
+            canonical_entities.append(canonical_entity)
+            _emit_progress(
+                options.on_progress,
+                stage="extract",
+                message="Extracting DXF entities.",
+                completed=index,
+                total=total_entities,
+                percent=(index / total_entities) if total_entities else 1.0,
+            )
+
+        extract_elapsed_ms = (time.monotonic() - extract_started_at) * 1000
+        budget.check()
+        xrefs = _xrefs_payload(document)
+        unresolved_xref_count = sum(
+            1
+            for xref in xrefs
+            if isinstance(xref.get("status"), str) and xref["status"] == "review_required"
+        )
+        if unresolved_xref_count > 0:
+            warnings.append(
+                AdapterWarning(
+                    code="xref_unresolved",
+                    message="DXF external references require review.",
+                    details={"xref_count": unresolved_xref_count},
+                )
+            )
+        _emit_progress(
+            options.on_progress,
+            stage="finalize",
+            message="Preparing canonical DXF payload.",
+            completed=total_entities,
+            total=total_entities,
+            percent=1.0,
+        )
+
+        canonical: dict[str, JSONValue] = {
+            "canonical_entity_schema_version": _CANONICAL_SCHEMA_VERSION,
+            "schema_version": _CANONICAL_SCHEMA_VERSION,
+            "units": units_payload,
+            "coordinate_system": {
+                "name": "local",
+                "type": "cartesian",
+                "axis_order": "x,y,z",
+                "source": "dxf_modelspace_coordinates",
+            },
+            "layouts": _layouts_payload(document),
+            "layers": _layers_payload(document, used_layers=used_layers),
+            "blocks": _blocks_payload(document, units=units_payload),
+            "entities": tuple(canonical_entities),
+            "xrefs": xrefs,
+        }
+
+        review_required = (
+            unsupported_entities > 0
+            or invalid_geometry_entities > 0
+            or units_review_required
+            or unresolved_xref_count > 0
+        )
+
+        diagnostics = (
+            AdapterDiagnostic(
+                code="dxf_document_loaded",
+                message="DXF document loaded successfully.",
+                details={
+                    "layout_count": len(tuple(document.layouts)),
+                    "modelspace_entity_count": total_entities,
+                    "version": str(document.dxfversion),
+                },
+                elapsed_ms=load_elapsed_ms,
+            ),
+            AdapterDiagnostic(
+                code="dxf_entities_extracted",
+                message="DXF entities extracted into canonical output.",
+                details={
+                    "entity_count": total_entities,
+                    "supported_entity_count": supported_entities,
+                    "unsupported_entity_count": unsupported_entities,
+                    "invalid_geometry_entity_count": invalid_geometry_entities,
+                    "unresolved_xref_count": unresolved_xref_count,
+                },
+                elapsed_ms=extract_elapsed_ms,
+            ),
+        )
+
+        provenance = (
+            ProvenanceRecord(
+                stage="extract",
+                adapter_key=self.descriptor.key,
+                source_ref=_source_ref(source),
+                details={
+                    "upload_format": source.upload_format.value,
+                    "input_family": source.input_family.value,
+                    "original_name": _safe_original_name(source.original_name),
+                    "modelspace_entity_count": total_entities,
+                },
+            ),
+        )
+
+        return AdapterResult(
+            canonical=canonical,
+            provenance=provenance,
+            confidence=ConfidenceSummary(
+                score=0.99 if not review_required else 0.95,
+                review_required=review_required,
+                basis="native_dxf_geometry",
+            ),
+            warnings=tuple(warnings),
+            diagnostics=diagnostics,
+        )
+
+    def _read_document(self, file_path: Path) -> Any:
+        try:
+            return self._runtime.ezdxf.readfile(file_path)
+        except OSError as exc:
+            raise RuntimeError("DXF source could not be opened.") from exc
+        except UnicodeDecodeError as exc:
+            raise RuntimeError("DXF source encoding could not be decoded.") from exc
+        except Exception as exc:
+            if isinstance(exc, self._runtime.dxf_structure_error):
+                raise RuntimeError("DXF source structure is invalid.") from exc
+            raise
+
+
+def create_adapter() -> EzdxfAdapter:
+    """Create the concrete DXF adapter instance for loader consumers."""
+    try:
+        return EzdxfAdapter(_load_runtime())
+    except Exception as exc:
+        raise RuntimeError("DXF adapter runtime could not be loaded.") from exc
+
+
+def _load_runtime() -> _RuntimeBindings:
+    import ezdxf
+    from ezdxf import units
+    from ezdxf.lldxf.const import DXFStructureError
+
+    return _RuntimeBindings(
+        ezdxf=ezdxf,
+        units=units,
+        dxf_structure_error=DXFStructureError,
+    )
+
+
+def _emit_progress(
+    callback: ProgressCallback | None,
+    *,
+    stage: str,
+    message: str,
+    completed: int | None = None,
+    total: int | None = None,
+    percent: float | None = None,
+) -> None:
+    if callback is None:
+        return
+
+    callback(
+        ProgressUpdate(
+            stage=stage,
+            message=message,
+            completed=completed,
+            total=total,
+            percent=percent,
+        )
+    )
+
+
+def _units_payload(document: Any, units_module: Any) -> dict[str, JSONValue]:
+    source_value = int(document.header.get("$INSUNITS", document.units))
+    conversion_factor_to_meter: float | None = None
+    if source_value != 0:
+        try:
+            candidate = float(units_module.conversion_factor(source_value, _METER_UNITS))
+        except Exception:
+            pass
+        else:
+            if isfinite(candidate) and candidate > 0:
+                conversion_factor_to_meter = candidate
+
+    normalized = (
+        "meter"
+        if conversion_factor_to_meter is not None
+        else _normalized_unit_name(source_value)
+    )
+
+    payload: dict[str, JSONValue] = {
+        "normalized": normalized,
+        "source": "$INSUNITS",
+        "source_value": source_value,
+        "conversion_target": "meter",
+        "conversion_factor": conversion_factor_to_meter,
+    }
+    return payload
+
+
+def _normalized_unit_name(source_value: int) -> str:
+    return _UNIT_NAMES.get(source_value, "unitless")
+
+
+def _units_are_normalized_to_meter(units: dict[str, JSONValue]) -> bool:
+    return _unit_scale_factor(units) is not None
+
+
+def _layouts_payload(document: Any) -> tuple[dict[str, JSONValue], ...]:
+    layouts: list[dict[str, JSONValue]] = []
+    for layout in document.layouts:
+        layouts.append(
+            {
+                "name": str(layout.name),
+                "kind": "modelspace" if str(layout.name) == _MODEL_LAYOUT_NAME else "paperspace",
+                "tab_order": int(getattr(layout.dxf, "taborder", 0)),
+            }
+        )
+    return tuple(layouts)
+
+
+def _layers_payload(document: Any, *, used_layers: set[str]) -> tuple[dict[str, JSONValue], ...]:
+    layers: list[dict[str, JSONValue]] = []
+    for layer in document.layers:
+        layer_name = str(layer.dxf.name)
+        if used_layers and layer_name not in used_layers:
+            continue
+        layers.append(
+            {
+                "name": layer_name,
+                "color": int(layer.color),
+                "linetype": str(layer.dxf.linetype),
+            }
+        )
+    return tuple(layers)
+
+
+def _blocks_payload(
+    document: Any,
+    *,
+    units: dict[str, JSONValue],
+) -> tuple[dict[str, JSONValue], ...]:
+    blocks: list[dict[str, JSONValue]] = []
+    for block in document.blocks:
+        if bool(getattr(block.block, "is_xref", False)):
+            continue
+        block_name = str(block.name)
+        if block_name.startswith("*"):
+            continue
+        try:
+            base_point: dict[str, JSONValue] | None = _scaled_point_payload(
+                block.block.dxf.base_point,
+                units=units,
+            )
+        except ValueError:
+            base_point = None
+        blocks.append(
+            {
+                "name": block_name,
+                "base_point": base_point,
+                "entity_count": len(list(block)),
+            }
+        )
+    return tuple(blocks)
+
+
+def _xrefs_payload(document: Any) -> tuple[dict[str, JSONValue], ...]:
+    xrefs: list[dict[str, JSONValue]] = []
+    for block in document.blocks:
+        if not bool(getattr(block.block, "is_xref", False)):
+            continue
+        xref_path = getattr(block.block.dxf, "xref_path", "")
+        reference = _safe_reference_name(xref_path)
+        path_hash = _redacted_path_hash(xref_path)
+        xrefs.append(
+            {
+                "name": str(block.name),
+                "reference": reference,
+                "path_sha256": path_hash,
+                "status": "review_required",
+            }
+        )
+    return tuple(xrefs)
+
+
+def _line_entity_payload(
+    entity: Any,
+    *,
+    layout_name: str,
+    units: dict[str, JSONValue],
+) -> dict[str, JSONValue]:
+    native_type = str(entity.dxftype()).upper()
+    handle = _entity_handle(entity)
+    layer_name = _entity_layer(entity)
+    start_native = _point_payload(entity.dxf.start)
+    end_native = _point_payload(entity.dxf.end)
+    start = _scaled_point_payload(entity.dxf.start, units=units, point_payload=start_native)
+    end = _scaled_point_payload(entity.dxf.end, units=units, point_payload=end_native)
+    native_length = _line_length(start_native, end_native)
+    length = _line_length(start, end)
+    adapter_native: dict[str, JSONValue] = {
+        "layer": layer_name,
+        "linetype": _optional_string(getattr(entity.dxf, "linetype", None)),
+    }
+    if _native_geometry_should_be_preserved(units):
+        adapter_native["geometry"] = {
+            "start": start_native,
+            "end": end_native,
+            "length": native_length,
+            "units": {
+                "normalized": _normalized_unit_name(_source_unit_value(units)),
+                "source_value": _source_unit_value(units),
+            },
+        }
+    entity_id = _entity_id(
+        native_type=native_type,
+        handle=handle,
+        layout_name=layout_name,
+        layer_name=layer_name,
+        geometry={"start": start, "end": end},
+    )
+    return {
+        "entity_id": entity_id,
+        "entity_type": "line",
+        "entity_schema_version": _CANONICAL_SCHEMA_VERSION,
+        "geometry": {
+            "start": start,
+            "end": end,
+            "bbox": _bbox_payload(start, end),
+            "units": dict(units),
+            "geometry_summary": {
+                "kind": "line_segment",
+                "length": length,
+                "vertex_count": 2,
+            },
+        },
+        "properties": {
+            "source_type": native_type,
+            "source_handle": handle or None,
+            "quantity_hints": {
+                "length": length,
+                "count": 1.0,
+            },
+            "adapter_native": {
+                "ezdxf": adapter_native
+            },
+        },
+        "provenance": _entity_provenance(
+            native_type=native_type,
+            handle=handle,
+            layout_name=layout_name,
+            layer_name=layer_name,
+            entity_id=entity_id,
+            geometry={"start": start, "end": end},
+        ),
+        "confidence": 0.99,
+        "drawing_revision_id": None,
+        "source_file_id": None,
+        "layout_ref": layout_name,
+        "layer_ref": layer_name,
+        "block_ref": None,
+        "parent_entity_ref": None,
+        "kind": "line",
+        "handle": handle,
+        "layer": layer_name,
+        "layout": layout_name,
+        "start": start,
+        "end": end,
+        "length": length,
+    }
+
+
+def _unknown_entity_payload(
+    entity: Any,
+    *,
+    layout_name: str,
+    units: dict[str, JSONValue],
+) -> dict[str, JSONValue]:
+    native_type = str(entity.dxftype()).upper()
+    handle = _entity_handle(entity)
+    layer_name = _entity_layer(entity)
+    entity_id = _entity_id(
+        native_type=native_type,
+        handle=handle,
+        layout_name=layout_name,
+        layer_name=layer_name,
+    )
+    return {
+        "entity_id": entity_id,
+        "entity_type": "unknown",
+        "entity_schema_version": _CANONICAL_SCHEMA_VERSION,
+        "geometry": {
+            "bbox": None,
+            "units": dict(units),
+            "geometry_summary": {
+                "kind": "unknown",
+                "source_type": native_type,
+            },
+        },
+        "properties": {
+            "source_type": native_type,
+            "source_handle": handle or None,
+            "quantity_hints": None,
+            "adapter_native": {
+                "ezdxf": {
+                    "layer": layer_name,
+                }
+            },
+        },
+        "provenance": _entity_provenance(
+            native_type=native_type,
+            handle=handle,
+            layout_name=layout_name,
+            layer_name=layer_name,
+            entity_id=entity_id,
+            geometry=None,
+        ),
+        "confidence": 0.0,
+        "drawing_revision_id": None,
+        "source_file_id": None,
+        "layout_ref": layout_name,
+        "layer_ref": layer_name,
+        "block_ref": None,
+        "parent_entity_ref": None,
+        "kind": "unknown",
+        "handle": handle,
+        "layer": layer_name,
+        "layout": layout_name,
+    }
+
+
+def _entity_provenance(
+    *,
+    native_type: str,
+    handle: str,
+    layout_name: str,
+    layer_name: str,
+    entity_id: str,
+    geometry: dict[str, JSONValue] | None,
+) -> dict[str, JSONValue]:
+    return {
+        "source_entity_ref": f"entities.{native_type}:{handle or entity_id}",
+        "dxf_handle": handle or None,
+        "native_entity_type": native_type,
+        "layout_name": layout_name,
+        "layer_name": layer_name,
+        "normalized_source_hash": _entity_fingerprint(
+            native_type=native_type,
+            handle=handle,
+            layout_name=layout_name,
+            layer_name=layer_name,
+            geometry=geometry,
+        ),
+    }
+
+
+def _entity_id(
+    *,
+    native_type: str,
+    handle: str,
+    layout_name: str,
+    layer_name: str,
+    geometry: dict[str, JSONValue] | None = None,
+) -> str:
+    if handle:
+        return f"dxf:{handle.lower()}"
+    fingerprint = _entity_fingerprint(
+        native_type=native_type,
+        handle=handle,
+        layout_name=layout_name,
+        layer_name=layer_name,
+        geometry=geometry,
+    )
+    return f"dxf:{fingerprint[:16]}"
+
+
+def _entity_fingerprint(
+    *,
+    native_type: str,
+    handle: str,
+    layout_name: str,
+    layer_name: str,
+    geometry: dict[str, JSONValue] | None,
+) -> str:
+    payload = {
+        "native_type": native_type,
+        "handle": handle,
+        "layout_name": layout_name,
+        "layer_name": layer_name,
+        "geometry": geometry,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _bbox_payload(
+    start: dict[str, JSONValue],
+    end: dict[str, JSONValue],
+) -> dict[str, JSONValue]:
+    return {
+        "min": {
+            "x": min(_point_component(start, "x"), _point_component(end, "x")),
+            "y": min(_point_component(start, "y"), _point_component(end, "y")),
+            "z": min(_point_component(start, "z"), _point_component(end, "z")),
+        },
+        "max": {
+            "x": max(_point_component(start, "x"), _point_component(end, "x")),
+            "y": max(_point_component(start, "y"), _point_component(end, "y")),
+            "z": max(_point_component(start, "z"), _point_component(end, "z")),
+        },
+    }
+
+
+def _line_length(start: dict[str, JSONValue], end: dict[str, JSONValue]) -> float:
+    try:
+        length = sqrt(
+            (_point_component(end, "x") - _point_component(start, "x")) ** 2
+            + (_point_component(end, "y") - _point_component(start, "y")) ** 2
+            + (_point_component(end, "z") - _point_component(start, "z")) ** 2
+        )
+    except OverflowError as exc:
+        raise ValueError("Line length must be finite.") from exc
+    if not isfinite(length):
+        raise ValueError("Line length must be finite.")
+    return length
+
+
+def _point_component(point: dict[str, JSONValue], axis: str) -> float:
+    value = point[axis]
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TypeError(f"Point component '{axis}' must be numeric.")
+    return float(value)
+
+
+def _point_payload(point: Any) -> dict[str, JSONValue]:
+    x = _finite_float(point.x, axis="x")
+    y = _finite_float(point.y, axis="y")
+    z = _finite_float(point.z, axis="z")
+    return {
+        "x": x,
+        "y": y,
+        "z": z,
+    }
+
+
+def _scaled_point_payload(
+    point: Any,
+    *,
+    units: dict[str, JSONValue],
+    point_payload: dict[str, JSONValue] | None = None,
+) -> dict[str, JSONValue]:
+    payload = point_payload if point_payload is not None else _point_payload(point)
+    scale_factor = _unit_scale_factor(units)
+    if scale_factor is None or scale_factor == 1.0:
+        return payload
+
+    return {
+        "x": _scaled_point_component(payload, axis="x", scale_factor=scale_factor),
+        "y": _scaled_point_component(payload, axis="y", scale_factor=scale_factor),
+        "z": _scaled_point_component(payload, axis="z", scale_factor=scale_factor),
+    }
+
+
+def _scaled_point_component(
+    point: dict[str, JSONValue],
+    *,
+    axis: str,
+    scale_factor: float,
+) -> float:
+    return _finite_float(_point_component(point, axis) * scale_factor, axis=axis)
+
+
+def _unit_scale_factor(units: dict[str, JSONValue]) -> float | None:
+    value = units.get("conversion_factor")
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    factor = float(value)
+    if not isfinite(factor) or factor <= 0:
+        return None
+    return factor
+
+
+def _native_geometry_should_be_preserved(units: dict[str, JSONValue]) -> bool:
+    scale_factor = _unit_scale_factor(units)
+    return scale_factor is not None and scale_factor != 1.0
+
+
+def _source_unit_value(units: dict[str, JSONValue]) -> int:
+    value = units.get("source_value")
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError("DXF source units must be represented as an integer.")
+    return value
+
+
+def _finite_float(value: Any, *, axis: str) -> float:
+    numeric = float(value)
+    if not isfinite(numeric):
+        raise ValueError(f"Point component '{axis}' must be finite.")
+    return numeric
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _entity_handle(entity: Any) -> str:
+    return str(getattr(entity.dxf, "handle", ""))
+
+
+def _entity_layer(entity: Any) -> str:
+    return str(getattr(entity.dxf, "layer", "0"))
+
+
+def _layout_name(entity: Any) -> str:
+    layout = entity.get_layout()
+    return str(layout.name) if layout is not None else _MODEL_LAYOUT_NAME
+
+
+def _source_ref(source: AdapterSource) -> str:
+    original_name = _safe_original_name(source.original_name)
+    return f"originals/{original_name or source.file_path.name}"
+
+
+def _safe_original_name(original_name: str | None) -> str | None:
+    if original_name is None:
+        return None
+    normalized = original_name.replace("\\", "/").split("/")[-1].strip()
+    return normalized or None
+
+
+def _safe_reference_name(reference: Any) -> str | None:
+    if reference is None:
+        return None
+    normalized = str(reference).replace("\\", "/").split("/")[-1].strip()
+    return normalized or None
+
+
+def _redacted_path_hash(reference: Any) -> str | None:
+    if reference is None:
+        return None
+    raw_reference = str(reference).strip()
+    if not raw_reference:
+        return None
+    return hashlib.sha256(raw_reference.encode("utf-8")).hexdigest()
+
+
+__all__ = ["EzdxfAdapter", "create_adapter"]

--- a/app/ingestion/runner.py
+++ b/app/ingestion/runner.py
@@ -158,6 +158,12 @@ async def run_ingestion(
             reason = "factory_invalid"
             last_unavailable_error = _adapter_load_error(candidate, reason=reason)
             continue
+        except RuntimeError as exc:
+            wrapped_load_error = _wrapped_adapter_load_error(candidate, exc)
+            if wrapped_load_error is None:
+                raise
+            last_unavailable_error = wrapped_load_error
+            continue
 
         materialization = OriginalSourceMaterialization(
             file_id=request.file_id,
@@ -281,6 +287,27 @@ def _adapter_load_error(candidate: AdapterCandidate, *, reason: str) -> Ingestio
             "reason": reason,
         },
     )
+
+
+def _wrapped_adapter_load_error(
+    candidate: AdapterCandidate,
+    exc: RuntimeError,
+) -> IngestionRunnerError | None:
+    cause = exc.__cause__
+    if isinstance(cause, ModuleNotFoundError):
+        return _adapter_load_error(
+            candidate,
+            reason=(
+                "module_missing"
+                if cause.name in {None, candidate.descriptor.module}
+                else "dependency_missing"
+            ),
+        )
+    if isinstance(cause, AttributeError):
+        return _adapter_load_error(candidate, reason="factory_missing")
+    if isinstance(cause, TypeError):
+        return _adapter_load_error(candidate, reason="factory_invalid")
+    return None
 
 
 def _storage_error(

--- a/tests/test_ezdxf_adapter.py
+++ b/tests/test_ezdxf_adapter.py
@@ -1,0 +1,686 @@
+"""Tests for the concrete ezdxf-backed DXF ingestion adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from collections.abc import Iterator
+from math import isfinite
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+import ezdxf
+import pytest
+
+from app.ingestion.adapters.ezdxf import EzdxfAdapter
+from app.ingestion.contracts import (
+    AdapterExecutionOptions,
+    AdapterTimeout,
+    IngestionAdapter,
+    InputFamily,
+    ProgressUpdate,
+)
+from app.ingestion.loader import load_adapter
+from app.ingestion.registry import get_descriptor
+from tests.ingestion_contract_harness import (
+    ContractFinalizationExpectation,
+    build_contract_source,
+    exercise_adapter_contract,
+)
+
+_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "dxf" / "simple-line.dxf"
+
+
+class _CancellationAfterChecks:
+    def __init__(self, *, cancel_after: int) -> None:
+        self._cancel_after = cancel_after
+        self.calls = 0
+
+    def is_cancelled(self) -> bool:
+        self.calls += 1
+        return self.calls >= self._cancel_after
+
+
+def _fake_point(x: object, y: object, z: object) -> Any:
+    return types.SimpleNamespace(x=x, y=y, z=z)
+
+
+class _FakeEntity:
+    def __init__(
+        self,
+        *,
+        entity_type: str,
+        handle: str,
+        layer: str,
+        layout_name: str,
+        start: Any | None = None,
+        end: Any | None = None,
+    ) -> None:
+        self._entity_type = entity_type
+        self._layout = types.SimpleNamespace(name=layout_name)
+        self.dxf = types.SimpleNamespace(
+            handle=handle,
+            layer=layer,
+            linetype="Continuous",
+            start=start,
+            end=end,
+        )
+
+    def dxftype(self) -> str:
+        return self._entity_type
+
+    def get_layout(self) -> Any:
+        return self._layout
+
+
+class _FakeBlock:
+    def __init__(
+        self,
+        *,
+        name: str,
+        is_xref: bool,
+        xref_path: str = "",
+        base_point: Any | None = None,
+        entities: tuple[Any, ...] = (),
+    ) -> None:
+        self.name = name
+        self.block = types.SimpleNamespace(
+            is_xref=is_xref,
+            dxf=types.SimpleNamespace(
+                base_point=base_point or _fake_point(0.0, 0.0, 0.0),
+                xref_path=xref_path,
+            ),
+        )
+        self._entities = entities
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._entities)
+
+
+class _FakeDocument:
+    def __init__(
+        self,
+        *,
+        entities: tuple[Any, ...],
+        units: int = 6,
+        blocks: tuple[Any, ...] = (),
+    ) -> None:
+        self._entities = entities
+        self.header = {"$INSUNITS": units}
+        self.units = units
+        self.layouts = [
+            types.SimpleNamespace(name="Model", dxf=types.SimpleNamespace(taborder=0)),
+            types.SimpleNamespace(name="Layout1", dxf=types.SimpleNamespace(taborder=1)),
+        ]
+        self.layers = [
+            types.SimpleNamespace(
+                color=7,
+                dxf=types.SimpleNamespace(name="0", linetype="Continuous"),
+            )
+        ]
+        self.blocks = list(blocks)
+        self.dxfversion = "AC1027"
+
+    def modelspace(self) -> tuple[Any, ...]:
+        return self._entities
+
+
+def _mapping_tuple(value: object) -> tuple[dict[str, object], ...]:
+    assert isinstance(value, tuple)
+    for item in value:
+        assert isinstance(item, dict)
+    return cast(tuple[dict[str, object], ...], value)
+
+
+def _mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return cast(dict[str, object], value)
+
+
+def _assert_no_nonfinite_numbers(value: object) -> None:
+    if isinstance(value, dict):
+        for nested in value.values():
+            _assert_no_nonfinite_numbers(nested)
+        return
+    if isinstance(value, (tuple, list)):
+        for nested in value:
+            _assert_no_nonfinite_numbers(nested)
+        return
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        assert isfinite(float(value))
+
+
+def _assert_common_entity_contract(
+    entity: dict[str, object],
+    *,
+    entity_type: str,
+    layout_ref: str,
+    layer_ref: str,
+) -> None:
+    assert entity["entity_id"] == f"dxf:{str(entity['handle']).lower()}"
+    assert entity["entity_type"] == entity_type
+    assert entity["entity_schema_version"] == "0.1"
+    assert entity["confidence"] in {0.0, 0.99}
+    assert entity["layout_ref"] == layout_ref
+    assert entity["layer_ref"] == layer_ref
+    assert entity["block_ref"] is None
+    assert entity["parent_entity_ref"] is None
+
+    geometry = _mapping(entity["geometry"])
+    assert "units" in geometry
+    assert "geometry_summary" in geometry
+
+    properties = _mapping(entity["properties"])
+    assert "source_type" in properties
+    assert "source_handle" in properties
+    assert "adapter_native" in properties
+
+    provenance = _mapping(entity["provenance"])
+    assert provenance["dxf_handle"] == entity["handle"]
+    assert isinstance(provenance["normalized_source_hash"], str)
+    assert len(provenance["normalized_source_hash"]) == 64
+
+
+def _load_ezdxf_adapter() -> IngestionAdapter:
+    return load_adapter(get_descriptor(input_family()))
+
+
+def input_family() -> InputFamily:
+    return InputFamily.DXF
+
+
+@pytest.mark.asyncio
+async def test_create_adapter_loads_through_loader() -> None:
+    adapter = _load_ezdxf_adapter()
+
+    availability = adapter.probe()
+
+    assert adapter.descriptor.key == "ezdxf"
+    assert availability.status.value == "available"
+    assert availability.details is not None
+    assert availability.details["package"] == "ezdxf"
+    assert availability.details["package_version"]
+    assert availability.observed[0].name == "ezdxf"
+
+
+def test_create_adapter_runtime_load_failure_is_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_path = "/Users/x/private/.venv/lib/python3.12/site-packages/ezdxf"
+
+    def _raise_runtime_load_error() -> NoReturn:
+        raise ModuleNotFoundError(f"No module named 'ezdxf' from {runtime_path}")
+
+    monkeypatch.setattr(
+        "app.ingestion.adapters.ezdxf._load_runtime",
+        _raise_runtime_load_error,
+    )
+
+    with pytest.raises(RuntimeError, match="DXF adapter runtime could not be loaded\\.") as exc:
+        _load_ezdxf_adapter()
+
+    assert runtime_path not in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_emits_canonical_line_geometry_for_smoke_fixture() -> None:
+    adapter = _load_ezdxf_adapter()
+    progress_updates: list[ProgressUpdate] = []
+    source = build_contract_source(
+        file_path=_FIXTURE_PATH,
+        original_name="simple-line.dxf",
+    )
+
+    result = await adapter.ingest(
+        source,
+        AdapterExecutionOptions(
+            timeout=AdapterTimeout(seconds=1),
+            on_progress=progress_updates.append,
+        ),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.score is not None and result.confidence.score >= 0.95
+    assert result.confidence.review_required is False
+    assert result.warnings == ()
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "dxf_document_loaded",
+        "dxf_entities_extracted",
+    ]
+    assert [update.stage for update in progress_updates] == [
+        "load",
+        "extract",
+        "extract",
+        "finalize",
+    ]
+    assert progress_updates[-1].percent == 1.0
+
+    units = _mapping(result.canonical["units"])
+    assert units["normalized"] == "meter"
+    assert units["source"] == "$INSUNITS"
+    assert units["source_value"] == 6
+    assert units["conversion_factor"] == 1.0
+
+    layouts = _mapping_tuple(result.canonical["layouts"])
+    assert [layout["name"] for layout in layouts] == ["Model", "Layout1"]
+
+    layers = _mapping_tuple(result.canonical["layers"])
+    assert [layer["name"] for layer in layers] == ["0"]
+
+    blocks = result.canonical["blocks"]
+    assert blocks == ()
+    assert result.canonical["xrefs"] == ()
+
+    entities = _mapping_tuple(result.canonical["entities"])
+    assert len(entities) == 1
+    entity = _mapping(entities[0])
+    _assert_common_entity_contract(
+        entity,
+        entity_type="line",
+        layout_ref="Model",
+        layer_ref="0",
+    )
+    assert entity["kind"] == "line"
+    assert entity["entity_type"] == "line"
+    assert entity["handle"] == "1"
+    assert entity["layer"] == "0"
+    assert entity["layout"] == "Model"
+    assert entity["start"] == {"x": 0.0, "y": 0.0, "z": 0.0}
+    assert entity["end"] == {"x": 10.0, "y": 0.0, "z": 0.0}
+    assert entity["length"] == pytest.approx(10.0)
+
+    geometry = _mapping(entity["geometry"])
+    assert geometry["start"] == entity["start"]
+    assert geometry["end"] == entity["end"]
+    assert geometry["bbox"] == {
+        "min": {"x": 0.0, "y": 0.0, "z": 0.0},
+        "max": {"x": 10.0, "y": 0.0, "z": 0.0},
+    }
+    assert geometry["units"] == units
+    assert geometry["geometry_summary"] == {
+        "kind": "line_segment",
+        "length": 10.0,
+        "vertex_count": 2,
+    }
+
+    properties = _mapping(entity["properties"])
+    assert properties["source_type"] == "LINE"
+    assert properties["source_handle"] == "1"
+    assert properties["quantity_hints"] == {"length": 10.0, "count": 1.0}
+
+    provenance = result.provenance[0]
+    assert provenance.adapter_key == "ezdxf"
+    assert provenance.source_ref == "originals/simple-line.dxf"
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_normalizes_non_meter_line_geometry_to_meters(
+    tmp_path: Path,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    source_path = tmp_path / "inch-line.dxf"
+    document = cast(Any, ezdxf).new(units=1)
+    document.modelspace().add_line((0.0, 0.0, 0.0), (12.0, 0.0, 0.0))
+    document.saveas(source_path)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=source_path, original_name=source_path.name),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    units = _mapping(result.canonical["units"])
+    assert units == {
+        "normalized": "meter",
+        "source": "$INSUNITS",
+        "source_value": 1,
+        "conversion_target": "meter",
+        "conversion_factor": pytest.approx(0.0254),
+    }
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["start"] == {"x": 0.0, "y": 0.0, "z": 0.0}
+    assert entity["end"] == {
+        "x": pytest.approx(0.3048),
+        "y": 0.0,
+        "z": 0.0,
+    }
+    assert entity["length"] == pytest.approx(0.3048)
+    assert _mapping(entity["properties"])["quantity_hints"] == {
+        "length": pytest.approx(0.3048),
+        "count": 1.0,
+    }
+
+    native = _mapping(_mapping(_mapping(entity["properties"])["adapter_native"])["ezdxf"])
+    assert native["geometry"] == {
+        "start": {"x": 0.0, "y": 0.0, "z": 0.0},
+        "end": {"x": 12.0, "y": 0.0, "z": 0.0},
+        "length": 12.0,
+        "units": {"normalized": "inch", "source_value": 1},
+    }
+
+
+def test_ezdxf_adapter_sanitizes_structure_errors() -> None:
+    class _FakeDXFStructureError(Exception):
+        pass
+
+    runtime = types.SimpleNamespace(
+        ezdxf=types.SimpleNamespace(
+            __version__="test",
+            readfile=lambda _path: (_ for _ in ()).throw(_FakeDXFStructureError("boom")),
+        ),
+        units=types.SimpleNamespace(),
+        dxf_structure_error=_FakeDXFStructureError,
+    )
+    adapter = EzdxfAdapter(cast(Any, runtime))
+
+    with pytest.raises(RuntimeError, match="DXF source structure is invalid\\."):
+        adapter._read_document(Path("broken.dxf"))
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_review_gates_malformed_numeric_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    malformed_document = _FakeDocument(
+        entities=(
+            _FakeEntity(
+                entity_type="LINE",
+                handle="10",
+                layer="0",
+                layout_name="Model",
+                start=_fake_point(float("nan"), 0.0, 0.0),
+                end=_fake_point(2.0, 0.0, 0.0),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: malformed_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="malformed.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["malformed_coordinates"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert entity["handle"] == "10"
+    assert _mapping(entity["properties"])["source_type"] == "LINE"
+    assert _mapping(entity["geometry"])["bbox"] is None
+    assert "start" not in entity
+    assert _mapping(result.warnings[0].details)["reason"] == "Point component 'x' must be finite."
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_review_gates_scaled_coordinate_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    overflow_document = _FakeDocument(
+        units=7,
+        entities=(
+            _FakeEntity(
+                entity_type="LINE",
+                handle="11",
+                layer="0",
+                layout_name="Model",
+                start=_fake_point(1e306, 0.0, 0.0),
+                end=_fake_point(0.0, 0.0, 0.0),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: overflow_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="scaled-overflow.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["malformed_coordinates"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert entity["handle"] == "11"
+    assert _mapping(entity["properties"])["source_type"] == "LINE"
+    assert _mapping(entity["geometry"])["bbox"] is None
+    assert "start" not in entity
+    assert "end" not in entity
+    assert "length" not in entity
+    assert _mapping(result.warnings[0].details)["reason"] == "Point component 'x' must be finite."
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_review_gates_scaled_length_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    overflow_document = _FakeDocument(
+        units=17,
+        entities=(
+            _FakeEntity(
+                entity_type="LINE",
+                handle="12",
+                layer="0",
+                layout_name="Model",
+                start=_fake_point(0.0, 0.0, 0.0),
+                end=_fake_point(2e145, 0.0, 0.0),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: overflow_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="scaled-length-overflow.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["malformed_coordinates"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert entity["handle"] == "12"
+    assert _mapping(entity["properties"])["source_type"] == "LINE"
+    assert _mapping(entity["geometry"])["bbox"] is None
+    assert "start" not in entity
+    assert "end" not in entity
+    assert "length" not in entity
+    assert _mapping(result.warnings[0].details)["reason"] == "Line length must be finite."
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_omits_scaled_block_base_point_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    overflow_document = _FakeDocument(
+        entities=(),
+        units=17,
+        blocks=(
+            _FakeBlock(
+                name="overflow-block",
+                is_xref=False,
+                base_point=_fake_point(1e300, 2.0, 3.0),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: overflow_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="block-overflow.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert _mapping_tuple(result.canonical["blocks"]) == (
+        {
+            "name": "overflow-block",
+            "base_point": None,
+            "entity_count": 0,
+        },
+    )
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_sanitizes_xref_paths_and_review_gates_unresolved_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    xref_document = _FakeDocument(
+        entities=(),
+        blocks=(
+            _FakeBlock(
+                name="site-plan",
+                is_xref=True,
+                xref_path="/Users/x/private/client/site/base-plan.dxf",
+            ),
+            _FakeBlock(name="missing-ref", is_xref=True, xref_path=""),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: xref_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="xrefed.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["xref_unresolved"]
+    assert _mapping(result.warnings[0].details)["xref_count"] == 2
+
+    xrefs = _mapping_tuple(result.canonical["xrefs"])
+    assert xrefs == (
+        {
+            "name": "site-plan",
+            "reference": "base-plan.dxf",
+            "path_sha256": cast(str, xrefs[0]["path_sha256"]),
+            "status": "review_required",
+        },
+        {
+            "name": "missing-ref",
+            "reference": None,
+            "path_sha256": None,
+            "status": "review_required",
+        },
+    )
+    assert isinstance(xrefs[0]["path_sha256"], str)
+    assert len(cast(str, xrefs[0]["path_sha256"])) == 64
+    assert "/Users/x/private/client/site/base-plan.dxf" not in str(result.canonical["xrefs"])
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_passes_shared_contract_harness_for_smoke_fixture() -> None:
+    adapter = _load_ezdxf_adapter()
+    source = build_contract_source(
+        file_path=_FIXTURE_PATH,
+        original_name="simple-line.dxf",
+    )
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=input_family(),
+        expectation=ContractFinalizationExpectation(
+            validation_status="valid",
+            review_state="approved",
+            quantity_gate="allowed",
+            diagnostic_codes=("dxf_document_loaded", "dxf_entities_extracted"),
+        ),
+        adapter_key="ezdxf",
+    )
+
+    assert payload.canonical_json["canonical_entity_schema_version"] == "0.1"
+    assert payload.report_json["summary"]["entity_counts"] == {
+        "layouts": 2,
+        "layers": 1,
+        "blocks": 0,
+        "entities": 1,
+    }
+    assert payload.review_state == "approved"
+    assert payload.validation_status == "valid"
+    assert payload.quantity_gate == "allowed"
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_retains_unsupported_entities_as_unknown_with_warning(
+    tmp_path: Path,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    source_path = tmp_path / "unsupported-circle.dxf"
+    ezdxf_module = cast(Any, ezdxf)
+    document = ezdxf_module.new(units=6)
+    document.modelspace().add_circle((2.0, 3.0), radius=4.0)
+    document.saveas(source_path)
+    source = build_contract_source(
+        file_path=source_path,
+        original_name=source_path.name,
+    )
+
+    result = await adapter.ingest(
+        source,
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert result.confidence.score == 0.95
+    assert [warning.code for warning in result.warnings] == ["unsupported_entity"]
+    assert result.canonical["layers"] == ({"name": "0", "color": 7, "linetype": "Continuous"},)
+
+    entities = _mapping_tuple(result.canonical["entities"])
+    assert len(entities) == 1
+    entity = _mapping(entities[0])
+    _assert_common_entity_contract(
+        entity,
+        entity_type="unknown",
+        layout_ref="Model",
+        layer_ref="0",
+    )
+    assert entity["kind"] == "unknown"
+    assert entity["entity_type"] == "unknown"
+    assert entity["layer"] == "0"
+    assert _mapping(entity["properties"])["source_type"] == "CIRCLE"
+    assert _mapping(entity["geometry"])["geometry_summary"] == {
+        "kind": "unknown",
+        "source_type": "CIRCLE",
+    }
+    assert result.warnings[0].details == {
+        "entity_type": "CIRCLE",
+        "handle": cast(str, entity["handle"]),
+        "layer": "0",
+        "layout": "Model",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_honors_cancellation_checkpoints() -> None:
+    adapter = _load_ezdxf_adapter()
+    source = build_contract_source(
+        file_path=_FIXTURE_PATH,
+        original_name="simple-line.dxf",
+    )
+    cancellation = _CancellationAfterChecks(cancel_after=3)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.ingest(
+            source,
+            AdapterExecutionOptions(
+                timeout=AdapterTimeout(seconds=1),
+                cancellation=cancellation,
+            ),
+        )
+
+    assert cancellation.calls >= 3

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -8,8 +8,10 @@ import types
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 from uuid import uuid4
 
+import ezdxf
 import pytest
 
 from app.core.errors import ErrorCode
@@ -29,6 +31,8 @@ from app.ingestion.selection import select_adapter_candidates
 from app.ingestion.source import OriginalSourceMaterialization, materialize_original_source
 from app.storage.keys import build_original_storage_key
 from app.storage.memory import MemoryStorage
+
+_DXF_SMOKE_FIXTURE = Path(__file__).parent / "fixtures" / "dxf" / "simple-line.dxf"
 
 
 class _FakeAdapter:
@@ -243,6 +247,42 @@ async def test_run_ingestion_maps_missing_dependency_to_sanitized_error(
 
 
 @pytest.mark.asyncio
+async def test_run_ingestion_maps_wrapped_runtime_dependency_failure_to_sanitized_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def create_adapter() -> object:
+        raise RuntimeError("DXF adapter runtime could not be loaded.") from ModuleNotFoundError(
+            name="ezdxf"
+        )
+
+    wrapped_module = _AdapterModule("wrapped_runtime_failure_module", create_adapter)
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ezdxf":
+            return wrapped_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=uuid4(),
+        checksum_sha256="deadbeef",
+        detected_format="dxf",
+        media_type="application/dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=MemoryStorage())
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter could not be loaded."
+    assert error.details["reason"] == "dependency_missing"
+
+
+@pytest.mark.asyncio
 async def test_run_ingestion_maps_unsupported_format_to_typed_error() -> None:
     request = IngestionRunRequest(
         job_id=uuid4(),
@@ -426,6 +466,178 @@ async def test_run_ingestion_maps_storage_checksum_mismatch_to_storage_failed(
     assert error.details["reason"] == "checksum_mismatch"
     assert expected_checksum not in str(error.details)
     assert actual_checksum not in str(error.details)
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_smoke_uses_real_ezdxf_adapter(tmp_path: Path) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    job_id = uuid4()
+    body = _DXF_SMOKE_FIXTURE.read_bytes()
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    progress_updates: list[ProgressUpdate] = []
+
+    request = IngestionRunRequest(
+        job_id=job_id,
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+        original_name="simple-line.dxf",
+        initial_job_id=job_id,
+    )
+
+    payload = await run_ingestion(
+        request,
+        storage=storage,
+        temp_root=tmp_path,
+        on_progress=progress_updates.append,
+    )
+
+    assert payload.adapter_key == "ezdxf"
+    assert payload.adapter_version != "unknown"
+    assert payload.input_family == InputFamily.DXF.value
+    assert payload.revision_kind == "ingest"
+    assert payload.review_state == "approved"
+    assert payload.validation_status == "valid"
+    assert payload.quantity_gate == "allowed"
+    assert payload.confidence_score >= 0.95
+    assert payload.canonical_json["canonical_entity_schema_version"] == "0.1"
+    assert payload.canonical_json["units"] == {
+        "normalized": "meter",
+        "source": "$INSUNITS",
+        "source_value": 6,
+        "conversion_target": "meter",
+        "conversion_factor": 1.0,
+    }
+    assert payload.canonical_json["layers"] == [
+        {"name": "0", "color": 7, "linetype": "Continuous"}
+    ]
+    assert payload.canonical_json["blocks"] == []
+    assert payload.canonical_json["xrefs"] == []
+    assert payload.report_json["summary"]["entity_counts"] == {
+        "layouts": 2,
+        "layers": 1,
+        "blocks": 0,
+        "entities": 1,
+    }
+    assert progress_updates[-1] == ProgressUpdate(
+        stage="finalize",
+        message="Preparing canonical DXF payload.",
+        completed=1,
+        total=1,
+        percent=1.0,
+    )
+
+    entity = payload.canonical_json["entities"][0]
+    assert entity["entity_id"] == "dxf:1"
+    assert entity["kind"] == "line"
+    assert entity["entity_type"] == "line"
+    assert entity["entity_schema_version"] == "0.1"
+    assert entity["handle"] == "1"
+    assert entity["layer"] == "0"
+    assert entity["layout"] == "Model"
+    assert entity["layout_ref"] == "Model"
+    assert entity["layer_ref"] == "0"
+    assert entity["block_ref"] is None
+    assert entity["parent_entity_ref"] is None
+    assert entity["start"] == {"x": 0.0, "y": 0.0, "z": 0.0}
+    assert entity["end"] == {"x": 10.0, "y": 0.0, "z": 0.0}
+    assert entity["length"] == 10.0
+    assert entity["geometry"] == {
+        "start": {"x": 0.0, "y": 0.0, "z": 0.0},
+        "end": {"x": 10.0, "y": 0.0, "z": 0.0},
+        "bbox": {
+            "min": {"x": 0.0, "y": 0.0, "z": 0.0},
+            "max": {"x": 10.0, "y": 0.0, "z": 0.0},
+        },
+        "units": payload.canonical_json["units"],
+        "geometry_summary": {
+            "kind": "line_segment",
+            "length": 10.0,
+            "vertex_count": 2,
+        },
+    }
+    assert entity["properties"]["source_type"] == "LINE"
+    assert entity["properties"]["source_handle"] == "1"
+    assert entity["properties"]["quantity_hints"] == {"length": 10.0, "count": 1.0}
+    assert entity["provenance"]["dxf_handle"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_review_gates_unitless_dxf_quantities(tmp_path: Path) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    job_id = uuid4()
+    source_path = tmp_path / "unitless-line.dxf"
+    dxf_document = cast(Any, ezdxf).new(units=0)
+    dxf_document.modelspace().add_line((0.0, 0.0, 0.0), (10.0, 0.0, 0.0))
+    dxf_document.saveas(source_path)
+
+    body = source_path.read_bytes()
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    request = IngestionRunRequest(
+        job_id=job_id,
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+        original_name=source_path.name,
+        initial_job_id=job_id,
+    )
+
+    payload = await run_ingestion(
+        request,
+        storage=storage,
+        temp_root=tmp_path,
+    )
+
+    assert payload.review_state == "review_required"
+    assert payload.validation_status == "needs_review"
+    assert payload.quantity_gate == "review_gated"
+    assert payload.canonical_json["units"] == {
+        "normalized": "unitless",
+        "source": "$INSUNITS",
+        "source_value": 0,
+        "conversion_target": "meter",
+        "conversion_factor": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_malformed_dxf_to_sanitized_adapter_failure(
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"not a dxf at all\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="dxf",
+        media_type="application/dxf",
+        original_name="broken.dxf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_FAILED
+    assert error.failure_kind.value == "failed"
+    assert error.message == "Adapter execution failed."
+    assert error.details == {"adapter_key": "ezdxf"}
+    assert "not a dxf" not in str(error)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #97

## Summary
- add the first concrete DXF ingestion path so DXF becomes a real contract-backed input, not just a registry placeholder
- normalize canonical DXF output and unit handling so downstream validation and quantity calculations can rely on stable meter-based geometry
- harden DXF ingestion against malformed or extreme input so dependency failures, invalid structure, XREF references, and non-finite geometry fail safely

## Key changes
- add an `ezdxf`-backed adapter with canonical v0.1 entity output, provenance, diagnostics, and progress/cancellation checkpoints
- update the ingestion runner to map wrapped adapter runtime load failures back to the existing sanitized `ADAPTER_UNAVAILABLE` contract
- add adapter and runner coverage for smoke-path extraction, unit normalization, malformed DXF handling, XREF sanitization, and overflow/non-finite guardrails

## Test plan
- [x] `uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test`
- [x] `uv run ruff check app/ingestion tests/test_ezdxf_adapter.py tests/test_ingestion_runner.py`
- [x] `uv run mypy app tests`
- [x] `uv run python -c "import ezdxf"`
- [x] `uv run pytest tests/test_ezdxf_adapter.py tests/test_ingestion_runner.py tests/test_ingestion_contracts.py tests/test_ingestion_validation.py`

## Notes
- no breaking changes
- follow-up work remains for parser offload/timeout preemption and retaining unsupported entities outside modelspace