### PR TITLE
feat: implement semantic IFC adapter via IfcOpenShell (#98)

### DIFF
--- a/app/ingestion/adapters/ifcopenshell.py
+++ b/app/ingestion/adapters/ifcopenshell.py
@@ -1,0 +1,875 @@
+"""Semantic-first IFC ingestion adapter with optional IfcOpenShell runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.metadata
+import importlib.util
+import inspect
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from types import ModuleType
+from typing import cast
+
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterCapabilities,
+    AdapterDescriptor,
+    AdapterDiagnostic,
+    AdapterExecutionOptions,
+    AdapterResult,
+    AdapterSource,
+    AdapterStatus,
+    AdapterWarning,
+    AvailabilityReason,
+    ConfidenceSummary,
+    IngestionAdapter,
+    InputFamily,
+    JSONValue,
+    LicenseState,
+    ProbeIssue,
+    ProbeKind,
+    ProbeObservation,
+    ProbeRequirement,
+    ProbeStatus,
+    ProgressUpdate,
+    ProvenanceRecord,
+    UploadFormat,
+)
+
+_PACKAGE_NAME = "ifcopenshell"
+_ADAPTER_KEY = "ifcopenshell"
+_SCHEMA_PATTERN = re.compile(r"FILE_SCHEMA\s*\(\s*\(\s*'([^']+)'", re.IGNORECASE)
+_SUPPORTED_SCHEMAS = frozenset({"IFC2X3", "IFC4", "IFC4X3"})
+_HEADER_READ_LIMIT_BYTES = 64 * 1024
+_STEP_HEADER_MARKERS = ("ISO-10303-21", "HEADER;")
+_SCHEMA_ALIASES = {
+    "IFC2X3TC1": "IFC2X3",
+    "IFC2X3CV2": "IFC2X3",
+    "IFC4ADD1": "IFC4",
+    "IFC4ADD2": "IFC4",
+    "IFC4ADD2TC1": "IFC4",
+    "IFC4X3ADD1": "IFC4X3",
+    "IFC4X3ADD2": "IFC4X3",
+    "IFC4X3ADD2TC1": "IFC4X3",
+}
+
+_BASE_DESCRIPTOR = AdapterDescriptor(
+    key=_ADAPTER_KEY,
+    family=InputFamily.IFC,
+    upload_formats=(UploadFormat.IFC,),
+    display_name="IfcOpenShell semantic IFC adapter",
+    module="app.ingestion.adapters.ifcopenshell",
+    license_name="LGPL-3.0-or-later",
+    capabilities=AdapterCapabilities(
+        extracts_materials=True,
+        extracts_layers=True,
+        supports_quantity_hints=True,
+    ),
+    probes=(
+        ProbeRequirement(
+            kind=ProbeKind.PYTHON_PACKAGE,
+            name=_PACKAGE_NAME,
+            failure_status=AdapterStatus.UNAVAILABLE,
+            detail="Install the optional ingestion dependency 'ifcopenshell'.",
+        ),
+    ),
+    notes=(
+        (
+            "Semantic-first IFC extraction only; tessellation and shape creation are "
+            "intentionally disabled."
+        ),
+    ),
+    confidence_range=(0.2, 0.55),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _SchemaSniff:
+    schema: str | None
+    readable: bool
+    supported: bool
+
+
+@dataclass(slots=True)
+class _RawEntity:
+    payload: dict[str, JSONValue]
+    preferred_id: str
+    has_global_id: bool
+    step_id_value: int | None
+
+
+def create_adapter() -> IngestionAdapter:
+    """Create an IFC adapter without importing IfcOpenShell at module import time."""
+
+    return IfcOpenShellAdapter()
+
+
+class IfcOpenShellAdapter(IngestionAdapter):
+    """Extract semantic IFC metadata with lazy runtime loading."""
+
+    def __init__(self) -> None:
+        self.descriptor = replace(_BASE_DESCRIPTOR, adapter_version=_package_version())
+
+    def probe(self) -> AdapterAvailability:
+        """Report runtime availability without importing IfcOpenShell."""
+
+        started_at = perf_counter()
+        observed_at = datetime.now(UTC)
+        spec = _find_runtime_spec()
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+
+        if spec is None:
+            observation = ProbeObservation(
+                kind=ProbeKind.PYTHON_PACKAGE,
+                name=_PACKAGE_NAME,
+                status=ProbeStatus.MISSING,
+                detail="Optional runtime package is not installed.",
+            )
+            issue = ProbeIssue(
+                kind=ProbeKind.PYTHON_PACKAGE,
+                name=_PACKAGE_NAME,
+                observed_status=ProbeStatus.MISSING,
+                adapter_status=AdapterStatus.UNAVAILABLE,
+                detail=(
+                    "Install draupnir[ingestion] or the ifcopenshell wheel to "
+                    "enable IFC parsing."
+                ),
+            )
+            return AdapterAvailability(
+                status=AdapterStatus.UNAVAILABLE,
+                availability_reason=AvailabilityReason.PROBE_FAILED,
+                license_state=LicenseState.NOT_REQUIRED,
+                issues=(issue,),
+                observed=(observation,),
+                last_checked_at=observed_at,
+                details={"package": _PACKAGE_NAME},
+                probe_elapsed_ms=elapsed_ms,
+            )
+
+        details: dict[str, JSONValue] = {"package": _PACKAGE_NAME}
+        version = _package_version()
+        if version is not None:
+            details["version"] = version
+        return AdapterAvailability(
+            status=AdapterStatus.AVAILABLE,
+            license_state=LicenseState.NOT_REQUIRED,
+            observed=(
+                ProbeObservation(
+                    kind=ProbeKind.PYTHON_PACKAGE,
+                    name=_PACKAGE_NAME,
+                    status=ProbeStatus.AVAILABLE,
+                    detail=version,
+                ),
+            ),
+            last_checked_at=observed_at,
+            details=details,
+            probe_elapsed_ms=elapsed_ms,
+        )
+
+    async def ingest(
+        self,
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> AdapterResult:
+        """Extract semantic IFC project/product metadata."""
+
+        started_at = perf_counter()
+        warnings: list[AdapterWarning] = []
+        diagnostics: list[AdapterDiagnostic] = []
+        provenance: list[ProvenanceRecord] = []
+        source_ref = _build_source_ref(source)
+
+        await _checkpoint(options, started_at)
+        await _emit_progress(
+            options,
+            ProgressUpdate(
+                stage="sniff_header",
+                message="Inspecting IFC STEP header",
+                percent=0.10,
+            ),
+        )
+
+        sniff_started_at = perf_counter()
+        sniff = _sniff_step_header(source.file_path)
+        diagnostics.append(
+            AdapterDiagnostic(
+                code="ifc.schema_sniff",
+                message="Inspected IFC STEP header for schema metadata.",
+                details={
+                    "ifc_schema": sniff.schema,
+                    "readable": sniff.readable,
+                    "supported": sniff.supported,
+                },
+                elapsed_ms=(perf_counter() - sniff_started_at) * 1000.0,
+            )
+        )
+        provenance.append(
+            ProvenanceRecord(
+                stage="sniff_header",
+                adapter_key=self.descriptor.key,
+                source_ref=source_ref,
+                details={
+                    "ifc_schema": sniff.schema,
+                    "readable": sniff.readable,
+                    "supported": sniff.supported,
+                },
+            )
+        )
+
+        if sniff.readable and (sniff.schema is None or not sniff.supported):
+            warnings.extend(_schema_warnings(sniff))
+            diagnostics.append(
+                AdapterDiagnostic(
+                    code="ifc.semantic_extract",
+                    message=(
+                        "Skipped native IFC parsing because schema metadata was "
+                        "missing or unsupported."
+                    ),
+                    details={
+                        "ifc_schema": sniff.schema,
+                        "native_runtime_used": False,
+                    },
+                )
+            )
+            provenance.append(
+                ProvenanceRecord(
+                    stage="semantic_extract",
+                    adapter_key=self.descriptor.key,
+                    source_ref=source_ref,
+                    details={
+                        "ifc_schema": sniff.schema,
+                        "native_runtime_used": False,
+                        "entity_count": 0,
+                    },
+                )
+            )
+            return AdapterResult(
+                canonical=_build_canonical(
+                    schema=sniff.schema,
+                    project_metadata={},
+                    entities=(),
+                    layer_names=(),
+                    units={"normalized": "meter", "source": "default", "assumed": True},
+                ),
+                provenance=tuple(provenance),
+                confidence=ConfidenceSummary(
+                    score=0.2,
+                    review_required=True,
+                    basis="semantic_ifc_metadata_only",
+                ),
+                warnings=tuple(warnings),
+                diagnostics=tuple(diagnostics),
+            )
+
+        await _checkpoint(options, started_at)
+        await _emit_progress(
+            options,
+            ProgressUpdate(stage="open_model", message="Opening IFC model", percent=0.35),
+        )
+
+        runtime = _load_runtime_module()
+        model = runtime.open(str(source.file_path))
+        runtime_schema = _normalize_schema(_maybe_call_or_value(getattr(model, "schema", None)))
+
+        await _checkpoint(options, started_at)
+        await _emit_progress(
+            options,
+            ProgressUpdate(
+                stage="extract_semantics",
+                message="Extracting semantic IFC entities",
+                percent=0.65,
+            ),
+        )
+
+        products = [
+            product
+            for product in _sequence(_model_by_type(model, "IfcProduct"))
+            if not _matches_ifc_type(product, "IfcProject")
+        ]
+        project = _first(_sequence(_model_by_type(model, "IfcProject")))
+        util_element = _resolve_element_module(runtime)
+
+        raw_entities = [
+            _extract_entity_payload(
+                product=product,
+                util_element=util_element,
+                warnings=warnings,
+            )
+            for product in products
+        ]
+        entities = _finalize_entity_ids(raw_entities)
+        layer_names = tuple(_unique_strings(entity.get("layer") for entity in entities))
+        project_metadata = _extract_project_metadata(project)
+        units = _extract_units(project)
+
+        if units.get("assumed") is True:
+            warnings.append(
+                AdapterWarning(
+                    code="ifc.units_assumed",
+                    message=(
+                        "IFC length units were not explicit; canonical units "
+                        "defaulted to meters."
+                    ),
+                )
+            )
+        if not entities:
+            warnings.append(
+                AdapterWarning(
+                    code="ifc.no_products",
+                    message="No concrete IfcProduct entities were found in the IFC model.",
+                )
+            )
+
+        diagnostics.append(
+            AdapterDiagnostic(
+                code="ifc.semantic_extract",
+                message="Extracted semantic IFC project and product metadata.",
+                details={
+                    "ifc_schema": runtime_schema or sniff.schema,
+                    "entity_count": len(entities),
+                    "project_present": project is not None,
+                    "runtime_version": self.descriptor.adapter_version,
+                },
+            )
+        )
+        provenance.append(
+            ProvenanceRecord(
+                stage="semantic_extract",
+                adapter_key=self.descriptor.key,
+                source_ref=source_ref,
+                details={
+                    "ifc_schema": runtime_schema or sniff.schema,
+                    "entity_count": len(entities),
+                    "runtime_version": self.descriptor.adapter_version,
+                },
+            )
+        )
+
+        await _checkpoint(options, started_at)
+        await _emit_progress(
+            options,
+            ProgressUpdate(
+                stage="finalize",
+                message="Finalizing canonical IFC payload",
+                percent=0.90,
+            ),
+        )
+
+        return AdapterResult(
+            canonical=_build_canonical(
+                schema=runtime_schema or sniff.schema,
+                project_metadata=project_metadata,
+                entities=tuple(entities),
+                layer_names=layer_names,
+                units=units,
+            ),
+            provenance=tuple(provenance),
+            confidence=ConfidenceSummary(
+                score=0.4,
+                review_required=True,
+                basis="semantic_ifc_metadata_only",
+            ),
+            warnings=tuple(warnings),
+            diagnostics=tuple(diagnostics),
+        )
+
+
+def _find_runtime_spec() -> importlib.machinery.ModuleSpec | None:
+    return importlib.util.find_spec(_PACKAGE_NAME)
+
+
+def _package_version() -> str | None:
+    try:
+        return importlib.metadata.version(_PACKAGE_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _load_runtime_module() -> ModuleType:
+    return importlib.import_module(_PACKAGE_NAME)
+
+
+async def _checkpoint(options: AdapterExecutionOptions, started_at: float) -> None:
+    cancellation = options.cancellation
+    if cancellation is not None and cancellation.is_cancelled():
+        raise asyncio.CancelledError
+
+    timeout = options.timeout
+    if timeout is not None and perf_counter() - started_at > timeout.seconds:
+        raise TimeoutError("IfcOpenShell adapter timed out.")
+
+
+async def _emit_progress(options: AdapterExecutionOptions, update: ProgressUpdate) -> None:
+    callback = options.on_progress
+    if callback is None:
+        return
+    result = callback(update)
+    if inspect.isawaitable(result):
+        await cast("asyncio.Future[object]", result)
+
+
+def _sniff_step_header(file_path: Path) -> _SchemaSniff:
+    try:
+        with file_path.open("rb") as stream:
+            header_bytes = stream.read(_HEADER_READ_LIMIT_BYTES)
+    except OSError:
+        return _SchemaSniff(schema=None, readable=False, supported=False)
+
+    header_text = header_bytes.decode("utf-8", errors="ignore")
+    upper_header = header_text.upper()
+    if not all(marker in upper_header for marker in _STEP_HEADER_MARKERS):
+        return _SchemaSniff(schema=None, readable=False, supported=False)
+
+    match = _SCHEMA_PATTERN.search(header_text)
+    if match is None:
+        return _SchemaSniff(schema=None, readable=True, supported=False)
+
+    schema = _normalize_schema(match.group(1))
+    return _SchemaSniff(
+        schema=schema,
+        readable=True,
+        supported=schema in _SUPPORTED_SCHEMAS,
+    )
+
+
+def _schema_warnings(sniff: _SchemaSniff) -> list[AdapterWarning]:
+    if sniff.schema is None:
+        return [
+            AdapterWarning(
+                code="ifc.schema_missing",
+                message="IFC STEP header did not declare FILE_SCHEMA metadata.",
+            )
+        ]
+    return [
+        AdapterWarning(
+            code="ifc.schema_unsupported",
+            message=f"IFC schema '{sniff.schema}' is not supported by the semantic IFC adapter.",
+            details={"ifc_schema": sniff.schema},
+        )
+    ]
+
+
+def _normalize_schema(schema: object) -> str | None:
+    if not isinstance(schema, str):
+        return None
+    normalized = (
+        schema.strip().upper().replace(" ", "").replace("_", "").replace("-", "")
+    )
+    if not normalized:
+        return None
+    if normalized in _SUPPORTED_SCHEMAS:
+        return normalized
+    alias = _SCHEMA_ALIASES.get(normalized)
+    if alias is not None:
+        return alias
+    return normalized
+
+
+def _build_source_ref(source: AdapterSource) -> str:
+    original_name = source.original_name
+    if isinstance(original_name, str) and original_name.strip():
+        candidate = original_name.strip().replace("\\", "/")
+        name = Path(candidate).name
+    else:
+        name = source.file_path.name
+    return f"originals/{name}"
+
+
+def _build_canonical(
+    *,
+    schema: str | None,
+    project_metadata: Mapping[str, JSONValue],
+    entities: Sequence[Mapping[str, JSONValue]],
+    layer_names: Sequence[str],
+    units: Mapping[str, JSONValue],
+) -> dict[str, JSONValue]:
+    project_payload = dict(project_metadata)
+    metadata: dict[str, JSONValue] = {"project": project_payload}
+    canonical: dict[str, JSONValue] = {
+        "units": dict(units),
+        "coordinate_system": {"name": "local", "source": "semantic_ifc_metadata"},
+        "layouts": (),
+        "layers": tuple({"name": name} for name in layer_names),
+        "blocks": (),
+        "entities": tuple(dict(entity) for entity in entities),
+        "xrefs": (),
+        "metadata": metadata,
+        "project": project_payload,
+    }
+    if schema is not None:
+        canonical["ifc_schema"] = schema
+        metadata["ifc_schema"] = schema
+    return canonical
+
+
+def _model_by_type(model: object, ifc_type: str) -> object:
+    by_type = getattr(model, "by_type", None)
+    if not callable(by_type):
+        return ()
+    return by_type(ifc_type)
+
+
+def _resolve_element_module(runtime: ModuleType) -> object | None:
+    util_module = getattr(runtime, "util", None)
+    if util_module is not None:
+        element_module = getattr(util_module, "element", None)
+        if element_module is not None:
+            return cast(object, element_module)
+    try:
+        return importlib.import_module("ifcopenshell.util.element")
+    except ModuleNotFoundError:
+        return None
+
+
+def _extract_entity_payload(
+    *,
+    product: object,
+    util_element: object | None,
+    warnings: list[AdapterWarning],
+) -> _RawEntity:
+    ifc_type = _entity_type(product)
+    global_id = _string_or_none(getattr(product, "GlobalId", None))
+    step_id_value = _step_id_value(product)
+    preferred_id = global_id or _step_id_token(step_id_value) or f"anonymous-{ifc_type}"
+    step_id_token = _step_id_token(step_id_value)
+    try:
+        psets = _extract_property_sets(product=product, util_element=util_element, qtos_only=False)
+    except Exception:
+        psets = ()
+        warnings.append(
+            _build_helper_warning(
+                code="ifc.psets_unavailable",
+                message=(
+                    "IfcOpenShell property-set helper failed; continuing without "
+                    "property sets."
+                ),
+                ifc_type=ifc_type,
+                step_id_token=step_id_token,
+            )
+        )
+    try:
+        qtos = _extract_property_sets(product=product, util_element=util_element, qtos_only=True)
+    except Exception:
+        qtos = ()
+        warnings.append(
+            _build_helper_warning(
+                code="ifc.qtos_unavailable",
+                message=(
+                    "IfcOpenShell quantity helper failed; continuing without "
+                    "quantity metadata."
+                ),
+                ifc_type=ifc_type,
+                step_id_token=step_id_token,
+            )
+        )
+    try:
+        material_refs = _extract_material_refs(product=product, util_element=util_element)
+    except Exception:
+        material_refs = ()
+        warnings.append(
+            _build_helper_warning(
+                code="ifc.material_refs_unavailable",
+                message=(
+                    "IfcOpenShell material helper failed; continuing without "
+                    "material references."
+                ),
+                ifc_type=ifc_type,
+                step_id_token=step_id_token,
+            )
+        )
+    payload: dict[str, JSONValue] = {
+        "id": preferred_id,
+        "kind": "ifc_product",
+        "ifc_type": ifc_type,
+        "layer": ifc_type,
+        "name": _string_or_none(getattr(product, "Name", None)),
+        "description": _string_or_none(getattr(product, "Description", None)),
+        "object_type": _string_or_none(getattr(product, "ObjectType", None)),
+        "predefined_type": _string_or_none(
+            _maybe_call_or_value(getattr(product, "PredefinedType", None))
+        ),
+        "ifc_global_id": global_id,
+        "ifc_step_id": _step_id_token(step_id_value),
+        "representation": _extract_representation_metadata(
+            getattr(product, "Representation", None)
+        ),
+        "psets": psets,
+        "qtos": qtos,
+        "material_refs": material_refs,
+    }
+    return _RawEntity(
+        payload={key: value for key, value in payload.items() if value is not None},
+        preferred_id=preferred_id,
+        has_global_id=global_id is not None,
+        step_id_value=step_id_value,
+    )
+
+
+def _build_helper_warning(
+    *,
+    code: str,
+    message: str,
+    ifc_type: str,
+    step_id_token: str | None,
+) -> AdapterWarning:
+    details: dict[str, JSONValue] = {"ifc_type": ifc_type}
+    if step_id_token is not None:
+        details["ifc_step_id"] = step_id_token
+    return AdapterWarning(code=code, message=message, details=details)
+
+
+def _finalize_entity_ids(raw_entities: Sequence[_RawEntity]) -> tuple[dict[str, JSONValue], ...]:
+    ordered = sorted(
+        raw_entities,
+        key=lambda entity: (
+            0 if entity.has_global_id else 1,
+            entity.preferred_id,
+            entity.step_id_value if entity.step_id_value is not None else 10**12,
+        ),
+    )
+    seen: dict[str, int] = {}
+    finalized: list[dict[str, JSONValue]] = []
+    for entity in ordered:
+        count = seen.get(entity.preferred_id, 0) + 1
+        seen[entity.preferred_id] = count
+        payload = dict(entity.payload)
+        payload["id"] = entity.preferred_id if count == 1 else f"{entity.preferred_id}-{count}"
+        finalized.append(payload)
+    return tuple(finalized)
+
+
+def _extract_project_metadata(project: object | None) -> dict[str, JSONValue]:
+    if project is None:
+        return {}
+    payload: dict[str, JSONValue] = {
+        "ifc_type": _entity_type(project),
+        "name": _string_or_none(getattr(project, "Name", None)),
+        "description": _string_or_none(getattr(project, "Description", None)),
+        "long_name": _string_or_none(getattr(project, "LongName", None)),
+        "phase": _string_or_none(getattr(project, "Phase", None)),
+        "global_id": _string_or_none(getattr(project, "GlobalId", None)),
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _extract_units(project: object | None) -> dict[str, JSONValue]:
+    unit_value = _string_or_none(getattr(project, "length_unit", None))
+    if unit_value is None:
+        units_in_context = getattr(project, "UnitsInContext", None)
+        if units_in_context is not None:
+            unit_value = _string_or_none(getattr(units_in_context, "length_unit", None))
+
+    normalized = _normalize_length_unit(unit_value)
+    if normalized is not None:
+        return {"normalized": normalized, "source": unit_value or normalized, "assumed": False}
+    return {"normalized": "meter", "source": "default", "assumed": True}
+
+
+def _normalize_length_unit(unit_value: str | None) -> str | None:
+    if unit_value is None:
+        return None
+    normalized = unit_value.strip().lower()
+    if normalized in {"m", "meter", "metre", "meters", "metres"}:
+        return "meter"
+    if normalized in {"mm", "millimeter", "millimetre", "millimeters", "millimetres"}:
+        return "millimeter"
+    if normalized in {"cm", "centimeter", "centimetre", "centimeters", "centimetres"}:
+        return "centimeter"
+    if normalized in {"ft", "foot", "feet"}:
+        return "foot"
+    if normalized in {"in", "inch", "inches"}:
+        return "inch"
+    return None
+
+
+def _extract_representation_metadata(representation: object) -> dict[str, JSONValue]:
+    if representation is None:
+        return {"has_representation": False, "representations": (), "representation_count": 0}
+
+    raw_representations = getattr(representation, "Representations", None)
+    representations = _sequence(raw_representations)
+    payload = tuple(
+        {
+            "representation_identifier": _string_or_none(
+                getattr(item, "RepresentationIdentifier", None)
+            ),
+            "representation_type": _string_or_none(getattr(item, "RepresentationType", None)),
+            "item_count": len(_sequence(getattr(item, "Items", None))),
+        }
+        for item in representations
+    )
+    return {
+        "has_representation": bool(representations),
+        "representations": payload,
+        "representation_count": len(representations),
+    }
+
+
+def _extract_property_sets(
+    *,
+    product: object,
+    util_element: object | None,
+    qtos_only: bool,
+) -> tuple[dict[str, JSONValue], ...]:
+    direct_attribute_name = "qtos" if qtos_only else "psets"
+    direct_payload = getattr(product, direct_attribute_name, None)
+    if isinstance(direct_payload, Mapping):
+        return _mapping_to_named_records(direct_payload)
+
+    if util_element is None:
+        return ()
+    get_psets = getattr(util_element, "get_psets", None)
+    if not callable(get_psets):
+        return ()
+
+    try:
+        raw_payload = get_psets(
+            product,
+            psets_only=not qtos_only,
+            qtos_only=qtos_only,
+            should_inherit=False,
+        )
+    except TypeError:
+        raw_payload = get_psets(product)
+    if not isinstance(raw_payload, Mapping):
+        return ()
+    return _mapping_to_named_records(raw_payload)
+
+
+def _extract_material_refs(
+    *,
+    product: object,
+    util_element: object | None,
+) -> tuple[dict[str, JSONValue], ...]:
+    direct_payload = getattr(product, "material_refs", None)
+    if direct_payload is not None:
+        return tuple(_material_to_record(material) for material in _sequence(direct_payload))
+
+    if util_element is None:
+        return ()
+    get_materials = getattr(util_element, "get_materials", None)
+    if callable(get_materials):
+        raw_materials = get_materials(product)
+        return tuple(_material_to_record(material) for material in _sequence(raw_materials))
+    return ()
+
+
+def _mapping_to_named_records(payload: Mapping[object, object]) -> tuple[dict[str, JSONValue], ...]:
+    records: list[dict[str, JSONValue]] = []
+    for name, value in sorted(payload.items(), key=lambda item: str(item[0])):
+        record: dict[str, JSONValue] = {"name": str(name)}
+        if isinstance(value, Mapping):
+            record["properties"] = _json_mapping(value)
+        else:
+            record["value"] = _json_value(value)
+        records.append(record)
+    return tuple(records)
+
+
+def _material_to_record(material: object) -> dict[str, JSONValue]:
+    if isinstance(material, Mapping):
+        return _json_mapping(material)
+
+    payload: dict[str, JSONValue] = {
+        "name": _string_or_none(getattr(material, "Name", None)) or str(material),
+        "ifc_type": _entity_type(material),
+        "category": _string_or_none(getattr(material, "Category", None)),
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _json_mapping(payload: Mapping[object, object]) -> dict[str, JSONValue]:
+    return {
+        str(key): _json_value(value)
+        for key, value in sorted(payload.items(), key=lambda item: str(item[0]))
+    }
+
+
+def _json_value(value: object) -> JSONValue:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return cast(JSONValue, value)
+    if isinstance(value, Mapping):
+        return cast(JSONValue, _json_mapping(value))
+    if isinstance(value, (list, tuple, set)):
+        return cast(JSONValue, tuple(_json_value(item) for item in value))
+    return cast(JSONValue, str(value))
+
+
+def _entity_type(entity: object) -> str:
+    is_a = getattr(entity, "is_a", None)
+    if callable(is_a):
+        result = is_a()
+        if isinstance(result, str):
+            return result
+    return entity.__class__.__name__
+
+
+def _matches_ifc_type(entity: object, type_name: str) -> bool:
+    is_a = getattr(entity, "is_a", None)
+    if callable(is_a):
+        try:
+            result = is_a(type_name)
+        except TypeError:
+            result = None
+        if isinstance(result, bool):
+            return result
+    return _entity_type(entity) == type_name
+
+
+def _step_id_value(entity: object) -> int | None:
+    step_id = getattr(entity, "id", None)
+    value = step_id() if callable(step_id) else step_id
+    return value if isinstance(value, int) else None
+
+
+def _step_id_token(step_id: int | None) -> str | None:
+    return f"#{step_id}" if step_id is not None else None
+
+
+def _string_or_none(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return str(value)
+
+
+def _maybe_call_or_value(value: object) -> object:
+    if callable(value):
+        result: object = value()
+        return result
+    return value
+
+
+def _sequence(value: object) -> tuple[object, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(value)
+    return tuple(cast(Sequence[object], value))
+
+
+def _first(values: Sequence[object]) -> object | None:
+    return values[0] if values else None
+
+
+def _unique_strings(values: Iterable[object]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return tuple(ordered)

--- a/app/ingestion/registry.py
+++ b/app/ingestion/registry.py
@@ -102,15 +102,15 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
         key="ifcopenshell",
         family=InputFamily.IFC,
         upload_formats=(UploadFormat.IFC,),
-        display_name="IfcOpenShell",
+        display_name="IfcOpenShell semantic IFC adapter",
         module="app.ingestion.adapters.ifcopenshell",
         license_name="LGPL-3.0-or-later",
         capabilities=AdapterCapabilities(
-            extracts_geometry=True,
             extracts_materials=True,
-            extracts_text=True,
+            extracts_layers=True,
+            supports_quantity_hints=True,
         ),
-        confidence_range=(0.95, 1.0),
+        confidence_range=(0.2, 0.55),
         probes=(
             ProbeRequirement(
                 kind=ProbeKind.PYTHON_PACKAGE,
@@ -119,6 +119,7 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
                 detail="The IfcOpenShell package is required to process IFC sources.",
             ),
         ),
+        notes=("Semantic-only IFC extraction; tessellation and shape creation are disabled.",),
     ),
     AdapterDescriptor(
         key="pymupdf",

--- a/app/ingestion/runner.py
+++ b/app/ingestion/runner.py
@@ -267,6 +267,25 @@ async def _execute_adapter(
             message="Adapter execution was cancelled.",
             details={"adapter_key": adapter_key, "stage": "execute"},
         ) from exc
+    except ModuleNotFoundError as exc:
+        if adapter_key == "ifcopenshell" and exc.name == "ifcopenshell":
+            raise IngestionRunnerError(
+                error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+                failure_kind=AdapterFailureKind.UNAVAILABLE,
+                message="Adapter execution dependency was unavailable.",
+                details={
+                    "adapter_key": adapter_key,
+                    "stage": "execute",
+                    "reason": "dependency_missing",
+                    "dependency": "ifcopenshell",
+                },
+            ) from exc
+        raise IngestionRunnerError(
+            error_code=ErrorCode.ADAPTER_FAILED,
+            failure_kind=AdapterFailureKind.FAILED,
+            message="Adapter execution failed.",
+            details={"adapter_key": adapter_key},
+        ) from exc
     except Exception as exc:
         raise IngestionRunnerError(
             error_code=ErrorCode.ADAPTER_FAILED,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@
 #   This allows swapping tools (e.g. LibreDWG → ODA, PyMuPDF → pdfplumber)
 #   without touching the core application code.
 #
-# System-level dependencies (NOT on PyPI):
+# System-level dependencies and adapter install notes:
 #   - LibreDWG (GPL-3.0+): required for DWG ingestion (ADR-0006).
 #     Install via system package manager (brew/apt) or conda.
-#   - IfcOpenShell: required for IFC ingestion.
-#     Install via conda-forge or platform-specific wheels.
+#   - IfcOpenShell: declared in the optional [ingestion] extra for IFC parsing.
+#     Platform-specific wheels or conda-forge may still be needed per environment.
 #   - Tesseract OCR: required by pytesseract (ADR-0008).
 #     Install via system package manager (brew/apt).
 # =============================================================================
@@ -86,10 +86,13 @@ jobs = [
 ]
 
 # Ingestion adapters — isolated behind the adapter contract (ADR-0006/0007/0008).
-# NOTE: LibreDWG and IfcOpenShell are NOT pip-installable; see top comments.
+# NOTE: LibreDWG still requires a system install; IfcOpenShell remains optional here.
 ingestion = [
     # DXF handling
     "ezdxf>=1.2",
+
+    # IFC semantic parsing (runtime-optional)
+    "ifcopenshell>=0.8",
 
     # Vector PDF adapter (ADR-0007) — PyMuPDF/MuPDF is AGPL or commercial;
     # pdfplumber (MIT) is the designated fallback if licensing becomes an issue.

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -1,0 +1,611 @@
+"""Contract tests for the semantic-first IfcOpenShell ingestion adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.machinery
+from collections.abc import Mapping
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from app.ingestion.adapters import ifcopenshell as adapter_module
+from app.ingestion.contracts import (
+    AdapterExecutionOptions,
+    AdapterStatus,
+    AdapterTimeout,
+    InputFamily,
+    ProgressUpdate,
+    UploadFormat,
+)
+from tests.ingestion_contract_harness import (
+    ContractFinalizationExpectation,
+    build_contract_source,
+    exercise_adapter_contract,
+)
+
+
+class _FakeIfcEntity:
+    def __init__(
+        self,
+        ifc_type: str,
+        step_id: int,
+        *,
+        global_id: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        long_name: str | None = None,
+        phase: str | None = None,
+        length_unit: str | None = None,
+        representation: object | None = None,
+        psets: dict[str, Any] | None = None,
+        qtos: dict[str, Any] | None = None,
+        material_refs: list[object] | None = None,
+        object_type: str | None = None,
+        predefined_type: str | None = None,
+    ) -> None:
+        self._ifc_type = ifc_type
+        self._step_id = step_id
+        self.GlobalId = global_id
+        self.Name = name
+        self.Description = description
+        self.LongName = long_name
+        self.Phase = phase
+        self.length_unit = length_unit
+        self.Representation = representation
+        self.psets: dict[str, Any] | None = psets or {}
+        self.qtos: dict[str, Any] | None = qtos or {}
+        self.material_refs: list[object] | None = material_refs or []
+        self.ObjectType = object_type
+        self.PredefinedType = predefined_type
+
+    def is_a(self, query: str | None = None) -> str | bool:
+        if query is None:
+            return self._ifc_type
+        if query == self._ifc_type:
+            return True
+        return query == "IfcProduct" and self._ifc_type != "IfcProject"
+
+    def id(self) -> int:
+        return self._step_id
+
+
+class _FakeModel:
+    def __init__(
+        self,
+        *,
+        schema: str,
+        project: _FakeIfcEntity | None,
+        products: list[_FakeIfcEntity],
+    ) -> None:
+        self.schema = schema
+        self._project = project
+        self._products = products
+
+    def by_type(self, ifc_type: str) -> list[_FakeIfcEntity]:
+        if ifc_type == "IfcProject":
+            return [] if self._project is None else [self._project]
+        if ifc_type == "IfcProduct":
+            return list(self._products)
+        return []
+
+
+def _module_spec() -> importlib.machinery.ModuleSpec:
+    return importlib.machinery.ModuleSpec(name="ifcopenshell", loader=None)
+
+
+def _write_ifc(path: Path, *, schema_line: str) -> None:
+    path.write_text(
+        "ISO-10303-21;\n"
+        "HEADER;\n"
+        "FILE_DESCRIPTION(('ViewDefinition'),'2;1');\n"
+        f"{schema_line}\n"
+        "ENDSEC;\n"
+        "DATA;\n"
+        "ENDSEC;\n"
+        "END-ISO-10303-21;\n",
+        encoding="utf-8",
+    )
+
+
+def _build_runtime(model: _FakeModel, *, util_element: object | None = None) -> object:
+    helper = util_element or SimpleNamespace(
+        get_psets=lambda product, **_: product.qtos if _.get("qtos_only") else product.psets,
+        get_materials=lambda product: product.material_refs,
+    )
+    return SimpleNamespace(open=lambda _: model, util=SimpleNamespace(element=helper))
+
+
+def _canonical_entities(result: object) -> tuple[Mapping[str, object], ...]:
+    return cast(tuple[Mapping[str, object], ...], cast(Any, result).canonical["entities"])
+
+
+def test_probe_reports_unavailable_without_ifcopenshell_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adapter_module, "_find_runtime_spec", lambda: None)
+    monkeypatch.setattr(adapter_module, "_package_version", lambda: None)
+
+    adapter = adapter_module.create_adapter()
+    availability = adapter.probe()
+
+    assert availability.status is AdapterStatus.UNAVAILABLE
+    assert availability.issues[0].name == "ifcopenshell"
+    assert availability.observed[0].detail == "Optional runtime package is not installed."
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "semantic.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    project = _FakeIfcEntity(
+        "IfcProject",
+        1,
+        global_id="PROJECT-1",
+        name="Demo Project",
+        description="Semantic adapter smoke model",
+        long_name="Demo Project Long Name",
+        phase="Concept",
+        length_unit="meter",
+    )
+    representation = SimpleNamespace(
+        Representations=[
+            SimpleNamespace(
+                RepresentationIdentifier="Body",
+                RepresentationType="SweptSolid",
+                Items=[object()],
+            )
+        ]
+    )
+    products = [
+        _FakeIfcEntity(
+            "IfcWall",
+            10,
+            global_id="DUPLICATE",
+            name="Wall A",
+            representation=representation,
+            psets={"Pset_WallCommon": {"FireRating": "2HR"}},
+            qtos={"Qto_WallBaseQuantities": {"Length": 5.2}},
+            material_refs=[SimpleNamespace(Name="Concrete", Category="structural")],
+            object_type="Wall",
+            predefined_type="STANDARD",
+        ),
+        _FakeIfcEntity(
+            "IfcWall",
+            11,
+            global_id="DUPLICATE",
+            name="Wall B",
+            psets={"Pset_WallCommon": {"LoadBearing": True}},
+            qtos={"Qto_WallBaseQuantities": {"Length": 7.8}},
+            material_refs=[SimpleNamespace(Name="Masonry", Category="finish")],
+            object_type="Wall",
+            predefined_type="STANDARD",
+        ),
+        _FakeIfcEntity(
+            "IfcDoor",
+            42,
+            name="Door A",
+            psets={"Pset_DoorCommon": {"IsExternal": False}},
+            qtos={"Qto_DoorBaseQuantities": {"Area": 2.1}},
+            material_refs=[SimpleNamespace(Name="Timber", Category="finish")],
+            object_type="Door",
+            predefined_type="DOOR",
+        ),
+    ]
+    runtime = _build_runtime(_FakeModel(schema="IFC4", project=project, products=products))
+
+    monkeypatch.setattr(adapter_module, "_find_runtime_spec", _module_spec)
+    monkeypatch.setattr(adapter_module, "_package_version", lambda: "0.8.5")
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    adapter = adapter_module.create_adapter()
+    source = build_contract_source(
+        file_path=fixture_path,
+        upload_format=UploadFormat.IFC,
+        input_family=InputFamily.IFC,
+        media_type="application/step",
+        original_name="semantic.ifc",
+    )
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=InputFamily.IFC,
+        adapter_key="ifcopenshell",
+        expectation=ContractFinalizationExpectation(
+            validation_status="needs_review",
+            review_state="review_required",
+            quantity_gate="review_gated",
+            diagnostic_codes=("ifc.schema_sniff", "ifc.semantic_extract"),
+        ),
+    )
+
+    canonical = payload.canonical_json
+    assert canonical["ifc_schema"] == "IFC4"
+    assert canonical["metadata"]["ifc_schema"] == "IFC4"
+    assert canonical["project"]["name"] == "Demo Project"
+    assert canonical["metadata"]["project"]["global_id"] == "PROJECT-1"
+
+    entities = canonical["entities"]
+    assert [entity["id"] for entity in entities] == ["DUPLICATE", "DUPLICATE-2", "#42"]
+    assert [entity["ifc_type"] for entity in entities] == ["IfcWall", "IfcWall", "IfcDoor"]
+    assert entities[0]["psets"][0]["name"] == "Pset_WallCommon"
+    assert entities[0]["qtos"][0]["name"] == "Qto_WallBaseQuantities"
+    assert entities[0]["material_refs"][0]["name"] == "Concrete"
+    assert (
+        entities[0]["representation"]["representations"][0]["representation_identifier"]
+        == "Body"
+    )
+    assert canonical["layers"] == [{"name": "IfcWall"}, {"name": "IfcDoor"}]
+    assert payload.provenance_json["records"][1]["details"]["entity_count"] == 3
+    assert {record["source_ref"] for record in payload.provenance_json["records"]} == {
+        "originals/semantic.ifc"
+    }
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_orders_duplicate_and_missing_ids_deterministically(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "ordered-ids.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    products = [
+        _FakeIfcEntity("IfcDoor", 7, name="Door B"),
+        _FakeIfcEntity("IfcWall", 11, global_id="DUPLICATE", name="Wall B"),
+        _FakeIfcEntity("IfcWindow", 3, name="Window A"),
+        _FakeIfcEntity("IfcWall", 10, global_id="DUPLICATE", name="Wall A"),
+    ]
+    runtime = _build_runtime(_FakeModel(schema="IFC4", project=None, products=products))
+
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    result = await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/step",
+            original_name="ordered-ids.ifc",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert [entity["id"] for entity in _canonical_entities(result)] == [
+        "DUPLICATE",
+        "DUPLICATE-2",
+        "#3",
+        "#7",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_gracefully_skips_missing_helpers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "missing-helpers.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    project = _FakeIfcEntity("IfcProject", 1, global_id="PROJECT-1", length_unit="meter")
+    product = _FakeIfcEntity("IfcWall", 10, global_id="WALL-1", name="Wall A")
+    product.psets = None
+    product.qtos = None
+    product.material_refs = None
+    runtime = SimpleNamespace(
+        open=lambda _: _FakeModel(schema="IFC4", project=project, products=[product])
+    )
+
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+    monkeypatch.setattr(adapter_module, "_resolve_element_module", lambda _runtime: None)
+
+    result = await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/step",
+            original_name="missing-helpers.ifc",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    entity = _canonical_entities(result)[0]
+    assert entity["psets"] == ()
+    assert entity["qtos"] == ()
+    assert entity["material_refs"] == ()
+    assert result.warnings == ()
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_warns_when_helper_lookups_fail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "helper-failures.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    project = _FakeIfcEntity("IfcProject", 1, global_id="PROJECT-1", length_unit="meter")
+    product = _FakeIfcEntity("IfcWall", 10, global_id="WALL-1", name="Wall A")
+    product.psets = None
+    product.qtos = None
+    product.material_refs = None
+
+    def _raise_helper_failure(*args: object, **kwargs: object) -> object:
+        _ = (args, kwargs)
+        raise RuntimeError("native helper exploded")
+
+    runtime = _build_runtime(
+        _FakeModel(schema="IFC4", project=project, products=[product]),
+        util_element=SimpleNamespace(
+            get_psets=_raise_helper_failure,
+            get_materials=_raise_helper_failure,
+        ),
+    )
+
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    result = await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/step",
+            original_name="helper-failures.ifc",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    entity = _canonical_entities(result)[0]
+    assert entity["psets"] == ()
+    assert entity["qtos"] == ()
+    assert entity["material_refs"] == ()
+    assert {warning.code for warning in result.warnings} == {
+        "ifc.psets_unavailable",
+        "ifc.qtos_unavailable",
+        "ifc.material_refs_unavailable",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_emits_progress_callbacks_in_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "progress.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    runtime = _build_runtime(
+        _FakeModel(
+            schema="IFC4",
+            project=None,
+            products=[_FakeIfcEntity("IfcWall", 10, global_id="WALL-1", name="Wall A")],
+        )
+    )
+    progress_updates: list[ProgressUpdate] = []
+
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/step",
+            original_name="progress.ifc",
+        ),
+        AdapterExecutionOptions(
+            timeout=AdapterTimeout(seconds=1),
+            on_progress=progress_updates.append,
+        ),
+    )
+
+    assert progress_updates == [
+        ProgressUpdate(stage="sniff_header", message="Inspecting IFC STEP header", percent=0.10),
+        ProgressUpdate(stage="open_model", message="Opening IFC model", percent=0.35),
+        ProgressUpdate(
+            stage="extract_semantics",
+            message="Extracting semantic IFC entities",
+            percent=0.65,
+        ),
+        ProgressUpdate(
+            stage="finalize",
+            message="Finalizing canonical IFC payload",
+            percent=0.90,
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_enforces_timeout_checkpoint_before_runtime_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "timeout.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    runtime_loaded = False
+
+    async def _slow_emit_progress(
+        options: AdapterExecutionOptions,
+        update: ProgressUpdate,
+    ) -> None:
+        _ = (options, update)
+        await asyncio.sleep(0.02)
+
+    def _unexpected_runtime_load() -> object:
+        nonlocal runtime_loaded
+        runtime_loaded = True
+        raise AssertionError("runtime should not load after timeout checkpoint")
+
+    monkeypatch.setattr(adapter_module, "_emit_progress", _slow_emit_progress)
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", _unexpected_runtime_load)
+
+    with pytest.raises(TimeoutError):
+        await adapter_module.create_adapter().ingest(
+            build_contract_source(
+                file_path=fixture_path,
+                upload_format=UploadFormat.IFC,
+                input_family=InputFamily.IFC,
+                media_type="application/step",
+                original_name="timeout.ifc",
+            ),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.01)),
+        )
+
+    assert runtime_loaded is False
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_enforces_cancellation_checkpoint_before_runtime_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "cancel.ifc"
+    _write_ifc(fixture_path, schema_line="FILE_SCHEMA(('IFC4'));")
+
+    class _CheckpointCancellation:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def is_cancelled(self) -> bool:
+            self.calls += 1
+            return self.calls >= 2
+
+    cancellation = _CheckpointCancellation()
+    runtime_loaded = False
+
+    def _unexpected_runtime_load() -> object:
+        nonlocal runtime_loaded
+        runtime_loaded = True
+        raise AssertionError("runtime should not load after cancellation checkpoint")
+
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", _unexpected_runtime_load)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter_module.create_adapter().ingest(
+            build_contract_source(
+                file_path=fixture_path,
+                upload_format=UploadFormat.IFC,
+                input_family=InputFamily.IFC,
+                media_type="application/step",
+                original_name="cancel.ifc",
+            ),
+            AdapterExecutionOptions(
+                timeout=AdapterTimeout(seconds=1),
+                cancellation=cancellation,
+            ),
+        )
+
+    assert cancellation.calls == 2
+    assert runtime_loaded is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("schema_line", "expected_warning", "expected_schema"),
+    [
+        ("FILE_NAME('missing-schema.ifc','2026-01-01T00:00:00');", "ifc.schema_missing", None),
+        ("FILE_SCHEMA((IFC4));", "ifc.schema_missing", None),
+        ("FILE_SCHEMA(('IFC5'));", "ifc.schema_unsupported", "IFC5"),
+        ("FILE_SCHEMA(('IFC4X2'));", "ifc.schema_unsupported", "IFC4X2"),
+    ],
+)
+async def test_ifcopenshell_adapter_short_circuits_invalid_schema_through_validation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    schema_line: str,
+    expected_warning: str,
+    expected_schema: str | None,
+) -> None:
+    fixture_path = tmp_path / "invalid-schema.ifc"
+    _write_ifc(fixture_path, schema_line=schema_line)
+
+    runtime_called = False
+
+    def _unexpected_runtime_load() -> object:
+        nonlocal runtime_called
+        runtime_called = True
+        raise AssertionError("native runtime should not load for invalid schema sniff path")
+
+    monkeypatch.setattr(adapter_module, "_find_runtime_spec", _module_spec)
+    monkeypatch.setattr(adapter_module, "_package_version", lambda: "0.8.5")
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", _unexpected_runtime_load)
+
+    adapter = adapter_module.create_adapter()
+    source = build_contract_source(
+        file_path=fixture_path,
+        upload_format=UploadFormat.IFC,
+        input_family=InputFamily.IFC,
+        media_type="application/step",
+        original_name="invalid-schema.ifc",
+    )
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=InputFamily.IFC,
+        adapter_key="ifcopenshell",
+        expectation=ContractFinalizationExpectation(
+            validation_status="invalid",
+            review_state="rejected",
+            quantity_gate="blocked",
+            warning_codes=(expected_warning,),
+            diagnostic_codes=("ifc.schema_sniff", "ifc.semantic_extract"),
+        ),
+    )
+
+    assert runtime_called is False
+    canonical = payload.canonical_json
+    if expected_schema is None:
+        assert "ifc_schema" not in canonical
+        assert "ifc_schema" not in canonical["metadata"]
+    else:
+        assert canonical["ifc_schema"] == expected_schema
+        assert canonical["metadata"]["ifc_schema"] == expected_schema
+    assert canonical["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_non_step_payload_does_not_short_circuit_schema_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "binary.ifc"
+    fixture_path.write_bytes(b"\x00\xff\x00\x01garbage payload")
+
+    runtime_called = False
+
+    def _open_runtime(path: str) -> _FakeModel:
+        nonlocal runtime_called
+        runtime_called = True
+        _ = path
+        return _FakeModel(schema="IFC4", project=None, products=[])
+
+    runtime = SimpleNamespace(open=_open_runtime)
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    result = await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/octet-stream",
+            original_name="nested/input.ifc",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert runtime_called is True
+    sniff_diagnostic = result.diagnostics[0]
+    assert sniff_diagnostic.code == "ifc.schema_sniff"
+    assert sniff_diagnostic.details == {"ifc_schema": None, "readable": False, "supported": False}
+    assert "ifc.schema_missing" not in {warning.code for warning in result.warnings}
+    assert {record.source_ref for record in result.provenance} == {"originals/input.ifc"}

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -112,6 +112,21 @@ def test_registry_is_static_and_covers_every_family() -> None:
     assert pdf_raster_binary_probe.failure_status is AdapterStatus.DEGRADED
 
 
+def test_ifc_registry_metadata_stays_semantic_only() -> None:
+    descriptor = get_registry()[InputFamily.IFC]
+
+    assert descriptor.display_name == "IfcOpenShell semantic IFC adapter"
+    assert descriptor.capabilities.extracts_geometry is False
+    assert descriptor.capabilities.extracts_materials is True
+    assert descriptor.capabilities.extracts_layers is True
+    assert descriptor.capabilities.supports_quantity_hints is True
+    assert descriptor.capabilities.extracts_text is False
+    assert descriptor.confidence_range == (0.2, 0.55)
+    assert descriptor.notes == (
+        "Semantic-only IFC extraction; tessellation and shape creation are disabled.",
+    )
+
+
 def test_registry_rejects_mutation_and_preserves_cached_metadata() -> None:
     registry = get_registry()
     mutable_registry = cast(Any, registry)

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import importlib.machinery
 import types
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -15,6 +16,7 @@ import ezdxf
 import pytest
 
 from app.core.errors import ErrorCode
+from app.ingestion.adapters import ifcopenshell as ifcopenshell_adapter_module
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterResult,
@@ -33,6 +35,15 @@ from app.storage.keys import build_original_storage_key
 from app.storage.memory import MemoryStorage
 
 _DXF_SMOKE_FIXTURE = Path(__file__).parent / "fixtures" / "dxf" / "simple-line.dxf"
+_IFC_SMOKE_BODY = (
+    b"ISO-10303-21;\n"
+    b"HEADER;\n"
+    b"FILE_SCHEMA(('IFC4'));\n"
+    b"ENDSEC;\n"
+    b"DATA;\n"
+    b"ENDSEC;\n"
+    b"END-ISO-10303-21;\n"
+)
 
 
 class _FakeAdapter:
@@ -68,6 +79,10 @@ class _AdapterModule(types.ModuleType):
     def __init__(self, name: str, create_adapter: Callable[[], object]) -> None:
         super().__init__(name)
         self.create_adapter = create_adapter
+
+
+def _ifcopenshell_module_spec() -> importlib.machinery.ModuleSpec:
+    return importlib.machinery.ModuleSpec(name="ifcopenshell", loader=None)
 
 
 @pytest.mark.asyncio
@@ -244,6 +259,63 @@ async def test_run_ingestion_maps_missing_dependency_to_sanitized_error(
     assert error.failure_kind.value == "unavailable"
     assert error.message == "Adapter could not be loaded."
     assert error.details["reason"] == "dependency_missing"
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_ifcopenshell_runtime_missing_during_execute(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    checksum = hashlib.sha256(_IFC_SMOKE_BODY).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, _IFC_SMOKE_BODY, immutable=True)
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ifcopenshell":
+            return ifcopenshell_adapter_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(
+        ifcopenshell_adapter_module,
+        "_find_runtime_spec",
+        _ifcopenshell_module_spec,
+    )
+    monkeypatch.setattr(ifcopenshell_adapter_module, "_package_version", lambda: "0.8.5")
+
+    def _raise_missing_runtime() -> object:
+        raise ModuleNotFoundError(name="ifcopenshell")
+
+    monkeypatch.setattr(
+        ifcopenshell_adapter_module,
+        "_load_runtime_module",
+        _raise_missing_runtime,
+    )
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="ifc",
+        media_type="application/step",
+        original_name="nested/broken.ifc",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter execution dependency was unavailable."
+    assert error.details == {
+        "adapter_key": "ifcopenshell",
+        "stage": "execute",
+        "reason": "dependency_missing",
+        "dependency": "ifcopenshell",
+    }
 
 
 @pytest.mark.asyncio
@@ -638,6 +710,58 @@ async def test_run_ingestion_maps_malformed_dxf_to_sanitized_adapter_failure(
     assert error.message == "Adapter execution failed."
     assert error.details == {"adapter_key": "ezdxf"}
     assert "not a dxf" not in str(error)
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_sanitizes_ifcopenshell_native_parse_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    binary_body = b"\x00\xff\x00\x01 not a step payload"
+    checksum = hashlib.sha256(binary_body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, binary_body, immutable=True)
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ifcopenshell":
+            return ifcopenshell_adapter_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    def _raise_native_parse_failure(path: str) -> object:
+        raise RuntimeError(f"native parse failed for {path}: broken STEP payload")
+
+    runtime = types.SimpleNamespace(open=_raise_native_parse_failure)
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(
+        ifcopenshell_adapter_module,
+        "_find_runtime_spec",
+        _ifcopenshell_module_spec,
+    )
+    monkeypatch.setattr(ifcopenshell_adapter_module, "_package_version", lambda: "0.8.5")
+    monkeypatch.setattr(ifcopenshell_adapter_module, "_load_runtime_module", lambda: runtime)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="ifc",
+        media_type="application/step",
+        original_name="broken.ifc",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_FAILED
+    assert error.failure_kind.value == "failed"
+    assert error.message == "Adapter execution failed."
+    assert error.details == {"adapter_key": "ifcopenshell"}
+    assert "broken STEP payload" not in str(error)
+    assert "source.ifc" not in str(error)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -515,6 +515,7 @@ all = [
     { name = "ezdxf" },
     { name = "factory-boy" },
     { name = "flower" },
+    { name = "ifcopenshell" },
     { name = "mypy" },
     { name = "opencv-python" },
     { name = "pillow" },
@@ -545,6 +546,7 @@ dev = [
 ]
 ingestion = [
     { name = "ezdxf" },
+    { name = "ifcopenshell" },
     { name = "opencv-python" },
     { name = "pillow" },
     { name = "pymupdf" },
@@ -578,6 +580,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110" },
     { name = "flower", marker = "extra == 'jobs'", specifier = ">=2.0" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "ifcopenshell", marker = "extra == 'ingestion'", specifier = ">=0.8" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "opencv-python", marker = "extra == 'ingestion'", specifier = ">=4.9" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
@@ -894,6 +897,46 @@ wheels = [
 ]
 
 [[package]]
+name = "ifcopenshell"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "lark" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "shapely" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/37/bb8c2b208ca2821993216eb4dc8f41d2585bbe6256739ea32d05b1ff654c/ifcopenshell-0.8.5-py310-none-macosx_10_15_x86_64.whl", hash = "sha256:3b1c5a2ea655d96914ddafd258aa6183f29fb7a08b2b10a329b204b8deca7226", size = 44982843, upload-time = "2026-04-13T13:42:40.878Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e1/03daf876c2496f21323a4a305c28c78b53ba7b6dceadc8ae4a59b7481432/ifcopenshell-0.8.5-py310-none-macosx_11_0_arm64.whl", hash = "sha256:beb9e761ea9b6678c5edff4d6ab31e40a771fffca3bc295810045de564f1b018", size = 42398229, upload-time = "2026-04-13T13:42:24.213Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9e/8f2ec71a22d73d42feb400ff893fbcf28d5ac88787ae4ad09e0c5ec29bc1/ifcopenshell-0.8.5-py310-none-manylinux_2_31_aarch64.whl", hash = "sha256:8de53ba37e762f2e2ba7cf502f15504b886233f681c30245ae7b4ed82087445d", size = 41035477, upload-time = "2026-04-13T13:42:26.462Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9d/ed885e74440cc145f56f661e128b66702cc880cba969a8444453b50ec202/ifcopenshell-0.8.5-py310-none-manylinux_2_31_x86_64.whl", hash = "sha256:487189a6a70f9c688ae58efa075312d0dbba3e83839abaafbfe669bbfdb66e2a", size = 43717796, upload-time = "2026-04-13T13:42:35.722Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6a/877930c416402b5d381cd1c5e9f1edbf56cee13eca64b41d894f6aa512dc/ifcopenshell-0.8.5-py310-none-win_amd64.whl", hash = "sha256:86b60a3fba3c5b3c5a152a71b1a5038a78384fcaa0bab61297bf363c8bedd325", size = 24538316, upload-time = "2026-04-13T13:42:14.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/28/a0caaf40e59418b84c2838a25e317ff61a323135bdd344cf4cc948238cca/ifcopenshell-0.8.5-py311-none-macosx_10_15_x86_64.whl", hash = "sha256:ba916b73a1dd011abeee564b2bb0027c3dc679d77733d44f2f38009b70d413b5", size = 44982843, upload-time = "2026-04-13T13:43:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/05/9217aaa1639da7190da7290bc032704286abd64099f347eedf1e8e722e93/ifcopenshell-0.8.5-py311-none-macosx_11_0_arm64.whl", hash = "sha256:7dba9a0348600bd59ceb9222333e493b9b1c49fc69251a73bc707e77a445007d", size = 42398229, upload-time = "2026-04-13T13:42:36.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/19/557539d3e61786d6bc7b65bed170f36d5f7cc0cd4ec570aecd9425504152/ifcopenshell-0.8.5-py311-none-manylinux_2_31_aarch64.whl", hash = "sha256:e568a859b489ba43013795c3d682758d1ee905fe08919d2c96b5c5676167b243", size = 41035572, upload-time = "2026-04-13T13:42:36.877Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d2/876d1f9564d06f8313b35c3c456241fba79d01a113655273cfb48303ff19/ifcopenshell-0.8.5-py311-none-manylinux_2_31_x86_64.whl", hash = "sha256:612e955ab0975bbc4134fe26c4c36d71a12525fd5c4b391573e6df3cd81713ec", size = 43717607, upload-time = "2026-04-13T13:42:53.312Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7f/077d6ade67326a8e919edb7c8b240f5cc31506947198e8de4e73b5ca7b38/ifcopenshell-0.8.5-py311-none-win_amd64.whl", hash = "sha256:a994cb398aa822b0153ace11fc19deea108706d3a10339de9ac9dc13da21076d", size = 24539716, upload-time = "2026-04-13T13:42:11.211Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/e0/fd69ad4d872031960be6169526aa51c2a2f0360b9d19d57d5fcc48f40b24/ifcopenshell-0.8.5-py312-none-macosx_10_15_x86_64.whl", hash = "sha256:38f63e13cf326b195e2b9ac4ed45396cdda9b3ad29318ce04d7c4a401f7a3921", size = 44991884, upload-time = "2026-04-13T13:43:29.707Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/37/93b6738a88dd138d917eb177f2c6e5fc6fbf59b519151e8d90f462582ee1/ifcopenshell-0.8.5-py312-none-macosx_11_0_arm64.whl", hash = "sha256:89e60dbe8ea7014174ab332b6caad25465c446c118a896435f594ab24602a10a", size = 42400012, upload-time = "2026-04-13T13:43:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/45/17/b2bf757bf2112ae20f28866a94e70b5f5e4441deb7f306fbeca660deb643/ifcopenshell-0.8.5-py312-none-manylinux_2_31_aarch64.whl", hash = "sha256:a5183ae0431a9b87d89ca2e880dae986e4140f088293c3872a88ed3177e7308d", size = 41035338, upload-time = "2026-04-13T13:42:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9f/3ae435c85e33f89e206b46965d02318d6b4276d89b39623dd1044c0a566f/ifcopenshell-0.8.5-py312-none-manylinux_2_31_x86_64.whl", hash = "sha256:dd154b121815e25bc4890f030bf2bdd8d99b059448e0d1205ac81388a3d321f4", size = 43718107, upload-time = "2026-04-13T13:43:15.989Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ce/0464df6a6e6ebf71a9407337d257ac94f63eb1494800a88485e361b1640b/ifcopenshell-0.8.5-py312-none-win_amd64.whl", hash = "sha256:7927921dbfd18024f44780880c37e48460bbca7476da3b0c2607e044b31521d5", size = 24539561, upload-time = "2026-04-13T13:42:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/36/d2584ab891c7a5a6e0cd6c46d23460a042dc56cba2ccd3972b404fd070ba/ifcopenshell-0.8.5-py313-none-macosx_10_15_x86_64.whl", hash = "sha256:f8abac2bd3a3eb11009beb290834d8a5a2330d59a8600dede0faf7ddf8a8f16f", size = 44991886, upload-time = "2026-04-13T13:43:20.236Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/7318741d1441e22ce08492f4000694cb88edf1c76dfdd30d9f3815659fa5/ifcopenshell-0.8.5-py313-none-macosx_11_0_arm64.whl", hash = "sha256:9444ed9b924eaa76037653c56261098846bffa2f4732eefa8b83687163addecd", size = 42399997, upload-time = "2026-04-13T13:42:18.858Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/09/f3b4456d4e8751ef87bf2612571fdfcfbd3c51293c06df5e71ac1a7785a9/ifcopenshell-0.8.5-py313-none-manylinux_2_31_aarch64.whl", hash = "sha256:233e2afd81456ac278f2dd21360c509999498d0b8dc207230eb05e3063f87860", size = 41034024, upload-time = "2026-04-13T13:42:26.885Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c8/2e6c88539020de9399298afec321c61d79929595877a7c4ed3bb24824d98/ifcopenshell-0.8.5-py313-none-manylinux_2_31_x86_64.whl", hash = "sha256:c03c47abbfd0afddcbc91b510d984d7c017a222877460da5e0a6496d89f185e4", size = 43718118, upload-time = "2026-04-13T13:42:37.221Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7b/d9b8b7bdd5e398cf29f28c55361cbe85f8b8f94afcc26ce4b02ed2e6185c/ifcopenshell-0.8.5-py313-none-win_amd64.whl", hash = "sha256:6dd40d29b21d1c92104a4585a1ee6a31811305b68f5e3f7ee991f89f4d386366", size = 24538206, upload-time = "2026-04-13T13:42:12.213Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/23/bf3df66ccf86a3a50103e7ee305eee0f02a684f088cedf3afa195acca2ce/ifcopenshell-0.8.5-py314-none-macosx_10_15_x86_64.whl", hash = "sha256:f9e35e2df5397c795b320421192fcdb006573d1b36524f420d2474a4f9d842cf", size = 44987044, upload-time = "2026-04-13T13:42:24.375Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/38f1a472b7c4657146125bc3eae8294289396a45cd1830cc0d88d5960506/ifcopenshell-0.8.5-py314-none-macosx_11_0_arm64.whl", hash = "sha256:8cf1f7fd49367aeba75eb56682f1454b2f353a979c6111a165bc05bc62148600", size = 42400429, upload-time = "2026-04-13T13:42:20.957Z" },
+    { url = "https://files.pythonhosted.org/packages/35/cb/05664ab9568b949687088d771ef9b1658a4c4cd135289553aa4d12cc93ee/ifcopenshell-0.8.5-py314-none-manylinux_2_31_aarch64.whl", hash = "sha256:005dced5aaa45064e73287c75ed9cf5f8ba54bce80c496fd76404313833cd62e", size = 41035596, upload-time = "2026-04-13T13:42:20.516Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/aa/6529f307901b03c49312a97ee9fa6aede996fb89094597a5b7743919e0f4/ifcopenshell-0.8.5-py314-none-manylinux_2_31_x86_64.whl", hash = "sha256:15b488347efce0d7f5ab5b6d5561cf30428353b6ee8c7c8a53724f4b10ad4ac6", size = 43717208, upload-time = "2026-04-13T13:42:50.056Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/32/333cfd39c468e2e365adba80e35cc551eb9c0f147cfe8497a64b0617919a/ifcopenshell-0.8.5-py314-none-win_amd64.whl", hash = "sha256:13a5992dc07e69c0c78df5479e1ff9635e6ce9fa70c841d9ce2931e8481eabb9", size = 24542242, upload-time = "2026-04-13T13:42:08.57Z" },
+]
+
+[[package]]
 name = "imageio"
 version = "2.37.3"
 source = { registry = "https://pypi.org/simple" }
@@ -916,6 +959,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "kombu"
 version = "5.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -928,6 +980,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #98

## Summary
- add a semantic-first IfcOpenShell adapter that keeps IFC support runtime-optional while emitting canonical metadata, provenance, validation, and review-gated results
- align the IFC registry/dependency metadata with semantic-only extraction and optional ingestion installation
- cover adapter, runner, contract, and failure-path behavior for IFC ingestion, including missing runtime and schema-sniff handling

## Test plan
- [x] uv run mypy app tests
- [x] uv run python -m compileall app tests
- [x] uv run ruff check app tests
- [x] uv run pytest

## Notes
- Follow-up: #112