### PR TITLE
feat: add PyMuPDF vector PDF adapter

### DIFF
--- a/app/ingestion/adapters/pymupdf.py
+++ b/app/ingestion/adapters/pymupdf.py
@@ -1,0 +1,1333 @@
+"""Conservative PyMuPDF vector PDF adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.metadata
+import math
+import multiprocessing
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from pathlib import Path, PureWindowsPath
+from time import perf_counter
+from types import ModuleType
+from typing import Any, cast
+
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDiagnostic,
+    AdapterExecutionOptions,
+    AdapterResult,
+    AdapterSource,
+    AdapterStatus,
+    AdapterTimeout,
+    AdapterWarning,
+    AvailabilityReason,
+    ConfidenceSummary,
+    IngestionAdapter,
+    InputFamily,
+    JSONValue,
+    ProbeKind,
+    ProbeObservation,
+    ProbeStatus,
+    ProvenanceRecord,
+    UploadFormat,
+)
+from app.ingestion.registry import evaluate_availability, get_descriptor
+
+_DESCRIPTOR = get_descriptor(InputFamily.PDF_VECTOR)
+_DISTRIBUTION_NAME = "PyMuPDF"
+_LICENSE_PROBE_NAME = "pymupdf-deployment-review"
+_RUNTIME_MODULE = "fitz"
+_SCHEMA_VERSION = "0.1"
+_DEFAULT_LAYER_NAME = "default"
+_VECTOR_CONFIDENCE_SCORE = 0.75
+_MAX_PAGES = 256
+_MAX_ENTITIES = 20_000
+_MAX_DRAWINGS_PER_PAGE = 5_000
+_MAX_TOTAL_DRAWINGS = 20_000
+_MAX_PATH_ITEMS_PER_DRAWING = 10_000
+_MAX_POINTS_PER_ENTITY = 5_000
+_MAX_TEXT_BLOCKS = 10_000
+_MAX_TEXT_BYTES = 1_000_000
+_PROCESS_POLL_INTERVAL_SECONDS = 0.01
+_PROCESS_TERMINATE_GRACE_SECONDS = 0.5
+_PROCESS_KILL_GRACE_SECONDS = 0.5
+
+
+class PyMuPDFAvailabilityError(Exception):
+    """Sanitized adapter preflight unavailability."""
+
+    def __init__(self, *, availability_reason: AvailabilityReason, message: str) -> None:
+        super().__init__(message)
+        self.availability_reason = availability_reason
+
+
+class PyMuPDFLicenseError(PermissionError):
+    """Sanitized missing deployment-review acknowledgement error."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.availability_reason = AvailabilityReason.MISSING_LICENSE
+
+
+class PyMuPDFExtractionLimitError(RuntimeError):
+    """Sanitized extraction budget/cap failure."""
+
+
+class PyMuPDFNonFiniteValueError(ValueError):
+    """Raised when parser output contains a non-finite number."""
+
+
+@dataclass(frozen=True)
+class _ExtractionBudget:
+    started_at: float
+    timeout_seconds: float | None
+
+    def checkpoint(self, options: AdapterExecutionOptions) -> None:
+        _raise_if_cancelled(options)
+        if self.timeout_seconds is None:
+            return
+        if self.timeout_seconds <= 0:
+            raise TimeoutError("PyMuPDF extraction timed out.")
+        elapsed_seconds = perf_counter() - self.started_at
+        if elapsed_seconds >= self.timeout_seconds:
+            raise TimeoutError("PyMuPDF extraction timed out.")
+
+
+@dataclass(frozen=True, slots=True)
+class _ProcessExtractionRequest:
+    file_path: str
+    upload_format: str
+    timeout_seconds: float | None
+
+
+@dataclass(slots=True)
+class _ProcessExtractionHandle:
+    process: Any
+    receiver: Any
+
+    def poll(self) -> bool:
+        return bool(self.receiver.poll())
+
+    def recv(self) -> dict[str, Any]:
+        return cast(dict[str, Any], self.receiver.recv())
+
+    def is_alive(self) -> bool:
+        return bool(self.process.is_alive())
+
+    def join(self, timeout: float | None = None) -> None:
+        self.process.join(timeout)
+
+    def terminate(self) -> None:
+        self.process.terminate()
+
+    def kill(self) -> None:
+        kill = getattr(self.process, "kill", None)
+        if callable(kill):
+            kill()
+
+    def close(self) -> None:
+        self.receiver.close()
+        close_process = getattr(self.process, "close", None)
+        if callable(close_process):
+            try:
+                close_process()
+            except ValueError:
+                return
+
+
+def create_adapter(
+    *,
+    license_acknowledged: Callable[[], bool] | None = None,
+) -> IngestionAdapter:
+    """Create the PyMuPDF adapter without importing fitz at module import time."""
+
+    return PyMuPDFAdapter(
+        license_acknowledged=license_acknowledged or _license_unacknowledged,
+    )
+
+
+class PyMuPDFAdapter(IngestionAdapter):
+    """Conservative vector PDF adapter backed by PyMuPDF."""
+
+    def __init__(self, *, license_acknowledged: Callable[[], bool]) -> None:
+        self._license_acknowledged = license_acknowledged
+        self.descriptor = replace(_DESCRIPTOR, adapter_version=_package_version())
+
+    def probe(self) -> AdapterAvailability:
+        """Report PyMuPDF runtime and deployment-review availability."""
+
+        started_at = perf_counter()
+        observations: list[ProbeObservation] = []
+        details: dict[str, JSONValue] = {"package": _RUNTIME_MODULE}
+
+        runtime, package_observation = _runtime_probe_observation()
+        observations.append(package_observation)
+
+        version = _runtime_version(runtime) if runtime is not None else _package_version()
+        if version is not None:
+            details["package_version"] = version
+
+        license_observation = _license_probe_observation(
+            self._license_acknowledged,
+            details=details,
+        )
+        observations.append(license_observation)
+
+        availability = evaluate_availability(
+            self.descriptor,
+            observations=tuple(observations),
+            details=details,
+            probe_elapsed_ms=(perf_counter() - started_at) * 1000.0,
+        )
+        if license_observation.status is ProbeStatus.UNKNOWN:
+            return replace(
+                availability,
+                status=AdapterStatus.UNAVAILABLE,
+                availability_reason=AvailabilityReason.PROBE_FAILED,
+            )
+        return availability
+
+    async def ingest(
+        self,
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> AdapterResult:
+        """Extract conservative vector linework and metadata from a PDF."""
+
+        started_at = perf_counter()
+        _raise_if_cancelled(options)
+        self._runtime_for_ingest()
+        _raise_if_cancelled(options)
+        canonical, warnings = await _extract_with_process(source, options)
+
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+        entity_count = len(cast(tuple[object, ...], canonical["entities"]))
+        metadata = cast(dict[str, JSONValue], canonical["metadata"])
+        page_count = int(cast(int, metadata["page_count"]))
+        text_block_count = len(cast(tuple[object, ...], metadata["text_blocks"]))
+
+        return AdapterResult(
+            canonical=canonical,
+            provenance=(
+                ProvenanceRecord(
+                    stage="extract",
+                    adapter_key=self.descriptor.key,
+                    source_ref=_durable_source_ref(source),
+                    details={
+                        "page_count": page_count,
+                        "entity_count": entity_count,
+                        "text_block_count": text_block_count,
+                    },
+                ),
+            ),
+            confidence=ConfidenceSummary(
+                score=_VECTOR_CONFIDENCE_SCORE,
+                review_required=True,
+                basis="vector_pdf_unconfirmed_scale",
+            ),
+            warnings=tuple(warnings),
+            diagnostics=(
+                AdapterDiagnostic(
+                    code="pymupdf.extract",
+                    message="Extracted conservative vector PDF geometry in unrotated page space.",
+                    details={
+                        "page_count": page_count,
+                        "entity_count": entity_count,
+                        "text_block_count": text_block_count,
+                    },
+                    elapsed_ms=elapsed_ms,
+                ),
+            ),
+        )
+
+    def _runtime_for_ingest(self) -> None:
+        availability = self.probe()
+        if availability.status is not AdapterStatus.AVAILABLE:
+            raise _availability_error(availability)
+
+
+def _runtime_probe_observation() -> tuple[ModuleType | None, ProbeObservation]:
+    try:
+        runtime = _load_runtime_module()
+    except ModuleNotFoundError:
+        return None, ProbeObservation(
+            kind=ProbeKind.PYTHON_PACKAGE,
+            name=_RUNTIME_MODULE,
+            status=ProbeStatus.MISSING,
+            detail="Optional runtime package is not installed.",
+        )
+    except Exception:
+        return None, ProbeObservation(
+            kind=ProbeKind.PYTHON_PACKAGE,
+            name=_RUNTIME_MODULE,
+            status=ProbeStatus.UNKNOWN,
+            detail="PyMuPDF runtime import failed.",
+        )
+
+    version = _runtime_version(runtime)
+    detail = (
+        f"PyMuPDF {version} is installed."
+        if version is not None
+        else "PyMuPDF runtime is importable."
+    )
+    return runtime, ProbeObservation(
+        kind=ProbeKind.PYTHON_PACKAGE,
+        name=_RUNTIME_MODULE,
+        status=ProbeStatus.AVAILABLE,
+        detail=detail,
+    )
+
+
+def _license_probe_observation(
+    provider: Callable[[], bool],
+    *,
+    details: dict[str, JSONValue],
+) -> ProbeObservation:
+    try:
+        acknowledged = bool(provider())
+    except Exception:
+        details["license_acknowledged"] = "unknown"
+        details["license_probe_status"] = "failed"
+        return ProbeObservation(
+            kind=ProbeKind.LICENSE,
+            name=_LICENSE_PROBE_NAME,
+            status=ProbeStatus.UNKNOWN,
+            detail="Deployment review probe failed.",
+        )
+
+    details["license_acknowledged"] = acknowledged
+    if acknowledged:
+        return ProbeObservation(
+            kind=ProbeKind.LICENSE,
+            name=_LICENSE_PROBE_NAME,
+            status=ProbeStatus.AVAILABLE,
+            detail="Deployment review acknowledgement is present.",
+        )
+
+    return ProbeObservation(
+        kind=ProbeKind.LICENSE,
+        name=_LICENSE_PROBE_NAME,
+        status=ProbeStatus.MISSING,
+        detail="Deployment review acknowledgement is required before use.",
+    )
+
+
+def _extract_document_canonical(
+    document: Any,
+    *,
+    source: AdapterSource,
+    options: AdapterExecutionOptions,
+    budget: _ExtractionBudget,
+) -> tuple[dict[str, JSONValue], list[AdapterWarning]]:
+    entities: list[dict[str, JSONValue]] = []
+    layouts: list[dict[str, JSONValue]] = []
+    text_blocks: list[dict[str, JSONValue]] = []
+    warnings: list[AdapterWarning] = []
+    layer_names: list[str] = [_DEFAULT_LAYER_NAME]
+    text_bytes = 0
+    total_drawings = 0
+
+    page_count = int(getattr(document, "page_count", 0))
+    if page_count > _MAX_PAGES:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded page limit.")
+
+    for page_index in range(page_count):
+        budget.checkpoint(options)
+        page = document.load_page(page_index)
+        budget.checkpoint(options)
+        page_number = page_index + 1
+        layout_name = f"page-{page_number}"
+        page_rect = getattr(page, "mediabox", page.rect)
+        layouts.append(
+            {
+                "name": layout_name,
+                "page_number": page_number,
+                "width": _round_float(float(page_rect.width)),
+                "height": _round_float(float(page_rect.height)),
+                "rotation": int(getattr(page, "rotation", 0)),
+                "bbox": _bbox_from_rect(page_rect),
+            }
+        )
+
+        budget.checkpoint(options)
+        drawings = cast(list[dict[str, Any]], page.get_drawings())
+        budget.checkpoint(options)
+        _enforce_drawings_limit(drawings, total_drawings=total_drawings)
+        total_drawings += len(drawings)
+        page_entities, page_warnings, page_layers = _extract_page_entities(
+            drawings,
+            page_number=page_number,
+            layout_name=layout_name,
+            options=options,
+            budget=budget,
+            entity_limit=_MAX_ENTITIES - len(entities),
+        )
+        entities.extend(page_entities)
+        warnings.extend(page_warnings)
+        for layer_name in page_layers:
+            if layer_name not in layer_names:
+                layer_names.append(layer_name)
+
+        budget.checkpoint(options)
+        page_text_blocks, page_text_warnings, page_text_bytes = _extract_text_blocks(
+            page,
+            page_number=page_number,
+            layout_name=layout_name,
+            options=options,
+            budget=budget,
+            text_block_limit=_MAX_TEXT_BLOCKS - len(text_blocks),
+            text_byte_limit=_MAX_TEXT_BYTES - text_bytes,
+        )
+        budget.checkpoint(options)
+        text_blocks.extend(page_text_blocks)
+        warnings.extend(page_text_warnings)
+        text_bytes += page_text_bytes
+
+    metadata: dict[str, JSONValue] = {
+        "source_format": source.upload_format.value,
+        "geometry_mode": "vector",
+        "page_count": page_count,
+        "default_layer": _DEFAULT_LAYER_NAME,
+        "pdf_scale": {
+            "status": "unconfirmed",
+            "coordinate_space": "pdf_page_space_unrotated",
+            "unit": "point",
+            "real_world_units": False,
+        },
+        "text_blocks": tuple(text_blocks),
+    }
+
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "canonical_entity_schema_version": _SCHEMA_VERSION,
+        "units": {"normalized": "unknown"},
+        "coordinate_system": {
+            "name": "pdf_page_space_unrotated",
+            "origin": "top_left",
+            "x_axis": "right",
+            "y_axis": "down",
+        },
+        "layouts": tuple(layouts),
+        "layers": tuple({"name": layer_name} for layer_name in layer_names),
+        "blocks": (),
+        "entities": tuple(entities),
+        "xrefs": (),
+        "metadata": metadata,
+    }, warnings
+
+
+def _extract_page_entities(
+    drawings: list[dict[str, Any]],
+    *,
+    page_number: int,
+    layout_name: str,
+    options: AdapterExecutionOptions,
+    budget: _ExtractionBudget,
+    entity_limit: int,
+) -> tuple[list[dict[str, JSONValue]], list[AdapterWarning], list[str]]:
+    entities: list[dict[str, JSONValue]] = []
+    warnings: list[AdapterWarning] = []
+    layer_names: list[str] = []
+
+    if entity_limit < 0:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded entity limit.")
+
+    for drawing_index, drawing in enumerate(drawings):
+        budget.checkpoint(options)
+        layer_name = _layer_name(drawing.get("layer"))
+        closed = bool(drawing.get("closePath"))
+        items = drawing.get("items", ())
+        _enforce_path_item_limit(items)
+        if layer_name not in layer_names:
+            layer_names.append(layer_name)
+
+        current_points: list[tuple[float, float]] = []
+        current_item_indices: list[int] = []
+        emitted_count = 0
+
+        for item_index, item in enumerate(cast(tuple[Any, ...], items)):
+            budget.checkpoint(options)
+            if item_index >= _MAX_PATH_ITEMS_PER_DRAWING:
+                raise PyMuPDFExtractionLimitError(
+                    "PyMuPDF extraction exceeded drawing path item limit."
+                )
+            if not isinstance(item, tuple) or not item:
+                warnings.append(
+                    AdapterWarning(
+                        code="pymupdf_path_item_invalid",
+                        message="Skipping invalid PyMuPDF path item.",
+                        details={
+                            "page_number": page_number,
+                            "drawing_index": drawing_index,
+                            "item_index": item_index,
+                        },
+                    )
+                )
+                continue
+
+            operator = item[0]
+            if operator == "l" and len(item) >= 3:
+                try:
+                    start = _point_tuple(item[1])
+                    end = _point_tuple(item[2])
+                except PyMuPDFNonFiniteValueError:
+                    emitted_count, warning = _flush_pending_entity(
+                        entities=entities,
+                        points=current_points,
+                        page_number=page_number,
+                        layout_name=layout_name,
+                        layer_name=layer_name,
+                        drawing_index=drawing_index,
+                        entity_index=emitted_count,
+                        item_indices=current_item_indices,
+                        drawing=drawing,
+                        closed=closed,
+                        entity_limit=entity_limit,
+                    )
+                    if warning is not None:
+                        warnings.append(warning)
+                    warnings.append(
+                        AdapterWarning(
+                            code="pymupdf_path_item_non_finite",
+                            message="Skipping PyMuPDF path item with non-finite numeric values.",
+                            details={
+                                "page_number": page_number,
+                                "drawing_index": drawing_index,
+                                "item_index": item_index,
+                            },
+                        )
+                    )
+                    continue
+                if not current_points:
+                    _enforce_pending_point_limit(current_points, additional_points=2)
+                    current_points.extend((start, end))
+                    current_item_indices.append(item_index)
+                    continue
+                if _same_point(current_points[-1], start):
+                    _enforce_pending_point_limit(current_points, additional_points=1)
+                    current_points.append(end)
+                    current_item_indices.append(item_index)
+                    continue
+                emitted_count, warning = _flush_pending_entity(
+                    entities=entities,
+                    points=current_points,
+                    page_number=page_number,
+                    layout_name=layout_name,
+                    layer_name=layer_name,
+                    drawing_index=drawing_index,
+                    entity_index=emitted_count,
+                    item_indices=current_item_indices,
+                    drawing=drawing,
+                    closed=closed,
+                    entity_limit=entity_limit,
+                )
+                if warning is not None:
+                    warnings.append(warning)
+                _enforce_pending_point_limit(current_points, additional_points=2)
+                current_points.extend((start, end))
+                current_item_indices.append(item_index)
+                continue
+
+            if operator == "re" and len(item) >= 2:
+                emitted_count, warning = _flush_pending_entity(
+                    entities=entities,
+                    points=current_points,
+                    page_number=page_number,
+                    layout_name=layout_name,
+                    layer_name=layer_name,
+                    drawing_index=drawing_index,
+                    entity_index=emitted_count,
+                    item_indices=current_item_indices,
+                    drawing=drawing,
+                    closed=closed,
+                    entity_limit=entity_limit,
+                )
+                if warning is not None:
+                    warnings.append(warning)
+                try:
+                    _append_entity(
+                        entities,
+                        _build_rect_entity(
+                            rect=item[1],
+                            page_number=page_number,
+                            layout_name=layout_name,
+                            layer_name=layer_name,
+                            drawing_index=drawing_index,
+                            entity_index=emitted_count,
+                            item_index=item_index,
+                            drawing=drawing,
+                        ),
+                        entity_limit=entity_limit,
+                    )
+                except PyMuPDFNonFiniteValueError:
+                    warnings.append(
+                        AdapterWarning(
+                            code="pymupdf_entity_non_finite",
+                            message="Skipping PyMuPDF entity with non-finite numeric values.",
+                            details={
+                                "page_number": page_number,
+                                "drawing_index": drawing_index,
+                                "item_index": item_index,
+                            },
+                        )
+                    )
+                    continue
+                emitted_count += 1
+                continue
+
+            emitted_count, warning = _flush_pending_entity(
+                entities=entities,
+                points=current_points,
+                page_number=page_number,
+                layout_name=layout_name,
+                layer_name=layer_name,
+                drawing_index=drawing_index,
+                entity_index=emitted_count,
+                item_indices=current_item_indices,
+                drawing=drawing,
+                closed=closed,
+                entity_limit=entity_limit,
+            )
+            if warning is not None:
+                warnings.append(warning)
+            warnings.append(
+                AdapterWarning(
+                    code="pymupdf_path_operator_unsupported",
+                    message="Skipping unsupported PyMuPDF path operator.",
+                    details={
+                        "page_number": page_number,
+                        "drawing_index": drawing_index,
+                        "item_index": item_index,
+                        "operator": str(operator),
+                    },
+                )
+            )
+
+        _, warning = _flush_pending_entity(
+            entities=entities,
+            points=current_points,
+            page_number=page_number,
+            layout_name=layout_name,
+            layer_name=layer_name,
+            drawing_index=drawing_index,
+            entity_index=emitted_count,
+            item_indices=current_item_indices,
+            drawing=drawing,
+            closed=closed,
+            entity_limit=entity_limit,
+        )
+        if warning is not None:
+            warnings.append(warning)
+
+    return entities, warnings, layer_names
+
+
+def _extract_text_blocks(
+    page: Any,
+    *,
+    page_number: int,
+    layout_name: str,
+    options: AdapterExecutionOptions,
+    budget: _ExtractionBudget,
+    text_block_limit: int,
+    text_byte_limit: int,
+) -> tuple[list[dict[str, JSONValue]], list[AdapterWarning], int]:
+    extracted: list[dict[str, JSONValue]] = []
+    warnings: list[AdapterWarning] = []
+    text_bytes = 0
+
+    if text_block_limit < 0:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded text block limit.")
+    if text_byte_limit < 0:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded text content limit.")
+
+    budget.checkpoint(options)
+    text_payload = cast(dict[str, Any], page.get_text("dict"))
+    budget.checkpoint(options)
+    for block in cast(list[dict[str, Any]], text_payload.get("blocks", [])):
+        budget.checkpoint(options)
+        if block.get("type") != 0:
+            continue
+        if len(extracted) >= text_block_limit:
+            raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded text block limit.")
+
+        lines = cast(list[dict[str, Any]], block.get("lines", []))
+        line_text: list[str] = []
+        for line in lines:
+            budget.checkpoint(options)
+            spans = cast(list[dict[str, Any]], line.get("spans", []))
+            line_text.append("".join(str(span.get("text", "")) for span in spans))
+
+        text = "\n".join(part for part in line_text if part)
+        block_text_bytes = len(text.encode("utf-8"))
+        if text_bytes + block_text_bytes > text_byte_limit:
+            raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded text content limit.")
+
+        try:
+            extracted.append(
+                {
+                    "page_number": page_number,
+                    "layout": layout_name,
+                    "block_number": int(block.get("number", 0)),
+                    "bbox": _bbox_from_tuple(_rect_tuple(block.get("bbox"))),
+                    "text": text,
+                }
+            )
+        except PyMuPDFNonFiniteValueError:
+            warnings.append(
+                AdapterWarning(
+                    code="pymupdf_text_block_non_finite",
+                    message="Skipping PyMuPDF text block with non-finite numeric values.",
+                    details={
+                        "page_number": page_number,
+                        "block_number": int(block.get("number", 0)),
+                    },
+                )
+            )
+            continue
+        text_bytes += block_text_bytes
+    return extracted, warnings, text_bytes
+
+
+def _build_lineish_entity(
+    *,
+    points: list[tuple[float, float]],
+    page_number: int,
+    layout_name: str,
+    layer_name: str,
+    drawing_index: int,
+    entity_index: int,
+    item_indices: tuple[int, ...],
+    drawing: dict[str, Any],
+    closed: bool,
+    rect_like: bool,
+) -> dict[str, JSONValue] | None:
+    normalized_points = _normalize_points(points, closed=closed)
+    if len(normalized_points) < 2:
+        return None
+    if len(normalized_points) > _MAX_POINTS_PER_ENTITY:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded entity point limit.")
+
+    entity_id = _entity_id(
+        page_number=page_number,
+        drawing_index=drawing_index,
+        entity_index=entity_index,
+    )
+    bbox = _bbox_from_points(normalized_points)
+    entity_type = "line" if len(normalized_points) == 2 and not closed else "polyline"
+    entity: dict[str, JSONValue] = {
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "entity_schema_version": _SCHEMA_VERSION,
+        "id": entity_id,
+        "layout": layout_name,
+        "layer": layer_name,
+        "bbox": bbox,
+        "properties": _entity_properties(drawing, closed=closed, rect_like=rect_like),
+        "provenance": {
+            "page_number": page_number,
+            "drawing_index": drawing_index,
+            "item_indices": item_indices,
+            "source": "pymupdf.get_drawings",
+        },
+        "confidence": {
+            "score": _VECTOR_CONFIDENCE_SCORE,
+            "basis": "vector_path_segment",
+        },
+    }
+    if entity_type == "line":
+        start, end = normalized_points
+        start_json = _point_json(start)
+        end_json = _point_json(end)
+        entity.update(
+            {
+                "kind": entity_type,
+                "start": start_json,
+                "end": end_json,
+                "geometry": _line_geometry(
+                    start=start_json,
+                    end=end_json,
+                    bbox=bbox,
+                    point_count=len(normalized_points),
+                    closed=closed,
+                ),
+            }
+        )
+        return entity
+
+    points_json = tuple(_point_json(point) for point in normalized_points)
+    entity.update(
+        {
+            "kind": entity_type,
+            "points": points_json,
+            "geometry": _polyline_geometry(
+                points=points_json,
+                bbox=bbox,
+                point_count=len(normalized_points),
+                closed=closed,
+            ),
+        }
+    )
+    return entity
+
+
+def _build_rect_entity(
+    *,
+    rect: Any,
+    page_number: int,
+    layout_name: str,
+    layer_name: str,
+    drawing_index: int,
+    entity_index: int,
+    item_index: int,
+    drawing: dict[str, Any],
+) -> dict[str, JSONValue]:
+    points = [
+        (_round_float(float(rect.x0)), _round_float(float(rect.y0))),
+        (_round_float(float(rect.x1)), _round_float(float(rect.y0))),
+        (_round_float(float(rect.x1)), _round_float(float(rect.y1))),
+        (_round_float(float(rect.x0)), _round_float(float(rect.y1))),
+        (_round_float(float(rect.x0)), _round_float(float(rect.y0))),
+    ]
+    entity = _build_lineish_entity(
+        points=points,
+        page_number=page_number,
+        layout_name=layout_name,
+        layer_name=layer_name,
+        drawing_index=drawing_index,
+        entity_index=entity_index,
+        item_indices=(item_index,),
+        drawing=drawing,
+        closed=True,
+        rect_like=True,
+    )
+    if entity is None:
+        raise AssertionError("Rect-like PyMuPDF entity unexpectedly failed to build.")
+    return entity
+
+
+def _flush_pending_entity(
+    *,
+    entities: list[dict[str, JSONValue]],
+    points: list[tuple[float, float]],
+    page_number: int,
+    layout_name: str,
+    layer_name: str,
+    drawing_index: int,
+    entity_index: int,
+    item_indices: list[int],
+    drawing: dict[str, Any],
+    closed: bool,
+    entity_limit: int,
+) -> tuple[int, AdapterWarning | None]:
+    if not points:
+        return entity_index, None
+
+    try:
+        entity = _build_lineish_entity(
+            points=points,
+            page_number=page_number,
+            layout_name=layout_name,
+            layer_name=layer_name,
+            drawing_index=drawing_index,
+            entity_index=entity_index,
+            item_indices=tuple(item_indices),
+            drawing=drawing,
+            closed=closed,
+            rect_like=False,
+        )
+    except PyMuPDFNonFiniteValueError:
+        warning = AdapterWarning(
+            code="pymupdf_entity_non_finite",
+            message="Skipping PyMuPDF entity with non-finite numeric values.",
+            details={
+                "page_number": page_number,
+                "drawing_index": drawing_index,
+                "item_indices": tuple(item_indices),
+            },
+        )
+        points.clear()
+        item_indices.clear()
+        return entity_index, warning
+
+    points.clear()
+    item_indices.clear()
+    if entity is None:
+        return entity_index, None
+
+    _append_entity(entities, entity, entity_limit=entity_limit)
+    return entity_index + 1, None
+
+
+def _entity_properties(
+    drawing: dict[str, Any],
+    *,
+    closed: bool,
+    rect_like: bool,
+) -> dict[str, JSONValue]:
+    return {
+        "path_type": str(drawing.get("type", "unknown")),
+        "stroke_width": _round_float(float(drawing.get("width", 0.0))),
+        "stroke_color_rgb": _color_tuple(drawing.get("color")),
+        "stroke_opacity": _optional_float(drawing.get("stroke_opacity")),
+        "fill_color_rgb": _color_tuple(drawing.get("fill")),
+        "fill_opacity": _optional_float(drawing.get("fill_opacity")),
+        "line_cap": tuple(
+            int(value)
+            for value in cast(tuple[int, ...], drawing.get("lineCap", ()))
+        ),
+        "line_join": _optional_float(drawing.get("lineJoin")),
+        "dashes": str(drawing.get("dashes", "")),
+        "closed": closed,
+        "rect_like": rect_like,
+        "sequence_number": int(drawing.get("seqno", 0)),
+    }
+
+
+def _line_geometry(
+    *,
+    start: dict[str, JSONValue],
+    end: dict[str, JSONValue],
+    bbox: dict[str, JSONValue],
+    point_count: int,
+    closed: bool,
+) -> dict[str, JSONValue]:
+    return {
+        "kind": "line",
+        "coordinate_space": "pdf_page_space_unrotated",
+        "unit": "point",
+        "bbox": bbox,
+        "summary": _geometry_summary(point_count=point_count, closed=closed),
+        "start": start,
+        "end": end,
+    }
+
+
+def _polyline_geometry(
+    *,
+    points: tuple[dict[str, JSONValue], ...],
+    bbox: dict[str, JSONValue],
+    point_count: int,
+    closed: bool,
+) -> dict[str, JSONValue]:
+    return {
+        "kind": "polyline",
+        "coordinate_space": "pdf_page_space_unrotated",
+        "unit": "point",
+        "bbox": bbox,
+        "summary": _geometry_summary(point_count=point_count, closed=closed),
+        "points": points,
+    }
+
+
+def _geometry_summary(*, point_count: int, closed: bool) -> dict[str, JSONValue]:
+    return {
+        "point_count": point_count,
+        "segment_count": max(point_count - 1, 0),
+        "closed": closed,
+    }
+
+
+def _availability_error(availability: AdapterAvailability) -> Exception:
+    if availability.availability_reason is AvailabilityReason.MISSING_LICENSE:
+        return PyMuPDFLicenseError(
+            "PyMuPDF deployment review acknowledgement is required before extraction."
+        )
+    if availability.availability_reason is AvailabilityReason.PROBE_FAILED:
+        return PyMuPDFAvailabilityError(
+            availability_reason=AvailabilityReason.PROBE_FAILED,
+            message="PyMuPDF adapter preflight reported unavailable.",
+        )
+    return RuntimeError("PyMuPDF adapter is unavailable for vector PDF extraction.")
+
+
+def _raise_if_cancelled(options: AdapterExecutionOptions) -> None:
+    if options.cancellation is not None and options.cancellation.is_cancelled():
+        raise asyncio.CancelledError
+
+
+async def _extract_with_process(
+    source: AdapterSource,
+    options: AdapterExecutionOptions,
+) -> tuple[dict[str, JSONValue], list[AdapterWarning]]:
+    handle = _start_extraction_process(
+        _ProcessExtractionRequest(
+            file_path=str(source.file_path),
+            upload_format=source.upload_format.value,
+            timeout_seconds=options.timeout.seconds if options.timeout is not None else None,
+        )
+    )
+    try:
+        envelope = await _wait_for_process_envelope(handle, options=options)
+    finally:
+        handle.close()
+    return _decode_process_envelope(envelope)
+
+
+def _start_extraction_process(request: _ProcessExtractionRequest) -> _ProcessExtractionHandle:
+    context = multiprocessing.get_context("spawn")
+    receiver, sender = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_run_process_extraction_child,
+        args=(sender, request),
+        daemon=True,
+    )
+    try:
+        process.start()
+    except Exception:
+        receiver.close()
+        sender.close()
+        raise
+    sender.close()
+    return _ProcessExtractionHandle(process=process, receiver=receiver)
+
+
+async def _wait_for_process_envelope(
+    handle: _ProcessExtractionHandle,
+    *,
+    options: AdapterExecutionOptions,
+) -> dict[str, Any]:
+    deadline = (
+        perf_counter() + options.timeout.seconds if options.timeout is not None else None
+    )
+    try:
+        while True:
+            _raise_if_cancelled(options)
+            if handle.poll():
+                envelope = handle.recv()
+                await _join_process_handle(handle, _PROCESS_TERMINATE_GRACE_SECONDS)
+                if handle.is_alive():
+                    await _stop_process_handle(handle)
+                return envelope
+            if not handle.is_alive():
+                await _join_process_handle(handle, _PROCESS_TERMINATE_GRACE_SECONDS)
+                raise RuntimeError("PyMuPDF extraction failed.")
+            if deadline is not None and perf_counter() >= deadline:
+                raise TimeoutError("PyMuPDF extraction timed out.")
+            await asyncio.sleep(_PROCESS_POLL_INTERVAL_SECONDS)
+    except BaseException:
+        await _stop_process_handle(handle)
+        raise
+
+
+async def _join_process_handle(
+    handle: _ProcessExtractionHandle,
+    timeout_seconds: float | None,
+) -> None:
+    await asyncio.to_thread(handle.join, timeout_seconds)
+
+
+async def _stop_process_handle(handle: _ProcessExtractionHandle) -> None:
+    if not handle.is_alive():
+        await _join_process_handle(handle, _PROCESS_TERMINATE_GRACE_SECONDS)
+        return
+    handle.terminate()
+    await _join_process_handle(handle, _PROCESS_TERMINATE_GRACE_SECONDS)
+    if not handle.is_alive():
+        return
+    handle.kill()
+    await _join_process_handle(handle, _PROCESS_KILL_GRACE_SECONDS)
+
+
+def _run_process_extraction_child(sender: Any, request: _ProcessExtractionRequest) -> None:
+    try:
+        sender.send(_extract_in_child_process(request))
+    except BaseException:
+        with suppress(Exception):
+            sender.send(
+                {
+                    "status": "error",
+                    "kind": "failed",
+                    "message": "PyMuPDF extraction failed.",
+                }
+            )
+    finally:
+        sender.close()
+
+
+def _extract_in_child_process(request: _ProcessExtractionRequest) -> dict[str, Any]:
+    timeout = (
+        AdapterTimeout(seconds=request.timeout_seconds)
+        if request.timeout_seconds is not None
+        else None
+    )
+    source = AdapterSource(
+        file_path=Path(request.file_path),
+        upload_format=UploadFormat(request.upload_format),
+        input_family=InputFamily.PDF_VECTOR,
+    )
+    options = AdapterExecutionOptions(timeout=timeout)
+    budget = _ExtractionBudget(
+        started_at=perf_counter(),
+        timeout_seconds=request.timeout_seconds,
+    )
+    document: Any | None = None
+
+    try:
+        budget.checkpoint(options)
+        runtime = _load_runtime_module()
+        budget.checkpoint(options)
+        document = _open_document(runtime, source.file_path)
+        budget.checkpoint(options)
+        canonical, warnings = _extract_document_canonical(
+            document,
+            source=source,
+            options=options,
+            budget=budget,
+        )
+    except TimeoutError:
+        return {
+            "status": "error",
+            "kind": "timeout",
+            "message": "PyMuPDF extraction timed out.",
+        }
+    except PyMuPDFExtractionLimitError as exc:
+        return {"status": "error", "kind": "limit", "message": str(exc)}
+    except ModuleNotFoundError as exc:
+        if exc.name == _RUNTIME_MODULE:
+            return {
+                "status": "error",
+                "kind": "dependency_missing",
+                "dependency": _RUNTIME_MODULE,
+            }
+        return {
+            "status": "error",
+            "kind": "failed",
+            "message": "PyMuPDF extraction failed.",
+        }
+    except Exception:
+        return {
+            "status": "error",
+            "kind": "failed",
+            "message": "PyMuPDF extraction failed.",
+        }
+    finally:
+        if document is not None:
+            _close_document(document)
+
+    return {
+        "status": "ok",
+        "canonical": canonical,
+        "warnings": [_warning_payload(warning) for warning in warnings],
+    }
+
+
+def _decode_process_envelope(
+    envelope: dict[str, Any],
+) -> tuple[dict[str, JSONValue], list[AdapterWarning]]:
+    status = envelope.get("status")
+    if status == "ok":
+        canonical = cast(dict[str, JSONValue], envelope["canonical"])
+        warnings = [
+            AdapterWarning(
+                code=str(item["code"]),
+                message=str(item["message"]),
+                details=cast(dict[str, JSONValue] | None, item.get("details")),
+            )
+            for item in cast(list[dict[str, Any]], envelope.get("warnings", []))
+        ]
+        return canonical, warnings
+
+    kind = str(envelope.get("kind", "failed"))
+    message = str(envelope.get("message", "PyMuPDF extraction failed."))
+    if kind == "timeout":
+        raise TimeoutError(message)
+    if kind == "dependency_missing":
+        raise ModuleNotFoundError(name=str(envelope.get("dependency", _RUNTIME_MODULE)))
+    if kind == "limit":
+        raise PyMuPDFExtractionLimitError(message)
+    raise RuntimeError(message)
+
+
+def _warning_payload(warning: AdapterWarning) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "code": warning.code,
+        "message": warning.message,
+    }
+    if warning.details is not None:
+        payload["details"] = warning.details
+    return payload
+
+
+def _append_entity(
+    entities: list[dict[str, JSONValue]],
+    entity: dict[str, JSONValue],
+    *,
+    entity_limit: int,
+) -> None:
+    if len(entities) >= entity_limit:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded entity limit.")
+    entities.append(entity)
+
+
+def _enforce_drawings_limit(drawings: list[dict[str, Any]], *, total_drawings: int) -> None:
+    drawing_count = len(drawings)
+    if drawing_count > _MAX_DRAWINGS_PER_PAGE:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded page drawing limit.")
+    if total_drawings + drawing_count > _MAX_TOTAL_DRAWINGS:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded total drawing limit.")
+
+
+def _enforce_path_item_limit(items: Any) -> None:
+    if hasattr(items, "__len__") and len(cast(Any, items)) > _MAX_PATH_ITEMS_PER_DRAWING:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded drawing path item limit.")
+
+
+def _enforce_pending_point_limit(
+    current_points: list[tuple[float, float]],
+    *,
+    additional_points: int,
+) -> None:
+    if len(current_points) + additional_points > _MAX_POINTS_PER_ENTITY:
+        raise PyMuPDFExtractionLimitError("PyMuPDF extraction exceeded entity point limit.")
+
+
+def _durable_source_ref(source: AdapterSource) -> str:
+    candidate = _safe_source_name(source.original_name)
+    if candidate is None:
+        candidate = _safe_source_name(source.file_path.name)
+    if candidate is None:
+        candidate = "source"
+    return f"originals/{candidate}"
+
+
+def _safe_source_name(raw_name: str | None) -> str | None:
+    if raw_name is None:
+        return None
+    stripped = raw_name.strip()
+    if not stripped:
+        return None
+    candidate = PureWindowsPath(stripped).name.strip()
+    if candidate in {"", ".", ".."}:
+        return None
+    return candidate
+
+
+def _open_document(runtime: ModuleType, file_path: Path) -> Any:
+    return runtime.open(file_path)
+
+
+def _close_document(document: Any) -> None:
+    close = getattr(document, "close", None)
+    if callable(close):
+        close()
+
+
+def _license_unacknowledged() -> bool:
+    return False
+
+
+def _package_version() -> str | None:
+    try:
+        return importlib.metadata.version(_DISTRIBUTION_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _runtime_version(runtime: ModuleType) -> str | None:
+    for attr_name in ("__version__", "VersionBind", "version"):
+        value = getattr(runtime, attr_name, None)
+        if isinstance(value, str) and value:
+            return value
+    return _package_version()
+
+
+def _load_runtime_module() -> ModuleType:
+    return importlib.import_module(_RUNTIME_MODULE)
+
+
+def _entity_id(*, page_number: int, drawing_index: int, entity_index: int) -> str:
+    return f"page-{page_number}:drawing-{drawing_index}:entity-{entity_index}"
+
+
+def _layer_name(raw_layer: Any) -> str:
+    if isinstance(raw_layer, str) and raw_layer.strip():
+        return raw_layer.strip()
+    return _DEFAULT_LAYER_NAME
+
+
+def _point_tuple(raw_point: Any) -> tuple[float, float]:
+    return (_round_float(float(raw_point.x)), _round_float(float(raw_point.y)))
+
+
+def _normalize_points(
+    points: list[tuple[float, float]],
+    *,
+    closed: bool,
+) -> tuple[tuple[float, float], ...]:
+    normalized: list[tuple[float, float]] = []
+    for point in points:
+        if not normalized or not _same_point(normalized[-1], point):
+            normalized.append(point)
+    if closed and normalized and not _same_point(normalized[0], normalized[-1]):
+        normalized.append(normalized[0])
+    return tuple(normalized)
+
+
+def _same_point(left: tuple[float, float], right: tuple[float, float]) -> bool:
+    return left[0] == right[0] and left[1] == right[1]
+
+
+def _point_json(point: tuple[float, float]) -> dict[str, JSONValue]:
+    return {"x": point[0], "y": point[1]}
+
+
+def _bbox_from_points(points: tuple[tuple[float, float], ...]) -> dict[str, JSONValue]:
+    xs = tuple(point[0] for point in points)
+    ys = tuple(point[1] for point in points)
+    return {
+        "x_min": min(xs),
+        "y_min": min(ys),
+        "x_max": max(xs),
+        "y_max": max(ys),
+    }
+
+
+def _bbox_from_rect(rect: Any) -> dict[str, JSONValue]:
+    return {
+        "x_min": _round_float(float(rect.x0)),
+        "y_min": _round_float(float(rect.y0)),
+        "x_max": _round_float(float(rect.x1)),
+        "y_max": _round_float(float(rect.y1)),
+    }
+
+
+def _rect_tuple(value: Any) -> tuple[float, float, float, float]:
+    if isinstance(value, tuple) and len(value) == 4:
+        return cast(tuple[float, float, float, float], value)
+    return (0.0, 0.0, 0.0, 0.0)
+
+
+def _bbox_from_tuple(rect: tuple[float, float, float, float]) -> dict[str, JSONValue]:
+    x0, y0, x1, y1 = rect
+    return {
+        "x_min": _round_float(float(x0)),
+        "y_min": _round_float(float(y0)),
+        "x_max": _round_float(float(x1)),
+        "y_max": _round_float(float(y1)),
+    }
+
+
+def _color_tuple(raw_color: Any) -> tuple[float, ...] | None:
+    if raw_color is None:
+        return None
+    return tuple(_round_float(float(component)) for component in raw_color)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return _round_float(float(value))
+
+
+def _round_float(value: float) -> float:
+    if not math.isfinite(value):
+        raise PyMuPDFNonFiniteValueError("PyMuPDF parser returned a non-finite number.")
+    return round(value, 6)
+
+
+__all__ = ["PyMuPDFAdapter", "create_adapter"]

--- a/app/ingestion/runner.py
+++ b/app/ingestion/runner.py
@@ -18,6 +18,7 @@ from app.ingestion.contracts import (
     AdapterResult,
     AdapterSource,
     AdapterTimeout,
+    AvailabilityReason,
     CancellationHandle,
     IngestionAdapter,
     ProgressCallback,
@@ -38,6 +39,10 @@ from app.ingestion.source import (
 from app.storage import Storage
 
 _DEFAULT_ADAPTER_TIMEOUT = AdapterTimeout(seconds=300)
+_EXECUTE_TIME_DEPENDENCIES: dict[str, str] = {
+    "ifcopenshell": "ifcopenshell",
+    "pymupdf": "fitz",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -268,18 +273,9 @@ async def _execute_adapter(
             details={"adapter_key": adapter_key, "stage": "execute"},
         ) from exc
     except ModuleNotFoundError as exc:
-        if adapter_key == "ifcopenshell" and exc.name == "ifcopenshell":
-            raise IngestionRunnerError(
-                error_code=ErrorCode.ADAPTER_UNAVAILABLE,
-                failure_kind=AdapterFailureKind.UNAVAILABLE,
-                message="Adapter execution dependency was unavailable.",
-                details={
-                    "adapter_key": adapter_key,
-                    "stage": "execute",
-                    "reason": "dependency_missing",
-                    "dependency": "ifcopenshell",
-                },
-            ) from exc
+        dependency_error = _execute_dependency_missing_error(adapter_key, exc)
+        if dependency_error is not None:
+            raise dependency_error from exc
         raise IngestionRunnerError(
             error_code=ErrorCode.ADAPTER_FAILED,
             failure_kind=AdapterFailureKind.FAILED,
@@ -287,6 +283,9 @@ async def _execute_adapter(
             details={"adapter_key": adapter_key},
         ) from exc
     except Exception as exc:
+        unavailable_error = _execute_preflight_unavailable_error(adapter_key, exc)
+        if unavailable_error is not None:
+            raise unavailable_error from exc
         raise IngestionRunnerError(
             error_code=ErrorCode.ADAPTER_FAILED,
             failure_kind=AdapterFailureKind.FAILED,
@@ -304,6 +303,53 @@ def _adapter_load_error(candidate: AdapterCandidate, *, reason: str) -> Ingestio
             "adapter_key": candidate.descriptor.key,
             "input_family": candidate.input_family.value,
             "reason": reason,
+        },
+    )
+
+
+def _execute_dependency_missing_error(
+    adapter_key: str,
+    exc: ModuleNotFoundError,
+) -> IngestionRunnerError | None:
+    dependency = _EXECUTE_TIME_DEPENDENCIES.get(adapter_key)
+    if dependency is None or exc.name != dependency:
+        return None
+
+    return IngestionRunnerError(
+        error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+        failure_kind=AdapterFailureKind.UNAVAILABLE,
+        message="Adapter execution dependency was unavailable.",
+        details={
+            "adapter_key": adapter_key,
+            "stage": "execute",
+            "reason": "dependency_missing",
+            "dependency": dependency,
+        },
+    )
+
+
+def _execute_preflight_unavailable_error(
+    adapter_key: str,
+    exc: Exception,
+) -> IngestionRunnerError | None:
+    if adapter_key != "pymupdf":
+        return None
+
+    availability_reason = getattr(exc, "availability_reason", None)
+    if availability_reason not in {
+        AvailabilityReason.MISSING_LICENSE,
+        AvailabilityReason.PROBE_FAILED,
+    }:
+        return None
+
+    return IngestionRunnerError(
+        error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+        failure_kind=AdapterFailureKind.UNAVAILABLE,
+        message="Adapter preflight reported unavailable.",
+        details={
+            "adapter_key": adapter_key,
+            "stage": "execute",
+            "reason": availability_reason.value,
         },
     )
 

--- a/tests/fixtures/manifest.yaml
+++ b/tests/fixtures/manifest.yaml
@@ -82,9 +82,9 @@ fixtures:
     units: unknown
     expected_extraction_notes: |
       Single-page vector PDF with simple stroke geometry and inline text marker.
-      Intended for vector-adapter smoke coverage with explicit scale metadata expected.
-    expected_review_state: provisional
-    expected_validation_status: valid
+      Intended for vector-adapter smoke coverage with explicit unconfirmed scale metadata expected.
+    expected_review_state: review_required
+    expected_validation_status: needs_review
     expected_quantities:
       page_count: 1
       linework_hint_count: 1
@@ -98,9 +98,9 @@ fixtures:
           expected: 1
           comparison: review_gated
           provenance_required: true
-          expected_review_state: provisional
+          expected_review_state: review_required
       notes: |
-        Vector PDF extraction should not be forced into raster review policy.
+        Vector PDF extraction stays safety-first until real-world scale is confirmed.
 
   - filename: pdf/raster-smoke.pdf
     format: PDF

--- a/tests/test_adapter_contract_harness.py
+++ b/tests/test_adapter_contract_harness.py
@@ -264,7 +264,7 @@ def test_fixture_manifest_has_multi_format_smoke_contract_coverage() -> None:
     expected = {
         "dxf/simple-line.dxf": ("approved", "valid", "total_length"),
         "ifc/smoke-minimal.ifc": ("review_required", "needs_review", "entity_count"),
-        "pdf/vector-smoke.pdf": ("provisional", "valid", "linework_hint_count"),
+        "pdf/vector-smoke.pdf": ("review_required", "needs_review", "linework_hint_count"),
         "pdf/raster-smoke.pdf": ("review_required", "needs_review", "page_count"),
         "dwg/libredwg-wrapper-smoke.txt": (
             "review_required",

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
+import math
+from collections.abc import Callable
 from dataclasses import fields
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
+
+import app.ingestion.adapters.pymupdf as pymupdf_adapter
 from app.core.errors import ErrorCode
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterCapabilities,
     AdapterDescriptor,
     AdapterDiagnostic,
+    AdapterExecutionOptions,
     AdapterFailureKind,
     AdapterResult,
+    AdapterSource,
     AdapterStatus,
     AdapterTimeout,
     AvailabilityReason,
@@ -36,6 +44,128 @@ from app.ingestion.registry import (
     get_registry,
     list_descriptors,
 )
+
+
+class _FakePoint:
+    def __init__(
+        self,
+        x: float,
+        y: float,
+        *,
+        on_read: Callable[[], None] | None = None,
+    ) -> None:
+        self._x = x
+        self._y = y
+        self._on_read = on_read
+
+    @property
+    def x(self) -> float:
+        if self._on_read is not None:
+            callback = self._on_read
+            self._on_read = None
+            callback()
+        return self._x
+
+    @property
+    def y(self) -> float:
+        return self._y
+
+
+class _FakeRect:
+    def __init__(self, x0: float, y0: float, x1: float, y1: float) -> None:
+        self.x0 = x0
+        self.y0 = y0
+        self.x1 = x1
+        self.y1 = y1
+        self.width = x1 - x0
+        self.height = y1 - y0
+
+
+class _FakePage:
+    def __init__(
+        self,
+        *,
+        drawings: list[dict[str, Any]] | None = None,
+        text_payload: dict[str, Any] | None = None,
+        rect: _FakeRect | None = None,
+    ) -> None:
+        self._drawings = drawings or []
+        self._text_payload = text_payload or {"blocks": []}
+        self.rect = rect or _FakeRect(0.0, 0.0, 100.0, 100.0)
+        self.mediabox = self.rect
+        self.rotation = 0
+
+    def get_drawings(self) -> list[dict[str, Any]]:
+        return self._drawings
+
+    def get_text(self, kind: str) -> dict[str, Any]:
+        assert kind == "dict"
+        return self._text_payload
+
+
+class _FakeDocument:
+    def __init__(self, pages: list[_FakePage]) -> None:
+        self._pages = pages
+        self.page_count = len(pages)
+        self.closed = False
+
+    def load_page(self, page_index: int) -> _FakePage:
+        return self._pages[page_index]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+async def _ingest_fake_document(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    document: _FakeDocument,
+    *,
+    original_name: str = "vector.pdf",
+    timeout: AdapterTimeout | None = None,
+    cancellation: Any = None,
+    perf_values: list[float] | None = None,
+) -> AdapterResult:
+    source_path = tmp_path / "vector.pdf"
+    source_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    adapter = cast(pymupdf_adapter.PyMuPDFAdapter, pymupdf_adapter.create_adapter())
+
+    monkeypatch.setattr(adapter, "_runtime_for_ingest", lambda: None)
+
+    async def _fake_extract_with_process(
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> tuple[dict[str, Any], list[Any]]:
+        budget = pymupdf_adapter._ExtractionBudget(
+            started_at=0.0,
+            timeout_seconds=options.timeout.seconds if options.timeout is not None else None,
+        )
+        try:
+            return pymupdf_adapter._extract_document_canonical(
+                document,
+                source=source,
+                options=options,
+                budget=budget,
+            )
+        finally:
+            pymupdf_adapter._close_document(document)
+
+    monkeypatch.setattr(pymupdf_adapter, "_extract_with_process", _fake_extract_with_process)
+
+    if perf_values is not None:
+        values = iter(perf_values)
+        last_value = perf_values[-1]
+        monkeypatch.setattr(pymupdf_adapter, "perf_counter", lambda: next(values, last_value))
+
+    return await adapter.ingest(
+        AdapterSource(
+            file_path=source_path,
+            upload_format=UploadFormat.PDF,
+            input_family=InputFamily.PDF_VECTOR,
+            original_name=original_name,
+        ),
+        AdapterExecutionOptions(timeout=timeout, cancellation=cancellation),
+    )
 
 
 def test_upload_formats_cover_all_input_families() -> None:
@@ -189,6 +319,824 @@ def test_pdf_upload_format_returns_vector_and_raster_candidates() -> None:
     )
 
     assert families == (InputFamily.PDF_VECTOR, InputFamily.PDF_RASTER)
+
+
+def test_pymupdf_create_adapter_returns_vector_pdf_adapter() -> None:
+    adapter = pymupdf_adapter.create_adapter()
+
+    assert adapter.descriptor.key == "pymupdf"
+    assert adapter.descriptor.family is InputFamily.PDF_VECTOR
+
+
+def test_pymupdf_probe_is_unavailable_when_package_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_missing() -> object:
+        raise ModuleNotFoundError("No module named 'fitz'")
+
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", _raise_missing)
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: None)
+
+    availability = pymupdf_adapter.create_adapter(
+        license_acknowledged=lambda: True,
+    ).probe()
+
+    assert availability.status is AdapterStatus.UNAVAILABLE
+    assert availability.availability_reason is AvailabilityReason.PROBE_FAILED
+    assert availability.license_state is LicenseState.PRESENT
+    assert availability.details == {"package": "fitz", "license_acknowledged": True}
+    assert {(item.kind, item.name, item.status) for item in availability.observed} == {
+        (ProbeKind.PYTHON_PACKAGE, "fitz", ProbeStatus.MISSING),
+        (ProbeKind.LICENSE, "pymupdf-deployment-review", ProbeStatus.AVAILABLE),
+    }
+
+
+def test_pymupdf_probe_handles_generic_runtime_probe_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_generic_runtime_error() -> object:
+        raise RuntimeError("runtime probe exploded")
+
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", _raise_generic_runtime_error)
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "1.26.0")
+
+    availability = pymupdf_adapter.create_adapter(
+        license_acknowledged=lambda: True,
+    ).probe()
+
+    assert availability.status is AdapterStatus.UNAVAILABLE
+    assert availability.availability_reason is AvailabilityReason.PROBE_FAILED
+    details = availability.details
+    assert details is not None
+    assert details["package"] == "fitz"
+    assert details["license_acknowledged"] is True
+    assert "runtime probe exploded" not in str(details)
+    assert "runtime probe exploded" not in str(availability.observed)
+    assert "runtime probe exploded" not in str(availability)
+
+
+def test_pymupdf_probe_handles_license_provider_exception_with_sanitized_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_license_provider_error() -> bool:
+        raise RuntimeError("sensitive license provider failure")
+
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter, "_runtime_version", lambda _runtime: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "1.26.0")
+
+    availability = pymupdf_adapter.create_adapter(
+        license_acknowledged=_raise_license_provider_error,
+    ).probe()
+
+    assert availability.status is AdapterStatus.UNAVAILABLE
+    assert availability.availability_reason is AvailabilityReason.PROBE_FAILED
+    details = availability.details
+    assert details is not None
+    assert details["package"] == "fitz"
+    assert "sensitive license provider failure" not in str(details)
+    assert "sensitive license provider failure" not in str(availability)
+
+
+def test_pymupdf_probe_is_unavailable_without_license_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _runtime_version(_runtime: object) -> str:
+        return "1.26.0"
+
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter, "_runtime_version", _runtime_version)
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "1.26.0")
+
+    availability = pymupdf_adapter.create_adapter().probe()
+
+    assert availability.status is AdapterStatus.UNAVAILABLE
+    assert availability.availability_reason is AvailabilityReason.MISSING_LICENSE
+    assert availability.license_state is LicenseState.MISSING
+    assert availability.details == {
+        "package": "fitz",
+        "package_version": "1.26.0",
+        "license_acknowledged": False,
+    }
+    assert {(item.kind, item.name, item.status) for item in availability.observed} == {
+        (ProbeKind.PYTHON_PACKAGE, "fitz", ProbeStatus.AVAILABLE),
+        (ProbeKind.LICENSE, "pymupdf-deployment-review", ProbeStatus.MISSING),
+    }
+
+
+def test_pymupdf_probe_is_available_with_license_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _runtime_version(_runtime: object) -> str:
+        return "1.26.0"
+
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter, "_runtime_version", _runtime_version)
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "1.26.0")
+
+    availability = pymupdf_adapter.create_adapter(
+        license_acknowledged=lambda: True,
+    ).probe()
+
+    assert availability.status is AdapterStatus.AVAILABLE
+    assert availability.availability_reason is None
+    assert availability.license_state is LicenseState.PRESENT
+    assert availability.details == {
+        "package": "fitz",
+        "package_version": "1.26.0",
+        "license_acknowledged": True,
+    }
+    assert {(item.kind, item.name, item.status) for item in availability.observed} == {
+        (ProbeKind.PYTHON_PACKAGE, "fitz", ProbeStatus.AVAILABLE),
+        (ProbeKind.LICENSE, "pymupdf-deployment-review", ProbeStatus.AVAILABLE),
+    }
+
+
+def test_pymupdf_probe_uses_package_version_when_runtime_attrs_are_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "9.9.9")
+
+    availability = pymupdf_adapter.create_adapter(
+        license_acknowledged=lambda: True,
+    ).probe()
+
+    assert availability.status is AdapterStatus.AVAILABLE
+    details = availability.details
+    assert details is not None
+    assert details["package_version"] == "9.9.9"
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_refuses_missing_license_before_open(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "vector.pdf"
+    source_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    process_attempted = False
+
+    def _runtime_version(_runtime: object) -> str:
+        return "1.26.0"
+
+    async def _extract_with_process(
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> tuple[dict[str, Any], list[Any]]:
+        nonlocal process_attempted
+        process_attempted = True
+        _ = (source, options)
+        raise AssertionError("process extraction should not be attempted")
+
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter, "_runtime_version", _runtime_version)
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter, "_extract_with_process", _extract_with_process)
+
+    adapter = pymupdf_adapter.create_adapter()
+
+    with pytest.raises(PermissionError):
+        await adapter.ingest(
+            AdapterSource(
+                file_path=source_path,
+                upload_format=UploadFormat.PDF,
+                input_family=InputFamily.PDF_VECTOR,
+            ),
+            AdapterExecutionOptions(),
+        )
+
+    assert process_attempted is False
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_vector_fixture_extracts_metadata_only_text() -> None:
+    adapter = pymupdf_adapter.create_adapter(license_acknowledged=lambda: True)
+    availability = adapter.probe()
+    if availability.status is not AdapterStatus.AVAILABLE:
+        pytest.skip("PyMuPDF runtime not installed for vector PDF smoke test.")
+
+    fixture_path = Path(__file__).parent / "fixtures" / "pdf" / "vector-smoke.pdf"
+    result = await adapter.ingest(
+        AdapterSource(
+            file_path=fixture_path,
+            upload_format=UploadFormat.PDF,
+            input_family=InputFamily.PDF_VECTOR,
+        ),
+        AdapterExecutionOptions(),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert result.canonical["schema_version"] == "0.1"
+    assert result.canonical["canonical_entity_schema_version"] == "0.1"
+    assert result.canonical["blocks"] == ()
+    assert result.canonical["xrefs"] == ()
+    assert result.canonical["layouts"] == (
+        {
+            "name": "page-1",
+            "page_number": 1,
+            "width": 100.0,
+            "height": 100.0,
+            "rotation": 0,
+            "bbox": {"x_min": 0.0, "y_min": 0.0, "x_max": 100.0, "y_max": 100.0},
+        },
+    )
+    layers = cast(tuple[dict[str, str], ...], result.canonical["layers"])
+    assert {layer["name"] for layer in layers} == {"default"}
+
+    entities = cast(tuple[dict[str, Any], ...], result.canonical["entities"])
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity["entity_id"] == "page-1:drawing-0:entity-0"
+    assert entity["entity_type"] == "polyline"
+    assert entity["entity_schema_version"] == "0.1"
+    assert entity["id"] == entity["entity_id"]
+    assert entity["kind"] == "polyline"
+    assert entity["layout"] == "page-1"
+    assert entity["layer"] == "default"
+    assert entity["points"] == (
+        {"x": 10.0, "y": 90.0},
+        {"x": 90.0, "y": 90.0},
+        {"x": 90.0, "y": 10.0},
+    )
+    assert entity["bbox"] == {
+        "x_min": 10.0,
+        "y_min": 10.0,
+        "x_max": 90.0,
+        "y_max": 90.0,
+    }
+    assert entity["properties"]["rect_like"] is False
+    assert entity["provenance"] == {
+        "page_number": 1,
+        "drawing_index": 0,
+        "item_indices": (0, 1),
+        "source": "pymupdf.get_drawings",
+    }
+
+    geometry = cast(dict[str, Any], entity["geometry"])
+    assert geometry["kind"] == entity["entity_type"]
+    assert geometry["coordinate_space"] == "pdf_page_space_unrotated"
+    assert geometry["unit"] == "point"
+    assert geometry["bbox"] == entity["bbox"]
+    assert geometry["points"] == entity["points"]
+    assert geometry["summary"] == {
+        "point_count": 3,
+        "segment_count": 2,
+        "closed": False,
+    }
+
+    metadata = cast(dict[str, Any], result.canonical["metadata"])
+    assert metadata["geometry_mode"] == "vector"
+    assert metadata["pdf_scale"]["status"] == "unconfirmed"
+    assert metadata["pdf_scale"]["coordinate_space"] == "pdf_page_space_unrotated"
+    assert metadata["text_blocks"] == (
+        {
+            "page_number": 1,
+            "layout": "page-1",
+            "block_number": 0,
+            "bbox": {
+                "x_min": 12.0,
+                "y_min": 75.363998,
+                "x_max": 20.664001,
+                "y_max": 91.372002,
+            },
+            "text": "V",
+        },
+    )
+    assert all("text" not in entity for entity in entities)
+    assert result.warnings == ()
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_uses_process_hook_instead_of_parent_parser_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "vector.pdf"
+    source_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    adapter = cast(pymupdf_adapter.PyMuPDFAdapter, pymupdf_adapter.create_adapter())
+
+    monkeypatch.setattr(adapter, "_runtime_for_ingest", lambda: None)
+    monkeypatch.setattr(
+        pymupdf_adapter,
+        "_open_document",
+        lambda _runtime, _path: (_ for _ in ()).throw(
+            AssertionError("parent process should not open the document")
+        ),
+    )
+
+    async def _extract_with_process(
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> tuple[dict[str, Any], list[Any]]:
+        _ = (source, options)
+        return (
+            {
+                "schema_version": "0.1",
+                "canonical_entity_schema_version": "0.1",
+                "units": {"normalized": "unknown"},
+                "coordinate_system": {
+                    "name": "pdf_page_space_unrotated",
+                    "origin": "top_left",
+                    "x_axis": "right",
+                    "y_axis": "down",
+                },
+                "layouts": (),
+                "layers": ({"name": "default"},),
+                "blocks": (),
+                "entities": (),
+                "xrefs": (),
+                "metadata": {
+                    "source_format": UploadFormat.PDF.value,
+                    "geometry_mode": "vector",
+                    "page_count": 0,
+                    "default_layer": "default",
+                    "pdf_scale": {
+                        "status": "unconfirmed",
+                        "coordinate_space": "pdf_page_space_unrotated",
+                        "unit": "point",
+                        "real_world_units": False,
+                    },
+                    "text_blocks": (),
+                },
+            },
+            [],
+        )
+
+    monkeypatch.setattr(pymupdf_adapter, "_extract_with_process", _extract_with_process)
+
+    result = await adapter.ingest(
+        AdapterSource(
+            file_path=source_path,
+            upload_format=UploadFormat.PDF,
+            input_family=InputFamily.PDF_VECTOR,
+        ),
+        AdapterExecutionOptions(),
+    )
+
+    assert result.canonical["entities"] == ()
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_timeout_stops_child_process(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "vector.pdf"
+    source_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    adapter = cast(pymupdf_adapter.PyMuPDFAdapter, pymupdf_adapter.create_adapter())
+
+    class _FakeHandle:
+        def __init__(self) -> None:
+            self.closed = False
+            self.terminated = False
+            self.killed = False
+
+        def poll(self) -> bool:
+            return False
+
+        def recv(self) -> dict[str, Any]:
+            raise AssertionError("child envelope should not be received")
+
+        def is_alive(self) -> bool:
+            return not self.killed
+
+        def join(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    handle = _FakeHandle()
+    perf_values = iter([0.0, 0.0, 0.02])
+
+    monkeypatch.setattr(adapter, "_runtime_for_ingest", lambda: None)
+    monkeypatch.setattr(pymupdf_adapter, "_start_extraction_process", lambda _request: handle)
+    monkeypatch.setattr(pymupdf_adapter, "_PROCESS_POLL_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(
+        pymupdf_adapter,
+        "perf_counter",
+        lambda: next(perf_values, 0.02),
+    )
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await adapter.ingest(
+            AdapterSource(
+                file_path=source_path,
+                upload_format=UploadFormat.PDF,
+                input_family=InputFamily.PDF_VECTOR,
+            ),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.01)),
+        )
+
+    assert str(exc_info.value) == "PyMuPDF extraction timed out."
+    assert handle.terminated is True
+    assert handle.killed is True
+    assert handle.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_cancellation_stops_child_process(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "vector.pdf"
+    source_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    adapter = cast(pymupdf_adapter.PyMuPDFAdapter, pymupdf_adapter.create_adapter())
+
+    class _FakeHandle:
+        def __init__(self) -> None:
+            self.closed = False
+            self.terminated = False
+            self.killed = False
+
+        def poll(self) -> bool:
+            return False
+
+        def recv(self) -> dict[str, Any]:
+            raise AssertionError("child envelope should not be received")
+
+        def is_alive(self) -> bool:
+            return not self.killed
+
+        def join(self, timeout: float | None = None) -> None:
+            _ = timeout
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _CancellationHandle:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def is_cancelled(self) -> bool:
+            self.calls += 1
+            return self.calls >= 3
+
+    cancellation = _CancellationHandle()
+    handle = _FakeHandle()
+
+    monkeypatch.setattr(adapter, "_runtime_for_ingest", lambda: None)
+    monkeypatch.setattr(pymupdf_adapter, "_start_extraction_process", lambda _request: handle)
+    monkeypatch.setattr(pymupdf_adapter, "_PROCESS_POLL_INTERVAL_SECONDS", 0.0)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.ingest(
+            AdapterSource(
+                file_path=source_path,
+                upload_format=UploadFormat.PDF,
+                input_family=InputFamily.PDF_VECTOR,
+            ),
+            AdapterExecutionOptions(cancellation=cancellation),
+        )
+
+    assert handle.terminated is True
+    assert handle.killed is True
+    assert handle.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_timeout_during_page_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument([_FakePage()])
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await _ingest_fake_document(
+            monkeypatch,
+            tmp_path,
+            document,
+            timeout=AdapterTimeout(seconds=0.005),
+            perf_values=[0.0, 0.0, 0.0, 0.0, 0.006],
+        )
+
+    assert str(exc_info.value) == "PyMuPDF extraction timed out."
+    assert document.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_cancellation_inside_drawing_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _CancellationHandle:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def is_cancelled(self) -> bool:
+            return self.cancelled
+
+    cancellation = _CancellationHandle()
+
+    drawing = {
+        "items": (
+            (
+                "l",
+                _FakePoint(0.0, 0.0, on_read=lambda: setattr(cancellation, "cancelled", True)),
+                _FakePoint(10.0, 10.0),
+            ),
+            ("l", _FakePoint(10.0, 10.0), _FakePoint(20.0, 20.0)),
+        ),
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
+    document = _FakeDocument([_FakePage(drawings=[drawing])])
+
+    with pytest.raises(asyncio.CancelledError):
+        await _ingest_fake_document(
+            monkeypatch,
+            tmp_path,
+            document,
+            cancellation=cancellation,
+        )
+
+    assert document.closed is True
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_page_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument([_FakePage(), _FakePage()])
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_PAGES", 1)
+
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    assert str(exc_info.value) == "PyMuPDF extraction exceeded page limit."
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_entity_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    drawing_one = {
+        "items": (("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),),
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
+    drawing_two = {
+        "items": (("l", _FakePoint(20.0, 20.0), _FakePoint(30.0, 20.0)),),
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
+    document = _FakeDocument([_FakePage(drawings=[drawing_one, drawing_two])])
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_ENTITIES", 1)
+
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    assert str(exc_info.value) == "PyMuPDF extraction exceeded entity limit."
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_page_and_total_drawings_caps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    drawing = {
+        "items": (("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),),
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
+
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_DRAWINGS_PER_PAGE", 1)
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as page_exc_info:
+        await _ingest_fake_document(
+            monkeypatch,
+            tmp_path,
+            _FakeDocument([_FakePage(drawings=[drawing, drawing])]),
+        )
+    assert str(page_exc_info.value) == "PyMuPDF extraction exceeded page drawing limit."
+
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_DRAWINGS_PER_PAGE", 10)
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_TOTAL_DRAWINGS", 1)
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as total_exc_info:
+        await _ingest_fake_document(
+            monkeypatch,
+            tmp_path,
+            _FakeDocument([_FakePage(drawings=[drawing]), _FakePage(drawings=[drawing])]),
+        )
+    assert str(total_exc_info.value) == "PyMuPDF extraction exceeded total drawing limit."
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_path_item_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[
+                    {
+                        "items": (
+                            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
+                            ("l", _FakePoint(10.0, 0.0), _FakePoint(20.0, 0.0)),
+                            ("l", _FakePoint(20.0, 0.0), _FakePoint(30.0, 0.0)),
+                        ),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    }
+                ]
+            )
+        ]
+    )
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_PATH_ITEMS_PER_DRAWING", 2)
+
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    assert str(exc_info.value) == "PyMuPDF extraction exceeded drawing path item limit."
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_connected_polyline_point_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[
+                    {
+                        "items": (
+                            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
+                            ("l", _FakePoint(10.0, 0.0), _FakePoint(20.0, 0.0)),
+                            ("l", _FakePoint(20.0, 0.0), _FakePoint(30.0, 0.0)),
+                        ),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    }
+                ]
+            )
+        ]
+    )
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_POINTS_PER_ENTITY", 3)
+
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    assert str(exc_info.value) == "PyMuPDF extraction exceeded entity point limit."
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_enforces_text_block_and_text_byte_caps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    text_payload = {
+        "blocks": [
+            {
+                "type": 0,
+                "number": 0,
+                "bbox": (0.0, 0.0, 10.0, 10.0),
+                "lines": [{"spans": [{"text": "alpha"}]}],
+            },
+            {
+                "type": 0,
+                "number": 1,
+                "bbox": (20.0, 20.0, 30.0, 30.0),
+                "lines": [{"spans": [{"text": "beta"}]}],
+            },
+        ]
+    }
+    document = _FakeDocument([_FakePage(text_payload=text_payload)])
+
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_TEXT_BLOCKS", 1)
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as block_exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+    assert str(block_exc_info.value) == "PyMuPDF extraction exceeded text block limit."
+
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_TEXT_BLOCKS", 10_000)
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_TEXT_BYTES", 4)
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as bytes_exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+    assert str(bytes_exc_info.value) == "PyMuPDF extraction exceeded text content limit."
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_skips_non_finite_entities_and_text_blocks_with_sanitized_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[
+                    {
+                        "items": (("l", _FakePoint(math.inf, 0.0), _FakePoint(10.0, 10.0)),),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    },
+                    {
+                        "items": (("l", _FakePoint(10.0, 10.0), _FakePoint(20.0, 20.0)),),
+                        "width": math.nan,
+                        "color": (0.1, 0.2, 0.3),
+                    },
+                    {
+                        "items": (("l", _FakePoint(30.0, 30.0), _FakePoint(40.0, 40.0)),),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    },
+                ],
+                text_payload={
+                    "blocks": [
+                        {
+                            "type": 0,
+                            "number": 0,
+                            "bbox": (0.0, 0.0, math.inf, 10.0),
+                            "lines": [{"spans": [{"text": "bad"}]}],
+                        },
+                        {
+                            "type": 0,
+                            "number": 1,
+                            "bbox": (10.0, 10.0, 20.0, 20.0),
+                            "lines": [{"spans": [{"text": "good"}]}],
+                        },
+                    ]
+                },
+            )
+        ]
+    )
+
+    result = await _ingest_fake_document(
+        monkeypatch,
+        tmp_path,
+        document,
+        original_name="../nested/plan.pdf",
+    )
+
+    assert result.provenance[0].source_ref == "originals/plan.pdf"
+
+    entities = cast(tuple[dict[str, Any], ...], result.canonical["entities"])
+    assert len(entities) == 1
+    assert entities[0]["start"] == {"x": 30.0, "y": 30.0}
+    assert entities[0]["end"] == {"x": 40.0, "y": 40.0}
+
+    metadata = cast(dict[str, Any], result.canonical["metadata"])
+    assert metadata["text_blocks"] == (
+        {
+            "page_number": 1,
+            "layout": "page-1",
+            "block_number": 1,
+            "bbox": {
+                "x_min": 10.0,
+                "y_min": 10.0,
+                "x_max": 20.0,
+                "y_max": 20.0,
+            },
+            "text": "good",
+        },
+    )
+
+    warning_codes = {warning.code for warning in result.warnings}
+    assert warning_codes == {
+        "pymupdf_path_item_non_finite",
+        "pymupdf_entity_non_finite",
+        "pymupdf_text_block_non_finite",
+    }
+
+
+@pytest.mark.parametrize(
+    ("original_name", "expected"),
+    [
+        ("C:\\Users\\alice\\plan.pdf", "originals/plan.pdf"),
+        ("..\\nested\\plan.pdf", "originals/plan.pdf"),
+        ("\\\\server\\share\\plan.pdf", "originals/plan.pdf"),
+        ("../nested/plan.pdf", "originals/plan.pdf"),
+        ("", "originals/source.pdf"),
+    ],
+)
+def test_pymupdf_durable_source_ref_sanitizes_windows_and_empty_names(
+    tmp_path: Path,
+    original_name: str,
+    expected: str,
+) -> None:
+    source = AdapterSource(
+        file_path=tmp_path / "source.pdf",
+        upload_format=UploadFormat.PDF,
+        input_family=InputFamily.PDF_VECTOR,
+        original_name=original_name,
+    )
+
+    assert pymupdf_adapter._durable_source_ref(source) == expected
 
 
 def test_degraded_status_keeps_optional_binary_issue_visible() -> None:

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -17,6 +17,7 @@ import pytest
 
 from app.core.errors import ErrorCode
 from app.ingestion.adapters import ifcopenshell as ifcopenshell_adapter_module
+from app.ingestion.adapters import pymupdf as pymupdf_adapter_module
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterResult,
@@ -79,6 +80,55 @@ class _AdapterModule(types.ModuleType):
     def __init__(self, name: str, create_adapter: Callable[[], object]) -> None:
         super().__init__(name)
         self.create_adapter = create_adapter
+
+
+class _FakePyMuPDFPoint:
+    def __init__(self, x: float, y: float) -> None:
+        self.x = x
+        self.y = y
+
+
+class _FakePyMuPDFRect:
+    def __init__(self, x0: float, y0: float, x1: float, y1: float) -> None:
+        self.x0 = x0
+        self.y0 = y0
+        self.x1 = x1
+        self.y1 = y1
+        self.width = x1 - x0
+        self.height = y1 - y0
+
+
+class _FakePyMuPDFPage:
+    def __init__(
+        self,
+        *,
+        drawings: list[dict[str, Any]] | None = None,
+        text_payload: dict[str, Any] | None = None,
+    ) -> None:
+        self._drawings = drawings or []
+        self._text_payload = text_payload or {"blocks": []}
+        self.rect = _FakePyMuPDFRect(0.0, 0.0, 100.0, 100.0)
+        self.mediabox = self.rect
+        self.rotation = 0
+
+    def get_drawings(self) -> list[dict[str, Any]]:
+        return self._drawings
+
+    def get_text(self, kind: str) -> dict[str, Any]:
+        assert kind == "dict"
+        return self._text_payload
+
+
+class _FakePyMuPDFDocument:
+    def __init__(self, pages: list[_FakePyMuPDFPage]) -> None:
+        self._pages = pages
+        self.page_count = len(pages)
+
+    def load_page(self, page_index: int) -> _FakePyMuPDFPage:
+        return self._pages[page_index]
+
+    def close(self) -> None:
+        return None
 
 
 def _ifcopenshell_module_spec() -> importlib.machinery.ModuleSpec:
@@ -833,6 +883,156 @@ async def test_run_ingestion_does_not_fall_through_after_runtime_failure(
 
 
 @pytest.mark.asyncio
+async def test_run_ingestion_maps_pymupdf_execute_dependency_missing_without_raster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    attempted_adapters: list[str] = []
+    imported_modules: list[str] = []
+
+    class _MissingRuntimeVectorAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("pymupdf")
+            assert source.file_path.exists()
+            _ = options
+            raise ModuleNotFoundError(name="fitz")
+
+    class _UnexpectedRasterAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("vtracer_tesseract")
+            _ = (source, options)
+            raise AssertionError("Runner should not import or run raster fallback")
+
+    vector_module = _AdapterModule(
+        "missing_runtime_vector_adapter_module",
+        lambda: _MissingRuntimeVectorAdapter(),
+    )
+    raster_module = _AdapterModule(
+        "unexpected_raster_dependency_adapter_module",
+        lambda: _UnexpectedRasterAdapter(),
+    )
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        imported_modules.append(module_name)
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return vector_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            return raster_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter execution dependency was unavailable."
+    assert error.details == {
+        "adapter_key": "pymupdf",
+        "stage": "execute",
+        "reason": "dependency_missing",
+        "dependency": "fitz",
+    }
+    assert imported_modules == ["app.ingestion.adapters.pymupdf"]
+    assert attempted_adapters == ["pymupdf"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_pymupdf_missing_license_without_raster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    imported_modules: list[str] = []
+    process_attempted = False
+
+    class _UnexpectedRasterAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            _ = (source, options)
+            raise AssertionError("Runner should not import or run raster fallback")
+
+    raster_module = _AdapterModule(
+        "unexpected_raster_missing_license_module",
+        lambda: _UnexpectedRasterAdapter(),
+    )
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        imported_modules.append(module_name)
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return pymupdf_adapter_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            return raster_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    async def _extract_with_process(source, options) -> tuple[dict[str, Any], list[Any]]:  # type: ignore[no-untyped-def]
+        nonlocal process_attempted
+        process_attempted = True
+        _ = (source, options)
+        raise AssertionError("process extraction should not be attempted")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(pymupdf_adapter_module, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter_module, "_runtime_version", lambda _runtime: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter_module, "_package_version", lambda: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter_module, "_extract_with_process", _extract_with_process)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter preflight reported unavailable."
+    assert error.details == {
+        "adapter_key": "pymupdf",
+        "stage": "execute",
+        "reason": "missing_license",
+    }
+    assert imported_modules == ["app.ingestion.adapters.pymupdf"]
+    assert process_attempted is False
+
+
+@pytest.mark.asyncio
 async def test_run_ingestion_maps_vector_execute_timeout_without_importing_raster_fallback(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -906,6 +1106,187 @@ async def test_run_ingestion_maps_vector_execute_timeout_without_importing_raste
     assert error.error_code is ErrorCode.ADAPTER_TIMEOUT
     assert error.failure_kind.value == "timeout"
     assert error.details["stage"] == "execute"
+    assert imported_modules == ["app.ingestion.adapters.pymupdf"]
+    assert attempted_adapters == ["pymupdf"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_pymupdf_internal_timeout_without_raster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    imported_modules: list[str] = []
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        imported_modules.append(module_name)
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return pymupdf_adapter_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            raise AssertionError("Raster fallback should not be imported after vector timeout")
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    async def _extract_with_process(source, options) -> tuple[dict[str, Any], list[Any]]:  # type: ignore[no-untyped-def]
+        _ = (source, options)
+        raise TimeoutError("PyMuPDF extraction timed out.")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(pymupdf_adapter_module, "_license_unacknowledged", lambda: True)
+    monkeypatch.setattr(pymupdf_adapter_module, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter_module, "_runtime_version", lambda _runtime: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter_module, "_package_version", lambda: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter_module, "_extract_with_process", _extract_with_process)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(
+            request,
+            storage=storage,
+            temp_root=tmp_path,
+            timeout=AdapterTimeout(seconds=0.005),
+        )
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_TIMEOUT
+    assert error.failure_kind.value == "timeout"
+    assert error.details == {"adapter_key": "pymupdf", "stage": "execute"}
+    assert imported_modules == ["app.ingestion.adapters.pymupdf"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_keeps_pymupdf_cap_failure_without_raster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    imported_modules: list[str] = []
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        imported_modules.append(module_name)
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return pymupdf_adapter_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            raise AssertionError("Raster fallback should not be imported after vector cap failure")
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    async def _extract_with_process(source, options) -> tuple[dict[str, Any], list[Any]]:  # type: ignore[no-untyped-def]
+        _ = (source, options)
+        raise pymupdf_adapter_module.PyMuPDFExtractionLimitError(
+            "PyMuPDF extraction exceeded entity limit."
+        )
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+    monkeypatch.setattr(pymupdf_adapter_module, "_license_unacknowledged", lambda: True)
+    monkeypatch.setattr(pymupdf_adapter_module, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter_module, "_runtime_version", lambda _runtime: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter_module, "_package_version", lambda: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter_module, "_extract_with_process", _extract_with_process)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_FAILED
+    assert error.failure_kind.value == "failed"
+    assert error.details == {"adapter_key": "pymupdf"}
+    assert imported_modules == ["app.ingestion.adapters.pymupdf"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_keeps_pymupdf_no_vector_result_without_raster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    attempted_adapters: list[str] = []
+    imported_modules: list[str] = []
+
+    class _NoVectorAdapter:
+        version = "vector-no-entities-1.0"
+
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            attempted_adapters.append("pymupdf")
+            assert source.file_path.exists()
+            _ = options
+            return AdapterResult(
+                canonical={"entities": ()},
+                provenance=(
+                    ProvenanceRecord(
+                        stage="extract",
+                        adapter_key="pymupdf",
+                        source_ref="originals/source.pdf",
+                    ),
+                ),
+                confidence=ConfidenceSummary(score=0.59, review_required=True, basis="vector"),
+                warnings=cast(Any, ("No vector drawing entities were extracted.",)),
+            )
+
+    vector_module = _AdapterModule("no_vector_adapter_module", lambda: _NoVectorAdapter())
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        imported_modules.append(module_name)
+        if module_name == "app.ingestion.adapters.pymupdf":
+            return vector_module
+        if module_name == "app.ingestion.adapters.vtracer_tesseract":
+            raise AssertionError("Raster fallback should not be imported for no-vector result")
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="pdf",
+        media_type="application/pdf",
+        original_name="sheet.pdf",
+    )
+
+    payload = await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    assert payload.adapter_key == "pymupdf"
+    assert payload.input_family == InputFamily.PDF_VECTOR.value
+    assert payload.review_state == "review_required"
+    assert payload.validation_status == "needs_review"
+    assert payload.quantity_gate == "review_gated"
+    assert payload.canonical_json["entities"] == []
+    assert payload.report_json["summary"]["entity_counts"]["entities"] == 0
+    assert payload.report_json["checks"]
     assert imported_modules == ["app.ingestion.adapters.pymupdf"]
     assert attempted_adapters == ["pymupdf"]
 


### PR DESCRIPTION
Closes #99

## Summary
- add a vector PDF ingestion path behind the shared adapter contract so PDFs can be normalized without leaking PyMuPDF into core ingestion code
- keep vector PDF outputs review-gated when scale is unconfirmed, aligning fixture expectations and validation with the project’s safety-first PDF policy
- isolate blocking PyMuPDF parsing in a killable child process so timeout, cancellation, and shape caps can contain hostile or oversized PDFs without falling through to raster

## Test plan
- [x] `uv run pytest -q`
- [x] `uv run ruff check .`
- [x] `uv run mypy app tests`
- [x] `uv build`

## Notes
- no breaking changes
- no raster fallback is attempted after PyMuPDF runtime failure, timeout, cap failure, or missing license acknowledgement