### PR TITLE
fix: avoid definitive IFC schema-missing on incomplete headers

### DIFF
--- a/app/ingestion/adapters/ifcopenshell.py
+++ b/app/ingestion/adapters/ifcopenshell.py
@@ -94,6 +94,7 @@ class _SchemaSniff:
     schema: str | None
     readable: bool
     supported: bool
+    header_complete: bool
 
 
 @dataclass(slots=True)
@@ -222,7 +223,10 @@ class IfcOpenShellAdapter(IngestionAdapter):
             )
         )
 
-        if sniff.readable and (sniff.schema is None or not sniff.supported):
+        if sniff.readable and (
+            (sniff.schema is None and sniff.header_complete)
+            or (sniff.schema is not None and not sniff.supported)
+        ):
             warnings.extend(_schema_warnings(sniff))
             diagnostics.append(
                 AdapterDiagnostic(
@@ -419,23 +423,88 @@ def _sniff_step_header(file_path: Path) -> _SchemaSniff:
         with file_path.open("rb") as stream:
             header_bytes = stream.read(_HEADER_READ_LIMIT_BYTES)
     except OSError:
-        return _SchemaSniff(schema=None, readable=False, supported=False)
+        return _SchemaSniff(
+            schema=None,
+            readable=False,
+            supported=False,
+            header_complete=False,
+        )
 
     header_text = header_bytes.decode("utf-8", errors="ignore")
     upper_header = header_text.upper()
     if not all(marker in upper_header for marker in _STEP_HEADER_MARKERS):
-        return _SchemaSniff(schema=None, readable=False, supported=False)
+        return _SchemaSniff(
+            schema=None,
+            readable=False,
+            supported=False,
+            header_complete=False,
+        )
 
-    match = _SCHEMA_PATTERN.search(header_text)
+    header_start = upper_header.find("HEADER;")
+    header_end = _find_step_header_terminator(header_text, header_start)
+    header_complete = header_end != -1
+    header_section = (
+        header_text[header_start : header_end + len("ENDSEC;")]
+        if header_complete
+        else header_text[header_start:]
+    )
+
+    match = _SCHEMA_PATTERN.search(header_section)
     if match is None:
-        return _SchemaSniff(schema=None, readable=True, supported=False)
+        return _SchemaSniff(
+            schema=None,
+            readable=True,
+            supported=False,
+            header_complete=header_complete,
+        )
 
     schema = _normalize_schema(match.group(1))
     return _SchemaSniff(
         schema=schema,
         readable=True,
         supported=schema in _SUPPORTED_SCHEMAS,
+        header_complete=header_complete,
     )
+
+
+def _find_step_header_terminator(header_text: str, header_start: int) -> int:
+    upper_header = header_text.upper()
+    in_comment = False
+    in_string = False
+    index = header_start + len("HEADER;")
+
+    while index < len(header_text):
+        if in_comment:
+            if header_text.startswith("*/", index):
+                in_comment = False
+                index += 2
+                continue
+            index += 1
+            continue
+
+        character = header_text[index]
+        if in_string:
+            if character == "'":
+                if index + 1 < len(header_text) and header_text[index + 1] == "'":
+                    index += 2
+                    continue
+                in_string = False
+            index += 1
+            continue
+
+        if header_text.startswith("/*", index):
+            in_comment = True
+            index += 2
+            continue
+        if character == "'":
+            in_string = True
+            index += 1
+            continue
+        if upper_header.startswith("ENDSEC;", index):
+            return index
+        index += 1
+
+    return -1
 
 
 def _schema_warnings(sniff: _SchemaSniff) -> list[AdapterWarning]:

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -110,6 +110,39 @@ def _write_ifc(path: Path, *, schema_line: str) -> None:
     )
 
 
+def _write_ifc_with_capped_header(path: Path) -> None:
+    oversized_description = "X" * adapter_module._HEADER_READ_LIMIT_BYTES
+    path.write_text(
+        "ISO-10303-21;\n"
+        "HEADER;\n"
+        "FILE_DESCRIPTION(('" + oversized_description + "'),'2;1');\n"
+        "FILE_SCHEMA(('IFC4'));\n"
+        "ENDSEC;\n"
+        "DATA;\n"
+        "ENDSEC;\n"
+        "END-ISO-10303-21;\n",
+        encoding="utf-8",
+    )
+
+
+def _write_ifc_with_capped_fake_header_terminator(
+    path: Path, *, fake_terminator_line: str
+) -> None:
+    oversized_description = "X" * adapter_module._HEADER_READ_LIMIT_BYTES
+    path.write_text(
+        "ISO-10303-21;\n"
+        "HEADER;\n"
+        f"{fake_terminator_line}\n"
+        "FILE_DESCRIPTION(('" + oversized_description + "'),'2;1');\n"
+        "FILE_SCHEMA(('IFC4'));\n"
+        "ENDSEC;\n"
+        "DATA;\n"
+        "ENDSEC;\n"
+        "END-ISO-10303-21;\n",
+        encoding="utf-8",
+    )
+
+
 def _build_runtime(model: _FakeModel, *, util_element: object | None = None) -> object:
     helper = util_element or SimpleNamespace(
         get_psets=lambda product, **_: product.qtos if _.get("qtos_only") else product.psets,
@@ -571,6 +604,119 @@ async def test_ifcopenshell_adapter_short_circuits_invalid_schema_through_valida
         assert canonical["ifc_schema"] == expected_schema
         assert canonical["metadata"]["ifc_schema"] == expected_schema
     assert canonical["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_capped_incomplete_header_continues_to_native_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "capped-header.ifc"
+    _write_ifc_with_capped_header(fixture_path)
+
+    sniff = adapter_module._sniff_step_header(fixture_path)
+    assert sniff.schema is None
+    assert sniff.readable is True
+    assert sniff.supported is False
+    assert sniff.header_complete is False
+
+    runtime_called = False
+
+    def _open_runtime(path: str) -> _FakeModel:
+        nonlocal runtime_called
+        runtime_called = True
+        _ = path
+        return _FakeModel(schema="IFC4", project=None, products=[])
+
+    runtime = SimpleNamespace(open=_open_runtime)
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    result = await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/step",
+            original_name="capped-header.ifc",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert runtime_called is True
+    assert result.diagnostics[0].details == {
+        "ifc_schema": None,
+        "readable": True,
+        "supported": False,
+    }
+    assert "ifc.schema_missing" not in {warning.code for warning in result.warnings}
+    assert result.canonical["ifc_schema"] == "IFC4"
+
+
+@pytest.mark.parametrize(
+    "fake_terminator_line",
+    [
+        "FILE_NAME('quoted ENDSEC; marker','2026-01-01T00:00:00');",
+        "/* comment ENDSEC; marker */",
+    ],
+)
+def test_sniff_step_header_ignores_embedded_endsec_before_real_header_end(
+    tmp_path: Path,
+    fake_terminator_line: str,
+) -> None:
+    fixture_path = tmp_path / "embedded-endsec.ifc"
+    _write_ifc_with_capped_fake_header_terminator(
+        fixture_path, fake_terminator_line=fake_terminator_line
+    )
+
+    sniff = adapter_module._sniff_step_header(fixture_path)
+
+    assert sniff.schema is None
+    assert sniff.readable is True
+    assert sniff.supported is False
+    assert sniff.header_complete is False
+
+
+@pytest.mark.asyncio
+async def test_ifcopenshell_adapter_quoted_endsec_in_capped_header_continues_native_parse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = tmp_path / "quoted-endsec-capped-header.ifc"
+    _write_ifc_with_capped_fake_header_terminator(
+        fixture_path,
+        fake_terminator_line="FILE_NAME('quoted ENDSEC; marker','2026-01-01T00:00:00');",
+    )
+
+    runtime_called = False
+
+    def _open_runtime(path: str) -> _FakeModel:
+        nonlocal runtime_called
+        runtime_called = True
+        _ = path
+        return _FakeModel(schema="IFC4", project=None, products=[])
+
+    runtime = SimpleNamespace(open=_open_runtime)
+    monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+
+    result = await adapter_module.create_adapter().ingest(
+        build_contract_source(
+            file_path=fixture_path,
+            upload_format=UploadFormat.IFC,
+            input_family=InputFamily.IFC,
+            media_type="application/step",
+            original_name="quoted-endsec-capped-header.ifc",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert runtime_called is True
+    assert result.diagnostics[0].details == {
+        "ifc_schema": None,
+        "readable": True,
+        "supported": False,
+    }
+    assert "ifc.schema_missing" not in {warning.code for warning in result.warnings}
+    assert result.canonical["ifc_schema"] == "IFC4"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #112

## Summary
- Prevent valid IFC files with capped or incomplete STEP headers from being rejected before native parse runs
- Only treat schema-missing as definitive after confirming the STEP header actually terminated
- Guard header termination detection against quoted or commented `ENDSEC;` text

## Test plan
- [x] `uv run ruff check app/ingestion/adapters/ifcopenshell.py tests/test_ifcopenshell_adapter.py`
- [x] `uv run mypy app/ingestion/adapters/ifcopenshell.py tests/test_ifcopenshell_adapter.py`
- [x] `uv run pytest tests/test_ifcopenshell_adapter.py`

## Notes
- No breaking changes