### PR TITLE
feat: add LibreDWG DWG adapter wrapper

### DIFF
--- a/app/ingestion/adapters/__init__.py
+++ b/app/ingestion/adapters/__init__.py
@@ -1,3 +1,3 @@
 """Concrete ingestion adapter implementations."""
 
-__all__ = ["ezdxf"]
+__all__ = ["ezdxf", "ifcopenshell", "libredwg", "pymupdf"]

--- a/app/ingestion/adapters/libredwg.py
+++ b/app/ingestion/adapters/libredwg.py
@@ -1,0 +1,547 @@
+"""Thin LibreDWG DWG adapter backed by the ``dwgread`` CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import resource
+import shutil
+import tempfile
+from collections.abc import Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from time import perf_counter
+from typing import Any, cast
+
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDiagnostic,
+    AdapterExecutionOptions,
+    AdapterResult,
+    AdapterSource,
+    AdapterStatus,
+    AdapterUnavailableError,
+    AdapterWarning,
+    AvailabilityReason,
+    ConfidenceSummary,
+    IngestionAdapter,
+    InputFamily,
+    JSONValue,
+    ProbeKind,
+    ProbeObservation,
+    ProbeStatus,
+    ProvenanceRecord,
+)
+from app.ingestion.registry import evaluate_availability, get_descriptor
+
+_DESCRIPTOR = get_descriptor(InputFamily.DWG)
+_BINARY_NAME = "dwgread"
+_LICENSE_PROBE_NAME = "libredwg-distribution-review"
+_SCHEMA_VERSION = "0.1"
+_PROCESS_POLL_INTERVAL_SECONDS = 0.05
+_PROCESS_TERMINATE_GRACE_SECONDS = 0.2
+_PROCESS_KILL_GRACE_SECONDS = 0.2
+_MAX_STDOUT_BYTES = 8 * 1024
+_MAX_STDERR_BYTES = 16 * 1024
+_MAX_OUTPUT_BYTES = 1 * 1024 * 1024
+_PLACEHOLDER_CONFIDENCE_SCORE = 0.4
+
+
+@dataclass(frozen=True, slots=True)
+class _CapturedText:
+    text: str
+    byte_count: int
+    truncated: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _DwgreadRunResult:
+    stdout: _CapturedText
+    stderr: _CapturedText
+    output_size_bytes: int
+    output_kind: str
+    output_key_count: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class _LiveFileLimit:
+    path: Path
+    limit_bytes: int
+    overflow_message: str
+
+
+def create_adapter() -> IngestionAdapter:
+    """Create the LibreDWG adapter without touching the runtime binary."""
+
+    return LibreDWGAdapter()
+
+
+class LibreDWGAdapter(IngestionAdapter):
+    """DWG adapter that shells out to ``dwgread`` and emits placeholder canonical JSON."""
+
+    descriptor = _DESCRIPTOR
+
+    def probe(self) -> AdapterAvailability:
+        """Report binary/license posture without invoking ``dwgread``."""
+
+        started_at = perf_counter()
+        binary_path = _binary_path()
+        observations = (
+            _binary_probe_observation(binary_path),
+            _license_probe_observation(),
+        )
+        details: dict[str, JSONValue] = {
+            "binary": _BINARY_NAME,
+            "distribution_review_required": True,
+            "placeholder_contract_phase": 2,
+        }
+        if binary_path is not None:
+            details["binary_name"] = Path(binary_path).name
+
+        return evaluate_availability(
+            self.descriptor,
+            observations=observations,
+            details=details,
+            probe_elapsed_ms=(perf_counter() - started_at) * 1000.0,
+        )
+
+    async def ingest(
+        self,
+        source: AdapterSource,
+        options: AdapterExecutionOptions,
+    ) -> AdapterResult:
+        """Run ``dwgread`` and emit a review-gated placeholder canonical payload."""
+
+        started_at = perf_counter()
+        _raise_if_cancelled(options)
+        binary_path = _binary_path_for_ingest(self.probe())
+        _raise_if_cancelled(options)
+
+        run_result = await _run_dwgread(
+            binary_path=binary_path,
+            source=source,
+            options=options,
+        )
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+
+        warning = AdapterWarning(
+            code="libredwg.placeholder_canonical",
+            message=(
+                "LibreDWG Phase 2 emits placeholder canonical output; "
+                "DWG entities remain review-gated until native mapping lands."
+            ),
+            details={
+                "output_kind": run_result.output_kind,
+                "output_size_bytes": run_result.output_size_bytes,
+            },
+        )
+        diagnostic_details: dict[str, JSONValue] = {
+            "command": (_BINARY_NAME, "-O", "JSON", "-o", "<tempdir>/dwgread.json", "<source>"),
+            "stdout_bytes": run_result.stdout.byte_count,
+            "stdout_truncated": run_result.stdout.truncated,
+            "stdout_excerpt": run_result.stdout.text,
+            "stderr_bytes": run_result.stderr.byte_count,
+            "stderr_truncated": run_result.stderr.truncated,
+            "stderr_excerpt": run_result.stderr.text,
+            "output_size_bytes": run_result.output_size_bytes,
+            "output_kind": run_result.output_kind,
+        }
+        if run_result.output_key_count is not None:
+            diagnostic_details["output_key_count"] = run_result.output_key_count
+
+        return AdapterResult(
+            canonical=_build_placeholder_canonical(source=source, run_result=run_result),
+            provenance=(
+                ProvenanceRecord(
+                    stage="extract",
+                    adapter_key=self.descriptor.key,
+                    source_ref=_source_ref(source),
+                    details={
+                        "upload_format": source.upload_format.value,
+                        "input_family": source.input_family.value,
+                        "output_kind": run_result.output_kind,
+                    },
+                ),
+            ),
+            confidence=ConfidenceSummary(
+                score=_PLACEHOLDER_CONFIDENCE_SCORE,
+                review_required=True,
+                basis="libredwg_placeholder_wrapper",
+            ),
+            warnings=(warning,),
+            diagnostics=(
+                AdapterDiagnostic(
+                    code="libredwg.extract",
+                    message="Executed dwgread and produced placeholder canonical DWG output.",
+                    details=diagnostic_details,
+                    elapsed_ms=elapsed_ms,
+                ),
+            ),
+        )
+
+
+def _binary_probe_observation(binary_path: str | None) -> ProbeObservation:
+    if binary_path is None:
+        return ProbeObservation(
+            kind=ProbeKind.BINARY,
+            name=_BINARY_NAME,
+            status=ProbeStatus.MISSING,
+            detail="LibreDWG dwgread binary is not installed.",
+        )
+
+    return ProbeObservation(
+        kind=ProbeKind.BINARY,
+        name=_BINARY_NAME,
+        status=ProbeStatus.AVAILABLE,
+        detail="LibreDWG dwgread binary is available for local execution.",
+    )
+
+
+def _license_probe_observation() -> ProbeObservation:
+    return ProbeObservation(
+        kind=ProbeKind.LICENSE,
+        name=_LICENSE_PROBE_NAME,
+        status=ProbeStatus.AVAILABLE,
+        detail="GPL distribution/on-prem bundling still requires external review.",
+    )
+
+
+def _binary_path() -> str | None:
+    return shutil.which(_BINARY_NAME)
+
+
+def _binary_path_for_ingest(availability: AdapterAvailability) -> str:
+    if availability.status is not AdapterStatus.AVAILABLE:
+        issue_detail = availability.issues[0].detail if availability.issues else None
+        raise AdapterUnavailableError(
+            availability.availability_reason or AvailabilityReason.PROBE_FAILED,
+            detail=issue_detail,
+        )
+
+    binary_path = _binary_path()
+    if binary_path is None:
+        raise AdapterUnavailableError(
+            AvailabilityReason.MISSING_BINARY,
+            detail="LibreDWG dwgread binary is not installed.",
+        )
+    return binary_path
+
+
+async def _run_dwgread(
+    *,
+    binary_path: str,
+    source: AdapterSource,
+    options: AdapterExecutionOptions,
+) -> _DwgreadRunResult:
+    with tempfile.TemporaryDirectory(prefix="libredwg-") as tempdir:
+        temp_path = Path(tempdir)
+        output_path = temp_path / "dwgread.json"
+        stdout_path = temp_path / "dwgread.stdout.log"
+        stderr_path = temp_path / "dwgread.stderr.log"
+
+        process = await _spawn_dwgread_process(
+            binary_path=binary_path,
+            source=source,
+            output_path=output_path,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
+        )
+        live_limits = (
+            _LiveFileLimit(
+                path=stdout_path,
+                limit_bytes=_MAX_STDOUT_BYTES,
+                overflow_message="LibreDWG stdout exceeded the adapter output limit.",
+            ),
+            _LiveFileLimit(
+                path=stderr_path,
+                limit_bytes=_MAX_STDERR_BYTES,
+                overflow_message="LibreDWG stderr exceeded the adapter output limit.",
+            ),
+            _LiveFileLimit(
+                path=output_path,
+                limit_bytes=_MAX_OUTPUT_BYTES,
+                overflow_message="LibreDWG JSON output exceeded the adapter output limit.",
+            ),
+        )
+
+        try:
+            returncode = await _wait_for_process(process, options, live_limits=live_limits)
+        except BaseException:
+            await asyncio.shield(_terminate_process(process))
+            raise
+
+        stdout = _read_text_capture(
+            stdout_path,
+            limit_bytes=_MAX_STDOUT_BYTES,
+            source_path=source.file_path,
+            temp_path=temp_path,
+        )
+        stderr = _read_text_capture(
+            stderr_path,
+            limit_bytes=_MAX_STDERR_BYTES,
+            source_path=source.file_path,
+            temp_path=temp_path,
+        )
+
+        if returncode != 0:
+            raise RuntimeError("LibreDWG dwgread execution failed.")
+
+        if not output_path.exists():
+            raise RuntimeError("LibreDWG dwgread did not produce JSON output.")
+
+        output_size_bytes = output_path.stat().st_size
+        if output_size_bytes > _MAX_OUTPUT_BYTES:
+            raise RuntimeError("LibreDWG JSON output exceeded the adapter output limit.")
+
+        output_payload = _load_output_payload(
+            output_path,
+            source_path=source.file_path,
+            temp_path=temp_path,
+        )
+        output_kind, output_key_count = _summarize_output_payload(output_payload)
+
+        return _DwgreadRunResult(
+            stdout=stdout,
+            stderr=stderr,
+            output_size_bytes=output_size_bytes,
+            output_kind=output_kind,
+            output_key_count=output_key_count,
+        )
+
+
+async def _spawn_dwgread_process(
+    *,
+    binary_path: str,
+    source: AdapterSource,
+    output_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> asyncio.subprocess.Process:
+    try:
+        with stdout_path.open("wb") as stdout_handle, stderr_path.open("wb") as stderr_handle:
+            return await asyncio.create_subprocess_exec(
+                binary_path,
+                "-O",
+                "JSON",
+                "-o",
+                str(output_path),
+                str(source.file_path),
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+                preexec_fn=_configure_child_file_size_limit,
+            )
+    except FileNotFoundError as exc:
+        raise AdapterUnavailableError(
+            AvailabilityReason.MISSING_BINARY,
+            detail="LibreDWG dwgread binary is not installed.",
+        ) from exc
+
+
+async def _wait_for_process(
+    process: asyncio.subprocess.Process,
+    options: AdapterExecutionOptions,
+    *,
+    live_limits: tuple[_LiveFileLimit, ...],
+) -> int:
+    started_at = perf_counter()
+    timeout_seconds = options.timeout.seconds if options.timeout is not None else None
+
+    while True:
+        _raise_if_cancelled(options)
+        _enforce_live_file_limits(live_limits)
+
+        if process.returncode is not None:
+            return process.returncode
+
+        poll_timeout = _PROCESS_POLL_INTERVAL_SECONDS
+        if timeout_seconds is not None:
+            remaining_seconds = timeout_seconds - (perf_counter() - started_at)
+            if remaining_seconds <= 0:
+                raise TimeoutError("LibreDWG extraction timed out.")
+            poll_timeout = min(poll_timeout, remaining_seconds)
+
+        try:
+            returncode = await asyncio.wait_for(process.wait(), timeout=poll_timeout)
+        except TimeoutError:
+            continue
+
+        _enforce_live_file_limits(live_limits)
+        return returncode
+
+
+def _configure_child_file_size_limit() -> None:
+    max_limit = max(_MAX_STDOUT_BYTES, _MAX_STDERR_BYTES, _MAX_OUTPUT_BYTES)
+
+    try:
+        _, hard_limit = resource.getrlimit(resource.RLIMIT_FSIZE)
+    except (OSError, ValueError):
+        return
+
+    target_limit = max_limit if hard_limit == resource.RLIM_INFINITY else min(max_limit, hard_limit)
+
+    try:
+        resource.setrlimit(resource.RLIMIT_FSIZE, (target_limit, target_limit))
+    except (OSError, ValueError):
+        return
+
+
+def _enforce_live_file_limits(live_limits: tuple[_LiveFileLimit, ...]) -> None:
+    for live_limit in live_limits:
+        try:
+            size_bytes = live_limit.path.stat().st_size
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise RuntimeError("LibreDWG process output could not be monitored.") from exc
+
+        if size_bytes > live_limit.limit_bytes:
+            raise RuntimeError(live_limit.overflow_message)
+
+
+async def _terminate_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        with suppress(ProcessLookupError):
+            await process.wait()
+        return
+
+    with suppress(ProcessLookupError):
+        process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=_PROCESS_TERMINATE_GRACE_SECONDS)
+        return
+    except TimeoutError:
+        pass
+
+    with suppress(ProcessLookupError):
+        process.kill()
+    with suppress(ProcessLookupError, asyncio.TimeoutError):
+        await asyncio.wait_for(process.wait(), timeout=_PROCESS_KILL_GRACE_SECONDS)
+
+
+def _load_output_payload(
+    output_path: Path,
+    *,
+    source_path: Path,
+    temp_path: Path,
+) -> Any:
+    try:
+        output_bytes = output_path.read_bytes()
+        output_text = _sanitize_text(
+            output_bytes.decode("utf-8", errors="replace"),
+            source_path=source_path,
+            temp_path=temp_path,
+        )
+        return json.loads(output_text)
+    except OSError as exc:
+        raise RuntimeError("LibreDWG JSON output could not be read.") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("LibreDWG JSON output was invalid.") from exc
+
+
+def _summarize_output_payload(payload: Any) -> tuple[str, int | None]:
+    if isinstance(payload, Mapping):
+        return "object", len(payload)
+    if isinstance(payload, list):
+        return "array", len(payload)
+    if payload is None:
+        return "null", None
+    if isinstance(payload, bool):
+        return "boolean", None
+    if isinstance(payload, (int, float)):
+        return "number", None
+    if isinstance(payload, str):
+        return "string", None
+    return type(payload).__name__, None
+
+
+def _read_text_capture(
+    capture_path: Path,
+    *,
+    limit_bytes: int,
+    source_path: Path,
+    temp_path: Path,
+) -> _CapturedText:
+    if not capture_path.exists():
+        return _CapturedText(text="", byte_count=0, truncated=False)
+
+    byte_count = capture_path.stat().st_size
+    with capture_path.open("rb") as capture_handle:
+        raw = capture_handle.read(limit_bytes)
+
+    return _CapturedText(
+        text=_sanitize_text(
+            raw.decode("utf-8", errors="replace"),
+            source_path=source_path,
+            temp_path=temp_path,
+        ),
+        byte_count=byte_count,
+        truncated=byte_count > limit_bytes,
+    )
+
+
+def _sanitize_text(text: str, *, source_path: Path, temp_path: Path) -> str:
+    sanitized = text.replace(str(source_path), "<source>")
+    sanitized = sanitized.replace(str(temp_path), "<tempdir>")
+    return "".join(
+        character if character.isprintable() or character in {"\n", "\t"} else "?"
+        for character in sanitized
+    ).strip()
+
+
+def _build_placeholder_canonical(
+    *,
+    source: AdapterSource,
+    run_result: _DwgreadRunResult,
+) -> dict[str, JSONValue]:
+    metadata: dict[str, JSONValue] = {
+        "source_format": source.upload_format.value,
+        "adapter_mode": "placeholder",
+        "dwgread": {
+            "output_kind": run_result.output_kind,
+            "output_size_bytes": run_result.output_size_bytes,
+            "stdout_bytes": run_result.stdout.byte_count,
+            "stderr_bytes": run_result.stderr.byte_count,
+        },
+    }
+    if run_result.output_key_count is not None:
+        dwgread_metadata = cast(dict[str, JSONValue], metadata["dwgread"])
+        dwgread_metadata["output_key_count"] = run_result.output_key_count
+
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "canonical_entity_schema_version": _SCHEMA_VERSION,
+        "units": {"normalized": "unknown"},
+        "coordinate_system": {
+            "name": "local",
+            "type": "cartesian",
+            "source": "libredwg_placeholder_wrapper",
+        },
+        "layouts": ({"name": "Model"},),
+        "layers": (),
+        "blocks": (),
+        "entities": (),
+        "xrefs": (),
+        "metadata": metadata,
+    }
+
+
+def _source_ref(source: AdapterSource) -> str:
+    candidate = (
+        source.original_name.replace("\\", "/").split("/")[-1].strip()
+        if source.original_name
+        else ""
+    )
+    return f"originals/{candidate or source.file_path.name}"
+
+
+def _raise_if_cancelled(options: AdapterExecutionOptions) -> None:
+    if options.cancellation is not None and options.cancellation.is_cancelled():
+        raise asyncio.CancelledError()
+
+
+__all__ = [
+    "LibreDWGAdapter",
+    "create_adapter",
+]

--- a/app/ingestion/contracts.py
+++ b/app/ingestion/contracts.py
@@ -97,6 +97,20 @@ class AdapterFailureKind(StrEnum):
     INTERNAL = "internal"
 
 
+class AdapterUnavailableError(Exception):
+    """Sanitized availability failure adapters can raise during preflight/execute."""
+
+    def __init__(
+        self,
+        availability_reason: AvailabilityReason,
+        *,
+        detail: str | None = None,
+    ) -> None:
+        super().__init__("Adapter reported unavailable.")
+        self.availability_reason = availability_reason
+        self.detail = detail
+
+
 def input_families_for_upload_format(upload_format: UploadFormat) -> tuple[InputFamily, ...]:
     """Return the normalized families that can satisfy an upload format."""
 

--- a/app/ingestion/runner.py
+++ b/app/ingestion/runner.py
@@ -18,6 +18,7 @@ from app.ingestion.contracts import (
     AdapterResult,
     AdapterSource,
     AdapterTimeout,
+    AdapterUnavailableError,
     AvailabilityReason,
     CancellationHandle,
     IngestionAdapter,
@@ -332,6 +333,22 @@ def _execute_preflight_unavailable_error(
     adapter_key: str,
     exc: Exception,
 ) -> IngestionRunnerError | None:
+    if isinstance(exc, AdapterUnavailableError):
+        details: dict[str, Any] = {
+            "adapter_key": adapter_key,
+            "stage": "execute",
+            "reason": exc.availability_reason.value,
+        }
+        if exc.detail is not None:
+            details["detail"] = exc.detail
+
+        return IngestionRunnerError(
+            error_code=ErrorCode.ADAPTER_UNAVAILABLE,
+            failure_kind=AdapterFailureKind.UNAVAILABLE,
+            message="Adapter preflight reported unavailable.",
+            details=details,
+        )
+
     if adapter_key != "pymupdf":
         return None
 

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -23,6 +23,8 @@ from app.ingestion.contracts import (
     AdapterResult,
     AdapterStatus,
     AdapterTimeout,
+    AdapterUnavailableError,
+    AvailabilityReason,
     ConfidenceSummary,
     InputFamily,
     ProgressUpdate,
@@ -365,6 +367,65 @@ async def test_run_ingestion_maps_ifcopenshell_runtime_missing_during_execute(
         "stage": "execute",
         "reason": "dependency_missing",
         "dependency": "ifcopenshell",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_ingestion_maps_shared_adapter_availability_error_during_execute(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    storage = MemoryStorage()
+    file_id = uuid4()
+    checksum = hashlib.sha256(_IFC_SMOKE_BODY).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, _IFC_SMOKE_BODY, immutable=True)
+
+    class _UnavailableIfcAdapter:
+        def probe(self) -> AdapterAvailability:
+            return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+        async def ingest(self, source, options) -> AdapterResult:  # type: ignore[no-untyped-def]
+            assert source.file_path.exists()
+            _ = options
+            raise AdapterUnavailableError(
+                AvailabilityReason.PROBE_FAILED,
+                detail="ifc runtime preflight failed",
+            )
+
+    unavailable_module = _AdapterModule(
+        "unavailable_ifc_adapter_module",
+        lambda: _UnavailableIfcAdapter(),
+    )
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        if module_name == "app.ingestion.adapters.ifcopenshell":
+            return unavailable_module
+        raise AssertionError(f"Unexpected module import: {module_name}")
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    request = IngestionRunRequest(
+        job_id=uuid4(),
+        file_id=file_id,
+        checksum_sha256=checksum,
+        detected_format="ifc",
+        media_type="application/step",
+        original_name="nested/unavailable.ifc",
+    )
+
+    with pytest.raises(IngestionRunnerError) as exc_info:
+        await run_ingestion(request, storage=storage, temp_root=tmp_path)
+
+    error = exc_info.value
+    assert error.error_code is ErrorCode.ADAPTER_UNAVAILABLE
+    assert error.failure_kind.value == "unavailable"
+    assert error.message == "Adapter preflight reported unavailable."
+    assert error.details == {
+        "adapter_key": "ifcopenshell",
+        "stage": "execute",
+        "reason": "probe_failed",
+        "detail": "ifc runtime preflight failed",
     }
 
 

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -1,0 +1,540 @@
+"""Contract tests for the thin LibreDWG DWG adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from app.ingestion.adapters import libredwg as adapter_module
+from app.ingestion.contracts import (
+    AdapterExecutionOptions,
+    AdapterSource,
+    AdapterStatus,
+    AdapterTimeout,
+    AdapterUnavailableError,
+    AvailabilityReason,
+    InputFamily,
+    UploadFormat,
+)
+from tests.ingestion_contract_harness import (
+    ContractFinalizationExpectation,
+    build_contract_source,
+    exercise_adapter_contract,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "dwg" / "libredwg-wrapper-smoke.txt"
+)
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        complete_with: int | None = None,
+        complete_when: asyncio.Event | None = None,
+    ) -> None:
+        self.returncode: int | None = None
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self._complete_with = complete_with
+        self._complete_when = complete_when
+        self._killed = asyncio.Event()
+
+    async def wait(self) -> int:
+        if self.returncode is not None:
+            return self.returncode
+        if self._complete_with is not None and self._complete_when is None:
+            self.returncode = self._complete_with
+            return self.returncode
+
+        wait_tasks = [asyncio.create_task(self._killed.wait())]
+        complete_task: asyncio.Task[bool] | None = None
+        if self._complete_when is not None:
+            complete_task = asyncio.create_task(self._complete_when.wait())
+            wait_tasks.append(complete_task)
+
+        done, pending = await asyncio.wait(wait_tasks, return_when=asyncio.FIRST_COMPLETED)
+        for pending_task in pending:
+            pending_task.cancel()
+
+        if (
+            complete_task is not None
+            and complete_task in done
+            and self.returncode is None
+            and self._complete_with is not None
+        ):
+            self.returncode = self._complete_with
+
+        return cast(int, self.returncode)
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+        self._killed.set()
+
+
+class _DeferredCancellation:
+    def __init__(self, *, cancel_after_calls: int) -> None:
+        self.calls = 0
+        self._cancel_after_calls = cancel_after_calls
+
+    def is_cancelled(self) -> bool:
+        self.calls += 1
+        return self.calls >= self._cancel_after_calls
+
+
+def _build_source() -> AdapterSource:
+    return build_contract_source(
+        file_path=_FIXTURE_PATH,
+        upload_format=UploadFormat.DWG,
+        input_family=InputFamily.DWG,
+        media_type="image/vnd.dwg",
+        original_name="fixtures/libredwg-wrapper-smoke.dwg",
+    )
+
+
+def _install_fake_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    process: _FakeProcess,
+    output_text: str = '{"drawing": {"version": "R2018"}}',
+    stdout_text: str = "",
+    stderr_text: str = "SUCCESS\n",
+    write_output: bool = True,
+    format_output: bool = False,
+    on_spawn: Callable[[Path, Path, Path], None] | None = None,
+) -> dict[str, tuple[str, ...]]:
+    seen: dict[str, tuple[str, ...]] = {}
+
+    async def _fake_create_subprocess_exec(*command: str, **kwargs: Any) -> _FakeProcess:
+        output_flag_index = command.index("-o") + 1
+        output_path = Path(command[output_flag_index])
+        stdout_path = Path(cast(str, kwargs["stdout"].name))
+        stderr_path = Path(cast(str, kwargs["stderr"].name))
+        tempdir = str(output_path.parent)
+        source_path = command[output_flag_index + 1]
+        if write_output:
+            rendered_output = (
+                output_text.format(source=source_path, tempdir=tempdir, output=output_path)
+                if format_output
+                else output_text
+            )
+            output_path.write_text(rendered_output, encoding="utf-8")
+
+        stdout_handle = kwargs["stdout"]
+        stderr_handle = kwargs["stderr"]
+        stdout_payload = stdout_text.format(
+            source=source_path,
+            tempdir=tempdir,
+            output=output_path,
+        ).encode("utf-8")
+        stderr_payload = stderr_text.format(
+            source=source_path,
+            tempdir=tempdir,
+            output=output_path,
+        ).encode("utf-8")
+        stdout_handle.write(
+            stdout_payload
+        )
+        stdout_handle.flush()
+        stderr_handle.write(stderr_payload)
+        stderr_handle.flush()
+
+        if on_spawn is not None:
+            on_spawn(output_path, stdout_path, stderr_path)
+
+        seen["command"] = command
+        return process
+
+    monkeypatch.setattr(
+        "app.ingestion.adapters.libredwg.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    return seen
+
+
+def _schedule_live_overflow_write(
+    *,
+    overflow_path_kind: str,
+    payload_text: str,
+) -> Callable[[Path, Path, Path], None]:
+    background_tasks: list[asyncio.Task[None]] = []
+
+    def _on_spawn(output_path: Path, stdout_path: Path, stderr_path: Path) -> None:
+        target_path = {
+            "output": output_path,
+            "stdout": stdout_path,
+            "stderr": stderr_path,
+        }[overflow_path_kind]
+
+        async def _writer() -> None:
+            await asyncio.sleep(adapter_module._PROCESS_POLL_INTERVAL_SECONDS)
+            target_path.write_text(payload_text, encoding="utf-8")
+
+        background_tasks.append(asyncio.create_task(_writer()))
+
+    return _on_spawn
+
+
+def test_probe_reports_missing_binary_with_license_review_posture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: None)
+
+    availability = adapter_module.create_adapter().probe()
+
+    assert availability.status is AdapterStatus.UNAVAILABLE
+    assert availability.availability_reason is AvailabilityReason.MISSING_BINARY
+    assert [(item.kind.value, item.name, item.status.value) for item in availability.observed] == [
+        ("binary", "dwgread", "missing"),
+        ("license", "libredwg-distribution-review", "available"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ingest_preflights_missing_binary_as_shared_unavailable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: None)
+
+    with pytest.raises(AdapterUnavailableError) as exc_info:
+        await adapter_module.create_adapter().ingest(
+            _build_source(),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.1)),
+        )
+
+    assert exc_info.value.availability_reason is AvailabilityReason.MISSING_BINARY
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_emits_review_gated_placeholder_canonical_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _build_source()
+    process = _FakeProcess(complete_with=0)
+    seen = _install_fake_subprocess(
+        monkeypatch,
+        process=process,
+        stdout_text="reading {source}\n",
+        stderr_text="wrote {source} to {output} from {tempdir}\n",
+    )
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+
+    adapter = adapter_module.create_adapter()
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=InputFamily.DWG,
+        adapter_key="libredwg",
+        expectation=ContractFinalizationExpectation(
+            validation_status="needs_review",
+            review_state="review_required",
+            quantity_gate="review_gated",
+            warning_codes=("libredwg.placeholder_canonical",),
+            diagnostic_codes=("libredwg.extract",),
+        ),
+    )
+
+    command = seen["command"]
+    output_path = Path(command[4])
+    assert command[:4] == ("/opt/homebrew/bin/dwgread", "-O", "JSON", "-o")
+    assert output_path.parent != _FIXTURE_PATH.parent
+    assert payload.canonical_json["entities"] == []
+    assert payload.canonical_json["metadata"]["adapter_mode"] == "placeholder"
+
+    result = await adapter.ingest(
+        source,
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+    )
+    second_output_path = Path(seen["command"][4])
+    diagnostic_details = cast(Mapping[str, object], result.diagnostics[0].details)
+    stdout_excerpt = cast(str, diagnostic_details["stdout_excerpt"])
+    stderr_excerpt = cast(str, diagnostic_details["stderr_excerpt"])
+    assert str(source.file_path) not in stdout_excerpt
+    assert str(source.file_path) not in stderr_excerpt
+    assert str(second_output_path.parent) not in stderr_excerpt
+    assert "<source>" in stdout_excerpt
+    assert "<tempdir>" in stderr_excerpt
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_rejects_oversized_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oversized_output = json.dumps({"x": "y" * adapter_module._MAX_OUTPUT_BYTES})
+    process = _FakeProcess(complete_with=0)
+    _install_fake_subprocess(monkeypatch, process=process, output_text=oversized_output)
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+
+    with pytest.raises(RuntimeError, match="output limit"):
+        await adapter_module.create_adapter().ingest(
+            _build_source(),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overflow_path_kind", "payload_text", "expected_message"),
+    [
+        ("stdout", "A" * (adapter_module._MAX_STDOUT_BYTES + 1), "stdout exceeded"),
+        ("stderr", "B" * (adapter_module._MAX_STDERR_BYTES + 1), "stderr exceeded"),
+        (
+            "output",
+            json.dumps({"x": "y" * adapter_module._MAX_OUTPUT_BYTES}),
+            "JSON output exceeded",
+        ),
+    ],
+)
+async def test_libredwg_adapter_kills_process_on_live_output_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+    overflow_path_kind: str,
+    payload_text: str,
+    expected_message: str,
+) -> None:
+    process = _FakeProcess(complete_with=0, complete_when=asyncio.Event())
+    _install_fake_subprocess(
+        monkeypatch,
+        process=process,
+        write_output=overflow_path_kind != "output",
+        on_spawn=_schedule_live_overflow_write(
+            overflow_path_kind=overflow_path_kind,
+            payload_text=payload_text,
+        ),
+    )
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+    monkeypatch.setattr(adapter_module, "_PROCESS_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_TERMINATE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_KILL_GRACE_SECONDS", 0.01)
+
+    with pytest.raises(RuntimeError, match=expected_message):
+        await adapter_module.create_adapter().ingest(
+            _build_source(),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+        )
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_terminates_and_kills_process_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess()
+    _install_fake_subprocess(monkeypatch, process=process)
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+    monkeypatch.setattr(adapter_module, "_PROCESS_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_TERMINATE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_KILL_GRACE_SECONDS", 0.01)
+
+    with pytest.raises(TimeoutError):
+        await adapter_module.create_adapter().ingest(
+            _build_source(),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.02)),
+        )
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_handles_task_cancellation_while_process_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess()
+    seen = _install_fake_subprocess(monkeypatch, process=process)
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+    monkeypatch.setattr(adapter_module, "_PROCESS_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_TERMINATE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_KILL_GRACE_SECONDS", 0.01)
+
+    task = asyncio.create_task(
+        adapter_module.create_adapter().ingest(
+            _build_source(),
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+        )
+    )
+    while "command" not in seen:
+        await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_reports_sanitized_stdio_excerpts_within_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess(complete_with=0)
+    stdout_template = "{source} {tempdir}\n" + ("A" * 1024)
+    stderr_template = "{source} {tempdir}\n" + ("B" * 1024)
+    seen = _install_fake_subprocess(
+        monkeypatch,
+        process=process,
+        stdout_text=stdout_template,
+        stderr_text=stderr_template,
+    )
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+
+    source = _build_source()
+    result = await adapter_module.create_adapter().ingest(
+        source,
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+    )
+
+    command = seen["command"]
+    output_path = Path(command[4])
+    source_path = str(source.file_path)
+    tempdir = str(output_path.parent)
+    expected_stdout_bytes = len(
+        stdout_template.format(source=source_path, tempdir=tempdir, output=output_path).encode(
+            "utf-8"
+        )
+    )
+    expected_stderr_bytes = len(
+        stderr_template.format(source=source_path, tempdir=tempdir, output=output_path).encode(
+            "utf-8"
+        )
+    )
+
+    diagnostic_details = cast(Mapping[str, object], result.diagnostics[0].details)
+    stdout_excerpt = cast(str, diagnostic_details["stdout_excerpt"])
+    stderr_excerpt = cast(str, diagnostic_details["stderr_excerpt"])
+
+    assert diagnostic_details["stdout_bytes"] == expected_stdout_bytes
+    assert diagnostic_details["stderr_bytes"] == expected_stderr_bytes
+    assert diagnostic_details["stdout_truncated"] is False
+    assert diagnostic_details["stderr_truncated"] is False
+    assert "<source>" in stdout_excerpt
+    assert "<tempdir>" in stdout_excerpt
+    assert "<source>" in stderr_excerpt
+    assert "<tempdir>" in stderr_excerpt
+    assert source_path not in stdout_excerpt
+    assert source_path not in stderr_excerpt
+    assert tempdir not in stdout_excerpt
+    assert tempdir not in stderr_excerpt
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_nonzero_exit_failure_is_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _build_source()
+    process = _FakeProcess(complete_with=3)
+    seen = _install_fake_subprocess(
+        monkeypatch,
+        process=process,
+        stdout_text="failed for {source} in {tempdir}\n",
+        stderr_text="error while writing {output}\n",
+    )
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+
+    with pytest.raises(RuntimeError, match="execution failed") as exc_info:
+        await adapter_module.create_adapter().ingest(
+            source,
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+        )
+
+    output_path = Path(seen["command"][4])
+    tempdir = str(output_path.parent)
+    message = str(exc_info.value)
+    assert str(source.file_path) not in message
+    assert tempdir not in message
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_missing_output_failure_is_sanitized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _build_source()
+    process = _FakeProcess(complete_with=0)
+    seen = _install_fake_subprocess(
+        monkeypatch,
+        process=process,
+        write_output=False,
+        stdout_text="source={source} tempdir={tempdir}\n",
+    )
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+
+    with pytest.raises(RuntimeError, match="did not produce JSON output") as exc_info:
+        await adapter_module.create_adapter().ingest(
+            source,
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+        )
+
+    tempdir = str(Path(seen["command"][4]).parent)
+    message = str(exc_info.value)
+    assert str(source.file_path) not in message
+    assert tempdir not in message
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_invalid_json_failure_sanitizes_decode_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _build_source()
+    process = _FakeProcess(complete_with=0)
+    seen = _install_fake_subprocess(
+        monkeypatch,
+        process=process,
+        output_text='{{"source":"{source}","tempdir":"{tempdir}"',
+        format_output=True,
+    )
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+
+    with pytest.raises(RuntimeError, match="output was invalid") as exc_info:
+        await adapter_module.create_adapter().ingest(
+            source,
+            AdapterExecutionOptions(timeout=AdapterTimeout(seconds=0.5)),
+        )
+
+    tempdir = str(Path(seen["command"][4]).parent)
+    message = str(exc_info.value)
+    assert str(source.file_path) not in message
+    assert tempdir not in message
+
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, json.JSONDecodeError)
+    assert str(source.file_path) not in cause.doc
+    assert tempdir not in cause.doc
+    assert "<source>" in cause.doc
+    assert "<tempdir>" in cause.doc
+
+
+@pytest.mark.asyncio
+async def test_libredwg_adapter_terminates_and_kills_process_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess()
+    cancellation = _DeferredCancellation(cancel_after_calls=4)
+    _install_fake_subprocess(monkeypatch, process=process)
+    monkeypatch.setattr(adapter_module, "_binary_path", lambda: "/opt/homebrew/bin/dwgread")
+    monkeypatch.setattr(adapter_module, "_PROCESS_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_TERMINATE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(adapter_module, "_PROCESS_KILL_GRACE_SECONDS", 0.01)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter_module.create_adapter().ingest(
+            _build_source(),
+            AdapterExecutionOptions(
+                timeout=AdapterTimeout(seconds=0.5),
+                cancellation=cancellation,
+            ),
+        )
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1


### PR DESCRIPTION
Closes #100

## Summary
- Add a thin `dwgread`-backed LibreDWG adapter behind the ingestion contract so DWG smoke ingestion can run without bundling LibreDWG into the Python environment
- Unify adapter preflight-unavailable handling so missing binary/runtime/license posture surfaces as `ADAPTER_UNAVAILABLE`
- Add fake subprocess coverage for placeholder DWG ingestion, timeout/cancellation cleanup, sanitized diagnostics, and live stdout/stderr/JSON overflow enforcement

## Test plan
- [x] `uv run ruff check app tests`
- [x] `uv run mypy app tests`
- [x] `uv build`
- [x] `uv run pytest`

## Notes
- No breaking changes
- Uses placeholder canonical output for Phase 2 smoke coverage while keeping the adapter replaceable