### PR TITLE
test: add upload-to-ingest smoke coverage

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -262,6 +262,7 @@ class TestIngestWorkflowSmoke:
         """Run one ingest happy path and verify persisted output visibility."""
         generated_at = datetime(2026, 1, 1, tzinfo=UTC)
         payload = _fake_ingest_payload(generated_at=generated_at)
+        enqueued_job_ids: list[UUID] = []
 
         async def _fake_run_ingestion(
             *args: object, **kwargs: object
@@ -269,7 +270,11 @@ class TestIngestWorkflowSmoke:
             del args, kwargs
             return payload
 
+        def _fake_enqueue_ingest_job(job_id: UUID) -> None:
+            enqueued_job_ids.append(job_id)
+
         monkeypatch.setattr("app.jobs.worker.run_ingestion", _fake_run_ingestion)
+        monkeypatch.setattr("app.api.v1.files.enqueue_ingest_job", _fake_enqueue_ingest_job)
 
         project_response = await async_client.post(
             "/v1/projects",
@@ -289,6 +294,8 @@ class TestIngestWorkflowSmoke:
         assert upload_data["initial_extraction_profile_id"] is not None
 
         job_id = UUID(upload_data["initial_job_id"])
+        assert enqueued_job_ids == [job_id]
+
         await process_ingest_job(job_id)
 
         job_response = await async_client.get(f"/v1/jobs/{job_id}")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,16 +5,29 @@ import json
 import logging
 import os
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from uuid import UUID
 
 import httpx
 import pytest
-from fastapi import FastAPI
-from httpx import ASGITransport
+from sqlalchemy import select
 
+import app.api.v1.system as system_endpoints
 from app import __version__
 from app.core.config import settings
 from app.core.middleware import REQUEST_ID_PATTERN
-from app.main import app as fastapi_app
+from app.db.session import AsyncSessionLocal
+from app.ingestion.finalization import IngestFinalizationPayload
+from app.jobs.worker import _INITIAL_INGEST_REVISION_KIND, process_ingest_job
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.drawing_revision import DrawingRevision
+from app.models.validation_report import ValidationReport
+from app.schemas.system import (
+    AdapterHealthCheck,
+    DependencyHealthCheck,
+    SystemCheckStatus,
+)
+from tests.conftest import requires_database
 
 
 def test_version() -> None:
@@ -23,19 +36,37 @@ def test_version() -> None:
     assert len(__version__) > 0
 
 
-@pytest.fixture
-def app() -> FastAPI:
-    """Provide the FastAPI application instance for testing."""
-    return fastapi_app
-
-
-@pytest.fixture
-async def async_client(app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
-    """Provide an async HTTP client for testing."""
-    transport = ASGITransport(app=app)
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        yield client
-
+def _fake_ingest_payload(*, generated_at: datetime) -> IngestFinalizationPayload:
+    return IngestFinalizationPayload(
+        revision_kind=_INITIAL_INGEST_REVISION_KIND,
+        adapter_key="smoke-test-adapter",
+        adapter_version="0.0.1",
+        input_family="vector_pdf",
+        canonical_entity_schema_version="v1",
+        canonical_json={"entities": []},
+        provenance_json={"source": "smoke-test"},
+        confidence_json={"entities": []},
+        confidence_score=0.99,
+        warnings_json=[],
+        diagnostics_json={},
+        result_checksum_sha256="a" * 64,
+        validation_report_schema_version="0.1",
+        validation_status="valid_with_warnings",
+        review_state="approved",
+        quantity_gate="allowed",
+        effective_confidence=0.99,
+        validator_name="smoke-validator",
+        validator_version="0.0.1",
+        report_json={
+            "summary": {"status": "ok", "issues": 0},
+            "checks": [],
+            "findings": [],
+            "adapter_warnings": [],
+            "provenance": {},
+            "validator": {"name": "smoke-validator", "version": "0.0.1"},
+        },
+        generated_at=generated_at,
+    )
 
 class TestHealthEndpoint:
     """Smoke tests for the health check endpoint."""
@@ -161,6 +192,151 @@ class TestHealthEndpoint:
             f"Request ID '{request_id}' from response header not found "
             f"in structlog JSON output. Captured stdout: {stdout_output[:500]}"
         )
+
+
+class TestSystemHealthSmoke:
+    """Smoke tests for degraded system health behavior."""
+
+    async def test_system_health_degraded_while_shallow_health_stays_ok(
+        self,
+        async_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """System health should degrade independently from shallow health."""
+
+        async def _probe_database_ok() -> DependencyHealthCheck:
+            return DependencyHealthCheck(
+                status=SystemCheckStatus.OK,
+                latency_ms=1.0,
+                details={"reachable": True},
+            )
+
+        async def _probe_storage_ok() -> DependencyHealthCheck:
+            return DependencyHealthCheck(
+                status=SystemCheckStatus.OK,
+                latency_ms=1.0,
+                details=None,
+            )
+
+        async def _probe_broker_degraded() -> DependencyHealthCheck:
+            return DependencyHealthCheck(
+                status=SystemCheckStatus.DEGRADED,
+                latency_ms=1.0,
+                details={"reachable": True, "warning": "simulated"},
+            )
+
+        async def _probe_adapters_ok() -> tuple[
+            list[AdapterHealthCheck],
+            SystemCheckStatus,
+        ]:
+            return ([], SystemCheckStatus.OK)
+
+        monkeypatch.setattr(system_endpoints, "_probe_database_check", _probe_database_ok)
+        monkeypatch.setattr(system_endpoints, "_probe_storage_check", _probe_storage_ok)
+        monkeypatch.setattr(system_endpoints, "_probe_broker_check", _probe_broker_degraded)
+        monkeypatch.setattr(system_endpoints, "_build_adapter_health_checks", _probe_adapters_ok)
+
+        system_response = await async_client.get("/v1/system/health")
+
+        assert system_response.status_code == 503
+        system_data = system_response.json()
+        assert system_data["status"] == "degraded"
+        assert system_data["checks"]["broker"]["status"] == "degraded"
+
+        shallow_response = await async_client.get("/v1/health")
+
+        assert shallow_response.status_code == 200
+        assert shallow_response.json()["status"] == "ok"
+
+
+@requires_database
+@pytest.mark.usefixtures("init_database_resources")
+class TestIngestWorkflowSmoke:
+    """Smoke tests for upload -> ingest -> persisted output visibility."""
+
+    async def test_upload_ingest_job_persists_outputs_and_exposes_validation(
+        self,
+        async_client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Run one ingest happy path and verify persisted output visibility."""
+        generated_at = datetime(2026, 1, 1, tzinfo=UTC)
+        payload = _fake_ingest_payload(generated_at=generated_at)
+
+        async def _fake_run_ingestion(
+            *args: object, **kwargs: object
+        ) -> IngestFinalizationPayload:
+            del args, kwargs
+            return payload
+
+        monkeypatch.setattr("app.jobs.worker.run_ingestion", _fake_run_ingestion)
+
+        project_response = await async_client.post(
+            "/v1/projects",
+            json={"name": "smoke-project"},
+        )
+        assert project_response.status_code == 201
+        project_id = project_response.json()["id"]
+
+        upload_response = await async_client.post(
+            f"/v1/projects/{project_id}/files",
+            files={"file": ("smoke.pdf", b"%PDF-1.4\n%%EOF\n", "application/pdf")},
+        )
+
+        assert upload_response.status_code == 201
+        upload_data = upload_response.json()
+        assert upload_data["initial_job_id"] is not None
+        assert upload_data["initial_extraction_profile_id"] is not None
+
+        job_id = UUID(upload_data["initial_job_id"])
+        await process_ingest_job(job_id)
+
+        job_response = await async_client.get(f"/v1/jobs/{job_id}")
+        assert job_response.status_code == 200
+        job_data = job_response.json()
+        assert job_data["status"] == "completed"
+        assert job_data["finished_at"] is not None
+
+        assert AsyncSessionLocal is not None
+        async with AsyncSessionLocal() as db_session:
+            adapter_output = await db_session.scalar(
+                select(AdapterRunOutput).where(AdapterRunOutput.source_job_id == job_id)
+            )
+            assert adapter_output is not None
+
+            drawing_revision = await db_session.scalar(
+                select(DrawingRevision).where(DrawingRevision.source_job_id == job_id)
+            )
+            assert drawing_revision is not None
+
+            validation_report = await db_session.scalar(
+                select(ValidationReport).where(ValidationReport.source_job_id == job_id)
+            )
+            assert validation_report is not None
+
+        validation_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/validation-report"
+        )
+        assert validation_response.status_code == 200
+        validation_data = validation_response.json()
+        assert validation_data["drawing_revision_id"] == str(drawing_revision.id)
+        assert validation_data["source_job_id"] == str(job_id)
+
+    async def test_upload_rejects_missing_file(
+        self,
+        async_client: httpx.AsyncClient,
+    ) -> None:
+        """Upload endpoint rejects requests without multipart file content."""
+        project_response = await async_client.post(
+            "/v1/projects",
+            json={"name": "smoke-project-missing-file"},
+        )
+        assert project_response.status_code == 201
+        project_id = project_response.json()["id"]
+
+        upload_response = await async_client.post(f"/v1/projects/{project_id}/files")
+
+        assert upload_response.status_code == 422
 
 
 # Skip unless SMOKE_BASE_URL is set (for compose-stack testing)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -301,7 +301,7 @@ class TestIngestWorkflowSmoke:
         job_response = await async_client.get(f"/v1/jobs/{job_id}")
         assert job_response.status_code == 200
         job_data = job_response.json()
-        assert job_data["status"] == "completed"
+        assert job_data["status"] == "succeeded"
         assert job_data["finished_at"] is not None
 
         assert AsyncSessionLocal is not None


### PR DESCRIPTION
Closes #103

## Summary
- Add end-to-end smoke coverage for the upload-to-ingest path so CI exercises the integration points that unit and contract tests cannot cover alone.
- Verify degraded system health reporting does not change the shallow `/v1/health` contract, preserving the intended separation between shallow and dependency-aware health checks.
- Add a small negative upload smoke case to confirm missing multipart file content is rejected cleanly.

## Test plan
- [x] `uv run ruff check tests/test_smoke.py`
- [x] `uv run mypy tests/test_smoke.py`
- [x] `uv run pytest tests/test_smoke.py`
- [x] `uv run pytest tests/test_smoke.py tests/test_system_endpoints.py tests/test_ingest_output_persistence.py`

## Breaking changes
- None
