### PR TITLE
feat: persist SVG debug overlay artifacts

### DIFF
--- a/app/ingestion/debug_overlay.py
+++ b/app/ingestion/debug_overlay.py
@@ -1,0 +1,888 @@
+"""Deterministic SVG debug overlay primitives for canonical outputs."""
+
+from __future__ import annotations
+
+import html
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final
+
+from app.ingestion.contracts import JSONValue
+
+SVG_DEBUG_OVERLAY_FILENAME: Final[str] = "debug-overlay.svg"
+SVG_DEBUG_OVERLAY_MEDIA_TYPE: Final[str] = "image/svg+xml"
+
+_DEFAULT_LAYOUT_KEY: Final[str] = "__document__"
+_CANVAS_WIDTH: Final[float] = 1200.0
+_CANVAS_MARGIN: Final[float] = 24.0
+_HEADER_HEIGHT: Final[float] = 128.0
+_PANEL_WIDTH: Final[float] = _CANVAS_WIDTH - (_CANVAS_MARGIN * 2.0)
+_PANEL_MIN_HEIGHT: Final[float] = 240.0
+_PANEL_ROW_HEIGHT: Final[float] = 16.0
+_PANEL_GAP: Final[float] = 20.0
+_VIEWPORT_WIDTH: Final[float] = 400.0
+_VIEWPORT_PADDING: Final[float] = 12.0
+_CONFIDENCE_REVIEW_REQUIRED: Final[float] = 0.60
+_CONFIDENCE_PROVISIONAL: Final[float] = 0.95
+
+
+@dataclass(frozen=True, slots=True)
+class DebugOverlayArtifactPlan:
+    """Ready-to-store debug overlay artifact payload."""
+
+    filename: str
+    media_type: str
+    payload: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class _Point:
+    x: float
+    y: float
+
+
+@dataclass(frozen=True, slots=True)
+class _BBox:
+    x_min: float
+    y_min: float
+    x_max: float
+    y_max: float
+
+    @property
+    def width(self) -> float:
+        span = self.x_max - self.x_min
+        if not math.isfinite(span):
+            return 1.0
+        return max(span, 1.0)
+
+    @property
+    def height(self) -> float:
+        span = self.y_max - self.y_min
+        if not math.isfinite(span):
+            return 1.0
+        return max(span, 1.0)
+
+    @property
+    def center(self) -> _Point:
+        return _Point(
+            x=self.x_min + ((self.x_max - self.x_min) / 2.0),
+            y=self.y_min + ((self.y_max - self.y_min) / 2.0),
+        )
+
+    def padded(self) -> _BBox | None:
+        span_x = self.x_max - self.x_min
+        span_y = self.y_max - self.y_min
+        if not math.isfinite(span_x) or not math.isfinite(span_y):
+            return None
+
+        padding = max(max(span_x, 1.0), max(span_y, 1.0)) * 0.05
+        if padding <= 0:
+            padding = 1.0
+        x_min = self.x_min - padding
+        y_min = self.y_min - padding
+        x_max = self.x_max + padding
+        y_max = self.y_max + padding
+        if not all(math.isfinite(value) for value in (x_min, y_min, x_max, y_max)):
+            return None
+        return _BBox(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max)
+
+
+@dataclass(frozen=True, slots=True)
+class _CueStyle:
+    class_name: str
+    review_state: str
+
+
+@dataclass(frozen=True, slots=True)
+class _OverlayLayout:
+    key: str
+    label: str
+    page_number: int | None
+    bbox: _BBox | None
+
+    @property
+    def heading(self) -> str:
+        if self.page_number is None:
+            return f"Layout: {self.label}"
+        return f"Layout: {self.label} | Page: {self.page_number}"
+
+
+@dataclass(frozen=True, slots=True)
+class _OverlayEntity:
+    stable_id: str
+    kind: str
+    layout_key: str
+    bbox: _BBox | None
+    points: tuple[_Point, ...]
+    start: _Point | None
+    end: _Point | None
+    cue: _CueStyle
+    confidence_score: float | None
+
+    @property
+    def has_geometry(self) -> bool:
+        return self.geometry_bounds() is not None
+
+    @property
+    def summary(self) -> str:
+        confidence = f"{self.confidence_score:.2f}" if self.confidence_score is not None else "n/a"
+        return f"{self.stable_id} | {self.kind} | {self.cue.review_state} | {confidence}"
+
+    def geometry_bounds(self) -> _BBox | None:
+        if self.bbox is not None:
+            return _validated_bbox(self.bbox)
+
+        points: list[_Point] = []
+        if len(self.points) >= 2:
+            points.extend(self.points)
+        if self.start is not None and self.end is not None:
+            points.extend((self.start, self.end))
+        if not points:
+            return None
+
+        x_values = [point.x for point in points]
+        y_values = [point.y for point in points]
+        return _validated_bbox(
+            _BBox(
+                x_min=min(x_values),
+                y_min=min(y_values),
+                x_max=max(x_values),
+                y_max=max(y_values),
+            )
+        )
+
+
+def plan_svg_debug_overlay(
+    canonical: Mapping[str, JSONValue],
+    *,
+    title: str,
+    source_label: str,
+    review_state: str | None = None,
+    confidence_score: float | None = None,
+) -> DebugOverlayArtifactPlan:
+    """Plan a deterministic SVG debug overlay artifact for later finalization."""
+    return DebugOverlayArtifactPlan(
+        filename=SVG_DEBUG_OVERLAY_FILENAME,
+        media_type=SVG_DEBUG_OVERLAY_MEDIA_TYPE,
+        payload=generate_svg_debug_overlay(
+            canonical,
+            title=title,
+            source_label=source_label,
+            review_state=review_state,
+            confidence_score=confidence_score,
+        ),
+    )
+
+
+def generate_svg_debug_overlay(
+    canonical: Mapping[str, JSONValue],
+    *,
+    title: str,
+    source_label: str,
+    review_state: str | None = None,
+    confidence_score: float | None = None,
+) -> bytes:
+    """Render a deterministic SVG debug overlay for canonical entities."""
+    layouts = _parse_layouts(canonical.get("layouts"))
+    entities = _parse_entities(
+        canonical.get("entities"),
+        fallback_review_state=review_state,
+        fallback_confidence_score=confidence_score,
+    )
+    grouped_entities = _group_entities_by_layout(layouts, entities)
+    ordered_layouts = _ordered_layouts(layouts, grouped_entities)
+    overall_review_state = review_state or "unknown"
+
+    panel_heights = {
+        layout.key: _panel_height(grouped_entities.get(layout.key, ()))
+        for layout in ordered_layouts
+    }
+    total_height = (
+        _HEADER_HEIGHT
+        + sum(panel_heights.values())
+        + (_PANEL_GAP * max(len(ordered_layouts) - 1, 0))
+        + _CANVAS_MARGIN
+    )
+
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        "<!-- Debug overlay only; not source of truth. -->",
+        (
+            '<svg xmlns="http://www.w3.org/2000/svg" '
+            f'width="{_format_number(_CANVAS_WIDTH)}" '
+            f'height="{_format_number(total_height)}" '
+            f'viewBox="0 0 {_format_number(_CANVAS_WIDTH)} {_format_number(total_height)}" '
+            'role="img" aria-labelledby="overlay-title overlay-desc">'
+        ),
+        f'  <title id="overlay-title">{_escape(title)} debug overlay</title>',
+        (
+            '  <desc id="overlay-desc">'
+            f"Diagnostic overlay for {_escape(source_label)}. Not source of truth."
+            "</desc>"
+        ),
+        "  <defs>",
+        "    <style>",
+        "      .bg { fill: #0f172a; }",
+        ("      .panel { fill: #111827; stroke: #334155; stroke-width: 1; rx: 12; ry: 12; }"),
+        ("      .viewport { fill: #020617; stroke: #475569; stroke-width: 1; rx: 8; ry: 8; }"),
+        (
+            "      .layout-box { fill: none; stroke: #64748b; stroke-width: 1; "
+            "stroke-dasharray: 4 4; }"
+        ),
+        "      .label { fill: #e2e8f0; font-family: monospace; font-size: 12px; }",
+        "      .meta { fill: #94a3b8; font-family: monospace; font-size: 12px; }",
+        (
+            "      .marker { fill: #f87171; font-family: monospace; font-size: 14px; "
+            "font-weight: 700; }"
+        ),
+        "      .entity-text { fill: #cbd5e1; font-family: monospace; font-size: 11px; }",
+        (
+            "      .placeholder { fill: #1e293b; stroke: #64748b; stroke-width: 1; "
+            "stroke-dasharray: 6 4; }"
+        ),
+        "      .cue-approved { stroke: #16a34a; fill: rgba(22, 163, 74, 0.08); }",
+        "      .cue-provisional { stroke: #d97706; fill: rgba(217, 119, 6, 0.08); }",
+        "      .cue-review-required { stroke: #dc2626; fill: rgba(220, 38, 38, 0.08); }",
+        "      .cue-rejected { stroke: #991b1b; fill: rgba(153, 27, 27, 0.08); }",
+        "      .cue-superseded { stroke: #475569; fill: rgba(71, 85, 105, 0.08); }",
+        "      .geometry { fill: none; stroke-width: 2; }",
+        "      .bbox { fill: none; stroke-width: 1; stroke-dasharray: 4 3; opacity: 0.8; }",
+        "    </style>",
+        "  </defs>",
+        _svg_rect(
+            class_name="bg",
+            x=0.0,
+            y=0.0,
+            width=_CANVAS_WIDTH,
+            height=total_height,
+        ),
+        _svg_text(
+            class_name="label",
+            x=_CANVAS_MARGIN,
+            y=40.0,
+            content=f"Title: {_escape(title)}",
+        ),
+        _svg_text(
+            class_name="meta",
+            x=_CANVAS_MARGIN,
+            y=62.0,
+            content=f"Source: {_escape(source_label)}",
+        ),
+        _svg_text(
+            class_name="meta",
+            x=_CANVAS_MARGIN,
+            y=84.0,
+            content=(
+                f"Review: {_escape(overall_review_state)} | "
+                f"Confidence: {_format_confidence(confidence_score)}"
+            ),
+        ),
+        _svg_text(
+            class_name="marker",
+            x=_CANVAS_MARGIN,
+            y=108.0,
+            content="NOT SOURCE OF TRUTH — diagnostic overlay only",
+        ),
+    ]
+
+    panel_y = _CANVAS_MARGIN + _HEADER_HEIGHT
+    for layout in ordered_layouts:
+        layout_entities = grouped_entities.get(layout.key, ())
+        panel_lines = _render_layout_panel(
+            layout,
+            layout_entities,
+            x=_CANVAS_MARGIN,
+            y=panel_y,
+            width=_PANEL_WIDTH,
+            height=panel_heights[layout.key],
+        )
+        lines.extend(panel_lines)
+        panel_y += panel_heights[layout.key] + _PANEL_GAP
+
+    lines.append("</svg>")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _parse_layouts(value: object) -> tuple[_OverlayLayout, ...]:
+    layouts: list[_OverlayLayout] = []
+    for index, item in enumerate(_sequence(value), start=1):
+        if not isinstance(item, Mapping):
+            continue
+        name = _string(item.get("name")) or f"layout-{index}"
+        layouts.append(
+            _OverlayLayout(
+                key=name,
+                label=name,
+                page_number=_int(item.get("page_number")),
+                bbox=_bbox(item.get("bbox")),
+            )
+        )
+    if layouts:
+        return tuple(layouts)
+    return (
+        _OverlayLayout(
+            key=_DEFAULT_LAYOUT_KEY,
+            label="document",
+            page_number=None,
+            bbox=None,
+        ),
+    )
+
+
+def _parse_entities(
+    value: object,
+    *,
+    fallback_review_state: str | None,
+    fallback_confidence_score: float | None,
+) -> tuple[_OverlayEntity, ...]:
+    entities: list[_OverlayEntity] = []
+    for index, item in enumerate(_sequence(value), start=1):
+        if not isinstance(item, Mapping):
+            continue
+
+        layout_key = _string(item.get("layout")) or _DEFAULT_LAYOUT_KEY
+        stable_id = (
+            _string(item.get("entity_id"))
+            or _string(item.get("id"))
+            or f"{layout_key}:entity-{index:04d}"
+        )
+        kind = _string(item.get("kind")) or _string(item.get("entity_type")) or "entity"
+        entity_review_state = (
+            _string(item.get("review_state")) or fallback_review_state or "unknown"
+        )
+        entity_confidence_score = _entity_confidence_score(item, fallback_confidence_score)
+        entities.append(
+            _OverlayEntity(
+                stable_id=stable_id,
+                kind=kind,
+                layout_key=layout_key,
+                bbox=_bbox(item.get("bbox")),
+                points=_points(item.get("points")),
+                start=_point(item.get("start")),
+                end=_point(item.get("end")),
+                cue=_cue_style(entity_review_state, entity_confidence_score),
+                confidence_score=entity_confidence_score,
+            )
+        )
+    return tuple(entities)
+
+
+def _group_entities_by_layout(
+    layouts: tuple[_OverlayLayout, ...],
+    entities: tuple[_OverlayEntity, ...],
+) -> dict[str, tuple[_OverlayEntity, ...]]:
+    grouped: dict[str, list[_OverlayEntity]] = {layout.key: [] for layout in layouts}
+    for entity in entities:
+        grouped.setdefault(entity.layout_key, []).append(entity)
+    return {key: tuple(items) for key, items in grouped.items()}
+
+
+def _ordered_layouts(
+    layouts: tuple[_OverlayLayout, ...],
+    grouped_entities: Mapping[str, tuple[_OverlayEntity, ...]],
+) -> tuple[_OverlayLayout, ...]:
+    ordered: list[_OverlayLayout] = list(layouts)
+    known = {layout.key for layout in layouts}
+    for key in grouped_entities:
+        if key in known:
+            continue
+        ordered.append(_OverlayLayout(key=key, label=key, page_number=None, bbox=None))
+    return tuple(ordered)
+
+
+def _panel_height(entities: Sequence[_OverlayEntity]) -> float:
+    row_count = max(len(entities), 1)
+    return max(_PANEL_MIN_HEIGHT, 132.0 + (row_count * _PANEL_ROW_HEIGHT))
+
+
+def _render_layout_panel(
+    layout: _OverlayLayout,
+    entities: Sequence[_OverlayEntity],
+    *,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+) -> list[str]:
+    lines = [
+        _svg_rect(class_name="panel", x=x, y=y, width=width, height=height),
+        _svg_text(
+            class_name="label",
+            x=x + 20.0,
+            y=y + 28.0,
+            content=_escape(layout.heading),
+        ),
+        _svg_text(
+            class_name="meta",
+            x=x + 20.0,
+            y=y + 48.0,
+            content=f"Entities: {len(entities)}",
+        ),
+    ]
+
+    viewport_x = x + 20.0
+    viewport_y = y + 62.0
+    viewport_height = height - 82.0
+    summary_x = viewport_x + _VIEWPORT_WIDTH + 28.0
+    summary_y = viewport_y + 14.0
+    lines.append(
+        _svg_rect(
+            class_name="viewport",
+            x=viewport_x,
+            y=viewport_y,
+            width=_VIEWPORT_WIDTH,
+            height=viewport_height,
+        )
+    )
+
+    bounds = _panel_bounds(layout, entities)
+    geometric_entities = [
+        entity for entity in entities if bounds is not None and entity.geometry_bounds() is not None
+    ]
+    placeholder_entities = [entity for entity in entities if entity not in geometric_entities]
+    layout_bbox = _validated_bbox(layout.bbox)
+
+    if layout_bbox is not None and bounds is not None:
+        lines.append(
+            _render_bbox(
+                layout_bbox,
+                bounds,
+                viewport_x,
+                viewport_y,
+                _VIEWPORT_WIDTH,
+                viewport_height,
+                "layout-box",
+            )
+        )
+
+    for entity in geometric_entities:
+        lines.extend(
+            _render_entity_geometry(
+                entity,
+                bounds,
+                viewport_x,
+                viewport_y,
+                _VIEWPORT_WIDTH,
+                viewport_height,
+            )
+        )
+
+    if placeholder_entities:
+        lines.extend(
+            _render_placeholder_entities(
+                placeholder_entities,
+                viewport_x,
+                viewport_y,
+                _VIEWPORT_WIDTH,
+                viewport_height,
+            )
+        )
+    elif not geometric_entities:
+        lines.append(
+            _svg_text(
+                class_name="entity-text",
+                x=viewport_x + 20.0,
+                y=viewport_y + 28.0,
+                content="No canonical geometry entities",
+            )
+        )
+
+    if entities:
+        for index, entity in enumerate(entities):
+            lines.append(
+                _svg_text(
+                    class_name="entity-text",
+                    x=summary_x,
+                    y=summary_y + (index * _PANEL_ROW_HEIGHT),
+                    content=_escape(entity.summary),
+                )
+            )
+    else:
+        lines.append(
+            _svg_text(
+                class_name="entity-text",
+                x=summary_x,
+                y=summary_y,
+                content="No canonical entities available for this layout",
+            )
+        )
+
+    return lines
+
+
+def _panel_bounds(
+    layout: _OverlayLayout,
+    entities: Sequence[_OverlayEntity],
+) -> _BBox | None:
+    boxes = [entity.geometry_bounds() for entity in entities]
+    finite_boxes = [box for box in boxes if box is not None]
+    layout_bbox = _validated_bbox(layout.bbox)
+    if layout_bbox is not None:
+        finite_boxes.insert(0, layout_bbox)
+    if not finite_boxes:
+        return None
+
+    x_min = min(box.x_min for box in finite_boxes)
+    y_min = min(box.y_min for box in finite_boxes)
+    x_max = max(box.x_max for box in finite_boxes)
+    y_max = max(box.y_max for box in finite_boxes)
+    return _BBox(x_min=x_min, y_min=y_min, x_max=x_max, y_max=y_max).padded()
+
+
+def _render_entity_geometry(
+    entity: _OverlayEntity,
+    bounds: _BBox | None,
+    viewport_x: float,
+    viewport_y: float,
+    viewport_width: float,
+    viewport_height: float,
+) -> list[str]:
+    if bounds is None:
+        return []
+
+    lines: list[str] = []
+    cue_class = entity.cue.class_name
+    if entity.bbox is not None:
+        lines.append(
+            _render_bbox(
+                entity.bbox,
+                bounds,
+                viewport_x,
+                viewport_y,
+                viewport_width,
+                viewport_height,
+                f"bbox {cue_class}",
+            )
+        )
+
+    if len(entity.points) >= 2:
+        points = [
+            _project_point(point, bounds, viewport_x, viewport_y, viewport_width, viewport_height)
+            for point in entity.points
+        ]
+        polyline_points = " ".join(
+            f"{_format_number(point.x)},{_format_number(point.y)}" for point in points
+        )
+        lines.append(_svg_polyline(class_name=f"geometry {cue_class}", points=polyline_points))
+        label_point = points[0]
+    elif entity.start is not None and entity.end is not None:
+        start = _project_point(
+            entity.start,
+            bounds,
+            viewport_x,
+            viewport_y,
+            viewport_width,
+            viewport_height,
+        )
+        end = _project_point(
+            entity.end,
+            bounds,
+            viewport_x,
+            viewport_y,
+            viewport_width,
+            viewport_height,
+        )
+        lines.append(
+            _svg_line(
+                class_name=f"geometry {cue_class}",
+                x1=start.x,
+                y1=start.y,
+                x2=end.x,
+                y2=end.y,
+            )
+        )
+        label_point = start
+    elif entity.bbox is not None:
+        label_point = _project_point(
+            entity.bbox.center,
+            bounds,
+            viewport_x,
+            viewport_y,
+            viewport_width,
+            viewport_height,
+        )
+    else:
+        return lines
+
+    lines.append(
+        _svg_text(
+            class_name="entity-text",
+            x=label_point.x + 6.0,
+            y=label_point.y - 6.0,
+            content=_escape(entity.stable_id),
+        )
+    )
+    return lines
+
+
+def _render_placeholder_entities(
+    entities: Sequence[_OverlayEntity],
+    viewport_x: float,
+    viewport_y: float,
+    viewport_width: float,
+    viewport_height: float,
+) -> list[str]:
+    lines: list[str] = []
+    placeholder_width = max(viewport_width - 24.0, 120.0)
+    placeholder_height = 26.0
+    for index, entity in enumerate(entities):
+        y_position = viewport_y + 12.0 + (index * 34.0)
+        if y_position + placeholder_height > viewport_y + viewport_height:
+            break
+        lines.append(
+            _svg_rect(
+                class_name=f"placeholder {entity.cue.class_name}",
+                x=viewport_x + 12.0,
+                y=y_position,
+                width=placeholder_width,
+                height=placeholder_height,
+            )
+        )
+        lines.append(
+            _svg_text(
+                class_name="entity-text",
+                x=viewport_x + 20.0,
+                y=y_position + 17.0,
+                content=f"{_escape(entity.stable_id)} | No canonical geometry",
+            )
+        )
+    return lines
+
+
+def _render_bbox(
+    bbox: _BBox,
+    bounds: _BBox,
+    viewport_x: float,
+    viewport_y: float,
+    viewport_width: float,
+    viewport_height: float,
+    class_name: str,
+) -> str:
+    top_left = _project_point(
+        _Point(x=bbox.x_min, y=bbox.y_max),
+        bounds,
+        viewport_x,
+        viewport_y,
+        viewport_width,
+        viewport_height,
+    )
+    bottom_right = _project_point(
+        _Point(x=bbox.x_max, y=bbox.y_min),
+        bounds,
+        viewport_x,
+        viewport_y,
+        viewport_width,
+        viewport_height,
+    )
+    width = max(bottom_right.x - top_left.x, 1.0)
+    height = max(bottom_right.y - top_left.y, 1.0)
+    return _svg_rect(
+        class_name=class_name,
+        x=top_left.x,
+        y=top_left.y,
+        width=width,
+        height=height,
+    )
+
+
+def _project_point(
+    point: _Point,
+    bounds: _BBox,
+    viewport_x: float,
+    viewport_y: float,
+    viewport_width: float,
+    viewport_height: float,
+) -> _Point:
+    drawable_width = max(viewport_width - (_VIEWPORT_PADDING * 2.0), 1.0)
+    drawable_height = max(viewport_height - (_VIEWPORT_PADDING * 2.0), 1.0)
+    scale = min(drawable_width / bounds.width, drawable_height / bounds.height)
+    scaled_width = bounds.width * scale
+    scaled_height = bounds.height * scale
+    offset_x = viewport_x + ((viewport_width - scaled_width) / 2.0)
+    offset_y = viewport_y + ((viewport_height - scaled_height) / 2.0)
+    x_position = offset_x + ((point.x - bounds.x_min) * scale)
+    y_position = offset_y + ((bounds.y_max - point.y) * scale)
+    return _Point(x=x_position, y=y_position)
+
+
+def _cue_style(review_state: str, confidence_score: float | None) -> _CueStyle:
+    normalized_review_state = review_state.strip().lower().replace("_", "-") or "unknown"
+    review_classes = {
+        "approved": "cue-approved",
+        "provisional": "cue-provisional",
+        "review-required": "cue-review-required",
+        "review_required": "cue-review-required",
+        "rejected": "cue-rejected",
+        "superseded": "cue-superseded",
+    }
+    class_name = review_classes.get(normalized_review_state)
+    if class_name is None:
+        class_name = _confidence_class(confidence_score)
+    display_review_state = normalized_review_state.replace("-", "_")
+    return _CueStyle(class_name=class_name, review_state=display_review_state)
+
+
+def _confidence_class(confidence_score: float | None) -> str:
+    if confidence_score is None or confidence_score < _CONFIDENCE_REVIEW_REQUIRED:
+        return "cue-review-required"
+    if confidence_score < _CONFIDENCE_PROVISIONAL:
+        return "cue-provisional"
+    return "cue-approved"
+
+
+def _entity_confidence_score(
+    entity: Mapping[str, object],
+    fallback_confidence_score: float | None,
+) -> float | None:
+    direct = _float(entity.get("confidence_score"))
+    if direct is not None:
+        return direct
+
+    confidence = entity.get("confidence")
+    if isinstance(confidence, Mapping):
+        nested_score = _float(confidence.get("score"))
+        if nested_score is not None:
+            return nested_score
+    else:
+        nested_score = _float(confidence)
+        if nested_score is not None:
+            return nested_score
+
+    return fallback_confidence_score
+
+
+def _sequence(value: object) -> tuple[object, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(value)
+    return ()
+
+
+def _point(value: object) -> _Point | None:
+    if not isinstance(value, Mapping):
+        return None
+    x = _float(value.get("x"))
+    y = _float(value.get("y"))
+    if x is None or y is None:
+        return None
+    return _Point(x=x, y=y)
+
+
+def _points(value: object) -> tuple[_Point, ...]:
+    points: list[_Point] = []
+    for item in _sequence(value):
+        point = _point(item)
+        if point is not None:
+            points.append(point)
+    return tuple(points)
+
+
+def _bbox(value: object) -> _BBox | None:
+    if not isinstance(value, Mapping):
+        return None
+    x_min = _float(value.get("x_min"))
+    y_min = _float(value.get("y_min"))
+    x_max = _float(value.get("x_max"))
+    y_max = _float(value.get("y_max"))
+    if x_min is None or y_min is None or x_max is None or y_max is None:
+        return None
+    minimum_x = min(x_min, x_max)
+    maximum_x = max(x_min, x_max)
+    minimum_y = min(y_min, y_max)
+    maximum_y = max(y_min, y_max)
+    return _BBox(x_min=minimum_x, y_min=minimum_y, x_max=maximum_x, y_max=maximum_y)
+
+
+def _string(value: object) -> str | None:
+    if isinstance(value, str):
+        candidate = value.strip()
+        return candidate or None
+    return None
+
+
+def _int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer() and math.isfinite(value):
+        return int(value)
+    return None
+
+
+def _validated_bbox(bbox: _BBox | None) -> _BBox | None:
+    if bbox is None:
+        return None
+
+    span_x = bbox.x_max - bbox.x_min
+    span_y = bbox.y_max - bbox.y_min
+    if not math.isfinite(span_x) or not math.isfinite(span_y):
+        return None
+
+    return bbox
+
+
+def _float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        candidate = float(value)
+        if math.isfinite(candidate):
+            return candidate
+    return None
+
+
+def _format_number(value: float) -> str:
+    if not math.isfinite(value):
+        return "0"
+    normalized = 0.0 if value == 0 else value
+    return f"{normalized:.6f}".rstrip("0").rstrip(".") or "0"
+
+
+def _format_confidence(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.2f}"
+
+
+def _svg_rect(
+    *,
+    class_name: str,
+    x: float,
+    y: float,
+    width: float,
+    height: float,
+) -> str:
+    return (
+        f'  <rect class="{class_name}" x="{_format_number(x)}" y="{_format_number(y)}" '
+        f'width="{_format_number(width)}" height="{_format_number(height)}" />'
+    )
+
+
+def _svg_text(*, class_name: str, x: float, y: float, content: str) -> str:
+    return (
+        f'  <text class="{class_name}" x="{_format_number(x)}" y="{_format_number(y)}">'
+        f"{content}</text>"
+    )
+
+
+def _svg_line(
+    *,
+    class_name: str,
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+) -> str:
+    return (
+        f'  <line class="{class_name}" x1="{_format_number(x1)}" y1="{_format_number(y1)}" '
+        f'x2="{_format_number(x2)}" y2="{_format_number(y2)}" />'
+    )
+
+
+def _svg_polyline(*, class_name: str, points: str) -> str:
+    return f'  <polyline class="{class_name}" points="{points}" />'
+
+
+def _escape(value: str) -> str:
+    return html.escape(value, quote=True)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -19,14 +19,18 @@ from app.core.errors import ErrorCode
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
 from app.ingestion.contracts import AdapterTimeout, ProgressUpdate
+from app.ingestion.debug_overlay import plan_svg_debug_overlay
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.file import File
+from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job
 from app.models.job_event import JobEvent
 from app.models.validation_report import ValidationReport
+from app.storage import get_storage
+from app.storage.keys import build_generated_artifact_storage_key
 
 logger = get_logger(__name__)
 
@@ -41,6 +45,10 @@ _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
 _PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
+_DEBUG_OVERLAY_ARTIFACT_KIND = "debug_overlay"
+_DEBUG_OVERLAY_ARTIFACT_FORMAT = "svg"
+_DEBUG_OVERLAY_GENERATOR_NAME = "app.ingestion.debug_overlay"
+_DEBUG_OVERLAY_GENERATOR_VERSION = "1"
 _SAFE_RUNNER_ERROR_DETAIL_KEYS = (
     "adapter_key",
     "input_family",
@@ -209,6 +217,27 @@ async def _get_latest_drawing_revision(
     return result.scalar_one_or_none()
 
 
+async def _get_generated_artifact_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    drawing_revision_id: UUID,
+    artifact_kind: str,
+) -> GeneratedArtifact | None:
+    """Load a committed artifact of a given kind for a drawing revision."""
+    result = await session.execute(
+        select(GeneratedArtifact)
+        .where(
+            (GeneratedArtifact.project_id == project_id)
+            & (GeneratedArtifact.drawing_revision_id == drawing_revision_id)
+            & (GeneratedArtifact.artifact_kind == artifact_kind)
+            & (GeneratedArtifact.deleted_at.is_(None))
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 def _resolve_revision_kind(job_id: UUID, *, initial_job_id: UUID | None) -> str:
     """Map file linkage to the correct ingest revision kind."""
     if initial_job_id == job_id:
@@ -301,6 +330,99 @@ def _build_persisted_validation_report_json(
     report_json["checks"] = checks
 
     return report_json
+
+
+def _build_debug_overlay_generator_config(
+    *,
+    title: str,
+    source_label: str,
+    review_state: str,
+    confidence_score: float,
+) -> dict[str, Any]:
+    """Build persisted generator settings for the debug overlay artifact."""
+    return {
+        "title": title,
+        "source_label": source_label,
+        "review_state": review_state,
+        "confidence_score": confidence_score,
+    }
+
+
+def _build_debug_overlay_lineage_json(
+    *,
+    source_file: File,
+    job: Job,
+    payload: IngestFinalizationPayload,
+    drawing_revision_id: UUID,
+    revision_sequence: int,
+    predecessor_revision_id: UUID | None,
+    adapter_run_output_id: UUID,
+) -> dict[str, Any]:
+    """Build lineage metadata for a persisted debug overlay artifact."""
+    entity_counts_json = payload.canonical_json.get("entity_counts")
+    entity_counts = deepcopy(entity_counts_json) if isinstance(entity_counts_json, dict) else {}
+
+    entities_json = payload.canonical_json.get("entities")
+    entity_total = len(entities_json) if isinstance(entities_json, list) else None
+
+    options_json = payload.provenance_json.get("options")
+    options = deepcopy(options_json) if isinstance(options_json, dict) else {}
+
+    return {
+        "source_file": {
+            "id": str(source_file.id),
+            "original_filename": source_file.original_filename,
+            "detected_format": source_file.detected_format,
+            "media_type": source_file.media_type,
+            "checksum_sha256": source_file.checksum_sha256,
+        },
+        "job": {
+            "id": str(job.id),
+            "extraction_profile_id": str(job.extraction_profile_id),
+            "attempts": job.attempts,
+        },
+        "drawing_revision": {
+            "id": str(drawing_revision_id),
+            "revision_sequence": revision_sequence,
+            "revision_kind": payload.revision_kind,
+            "predecessor_revision_id": (
+                str(predecessor_revision_id) if predecessor_revision_id is not None else None
+            ),
+        },
+        "adapter": {
+            "id": str(adapter_run_output_id),
+            "key": payload.adapter_key,
+            "version": payload.adapter_version,
+            "input_family": payload.input_family,
+            "result_checksum_sha256": payload.result_checksum_sha256,
+        },
+        "entities": {
+            "schema_version": payload.canonical_entity_schema_version,
+            "counts": entity_counts,
+            "total": entity_total,
+        },
+        "options": options,
+    }
+
+
+async def _cleanup_failed_storage_writes(
+    storage: Any,
+    writes: list[tuple[str, str]],
+    *,
+    job_id: UUID,
+) -> None:
+    """Best-effort cleanup for pre-commit immutable storage writes."""
+    for key, storage_uri in reversed(writes):
+        try:
+            await storage.delete_failed_put(key, storage_uri=storage_uri)
+        except Exception:
+            logger.warning(
+                "generated_artifact_cleanup_failed",
+                job_id=str(job_id),
+                storage_key=key,
+                storage_uri=storage_uri,
+                exc_info=True,
+            )
 
 
 async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
@@ -417,89 +539,185 @@ async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPaylo
             revision_sequence = predecessor_revision.revision_sequence + 1
             predecessor_revision_id = predecessor_revision.id
 
+        predecessor_debug_overlay = None
+        if predecessor_revision_id is not None:
+            predecessor_debug_overlay = await _get_generated_artifact_for_revision(
+                session,
+                project_id=job.project_id,
+                drawing_revision_id=predecessor_revision_id,
+                artifact_kind=_DEBUG_OVERLAY_ARTIFACT_KIND,
+            )
+
         adapter_run_output_id = uuid.uuid4()
         drawing_revision_id = uuid.uuid4()
         validation_report_id = uuid.uuid4()
+        debug_overlay_artifact_id = uuid.uuid4()
         finished_at = _utcnow()
+        overlay_source_label = source_file.original_filename
+        overlay_title = f"{overlay_source_label} revision {revision_sequence}"
+        overlay_plan = plan_svg_debug_overlay(
+            payload.canonical_json,
+            title=overlay_title,
+            source_label=overlay_source_label,
+            review_state=payload.review_state,
+            confidence_score=payload.confidence_score,
+        )
+        overlay_storage_key = build_generated_artifact_storage_key(
+            debug_overlay_artifact_id,
+            overlay_plan.filename,
+        )
+        overlay_generator_config = _build_debug_overlay_generator_config(
+            title=overlay_title,
+            source_label=overlay_source_label,
+            review_state=payload.review_state,
+            confidence_score=payload.confidence_score,
+        )
+        overlay_lineage_json = _build_debug_overlay_lineage_json(
+            source_file=source_file,
+            job=job,
+            payload=payload,
+            drawing_revision_id=drawing_revision_id,
+            revision_sequence=revision_sequence,
+            predecessor_revision_id=predecessor_revision_id,
+            adapter_run_output_id=adapter_run_output_id,
+        )
+        storage = get_storage()
+        written_storage_objects: list[tuple[str, str]] = []
+        commit_started = False
 
-        session.add(
-            AdapterRunOutput(
-                id=adapter_run_output_id,
-                project_id=job.project_id,
-                source_file_id=source_file.id,
-                extraction_profile_id=job.extraction_profile_id,
-                source_job_id=job.id,
-                adapter_key=payload.adapter_key,
-                adapter_version=payload.adapter_version,
-                input_family=payload.input_family,
-                canonical_entity_schema_version=payload.canonical_entity_schema_version,
-                canonical_json=payload.canonical_json,
-                provenance_json=payload.provenance_json,
-                confidence_json=payload.confidence_json,
-                confidence_score=payload.confidence_score,
-                warnings_json=payload.warnings_json,
-                diagnostics_json=payload.diagnostics_json,
-                result_checksum_sha256=payload.result_checksum_sha256,
+        try:
+            stored_overlay = await storage.put(
+                overlay_storage_key,
+                overlay_plan.payload,
+                immutable=True,
             )
-        )
-        session.add(
-            DrawingRevision(
-                id=drawing_revision_id,
-                project_id=job.project_id,
-                source_file_id=source_file.id,
-                extraction_profile_id=job.extraction_profile_id,
-                source_job_id=job.id,
-                adapter_run_output_id=adapter_run_output_id,
-                predecessor_revision_id=predecessor_revision_id,
-                revision_sequence=revision_sequence,
-                revision_kind=payload.revision_kind,
-                review_state=payload.review_state,
-                canonical_entity_schema_version=payload.canonical_entity_schema_version,
-                confidence_score=payload.confidence_score,
+            written_storage_objects.append((stored_overlay.key, stored_overlay.storage_uri))
+
+            session.add(
+                AdapterRunOutput(
+                    id=adapter_run_output_id,
+                    project_id=job.project_id,
+                    source_file_id=source_file.id,
+                    extraction_profile_id=job.extraction_profile_id,
+                    source_job_id=job.id,
+                    adapter_key=payload.adapter_key,
+                    adapter_version=payload.adapter_version,
+                    input_family=payload.input_family,
+                    canonical_entity_schema_version=payload.canonical_entity_schema_version,
+                    canonical_json=payload.canonical_json,
+                    provenance_json=payload.provenance_json,
+                    confidence_json=payload.confidence_json,
+                    confidence_score=payload.confidence_score,
+                    warnings_json=payload.warnings_json,
+                    diagnostics_json=payload.diagnostics_json,
+                    result_checksum_sha256=payload.result_checksum_sha256,
+                )
             )
-        )
-        session.add(
-            ValidationReport(
-                id=validation_report_id,
-                project_id=job.project_id,
-                drawing_revision_id=drawing_revision_id,
-                source_job_id=job.id,
-                validation_report_schema_version=payload.validation_report_schema_version,
-                canonical_entity_schema_version=payload.canonical_entity_schema_version,
-                validation_status=payload.validation_status,
-                review_state=payload.review_state,
-                quantity_gate=payload.quantity_gate,
-                effective_confidence=payload.effective_confidence,
-                validator_name=payload.validator_name,
-                validator_version=payload.validator_version,
-                report_json=_build_persisted_validation_report_json(
-                    payload,
+            session.add(
+                DrawingRevision(
+                    id=drawing_revision_id,
+                    project_id=job.project_id,
+                    source_file_id=source_file.id,
+                    extraction_profile_id=job.extraction_profile_id,
+                    source_job_id=job.id,
+                    adapter_run_output_id=adapter_run_output_id,
+                    predecessor_revision_id=predecessor_revision_id,
+                    revision_sequence=revision_sequence,
+                    revision_kind=payload.revision_kind,
+                    review_state=payload.review_state,
+                    canonical_entity_schema_version=payload.canonical_entity_schema_version,
+                    confidence_score=payload.confidence_score,
+                )
+            )
+            session.add(
+                ValidationReport(
+                    id=validation_report_id,
+                    project_id=job.project_id,
                     drawing_revision_id=drawing_revision_id,
                     source_job_id=job.id,
-                    validation_report_id=validation_report_id,
-                ),
-                generated_at=payload.generated_at,
+                    validation_report_schema_version=payload.validation_report_schema_version,
+                    canonical_entity_schema_version=payload.canonical_entity_schema_version,
+                    validation_status=payload.validation_status,
+                    review_state=payload.review_state,
+                    quantity_gate=payload.quantity_gate,
+                    effective_confidence=payload.effective_confidence,
+                    validator_name=payload.validator_name,
+                    validator_version=payload.validator_version,
+                    report_json=_build_persisted_validation_report_json(
+                        payload,
+                        drawing_revision_id=drawing_revision_id,
+                        source_job_id=job.id,
+                        validation_report_id=validation_report_id,
+                    ),
+                    generated_at=payload.generated_at,
+                )
             )
-        )
+            session.add(
+                GeneratedArtifact(
+                    id=debug_overlay_artifact_id,
+                    project_id=job.project_id,
+                    source_file_id=source_file.id,
+                    job_id=job.id,
+                    drawing_revision_id=drawing_revision_id,
+                    adapter_run_output_id=adapter_run_output_id,
+                    artifact_kind=_DEBUG_OVERLAY_ARTIFACT_KIND,
+                    name=overlay_plan.filename,
+                    format=_DEBUG_OVERLAY_ARTIFACT_FORMAT,
+                    media_type=overlay_plan.media_type,
+                    size_bytes=stored_overlay.size_bytes,
+                    checksum_sha256=stored_overlay.checksum_sha256,
+                    generator_name=_DEBUG_OVERLAY_GENERATOR_NAME,
+                    generator_version=_DEBUG_OVERLAY_GENERATOR_VERSION,
+                    generator_config_json=overlay_generator_config,
+                    storage_key=stored_overlay.key,
+                    storage_uri=stored_overlay.storage_uri,
+                    lineage_json=overlay_lineage_json,
+                    predecessor_artifact_id=(
+                        predecessor_debug_overlay.id
+                        if predecessor_debug_overlay is not None
+                        else None
+                    ),
+                )
+            )
 
-        job.status = "succeeded"
-        job.finished_at = finished_at
-        job.error_code = None
-        job.error_message = None
-        await emit_job_event(
-            job.id,
-            level="info",
-            message="Job succeeded",
-            data_json={
-                "status": "succeeded",
-                "attempts": job.attempts,
-                "adapter_run_output_id": str(adapter_run_output_id),
-                "drawing_revision_id": str(drawing_revision_id),
-                "validation_report_id": str(validation_report_id),
-            },
-            session=session,
-        )
-        await session.commit()
+            job.status = "succeeded"
+            job.finished_at = finished_at
+            job.error_code = None
+            job.error_message = None
+            await emit_job_event(
+                job.id,
+                level="info",
+                message="Job succeeded",
+                data_json={
+                    "status": "succeeded",
+                    "attempts": job.attempts,
+                    "adapter_run_output_id": str(adapter_run_output_id),
+                    "drawing_revision_id": str(drawing_revision_id),
+                    "validation_report_id": str(validation_report_id),
+                    "generated_artifact_id": str(debug_overlay_artifact_id),
+                },
+                session=session,
+            )
+            commit_started = True
+            await session.commit()
+        except asyncio.CancelledError:
+            if not commit_started:
+                await session.rollback()
+                await _cleanup_failed_storage_writes(
+                    storage,
+                    written_storage_objects,
+                    job_id=job_id,
+                )
+            raise
+        except Exception:
+            if not commit_started:
+                await session.rollback()
+                await _cleanup_failed_storage_writes(
+                    storage,
+                    written_storage_objects,
+                    job_id=job_id,
+                )
+            raise
 
     return True
 
@@ -881,6 +1099,10 @@ async def process_ingest_job(job_id: UUID) -> None:
 
     try:
         finalized = await _finalize_ingest_job(job_id, payload=payload)
+    except asyncio.CancelledError:
+        await _mark_job_cancelled(job_id)
+        logger.info("ingest_job_cancelled_during_finalization", job_id=str(job_id))
+        raise
     except Exception as exc:
         await _mark_job_failed(job_id, error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE)
         logger.error(

--- a/app/storage/keys.py
+++ b/app/storage/keys.py
@@ -1,8 +1,29 @@
 """Shared helpers for immutable storage object keys."""
 
+from pathlib import PureWindowsPath
 from uuid import UUID
 
 
 def build_original_storage_key(file_id: UUID, checksum: str) -> str:
     """Build the immutable storage key for an uploaded source file."""
     return f"originals/{file_id}/{checksum}"
+
+
+def build_generated_artifact_storage_key(artifact_id: UUID, filename: str) -> str:
+    """Build the immutable storage key for a generated artifact payload."""
+    return f"artifacts/{artifact_id}/{_normalize_artifact_filename(filename)}"
+
+
+def _normalize_artifact_filename(filename: str) -> str:
+    stripped = filename.strip()
+    if not stripped:
+        raise ValueError("Artifact filename must not be empty.")
+
+    candidate_path = PureWindowsPath(stripped)
+    candidate = candidate_path.name.strip()
+    if candidate in {"", ".", ".."}:
+        raise ValueError("Artifact filename must resolve to a single file name.")
+    if candidate_path.parent != PureWindowsPath("."):
+        raise ValueError("Artifact filename must not contain path segments.")
+
+    return candidate

--- a/tests/test_debug_overlay.py
+++ b/tests/test_debug_overlay.py
@@ -1,0 +1,266 @@
+"""Focused tests for debug overlay generation primitives."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from app.ingestion.contracts import JSONValue
+from app.ingestion.debug_overlay import (
+    SVG_DEBUG_OVERLAY_FILENAME,
+    SVG_DEBUG_OVERLAY_MEDIA_TYPE,
+    plan_svg_debug_overlay,
+)
+from app.storage.keys import build_generated_artifact_storage_key
+
+
+def test_build_generated_artifact_storage_key_uses_artifact_namespace() -> None:
+    """Generated artifact keys should always be anchored under the artifact id."""
+    artifact_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+    key = build_generated_artifact_storage_key(artifact_id, "debug-overlay.svg")
+
+    assert key == "artifacts/11111111-1111-1111-1111-111111111111/debug-overlay.svg"
+
+
+def test_build_generated_artifact_storage_key_rejects_path_segments() -> None:
+    """Generated artifact keys should reject nested or traversal-like filenames."""
+    artifact_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+    try:
+        build_generated_artifact_storage_key(artifact_id, "nested/debug-overlay.svg")
+    except ValueError as exc:
+        assert str(exc) == "Artifact filename must not contain path segments."
+    else:
+        raise AssertionError("Expected path segment rejection for generated artifact name.")
+
+
+def test_plan_svg_debug_overlay_emits_deterministic_svg_with_geometry_and_placeholders() -> None:
+    """Overlay plans should render deterministic SVG bytes for mixed canonical geometry."""
+    canonical: dict[str, JSONValue] = {
+        "layouts": (
+            {
+                "name": "page-1",
+                "page_number": 1,
+                "bbox": {
+                    "x_min": 0.0,
+                    "y_min": 0.0,
+                    "x_max": 100.0,
+                    "y_max": 100.0,
+                },
+            },
+            {"name": "Model"},
+        ),
+        "entities": (
+            {
+                "entity_id": "page-1:line-1",
+                "kind": "line",
+                "layout": "page-1",
+                "start": {"x": 10.0, "y": 10.0},
+                "end": {"x": 90.0, "y": 90.0},
+                "bbox": {
+                    "x_min": 10.0,
+                    "y_min": 10.0,
+                    "x_max": 90.0,
+                    "y_max": 90.0,
+                },
+                "confidence_score": 0.97,
+            },
+            {
+                "kind": "polyline",
+                "layout": "page-1",
+                "points": (
+                    {"x": 10.0, "y": 90.0},
+                    {"x": 50.0, "y": 55.0},
+                    {"x": 90.0, "y": 10.0},
+                ),
+                "bbox": {
+                    "x_min": 10.0,
+                    "y_min": 10.0,
+                    "x_max": 90.0,
+                    "y_max": 90.0,
+                },
+                "confidence": {"score": 0.75},
+                "review_state": "provisional",
+            },
+            {
+                "entity_id": "ifc:wall-1",
+                "kind": "ifc_wall",
+                "layout": "Model",
+                "confidence": 0.31,
+            },
+        ),
+    }
+
+    first_plan = plan_svg_debug_overlay(
+        canonical,
+        title="Debug Overlay Sample",
+        source_label="originals/plan.pdf",
+        review_state="review_required",
+        confidence_score=0.42,
+    )
+    second_plan = plan_svg_debug_overlay(
+        canonical,
+        title="Debug Overlay Sample",
+        source_label="originals/plan.pdf",
+        review_state="review_required",
+        confidence_score=0.42,
+    )
+
+    assert first_plan.filename == SVG_DEBUG_OVERLAY_FILENAME
+    assert first_plan.media_type == SVG_DEBUG_OVERLAY_MEDIA_TYPE
+    assert first_plan.payload == second_plan.payload
+
+    payload = first_plan.payload.decode("utf-8")
+    assert "<!-- Debug overlay only; not source of truth. -->" in payload
+    assert "Title: Debug Overlay Sample" in payload
+    assert "Source: originals/plan.pdf" in payload
+    assert "NOT SOURCE OF TRUTH" in payload
+    assert "Layout: page-1 | Page: 1" in payload
+    assert "Layout: Model" in payload
+    assert "page-1:line-1 | line | review_required | 0.97" in payload
+    assert "page-1:entity-0002 | polyline | provisional | 0.75" in payload
+    assert "ifc:wall-1 | ifc_wall | review_required | 0.31" in payload
+    assert "ifc:wall-1 | No canonical geometry" in payload
+    assert "cue-review-required" in payload
+    assert "cue-provisional" in payload
+    assert '<line class="geometry cue-review-required"' in payload
+    assert '<polyline class="geometry cue-provisional"' in payload
+
+
+def test_plan_svg_debug_overlay_escapes_title_source_layout_and_entity_metadata() -> None:
+    """Overlay SVG should HTML-escape user-provided metadata fields."""
+    canonical: dict[str, JSONValue] = {
+        "layouts": (
+            {
+                "name": 'Model <A>&"B"',
+                "page_number": 2,
+                "bbox": {
+                    "x_min": 0.0,
+                    "y_min": 0.0,
+                    "x_max": 10.0,
+                    "y_max": 10.0,
+                },
+            },
+        ),
+        "entities": (
+            {
+                "entity_id": 'entity<1>&"2"',
+                "kind": 'line<kind>&"shape"',
+                "layout": 'Model <A>&"B"',
+                "review_state": 'review<state>&"needed"',
+                "confidence_score": 0.51,
+                "start": {"x": 1.0, "y": 1.0},
+                "end": {"x": 9.0, "y": 9.0},
+            },
+        ),
+    }
+
+    payload = plan_svg_debug_overlay(
+        canonical,
+        title='Debug <Overlay> "Phase" & Check',
+        source_label='originals/<plan>&"sheet".pdf',
+        review_state="review_required",
+        confidence_score=0.51,
+    ).payload.decode("utf-8")
+
+    assert (
+        '<title id="overlay-title">Debug &lt;Overlay&gt; &quot;Phase&quot; &amp; Check '
+        'debug overlay</title>'
+    ) in payload
+    assert (
+        "Diagnostic overlay for originals/&lt;plan&gt;&amp;&quot;sheet&quot;.pdf. "
+        "Not source of truth."
+    ) in payload
+    assert "Title: Debug &lt;Overlay&gt; &quot;Phase&quot; &amp; Check" in payload
+    assert "Source: originals/&lt;plan&gt;&amp;&quot;sheet&quot;.pdf" in payload
+    assert "Layout: Model &lt;A&gt;&amp;&quot;B&quot; | Page: 2" in payload
+    assert (
+        "entity&lt;1&gt;&amp;&quot;2&quot; | line&lt;kind&gt;&amp;&quot;shape&quot; | "
+        "review&lt;state&gt;&amp;&quot;needed&quot; | 0.51"
+    ) in payload
+    assert 'Debug <Overlay> "Phase" & Check debug overlay' not in payload
+    assert 'Layout: Model <A>&"B" | Page: 2' not in payload
+    assert 'entity<1>&"2" | line<kind>&"shape" | review<state>&"needed" | 0.51' not in payload
+
+
+def test_plan_svg_debug_overlay_degrades_invalid_geometry_to_placeholder_without_nan_or_inf(
+) -> None:
+    """Invalid or non-finite geometry should render as safe diagnostic placeholders."""
+    canonical: dict[str, JSONValue] = {
+        "layouts": ({"name": "page-1"},),
+        "entities": (
+            {
+                "entity_id": "broken-entity",
+                "kind": "polyline",
+                "layout": "page-1",
+                "bbox": {
+                    "x_min": 0.0,
+                    "y_min": 0.0,
+                    "x_max": float("inf"),
+                    "y_max": 10.0,
+                },
+                "points": (
+                    {"x": 1.0, "y": 1.0},
+                    {"x": float("nan"), "y": 3.0},
+                ),
+                "start": {"x": float("inf"), "y": 0.0},
+                "end": {"x": 5.0, "y": float("nan")},
+            },
+        ),
+    }
+
+    payload = plan_svg_debug_overlay(
+        canonical,
+        title="Debug Overlay Sample",
+        source_label="originals/plan.pdf",
+        review_state="review_required",
+        confidence_score=0.42,
+    ).payload.decode("utf-8")
+
+    assert "broken-entity | No canonical geometry" in payload
+    assert '<polyline class="geometry' not in payload
+    assert '<line class="geometry' not in payload
+    assert re.search(r'(?:x|y|x1|y1|x2|y2|width|height|points)="[^"]*(?:nan|inf)', payload) is None
+
+
+def test_plan_svg_debug_overlay_degrades_finite_overflow_geometry_to_placeholder() -> None:
+    """Finite-but-overflowing geometry spans should not serialize invalid SVG coordinates."""
+    canonical: dict[str, JSONValue] = {
+        "layouts": (
+            {
+                "name": "page-1",
+                "bbox": {
+                    "x_min": -1.7976931348623157e308,
+                    "y_min": 0.0,
+                    "x_max": 1.7976931348623157e308,
+                    "y_max": 10.0,
+                },
+            },
+        ),
+        "entities": (
+            {
+                "entity_id": "overflow-entity",
+                "kind": "polyline",
+                "layout": "page-1",
+                "points": (
+                    {"x": -1.7976931348623157e308, "y": 1.0},
+                    {"x": 1.7976931348623157e308, "y": 9.0},
+                ),
+            },
+        ),
+    }
+
+    payload = plan_svg_debug_overlay(
+        canonical,
+        title="Debug Overlay Sample",
+        source_label="originals/plan.pdf",
+        review_state="review_required",
+        confidence_score=0.42,
+    ).payload.decode("utf-8")
+
+    assert "overflow-entity | No canonical geometry" in payload
+    assert '<polyline class="geometry' not in payload
+    assert '<line class="geometry' not in payload
+    assert '<rect class="layout-box"' not in payload
+    assert re.search(r'(?:x|y|x1|y1|x2|y2|width|height|points)="[^"]*(?:nan|inf)', payload) is None

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -3,6 +3,8 @@
 import asyncio
 import uuid
 from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -20,6 +22,7 @@ from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job
 from app.models.job_event import JobEvent
 from app.models.validation_report import ValidationReport
+from app.storage.keys import build_generated_artifact_storage_key
 from tests.conftest import requires_database
 from tests.test_jobs import (
     _FAKE_RUNNER_ADAPTER_KEY,
@@ -79,6 +82,75 @@ def _assert_validation_report_json_matches_columns(report: ValidationReport) -> 
     assert report_json["summary"]["quantity_gate"] == report.quantity_gate
     assert report_json["summary"]["effective_confidence"] == report.effective_confidence
     assert report_json["checks"]
+
+
+def _assert_debug_overlay_artifact(
+    artifact: GeneratedArtifact,
+    *,
+    job: Job,
+    drawing_revision: DrawingRevision,
+    adapter_output: AdapterRunOutput,
+    predecessor_artifact_id: uuid.UUID | None,
+) -> None:
+    """Assert persisted SVG debug overlay artifact metadata and lineage."""
+    assert artifact.project_id == job.project_id
+    assert artifact.source_file_id == job.file_id
+    assert artifact.job_id == job.id
+    assert artifact.drawing_revision_id == drawing_revision.id
+    assert artifact.adapter_run_output_id == adapter_output.id
+    assert artifact.artifact_kind == "debug_overlay"
+    assert artifact.name == "debug-overlay.svg"
+    assert artifact.format == "svg"
+    assert artifact.media_type == "image/svg+xml"
+    assert artifact.size_bytes > 0
+    assert len(artifact.checksum_sha256) == 64
+    assert artifact.generator_name == "app.ingestion.debug_overlay"
+    assert artifact.generator_version == "1"
+    assert artifact.generator_config_json == {
+        "title": f"plan.pdf revision {drawing_revision.revision_sequence}",
+        "source_label": "plan.pdf",
+        "review_state": drawing_revision.review_state,
+        "confidence_score": drawing_revision.confidence_score,
+    }
+    assert artifact.storage_key == build_generated_artifact_storage_key(artifact.id, artifact.name)
+    assert artifact.storage_uri
+    assert artifact.predecessor_artifact_id == predecessor_artifact_id
+
+    lineage = cast(dict[str, Any], artifact.lineage_json)
+    source_file_lineage = cast(dict[str, Any], lineage["source_file"])
+    assert source_file_lineage["id"] == str(job.file_id)
+    assert source_file_lineage["original_filename"] == "plan.pdf"
+    assert source_file_lineage["detected_format"] == "pdf"
+    assert source_file_lineage["media_type"] == "application/pdf"
+    assert source_file_lineage["checksum_sha256"]
+    assert lineage["job"] == {
+        "id": str(job.id),
+        "extraction_profile_id": str(job.extraction_profile_id),
+        "attempts": job.attempts,
+    }
+    assert lineage["drawing_revision"] == {
+        "id": str(drawing_revision.id),
+        "revision_sequence": drawing_revision.revision_sequence,
+        "revision_kind": drawing_revision.revision_kind,
+        "predecessor_revision_id": (
+            str(drawing_revision.predecessor_revision_id)
+            if drawing_revision.predecessor_revision_id is not None
+            else None
+        ),
+    }
+    assert lineage["adapter"] == {
+        "id": str(adapter_output.id),
+        "key": adapter_output.adapter_key,
+        "version": adapter_output.adapter_version,
+        "input_family": adapter_output.input_family,
+        "result_checksum_sha256": adapter_output.result_checksum_sha256,
+    }
+    assert lineage["entities"] == {
+        "schema_version": adapter_output.canonical_entity_schema_version,
+        "counts": adapter_output.canonical_json["entity_counts"],
+        "total": len(adapter_output.canonical_json["entities"]),
+    }
+    assert lineage["options"] == {}
 
 
 async def _load_project_outputs(
@@ -190,6 +262,7 @@ class TestIngestOutputPersistence:
         job = await _get_job_for_file(str(uploaded["id"]))
 
         await process_ingest_job(job.id)
+        job = await _get_job(job.id)
 
         (
             adapter_outputs,
@@ -201,11 +274,12 @@ class TestIngestOutputPersistence:
         assert len(adapter_outputs) == 1
         assert len(drawing_revisions) == 1
         assert len(validation_reports) == 1
-        assert generated_artifacts == []
+        assert len(generated_artifacts) == 1
 
         adapter_output = adapter_outputs[0]
         drawing_revision = drawing_revisions[0]
         validation_report = validation_reports[0]
+        generated_artifact = generated_artifacts[0]
 
         assert adapter_output.project_id == job.project_id
         assert adapter_output.source_file_id == job.file_id
@@ -290,6 +364,13 @@ class TestIngestOutputPersistence:
         assert validation_report.report_json["findings"] == []
         assert validation_report.report_json["adapter_warnings"] == []
         assert validation_report.report_json["provenance"] == adapter_output.provenance_json
+        _assert_debug_overlay_artifact(
+            generated_artifact,
+            job=job,
+            drawing_revision=drawing_revision,
+            adapter_output=adapter_output,
+            predecessor_artifact_id=None,
+        )
 
     async def test_process_ingest_job_persists_payload_provenance_and_confidence_precedence(
         self,
@@ -371,6 +452,7 @@ class TestIngestOutputPersistence:
         first_job = await _get_job_for_file(str(uploaded["id"]))
 
         await process_ingest_job(first_job.id)
+        first_job = await _get_job(first_job.id)
 
         reprocess_response = await async_client.post(
             f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
@@ -384,6 +466,7 @@ class TestIngestOutputPersistence:
         assert enqueued_job_ids == [str(first_job.id), str(second_job.id)]
 
         await process_ingest_job(second_job.id)
+        second_job = await _get_job(second_job.id)
 
         (
             adapter_outputs,
@@ -395,7 +478,7 @@ class TestIngestOutputPersistence:
         assert len(adapter_outputs) == 2
         assert len(drawing_revisions) == 2
         assert len(validation_reports) == 2
-        assert generated_artifacts == []
+        assert len(generated_artifacts) == 2
 
         first_revision, second_revision = drawing_revisions
         first_adapter_output = next(
@@ -409,6 +492,12 @@ class TestIngestOutputPersistence:
         )
         second_validation_report = next(
             report for report in validation_reports if report.source_job_id == second_job.id
+        )
+        first_generated_artifact = next(
+            artifact for artifact in generated_artifacts if artifact.job_id == first_job.id
+        )
+        second_generated_artifact = next(
+            artifact for artifact in generated_artifacts if artifact.job_id == second_job.id
         )
 
         assert first_revision.revision_sequence == 1
@@ -439,6 +528,20 @@ class TestIngestOutputPersistence:
         assert second_validation_report.review_state == _FAKE_RUNNER_REVIEW_STATE
         assert second_validation_report.quantity_gate == _FAKE_RUNNER_QUANTITY_GATE
         assert second_validation_report.effective_confidence == _FAKE_RUNNER_CONFIDENCE_SCORE
+        _assert_debug_overlay_artifact(
+            first_generated_artifact,
+            job=first_job,
+            drawing_revision=first_revision,
+            adapter_output=first_adapter_output,
+            predecessor_artifact_id=None,
+        )
+        _assert_debug_overlay_artifact(
+            second_generated_artifact,
+            job=second_job,
+            drawing_revision=second_revision,
+            adapter_output=second_adapter_output,
+            predecessor_artifact_id=first_generated_artifact.id,
+        )
 
     async def test_validation_report_allows_trd_status_and_gate_values(
         self,
@@ -533,9 +636,15 @@ class TestIngestOutputPersistence:
         assert len(adapter_outputs) == 3
         assert len(drawing_revisions) == 3
         assert len(validation_reports) == 3
-        assert generated_artifacts == []
+        assert len(generated_artifacts) == 3
 
         first_revision, second_revision, _third_revision = drawing_revisions
+        artifacts_by_revision_id = {
+            artifact.drawing_revision_id: artifact for artifact in generated_artifacts
+        }
+        first_artifact = artifacts_by_revision_id[first_revision.id]
+        second_artifact = artifacts_by_revision_id[second_revision.id]
+        third_artifact = artifacts_by_revision_id[drawing_revisions[2].id]
         assert [revision.revision_sequence for revision in drawing_revisions] == [1, 2, 3]
         assert [revision.predecessor_revision_id for revision in drawing_revisions] == [
             None,
@@ -551,6 +660,10 @@ class TestIngestOutputPersistence:
         expected_job_ids = {first_job.id, second_job.id, third_job.id}
         assert {output.source_job_id for output in adapter_outputs} == expected_job_ids
         assert {report.source_job_id for report in validation_reports} == expected_job_ids
+        assert {artifact.job_id for artifact in generated_artifacts} == expected_job_ids
+        assert first_artifact.predecessor_artifact_id is None
+        assert second_artifact.predecessor_artifact_id == first_artifact.id
+        assert third_artifact.predecessor_artifact_id == second_artifact.id
 
     async def test_reprocess_before_initial_finalization_fails_without_outputs(
         self,
@@ -611,6 +724,7 @@ class TestIngestOutputPersistence:
         assert generated_artifacts == []
 
         await process_ingest_job(initial_job.id)
+        initial_job = await _get_job(initial_job.id)
 
         (
             adapter_outputs,
@@ -621,12 +735,19 @@ class TestIngestOutputPersistence:
         assert len(adapter_outputs) == 1
         assert len(drawing_revisions) == 1
         assert len(validation_reports) == 1
-        assert generated_artifacts == []
+        assert len(generated_artifacts) == 1
         assert adapter_outputs[0].source_job_id == initial_job.id
         assert drawing_revisions[0].source_job_id == initial_job.id
         assert drawing_revisions[0].revision_sequence == 1
         assert drawing_revisions[0].predecessor_revision_id is None
         assert drawing_revisions[0].revision_kind == "ingest"
+        _assert_debug_overlay_artifact(
+            generated_artifacts[0],
+            job=initial_job,
+            drawing_revision=drawing_revisions[0],
+            adapter_output=adapter_outputs[0],
+            predecessor_artifact_id=None,
+        )
 
     async def test_process_ingest_job_cancelled_before_finalization_creates_no_outputs(
         self,
@@ -695,10 +816,11 @@ class TestIngestOutputPersistence:
         assert len(second_outputs[0]) == 1
         assert len(second_outputs[1]) == 1
         assert len(second_outputs[2]) == 1
-        assert second_outputs[3] == []
+        assert len(second_outputs[3]) == 1
         assert [row.id for row in second_outputs[0]] == [row.id for row in first_outputs[0]]
         assert [row.id for row in second_outputs[1]] == [row.id for row in first_outputs[1]]
         assert [row.id for row in second_outputs[2]] == [row.id for row in first_outputs[2]]
+        assert [row.id for row in second_outputs[3]] == [row.id for row in first_outputs[3]]
 
     async def test_process_ingest_job_missing_profile_fails_without_outputs(
         self,
@@ -733,6 +855,164 @@ class TestIngestOutputPersistence:
             "error_code": ErrorCode.INTERNAL_ERROR.value,
             "error_message": worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE,
         }
+
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+
+        assert adapter_outputs == []
+        assert drawing_revisions == []
+        assert validation_reports == []
+        assert generated_artifacts == []
+
+    async def test_process_ingest_job_precommit_overlay_failure_cleans_storage_without_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pre-commit overlay failure should clean storage and persist no outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        @dataclass(frozen=True, slots=True)
+        class _StoredOverlay:
+            key: str
+            storage_uri: str
+            size_bytes: int
+            checksum_sha256: str
+
+        class _RecordingStorage:
+            def __init__(self) -> None:
+                self.put_calls: list[str] = []
+                self.delete_calls: list[tuple[str, str]] = []
+
+            async def put(self, key: str, payload: bytes, *, immutable: bool) -> _StoredOverlay:
+                assert immutable is True
+                self.put_calls.append(key)
+                return _StoredOverlay(
+                    key=key,
+                    storage_uri=f"memory://{key}",
+                    size_bytes=len(payload),
+                    checksum_sha256="0" * 64,
+                )
+
+            async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+                self.delete_calls.append((key, storage_uri))
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        storage = _RecordingStorage()
+        original_emit_job_event = worker_module.emit_job_event
+
+        async def _run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+            return _build_fake_ingest_payload(request)
+
+        async def _fail_success_event(*args: Any, **kwargs: Any) -> None:
+            if kwargs.get("message") == "Job succeeded":
+                raise RuntimeError("forced overlay finalization failure")
+            await original_emit_job_event(*args, **kwargs)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_ingestion)
+        monkeypatch.setattr(worker_module, "get_storage", lambda: storage)
+        monkeypatch.setattr(worker_module, "emit_job_event", _fail_success_event)
+
+        with pytest.raises(RuntimeError, match="forced overlay finalization failure"):
+            await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert updated_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
+        assert len(storage.put_calls) == 1
+        assert storage.delete_calls == [
+            (storage.put_calls[0], f"memory://{storage.put_calls[0]}")
+        ]
+
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+
+        assert adapter_outputs == []
+        assert drawing_revisions == []
+        assert validation_reports == []
+        assert generated_artifacts == []
+
+    async def test_process_ingest_job_precommit_cancellation_cleans_storage_without_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pre-commit cancellation should clean storage and persist no outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        @dataclass(frozen=True, slots=True)
+        class _StoredOverlay:
+            key: str
+            storage_uri: str
+            size_bytes: int
+            checksum_sha256: str
+
+        class _RecordingStorage:
+            def __init__(self) -> None:
+                self.put_calls: list[str] = []
+                self.delete_calls: list[tuple[str, str]] = []
+
+            async def put(self, key: str, payload: bytes, *, immutable: bool) -> _StoredOverlay:
+                assert immutable is True
+                self.put_calls.append(key)
+                return _StoredOverlay(
+                    key=key,
+                    storage_uri=f"memory://{key}",
+                    size_bytes=len(payload),
+                    checksum_sha256="0" * 64,
+                )
+
+            async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+                self.delete_calls.append((key, storage_uri))
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        storage = _RecordingStorage()
+        original_emit_job_event = worker_module.emit_job_event
+
+        async def _run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+            return _build_fake_ingest_payload(request)
+
+        async def _cancel_success_event(*args: Any, **kwargs: Any) -> None:
+            if kwargs.get("message") == "Job succeeded":
+                raise asyncio.CancelledError()
+            await original_emit_job_event(*args, **kwargs)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_ingestion)
+        monkeypatch.setattr(worker_module, "get_storage", lambda: storage)
+        monkeypatch.setattr(worker_module, "emit_job_event", _cancel_success_event)
+
+        with suppress(asyncio.CancelledError):
+            await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated_job.error_message is None
+        assert len(storage.put_calls) == 1
+        assert storage.delete_calls == [
+            (storage.put_calls[0], f"memory://{storage.put_calls[0]}")
+        ]
 
         (
             adapter_outputs,


### PR DESCRIPTION
Closes #102

## Summary
- Persist deterministic SVG debug overlays during ingest finalization so QA can inspect extracted entities without weakening immutable artifact guarantees
- Record overlay storage metadata, lineage, and predecessor linkage so regenerated overlays stay auditable across reprocess chains
- Add coverage for SVG escaping, invalid/overflow geometry fallback, and pre-commit cleanup on failure or cancellation

## Test plan
- [x] `uv run pytest tests/test_debug_overlay.py`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_overlay_test uv run pytest tests/test_ingest_output_persistence.py`
- [x] `uv run mypy app tests`
- [x] `uv run ruff check app tests`
- [x] `uv run python -m compileall app tests`

## Notes
- No breaking changes
- SVG-only for MVP; PNG/PDF remain follow-up work