### PR TITLE
fix(compose): share upload storage between API and worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ COPY app/ ./app/
 # Install project and runtime extras into the project environment
 RUN uv sync --locked --no-dev --extra db --extra jobs
 
-# Create non-root user
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+# Create non-root user and shared upload root
+RUN useradd -m -u 1000 appuser \
+    && mkdir -p /app/var/uploads \
+    && chown -R appuser:appuser /app
 USER appuser
 
 # Expose port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - LOG_LEVEL=info
       - MAX_UPLOAD_MB=50
       - SERVICE_NAME=draupnir-api
+      - STORAGE_LOCAL_ROOT=/app/var/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -33,6 +34,7 @@ services:
       - ./app:/app/app
       - ./alembic.ini:/app/alembic.ini
       - ./alembic:/app/alembic
+      - upload_storage:/app/var/uploads:rw
 
   worker:
     build: .
@@ -43,6 +45,7 @@ services:
       - LOG_LEVEL=info
       - MAX_UPLOAD_MB=50
       - SERVICE_NAME=draupnir-worker
+      - STORAGE_LOCAL_ROOT=/app/var/uploads
     depends_on:
       postgres:
         condition: service_healthy
@@ -59,6 +62,8 @@ services:
     restart: unless-stopped
     networks:
       - draupnir-network
+    volumes:
+      - upload_storage:/app/var/uploads:rw
 
   postgres:
     image: postgres:17-alpine
@@ -115,6 +120,7 @@ services:
 
 volumes:
   postgres_data:
+  upload_storage:
 
 networks:
   draupnir-network:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,8 +4,11 @@ import io
 import json
 import logging
 import os
+import subprocess
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
 from uuid import UUID
 
 import httpx
@@ -346,13 +349,100 @@ class TestIngestWorkflowSmoke:
         assert upload_response.status_code == 422
 
 
-# Skip unless SMOKE_BASE_URL is set (for compose-stack testing)
+# Skip unless compose smoke is explicitly enabled.
+COMPOSE_SMOKE = os.environ.get("COMPOSE_SMOKE") == "1"
 SMOKE_BASE_URL = os.environ.get("SMOKE_BASE_URL", "")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKER_STORAGE_READ_SCRIPT = """
+import asyncio
+import hashlib
+import inspect
+import json
+import os
+
+from app.storage.dependencies import get_storage
+
+
+async def _maybe_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+async def main():
+    storage = get_storage()
+    storage_key = os.environ["STORAGE_KEY"]
+    expected_sha256 = os.environ["EXPECTED_SHA256"]
+
+    metadata = await _maybe_await(
+        storage.stat(storage_key, expected_checksum_sha256=expected_sha256)
+    )
+    stored_object = await _maybe_await(
+        storage.get(storage_key, expected_checksum_sha256=expected_sha256)
+    )
+    content = stored_object.body
+    if hasattr(content, "read"):
+        content = await _maybe_await(content.read())
+
+    digest = hashlib.sha256(content).hexdigest()
+    if digest != expected_sha256:
+        raise AssertionError(f"sha256 mismatch: {digest} != {expected_sha256}")
+
+    print(
+        json.dumps(
+            {
+                "path": storage_key,
+                "sha256": digest,
+                "size": metadata.size_bytes,
+            }
+        )
+    )
+
+
+asyncio.run(main())
+"""
+
+
+def _read_original_from_worker_storage(
+    *, storage_key: str, expected_sha256: str
+) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "-e",
+            f"STORAGE_KEY={storage_key}",
+            "-e",
+            f"EXPECTED_SHA256={expected_sha256}",
+            "worker",
+            "python",
+            "-c",
+            WORKER_STORAGE_READ_SCRIPT,
+        ],
+        check=False,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    stdout_lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert stdout_lines, "worker storage probe produced no stdout"
+
+    payload: object = json.loads(stdout_lines[-1])
+    assert isinstance(payload, dict), "worker storage probe returned non-object JSON"
+    assert all(
+        isinstance(key, str) for key in payload
+    ), "worker storage probe returned non-string keys"
+
+    return cast(dict[str, object], payload)
 
 
 @pytest.mark.skipif(
-    not SMOKE_BASE_URL,
-    reason="SMOKE_BASE_URL not set (set to run against real server)",
+    not (COMPOSE_SMOKE and SMOKE_BASE_URL),
+    reason="COMPOSE_SMOKE=1 and SMOKE_BASE_URL must be set for compose smoke",
 )
 class TestHealthEndpointRealServer:
     """Smoke tests against a real running server (compose stack)."""
@@ -371,8 +461,7 @@ class TestHealthEndpointRealServer:
         """Test that GET /v1/health returns 200 against real server.
 
         Success case: Real server responds with 200 and correct JSON shape.
-        This test only runs when SMOKE_BASE_URL environment variable is set,
-        allowing CI to test against the compose stack after `docker compose up`.
+        This test only runs when compose smoke is explicitly enabled.
         """
         response = await real_async_client.get("/v1/health")
 
@@ -395,3 +484,40 @@ class TestHealthEndpointRealServer:
         # Assert request ID length is within bounds
         assert len(request_id) <= 64
         assert len(request_id) > 0
+
+    async def test_upload_original_is_readable_from_worker_storage(
+        self,
+        real_async_client: httpx.AsyncClient,
+    ) -> None:
+        """Compose stack shares immutable upload storage between API and worker."""
+        pdf_bytes = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+
+        project_response = await real_async_client.post(
+            "/v1/projects",
+            json={"name": "compose-smoke-project"},
+        )
+        assert project_response.status_code == 201
+        project_id = project_response.json()["id"]
+
+        upload_response = await real_async_client.post(
+            f"/v1/projects/{project_id}/files",
+            files={"file": ("compose-smoke.pdf", pdf_bytes, "application/pdf")},
+        )
+        assert upload_response.status_code == 201
+
+        upload_data = upload_response.json()
+        file_id = upload_data["id"]
+        UUID(file_id)
+        checksum_sha256 = upload_data["checksum_sha256"]
+        storage_key = f"originals/{file_id}/{checksum_sha256}"
+
+        worker_data = _read_original_from_worker_storage(
+            storage_key=storage_key,
+            expected_sha256=checksum_sha256,
+        )
+
+        assert worker_data == {
+            "path": storage_key,
+            "sha256": checksum_sha256,
+            "size": len(pdf_bytes),
+        }


### PR DESCRIPTION
Closes #122

## Summary
- ensure the API and worker share the same local upload storage root in Compose so worker jobs can read immutable originals written by the API
- create and own /app/var/uploads in the image so the non-root runtime can use the shared named volume reliably
- add gated compose smoke coverage that uploads a PDF through the API and verifies the worker can read the stored original through the app storage adapter

## Test plan
- [x] docker compose config --format json
- [x] docker build -f Dockerfile .
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv run pytest tests/test_smoke.py -k TestHealthEndpointRealServer *(gated; skipped without COMPOSE_SMOKE=1 and SMOKE_BASE_URL)*
- [x] uv run pytest tests/test_smoke.py tests/test_storage.py

## Notes
- No breaking changes.
- Full compose smoke remains manual: docker compose up -d --build && COMPOSE_SMOKE=1 SMOKE_BASE_URL=http://localhost:8000 uv run pytest tests/test_smoke.py -k TestHealthEndpointRealServer