### PR TITLE
chore(compose): bind RabbitMQ port to loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Docker Compose development stack is available. See "Local Development" below for
    ```
 
 5. **View RabbitMQ management UI**:
-   - Open http://localhost:15672 in your browser
-   - Login: guest / guest
+    - Open http://localhost:15672 in your browser
+    - Login: guest / guest
+    - AMQP is also exposed on localhost:5672 for host-side clients only
 
 6. **View logs**:
    ```bash
@@ -64,9 +65,12 @@ Docker Compose development stack is available. See "Local Development" below for
 |-----------|----------------------|--------------------------------|
 | api       | 8000                 | FastAPI application            |
 | worker    | —                    | Celery background worker       |
-| postgres  | 5432                 | PostgreSQL database            |
-| rabbitmq  | 5672, 15672          | RabbitMQ message broker        |
-| flower    | 5555                 | Celery dashboard (optional)    |
+| postgres  | localhost:5432       | PostgreSQL database            |
+| rabbitmq  | localhost:5672, localhost:15672 | RabbitMQ message broker |
+| flower    | localhost:5555       | Celery dashboard (optional)    |
+
+Postgres, RabbitMQ, and Flower host ports bind to `127.0.0.1` only. Containers
+still reach RabbitMQ over the internal Docker network at `rabbitmq:5672`.
 
 ### Useful Commands
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Local development stack only. Do not use in production.
 #
-# Internal services (postgres, rabbitmq management, flower) bind to 127.0.0.1
-# to avoid exposing data-plane and admin ports on shared hosts.
+# Internal services (postgres, rabbitmq AMQP/management, flower) bind to
+# 127.0.0.1 to avoid exposing data-plane and admin ports on shared hosts.
 
 services:
   api:
@@ -86,7 +86,7 @@ services:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
     ports:
-      - "${RABBITMQ_HOST_PORT:-5672}:5672"
+      - "127.0.0.1:${RABBITMQ_HOST_PORT:-5672}:5672"
       - "127.0.0.1:${RABBITMQ_MGMT_HOST_PORT:-15672}:15672"
     healthcheck:
       test: ["CMD-SHELL", "rabbitmq-diagnostics -q ping"]


### PR DESCRIPTION
Closes #123

## Summary
- Restrict the host-side RabbitMQ AMQP port to localhost-only access for the local Compose stack.
- Reduce accidental exposure of local broker ports on shared hosts without changing container-to-container broker connectivity.

## Key changes
- Bind RabbitMQ AMQP host port to `127.0.0.1` in `docker-compose.yml`
- Update README to clarify localhost-only host access and internal Docker networking behavior

## Test plan
- [x] `docker compose config`
- [x] `docker compose --profile debug config`
- [x] Verify rendered RabbitMQ host bindings stay on `127.0.0.1`
- [x] Verify API/worker/Flower broker URLs remain `amqp://guest:guest@rabbitmq:5672//`

## Breaking changes
- None