### PR TITLE
refactor: route storage health through backend abstraction (#144)

### DIFF
--- a/app/api/v1/system.py
+++ b/app/api/v1/system.py
@@ -9,7 +9,6 @@ import shutil
 import socket
 from collections.abc import Callable, Iterable
 from datetime import UTC, datetime
-from pathlib import Path
 from time import perf_counter
 from urllib.parse import urlparse
 
@@ -375,15 +374,6 @@ def _aggregate_adapter_check_status(adapters: Iterable[AdapterHealthCheck]) -> S
     return SystemCheckStatus.DOWN
 
 
-def _nearest_existing_ancestor(path: Path) -> Path | None:
-    """Return the nearest existing path at or above the given path."""
-
-    for candidate in (path, *path.parents):
-        if candidate.exists():
-            return candidate
-    return None
-
-
 async def _probe_database_check() -> DependencyHealthCheck:
     """Run a bounded liveness query against the configured database."""
 
@@ -418,43 +408,15 @@ async def _probe_database_check() -> DependencyHealthCheck:
     )
 
 
-def _probe_storage_root_sync(storage_root: Path) -> bool:
-    """Check whether the configured local storage root can be traversed or created."""
-
-    existing = _nearest_existing_ancestor(storage_root)
-    if existing is None or not existing.is_dir():
-        return False
-    return os.access(existing, os.R_OK | os.W_OK | os.X_OK)
-
-
 async def _probe_storage_check() -> DependencyHealthCheck:
     """Run a bounded health check for the configured storage backend."""
 
     storage = get_storage()
     started_at = perf_counter()
 
-    storage_attributes = vars(storage) if hasattr(storage, "__dict__") else {}
-    raw_root = storage_attributes.get("root")
-    if isinstance(raw_root, Path):
-        try:
-            async with asyncio.timeout(_DEPENDENCY_PROBE_TIMEOUT_SECONDS):
-                healthy = await asyncio.to_thread(_probe_storage_root_sync, raw_root)
-        except TimeoutError:
-            return DependencyHealthCheck(
-                status=SystemCheckStatus.DOWN,
-                latency_ms=(perf_counter() - started_at) * 1000,
-                details={"timed_out": True},
-            )
-
-        return DependencyHealthCheck(
-            status=SystemCheckStatus.OK if healthy else SystemCheckStatus.DOWN,
-            latency_ms=(perf_counter() - started_at) * 1000,
-            details=None if healthy else {"reachable": False},
-        )
-
     try:
         async with asyncio.timeout(_DEPENDENCY_PROBE_TIMEOUT_SECONDS):
-            await storage.exists("__draupnir_system_health__/nonexistent")
+            report = await storage.healthcheck()
     except TimeoutError:
         return DependencyHealthCheck(
             status=SystemCheckStatus.DOWN,
@@ -469,8 +431,9 @@ async def _probe_storage_check() -> DependencyHealthCheck:
         )
 
     return DependencyHealthCheck(
-        status=SystemCheckStatus.OK,
+        status=SystemCheckStatus.OK if report.ok else SystemCheckStatus.DOWN,
         latency_ms=(perf_counter() - started_at) * 1000,
+        details=report.details if report.ok or report.details is not None else {"reachable": False},
     )
 
 

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,6 +1,6 @@
 """Storage backends and file persistence."""
 
-from app.storage.base import Storage, StoredObject, StoredObjectMeta
+from app.storage.base import Storage, StorageHealthReport, StoredObject, StoredObjectMeta
 from app.storage.dependencies import get_storage
 from app.storage.local import LocalFilesystemStorage, LocalStorage
 from app.storage.memory import MemoryStorage
@@ -10,6 +10,7 @@ __all__ = [
     "LocalStorage",
     "MemoryStorage",
     "Storage",
+    "StorageHealthReport",
     "StoredObject",
     "StoredObjectMeta",
     "get_storage",

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -39,6 +39,14 @@ class StoredObject:
     body: bytes
 
 
+@dataclass(frozen=True, slots=True)
+class StorageHealthReport:
+    """Backend-specific health check result."""
+
+    ok: bool
+    details: dict[str, object] | None = None
+
+
 class Storage(Protocol):
     """Abstract storage backend contract."""
 
@@ -84,3 +92,6 @@ class Storage(Protocol):
         expires_in_seconds: int = 3600,
     ) -> str | None:
         """Return a presigned URL when supported."""
+
+    async def healthcheck(self) -> StorageHealthReport:
+        """Run a bounded, side-effect-free backend health check."""

--- a/app/storage/local.py
+++ b/app/storage/local.py
@@ -12,6 +12,7 @@ from typing import BinaryIO
 
 from app.storage.base import (
     StorageChecksumMismatchError,
+    StorageHealthReport,
     StoragePayload,
     StoredObject,
     StoredObjectMeta,
@@ -76,6 +77,10 @@ class LocalFilesystemStorage:
         """Stub presign support for local storage."""
         _ = (key, method, expires_in_seconds)
         return None
+
+    async def healthcheck(self) -> StorageHealthReport:
+        """Report whether the configured local storage root is reachable."""
+        return await asyncio.to_thread(self._healthcheck_sync)
 
     def _put_sync(self, key: str, data: StoragePayload, immutable: bool) -> StoredObjectMeta:
         final_path = self._path_for_key(key)
@@ -153,6 +158,23 @@ class LocalFilesystemStorage:
     def _exists_sync(self, key: str) -> bool:
         return self._path_for_key(key).exists()
 
+    def _healthcheck_sync(self) -> StorageHealthReport:
+        existing = self._nearest_existing_ancestor(self.root)
+        root_exists = self.root.exists()
+        details: dict[str, object] = {
+            "backend": "local_filesystem",
+            "root_configured": True,
+            "root_exists": root_exists,
+        }
+
+        reachable = (
+            existing is not None
+            and existing.is_dir()
+            and os.access(existing, os.R_OK | os.W_OK | os.X_OK)
+        )
+        details["reachable"] = reachable
+        return StorageHealthReport(ok=reachable, details=details)
+
     def _write_temp_file(self, temp_path: Path, data: StoragePayload) -> tuple[int, str]:
         with temp_path.open("xb") as stream:
             temp_path.chmod(0o600)
@@ -223,6 +245,12 @@ class LocalFilesystemStorage:
 
     def _target_mode(self, immutable: bool) -> int:
         return 0o444 if immutable else 0o600
+
+    def _nearest_existing_ancestor(self, path: Path) -> Path | None:
+        for candidate in (path, *path.parents):
+            if candidate.exists():
+                return candidate
+        return None
 
     def _path_for_key(self, key: str) -> Path:
         if key == "":

--- a/app/storage/memory.py
+++ b/app/storage/memory.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from app.storage.base import (
     StorageChecksumMismatchError,
+    StorageHealthReport,
     StoragePayload,
     StoredObject,
     StoredObjectMeta,
@@ -112,6 +113,10 @@ class MemoryStorage:
         """Stub presign support for interface parity."""
         _ = (key, method, expires_in_seconds)
         return None
+
+    async def healthcheck(self) -> StorageHealthReport:
+        """Report that in-memory storage is available."""
+        return StorageHealthReport(ok=True, details={"backend": "memory", "reachable": True})
 
     def _read_path_bytes(self, path: Path) -> bytes:
         body = bytearray()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -59,6 +59,17 @@ async def test_memory_storage_stat_and_presign_stub() -> None:
 
 
 @pytest.mark.asyncio
+async def test_memory_storage_healthcheck_reports_backend_details() -> None:
+    """Memory storage should expose health through the shared abstraction."""
+    storage = MemoryStorage()
+
+    report = await storage.healthcheck()
+
+    assert report.ok is True
+    assert report.details == {"backend": "memory", "reachable": True}
+
+
+@pytest.mark.asyncio
 async def test_memory_storage_rejects_overwrite_for_mutable_keys() -> None:
     """Memory storage should refuse overwrite operations for mutable keys."""
     storage = MemoryStorage()
@@ -141,6 +152,28 @@ async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
 
     assert await storage.exists(key) is True
     assert list((tmp_path / "originals" / "file-4").glob("*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_local_storage_healthcheck_reports_root_details_without_creating_root(
+    tmp_path: Path,
+) -> None:
+    """Local storage health should describe the configured root without side effects."""
+    root = tmp_path / "storage-root"
+    storage = LocalFilesystemStorage(root)
+
+    report = await storage.healthcheck()
+
+    assert report.ok is True
+    assert report.details == {
+        "backend": "local_filesystem",
+        "reachable": True,
+        "root_configured": True,
+        "root_exists": False,
+    }
+    assert "root" not in report.details
+    assert "nearest_existing_ancestor" not in report.details
+    assert root.exists() is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 import httpx
 import pytest
@@ -27,6 +28,8 @@ from app.schemas.system import (
     DependencyHealthCheck,
     SystemCheckStatus,
 )
+from app.storage import LocalFilesystemStorage
+from app.storage.base import StorageHealthReport
 
 
 @pytest.fixture
@@ -416,3 +419,49 @@ async def test_probe_descriptor_availability_reuses_inflight_thread_probe_on_tim
         await asyncio.sleep(0.01)
 
     assert descriptor.adapter_key not in system_api._INFLIGHT_ADAPTER_PROBE_TASKS
+
+
+@pytest.mark.asyncio
+async def test_probe_storage_check_uses_storage_health_abstraction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Storage health should come from the storage protocol, not backend internals."""
+
+    class SlotBackedStorage:
+        __slots__ = ()
+
+        async def healthcheck(self) -> StorageHealthReport:
+            return StorageHealthReport(
+                ok=True,
+                details={"backend": "slot_storage", "reachable": True},
+            )
+
+    monkeypatch.setattr(system_api, "get_storage", lambda: SlotBackedStorage())
+
+    result = await system_api._probe_storage_check()
+
+    assert result.status is SystemCheckStatus.OK
+    assert result.details == {"backend": "slot_storage", "reachable": True}
+
+
+@pytest.mark.asyncio
+async def test_probe_storage_check_surfaces_local_storage_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local storage health should surface operator-useful backend details."""
+
+    storage = LocalFilesystemStorage(tmp_path / "storage-root")
+    monkeypatch.setattr(system_api, "get_storage", lambda: storage)
+
+    result = await system_api._probe_storage_check()
+
+    assert result.status is SystemCheckStatus.OK
+    assert result.details == {
+        "backend": "local_filesystem",
+        "reachable": True,
+        "root_configured": True,
+        "root_exists": False,
+    }
+    assert "root" not in result.details
+    assert "nearest_existing_ancestor" not in result.details


### PR DESCRIPTION
Closes #144

## Summary
- add a storage-level healthcheck abstraction so `/v1/system/health` no longer inspects backend internals to decide reachability
- keep local filesystem diagnostics useful while sanitizing public health details to avoid leaking absolute paths

## Test plan
- [x] `uv run ruff check app/api/v1/system.py app/storage tests/test_system_endpoints.py tests/test_storage.py`
- [x] `uv run mypy app/api/v1/system.py app/storage`
- [x] `uv run pytest tests/test_system_endpoints.py tests/test_storage.py` (`35 passed`)