### PR TITLE
test: move shared enqueue fixtures into conftest (#124)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from httpx import ASGITransport
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.api.v1.files as files_api
+import app.jobs.worker as worker_module
 from app.core.config import settings
 from app.db.session import get_db
 from app.main import app as fastapi_app
@@ -112,3 +114,16 @@ async def cleanup_projects() -> AsyncGenerator[None, None]:
     async with session_maker() as session:
         await session.execute(text("TRUNCATE TABLE projects CASCADE"))
         await session.commit()
+
+
+@pytest.fixture
+def enqueued_job_ids(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture enqueue calls without requiring a live broker."""
+    recorded_job_ids: list[str] = []
+
+    def _fake_enqueue(job_id: object) -> None:
+        recorded_job_ids.append(str(job_id))
+
+    monkeypatch.setattr(files_api, "enqueue_ingest_job", _fake_enqueue)
+    monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_enqueue)
+    return recorded_job_ids

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -41,7 +41,20 @@ from tests.test_jobs import (
     _upload_file,
 )
 
-pytest_plugins = ("tests.test_jobs",)
+
+@pytest.fixture(autouse=True)
+def fake_ingestion_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[IngestionRunRequest]:
+    """Patch worker ingestion with a deterministic fake runner payload."""
+    recorded_requests: list[IngestionRunRequest] = []
+
+    async def _fake_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+        recorded_requests.append(request)
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+    return recorded_requests
 
 
 def _as_uuid(value: str | uuid.UUID) -> uuid.UUID:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -323,18 +323,6 @@ async def _create_job_event(
     return event
 
 
-@pytest.fixture
-def enqueued_job_ids(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Capture enqueue calls without requiring a live broker."""
-    recorded_job_ids: list[str] = []
-
-    def _fake_enqueue(job_id: uuid.UUID) -> None:
-        recorded_job_ids.append(str(job_id))
-
-    monkeypatch.setattr(files_api, "enqueue_ingest_job", _fake_enqueue)
-    return recorded_job_ids
-
-
 @pytest.fixture(autouse=True)
 def fake_ingestion_runner(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_validation_report_api.py
+++ b/tests/test_validation_report_api.py
@@ -4,9 +4,13 @@ import uuid
 from datetime import UTC, datetime
 
 import httpx
+import pytest
 
 import app.db.session as session_module
+import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
+from app.ingestion.finalization import IngestFinalizationPayload
+from app.ingestion.runner import IngestionRunRequest
 from app.jobs.worker import process_ingest_job
 from app.models.validation_report import ValidationReport
 from tests.conftest import requires_database
@@ -14,9 +18,27 @@ from tests.test_ingest_output_persistence import (
     _assert_validation_report_json_matches_columns,
     _load_project_outputs,
 )
-from tests.test_jobs import _create_project, _get_job_for_file, _upload_file
+from tests.test_jobs import (
+    _build_fake_ingest_payload,
+    _create_project,
+    _get_job_for_file,
+    _upload_file,
+)
 
-pytest_plugins = ("tests.test_jobs",)
+
+@pytest.fixture(autouse=True)
+def fake_ingestion_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[IngestionRunRequest]:
+    """Patch worker ingestion with a deterministic fake runner payload."""
+    recorded_requests: list[IngestionRunRequest] = []
+
+    async def _fake_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+        recorded_requests.append(request)
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+    return recorded_requests
 
 
 def _parse_timestamp(value: str) -> datetime:


### PR DESCRIPTION
Closes #124

## Summary
- move the shared enqueue recorder into `tests/conftest.py` so DB-backed API and job tests patch the same enqueue surfaces consistently
- keep deterministic ingestion payload coverage in the affected modules with local autouse fake runner fixtures after removing plugin-only wiring

## Test plan
- [x] `uv run ruff check tests/conftest.py tests/test_jobs.py tests/test_ingest_output_persistence.py tests/test_validation_report_api.py`
- [x] `uv run mypy tests/conftest.py tests/test_jobs.py tests/test_ingest_output_persistence.py tests/test_validation_report_api.py`
- [x] `uv run pytest tests/test_jobs.py tests/test_ingest_output_persistence.py tests/test_validation_report_api.py` (`1 passed, 50 skipped` because `DATABASE_URL` is unset)

## Notes
- DB-dependent tests still need a `DATABASE_URL`-backed run in CI or a local database environment.