### PR TITLE
fix(worker): stream originals to temp staging from storage

### DIFF
--- a/app/ingestion/source.py
+++ b/app/ingestion/source.py
@@ -11,7 +11,11 @@ from uuid import UUID
 
 from app.ingestion.contracts import AdapterSource, InputFamily, UploadFormat
 from app.storage import Storage, get_storage
-from app.storage.base import StorageChecksumMismatchError
+from app.storage.base import (
+    StorageChecksumMismatchError,
+    StorageReadError,
+    StorageWriteError,
+)
 from app.storage.keys import build_original_storage_key
 
 
@@ -54,32 +58,32 @@ async def materialize_original_source(
     """Fetch an immutable original and stage it into an attempt-local tempdir."""
     resolved_storage = storage or get_storage()
     storage_key = build_original_storage_key(source.file_id, source.checksum_sha256)
-    try:
-        stored_object = await resolved_storage.get(
-            storage_key,
-            expected_checksum_sha256=source.checksum_sha256,
-        )
-    except StorageChecksumMismatchError as exc:
-        raise OriginalSourceReadError(
-            storage_key=storage_key,
-            reason="checksum_mismatch",
-        ) from exc
-    except (FileNotFoundError, KeyError) as exc:
-        raise OriginalSourceReadError(
-            storage_key=storage_key,
-            reason="not_found",
-        ) from exc
-    except OSError as exc:
-        raise OriginalSourceReadError(
-            storage_key=storage_key,
-            reason="read_failed",
-        ) from exc
-
     temp_dir_root = str(temp_root) if temp_root is not None else None
     with TemporaryDirectory(prefix="ingestion-source-", dir=temp_dir_root) as temp_dir:
         file_path = Path(temp_dir) / _materialized_name(source)
         try:
-            file_path.write_bytes(stored_object.body)
+            await resolved_storage.copy_to_path(
+                storage_key,
+                file_path,
+                expected_checksum_sha256=source.checksum_sha256,
+            )
+        except StorageChecksumMismatchError as exc:
+            raise OriginalSourceReadError(
+                storage_key=storage_key,
+                reason="checksum_mismatch",
+            ) from exc
+        except (FileNotFoundError, KeyError) as exc:
+            raise OriginalSourceReadError(
+                storage_key=storage_key,
+                reason="not_found",
+            ) from exc
+        except StorageReadError as exc:
+            raise OriginalSourceReadError(
+                storage_key=storage_key,
+                reason="read_failed",
+            ) from exc
+        except StorageWriteError as exc:
+            raise OriginalSourceStageError(reason="stage_failed") from exc
         except OSError as exc:
             raise OriginalSourceStageError(reason="stage_failed") from exc
         yield AdapterSource(

--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -31,6 +31,14 @@ class StorageChecksumMismatchError(ValueError):
         )
 
 
+class StorageReadError(OSError):
+    """Raised when a storage backend cannot read object bytes."""
+
+
+class StorageWriteError(OSError):
+    """Raised when a storage backend cannot stage bytes to a destination path."""
+
+
 @dataclass(frozen=True, slots=True)
 class StoredObject:
     """Stored object bytes and metadata."""
@@ -66,6 +74,15 @@ class Storage(Protocol):
         expected_checksum_sha256: str | None = None,
     ) -> StoredObject:
         """Read an object by key and optionally verify its checksum."""
+
+    async def copy_to_path(
+        self,
+        key: str,
+        destination: Path,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
+        """Stream an object into a caller-owned destination path and verify its checksum."""
 
     async def stat(
         self,

--- a/app/storage/local.py
+++ b/app/storage/local.py
@@ -14,6 +14,8 @@ from app.storage.base import (
     StorageChecksumMismatchError,
     StorageHealthReport,
     StoragePayload,
+    StorageReadError,
+    StorageWriteError,
     StoredObject,
     StoredObjectMeta,
 )
@@ -45,6 +47,21 @@ class LocalFilesystemStorage:
     ) -> StoredObject:
         """Load a stored object and optionally verify its checksum."""
         return await asyncio.to_thread(self._get_sync, key, expected_checksum_sha256)
+
+    async def copy_to_path(
+        self,
+        key: str,
+        destination: Path,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
+        """Copy a stored object into a caller-owned destination path."""
+        return await asyncio.to_thread(
+            self._copy_to_path_sync,
+            key,
+            destination,
+            expected_checksum_sha256,
+        )
 
     async def stat(
         self,
@@ -142,6 +159,45 @@ class LocalFilesystemStorage:
             checksum_sha256=checksum_sha256,
         )
 
+    def _copy_to_path_sync(
+        self,
+        key: str,
+        destination: Path,
+        expected_checksum_sha256: str | None,
+    ) -> StoredObjectMeta:
+        source_path = self._path_for_key(key)
+        destination_created = False
+        try:
+            with (
+                self._open_copy_source(source_path, key) as source_stream,
+                self._open_copy_destination(destination, key) as destination_stream,
+            ):
+                destination_created = True
+                size_bytes, checksum_sha256 = self._copy_stream_to_destination(
+                    source_stream,
+                    destination_stream,
+                    key=key,
+                )
+                try:
+                    destination_stream.flush()
+                    os.fsync(destination_stream.fileno())
+                except OSError as exc:
+                    raise StorageWriteError(
+                        f"Failed to stage storage key '{key}' to destination."
+                    ) from exc
+            self._verify_checksum(key, expected_checksum_sha256, checksum_sha256)
+            return StoredObjectMeta(
+                key=key,
+                storage_uri=f"file://{source_path}",
+                size_bytes=size_bytes,
+                checksum_sha256=checksum_sha256,
+            )
+        except BaseException:
+            if destination_created:
+                with suppress(OSError):
+                    destination.unlink()
+            raise
+
     def _delete_sync(self, key: str) -> None:
         path = self._path_for_key(key)
         if path.exists() and self._is_immutable_path(path):
@@ -201,6 +257,49 @@ class LocalFilesystemStorage:
             checksum_builder.update(chunk)
             size_bytes += len(chunk)
         return size_bytes, checksum_builder.hexdigest()
+
+    def _copy_stream_to_destination(
+        self,
+        source_stream: BinaryIO,
+        destination_stream: BinaryIO,
+        *,
+        key: str,
+    ) -> tuple[int, str]:
+        checksum_builder = hashlib.sha256()
+        size_bytes = 0
+        while True:
+            try:
+                chunk = source_stream.read(_COPY_CHUNK_SIZE_BYTES)
+            except OSError as exc:
+                raise StorageReadError(f"Failed to read storage key '{key}'.") from exc
+            if not chunk:
+                return size_bytes, checksum_builder.hexdigest()
+            try:
+                destination_stream.write(chunk)
+            except OSError as exc:
+                raise StorageWriteError(
+                    f"Failed to stage storage key '{key}' to destination."
+                ) from exc
+            checksum_builder.update(chunk)
+            size_bytes += len(chunk)
+
+    def _open_copy_source(self, source_path: Path, key: str) -> BinaryIO:
+        try:
+            return source_path.open("rb")
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise StorageReadError(f"Failed to read storage key '{key}'.") from exc
+
+    def _open_copy_destination(self, destination: Path, key: str) -> BinaryIO:
+        try:
+            return destination.open("xb")
+        except FileExistsError:
+            raise
+        except OSError as exc:
+            raise StorageWriteError(
+                f"Failed to stage storage key '{key}' to destination."
+            ) from exc
 
     def _read_body_with_checksum(self, path: Path) -> tuple[bytes, str]:
         checksum_builder = hashlib.sha256()

--- a/app/storage/memory.py
+++ b/app/storage/memory.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+from typing import BinaryIO
 
 from app.storage.base import (
     StorageChecksumMismatchError,
     StorageHealthReport,
     StoragePayload,
+    StorageWriteError,
     StoredObject,
     StoredObjectMeta,
 )
@@ -64,6 +66,44 @@ class MemoryStorage:
             body=body,
         )
 
+    async def copy_to_path(
+        self,
+        key: str,
+        destination: Path,
+        *,
+        expected_checksum_sha256: str | None = None,
+    ) -> StoredObjectMeta:
+        """Copy a stored object into a caller-owned destination path."""
+        body, _ = self._objects[key]
+        checksum_builder = hashlib.sha256()
+        size_bytes = 0
+        destination_created = False
+        try:
+            with self._open_copy_destination(destination, key) as stream:
+                destination_created = True
+                for index in range(0, len(body), _MEMORY_READ_CHUNK_SIZE_BYTES):
+                    chunk = body[index : index + _MEMORY_READ_CHUNK_SIZE_BYTES]
+                    try:
+                        stream.write(chunk)
+                    except OSError as exc:
+                        raise StorageWriteError(
+                            f"Failed to stage storage key '{key}' to destination."
+                        ) from exc
+                    checksum_builder.update(chunk)
+                    size_bytes += len(chunk)
+            checksum_sha256 = checksum_builder.hexdigest()
+            self._verify_checksum(key, expected_checksum_sha256, checksum_sha256)
+            return StoredObjectMeta(
+                key=key,
+                storage_uri=f"memory://{key}",
+                size_bytes=size_bytes,
+                checksum_sha256=checksum_sha256,
+            )
+        except BaseException:
+            if destination_created:
+                destination.unlink(missing_ok=True)
+            raise
+
     async def stat(
         self,
         key: str,
@@ -117,6 +157,16 @@ class MemoryStorage:
     async def healthcheck(self) -> StorageHealthReport:
         """Report that in-memory storage is available."""
         return StorageHealthReport(ok=True, details={"backend": "memory", "reachable": True})
+
+    def _open_copy_destination(self, destination: Path, key: str) -> BinaryIO:
+        try:
+            return destination.open("xb")
+        except FileExistsError:
+            raise
+        except OSError as exc:
+            raise StorageWriteError(
+                f"Failed to stage storage key '{key}' to destination."
+            ) from exc
 
     def _read_path_bytes(self, path: Path) -> bytes:
         body = bytearray()

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -9,7 +9,7 @@ import types
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, BinaryIO, Literal, cast
 from uuid import uuid4
 
 import ezdxf
@@ -33,8 +33,14 @@ from app.ingestion.contracts import (
 )
 from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
 from app.ingestion.selection import select_adapter_candidates
-from app.ingestion.source import OriginalSourceMaterialization, materialize_original_source
+from app.ingestion.source import (
+    OriginalSourceMaterialization,
+    OriginalSourceReadError,
+    OriginalSourceStageError,
+    materialize_original_source,
+)
 from app.storage.keys import build_original_storage_key
+from app.storage.local import LocalFilesystemStorage
 from app.storage.memory import MemoryStorage
 
 _DXF_SMOKE_FIXTURE = Path(__file__).parent / "fixtures" / "dxf" / "simple-line.dxf"
@@ -167,6 +173,152 @@ async def test_materialize_original_source_stages_and_cleans_up(tmp_path: Path) 
         assert source.original_name == "../drawing.pdf"
 
     assert not staged_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_materialize_original_source_uses_copy_to_path_when_get_is_broken(
+    tmp_path: Path,
+) -> None:
+    class _CopyOnlyMemoryStorage(MemoryStorage):
+        async def get(self, *_args: object, **_kwargs: object) -> Any:
+            raise AssertionError("get should not be used for staging")
+
+    storage = _CopyOnlyMemoryStorage()
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+
+    materialization = OriginalSourceMaterialization(
+        file_id=file_id,
+        checksum_sha256=checksum,
+        upload_format=UploadFormat.PDF,
+        input_family=InputFamily.PDF_VECTOR,
+        media_type="application/pdf",
+    )
+
+    async with materialize_original_source(
+        materialization,
+        storage=storage,
+        temp_root=tmp_path,
+    ) as source:
+        assert source.file_path.read_bytes() == body
+
+
+@pytest.mark.asyncio
+async def test_materialize_original_source_maps_local_source_read_oserror_to_read_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = LocalFilesystemStorage(tmp_path / "storage")
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+
+    class _BrokenSourceStream:
+        def __enter__(self) -> _BrokenSourceStream:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+            return False
+
+        def read(self, _size: int) -> bytes:
+            raise OSError("source read failed")
+
+        def close(self) -> None:
+            return None
+
+    def _open_copy_source(_source_path: Path, _key: str) -> BinaryIO:
+        return cast(BinaryIO, _BrokenSourceStream())
+
+    monkeypatch.setattr(storage, "_open_copy_source", _open_copy_source)
+
+    materialization = OriginalSourceMaterialization(
+        file_id=file_id,
+        checksum_sha256=checksum,
+        upload_format=UploadFormat.PDF,
+        input_family=InputFamily.PDF_VECTOR,
+        media_type="application/pdf",
+    )
+
+    with pytest.raises(OriginalSourceReadError) as exc_info:
+        async with materialize_original_source(
+            materialization,
+            storage=storage,
+            temp_root=temp_root,
+        ):
+            pytest.fail("materialization should fail before yielding")
+
+    assert exc_info.value.reason == "read_failed"
+    assert exc_info.value.storage_key == key
+    assert list(temp_root.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_materialize_original_source_maps_destination_write_oserror_to_stage_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = LocalFilesystemStorage(tmp_path / "storage")
+    file_id = uuid4()
+    body = b"%PDF-1.7\n"
+    checksum = hashlib.sha256(body).hexdigest()
+    key = build_original_storage_key(file_id, checksum)
+    await storage.put(key, body, immutable=True)
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+
+    class _BrokenDestinationStream:
+        def __init__(self, stream: BinaryIO) -> None:
+            self._stream = stream
+
+        def __enter__(self) -> _BrokenDestinationStream:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+            self._stream.close()
+            return False
+
+        def write(self, _chunk: bytes) -> int:
+            raise OSError("destination write failed")
+
+        def flush(self) -> None:
+            self._stream.flush()
+
+        def fileno(self) -> int:
+            return self._stream.fileno()
+
+        def close(self) -> None:
+            self._stream.close()
+
+    def _open_copy_destination(destination: Path, _key: str) -> BinaryIO:
+        return cast(BinaryIO, _BrokenDestinationStream(destination.open("xb")))
+
+    monkeypatch.setattr(storage, "_open_copy_destination", _open_copy_destination)
+
+    materialization = OriginalSourceMaterialization(
+        file_id=file_id,
+        checksum_sha256=checksum,
+        upload_format=UploadFormat.PDF,
+        input_family=InputFamily.PDF_VECTOR,
+        media_type="application/pdf",
+    )
+
+    with pytest.raises(OriginalSourceStageError) as exc_info:
+        async with materialize_original_source(
+            materialization,
+            storage=storage,
+            temp_root=temp_root,
+        ):
+            pytest.fail("materialization should fail before yielding")
+
+    assert exc_info.value.reason == "stage_failed"
+    assert list(temp_root.iterdir()) == []
 
 
 def test_select_adapter_candidates_keeps_pdf_vector_then_raster_order() -> None:
@@ -1359,9 +1511,9 @@ async def test_run_ingestion_enforces_source_timeout_checkpoint(
     module = _AdapterModule("timeout_adapter_module", lambda: _FakeAdapter(seen_paths=[]))
 
     class _SlowMemoryStorage(MemoryStorage):
-        async def get(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        async def copy_to_path(self, *args, **kwargs):  # type: ignore[no-untyped-def]
             await asyncio.sleep(0.02)
-            return await super().get(*args, **kwargs)
+            return await super().copy_to_path(*args, **kwargs)
 
     def fake_import_module(module_name: str) -> types.ModuleType:
         if module_name == "app.ingestion.adapters.ezdxf":

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -609,8 +609,8 @@ class TestJobs:
         def _capture_logger_error(event: str, **kwargs: Any) -> None:
             logger_error_calls.append((event, kwargs))
 
-        def _fail_write_bytes(self: Any, _: bytes) -> int:
-            raise OSError(f"{secret_temp_marker}: {self}")
+        async def _fail_copy_to_path(*args: Any, **kwargs: Any) -> Any:
+            raise OSError(f"{secret_temp_marker}: staging")
 
         module = _AdapterModule("available_stage_vector_adapter_module", lambda: object())
 
@@ -627,7 +627,11 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
         await _update_source_file(uuid.UUID(uploaded["id"]), original_filename="..")
-        monkeypatch.setattr("app.ingestion.source.Path.write_bytes", _fail_write_bytes)
+        monkeypatch.setattr("app.storage.memory.MemoryStorage.copy_to_path", _fail_copy_to_path)
+        monkeypatch.setattr(
+            "app.storage.local.LocalFilesystemStorage.copy_to_path",
+            _fail_copy_to_path,
+        )
 
         with pytest.raises(IngestionRunnerError, match="Failed to stage original source"):
             await worker_module.process_ingest_job(job.id)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,7 +1,10 @@
 """Unit tests for storage backends."""
 
+from __future__ import annotations
+
 import hashlib
 from pathlib import Path
+from typing import BinaryIO, Literal, cast
 
 import pytest
 
@@ -10,7 +13,11 @@ from app.storage import (
     LocalStorage,
     MemoryStorage,
 )
-from app.storage.base import StorageChecksumMismatchError
+from app.storage.base import (
+    StorageChecksumMismatchError,
+    StorageReadError,
+    StorageWriteError,
+)
 
 
 @pytest.mark.asyncio
@@ -56,6 +63,28 @@ async def test_memory_storage_stat_and_presign_stub() -> None:
     assert stat.size_bytes == 3
     assert stat.checksum_sha256 == hashlib.sha256(b"abc").hexdigest()
     assert await storage.presign(key) is None
+
+
+@pytest.mark.asyncio
+async def test_memory_storage_copy_to_path_round_trip(tmp_path: Path) -> None:
+    """Memory storage should stream a stored object into a destination path."""
+    storage = MemoryStorage()
+    key = "originals/file-copy/checksum-copy"
+    payload = b"copy-payload"
+    await storage.put(key, payload, immutable=True)
+    destination = tmp_path / "staged.bin"
+
+    meta = await storage.copy_to_path(
+        key,
+        destination,
+        expected_checksum_sha256=hashlib.sha256(payload).hexdigest(),
+    )
+
+    assert destination.read_bytes() == payload
+    assert meta.key == key
+    assert meta.storage_uri == f"memory://{key}"
+    assert meta.size_bytes == len(payload)
+    assert meta.checksum_sha256 == hashlib.sha256(payload).hexdigest()
 
 
 @pytest.mark.asyncio
@@ -152,6 +181,110 @@ async def test_local_storage_round_trip_and_cleanup(tmp_path: Path) -> None:
 
     assert await storage.exists(key) is True
     assert list((tmp_path / "originals" / "file-4").glob("*.tmp")) == []
+
+
+@pytest.mark.asyncio
+async def test_local_storage_copy_to_path_round_trip(tmp_path: Path) -> None:
+    """Local storage should stream a stored object into a destination path."""
+    storage = LocalFilesystemStorage(tmp_path / "storage")
+    key = "originals/file-copy/checksum-copy"
+    payload = b"copy-payload"
+    meta = await storage.put(key, payload, immutable=True)
+    destination = tmp_path / "staging" / "staged.bin"
+    destination.parent.mkdir()
+
+    copied = await storage.copy_to_path(
+        key,
+        destination,
+        expected_checksum_sha256=meta.checksum_sha256,
+    )
+
+    assert destination.read_bytes() == payload
+    assert copied == meta
+
+
+@pytest.mark.asyncio
+async def test_local_storage_copy_to_path_classifies_source_read_oserror_and_cleans_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local storage should classify source read failures and remove partial outputs."""
+    storage = LocalFilesystemStorage(tmp_path / "storage")
+    key = "originals/file-copy/checksum-copy"
+    payload = b"copy-payload"
+    await storage.put(key, payload, immutable=True)
+    destination = tmp_path / "staging" / "staged.bin"
+    destination.parent.mkdir()
+
+    class _BrokenSourceStream:
+        def __enter__(self) -> _BrokenSourceStream:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+            return False
+
+        def read(self, _size: int) -> bytes:
+            raise OSError("source read failed")
+
+        def close(self) -> None:
+            return None
+
+    def _open_copy_source(_source_path: Path, _key: str) -> BinaryIO:
+        return cast(BinaryIO, _BrokenSourceStream())
+
+    monkeypatch.setattr(storage, "_open_copy_source", _open_copy_source)
+
+    with pytest.raises(StorageReadError):
+        await storage.copy_to_path(key, destination)
+
+    assert destination.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_local_storage_copy_to_path_classifies_destination_write_oserror_and_cleans_up(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local storage should classify destination write failures and remove partial outputs."""
+    storage = LocalFilesystemStorage(tmp_path / "storage")
+    key = "originals/file-copy/checksum-copy"
+    payload = b"copy-payload"
+    await storage.put(key, payload, immutable=True)
+    destination = tmp_path / "staging" / "staged.bin"
+    destination.parent.mkdir()
+
+    class _BrokenDestinationStream:
+        def __init__(self, stream: BinaryIO) -> None:
+            self._stream = stream
+
+        def __enter__(self) -> _BrokenDestinationStream:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> Literal[False]:
+            self._stream.close()
+            return False
+
+        def write(self, _chunk: bytes) -> int:
+            raise OSError("destination write failed")
+
+        def flush(self) -> None:
+            self._stream.flush()
+
+        def fileno(self) -> int:
+            return self._stream.fileno()
+
+        def close(self) -> None:
+            self._stream.close()
+
+    def _open_copy_destination(_destination: Path, _key: str) -> BinaryIO:
+        return cast(BinaryIO, _BrokenDestinationStream(destination.open("xb")))
+
+    monkeypatch.setattr(storage, "_open_copy_destination", _open_copy_destination)
+
+    with pytest.raises(StorageWriteError):
+        await storage.copy_to_path(key, destination)
+
+    assert destination.exists() is False
 
 
 @pytest.mark.asyncio
@@ -338,3 +471,56 @@ async def test_local_storage_detects_checksum_tampering_on_get_and_stat(tmp_path
 
     with pytest.raises(StorageChecksumMismatchError):
         await storage.stat(key, expected_checksum_sha256=meta.checksum_sha256)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("storage_kind", ["memory", "local"])
+async def test_storage_copy_to_path_removes_partial_destination_on_checksum_mismatch(
+    tmp_path: Path,
+    storage_kind: str,
+) -> None:
+    """Streaming copy should clean up partial destinations on checksum mismatch."""
+    storage: MemoryStorage | LocalFilesystemStorage
+    if storage_kind == "memory":
+        storage = MemoryStorage()
+    else:
+        storage = LocalFilesystemStorage(tmp_path / "storage")
+
+    key = "originals/file-copy/checksum-copy"
+    payload = b"copy-payload"
+    await storage.put(key, payload, immutable=True)
+    destination = tmp_path / f"{storage_kind}-checksum.bin"
+
+    with pytest.raises(StorageChecksumMismatchError):
+        await storage.copy_to_path(
+            key,
+            destination,
+            expected_checksum_sha256=hashlib.sha256(b"different").hexdigest(),
+        )
+
+    assert destination.exists() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("storage_kind", ["memory", "local"])
+async def test_storage_copy_to_path_rejects_existing_destination_without_overwrite(
+    tmp_path: Path,
+    storage_kind: str,
+) -> None:
+    """Streaming copy should fail when the destination already exists."""
+    storage: MemoryStorage | LocalFilesystemStorage
+    if storage_kind == "memory":
+        storage = MemoryStorage()
+    else:
+        storage = LocalFilesystemStorage(tmp_path / "storage")
+
+    key = "originals/file-copy/checksum-copy"
+    payload = b"copy-payload"
+    await storage.put(key, payload, immutable=True)
+    destination = tmp_path / f"{storage_kind}-exists.bin"
+    destination.write_bytes(b"existing")
+
+    with pytest.raises(FileExistsError):
+        await storage.copy_to_path(key, destination)
+
+    assert destination.read_bytes() == b"existing"


### PR DESCRIPTION
Closes #130

## Summary
- add a streaming storage-to-path abstraction for original-source staging
- preserve checksum verification and partial-file cleanup while avoiding full-body loads
- distinguish storage read failures from staging write failures in worker error handling

## Test plan
- [x] uv run ruff check app/ingestion/source.py app/storage tests/test_storage.py tests/test_jobs.py tests/test_ingestion_runner.py
- [x] uv run mypy app/ingestion/source.py app/storage
- [x] uv run pytest tests/test_storage.py tests/test_ingestion_runner.py -k "copy_to_path or materialize_original_source or storage_read_errors or checksum_mismatch"