### PR TITLE
test(ingestion): enforce canonical entity envelope across adapters

### DIFF
--- a/app/ingestion/adapters/ezdxf.py
+++ b/app/ingestion/adapters/ezdxf.py
@@ -288,6 +288,10 @@ class EzdxfAdapter:
             "entities": tuple(canonical_entities),
             "xrefs": xrefs,
         }
+        if not canonical_entities:
+            canonical["metadata"] = {
+                "empty_entities_reason": "dxf_modelspace_empty",
+            }
 
         review_required = (
             unsupported_entities > 0
@@ -625,9 +629,12 @@ def _unknown_entity_payload(
         "geometry": {
             "bbox": None,
             "units": dict(units),
+            "status": "absent",
+            "reason": "unsupported_or_invalid_geometry",
             "geometry_summary": {
                 "kind": "unknown",
                 "source_type": native_type,
+                "reason": "unsupported_or_invalid_geometry",
             },
         },
         "properties": {

--- a/app/ingestion/adapters/ifcopenshell.py
+++ b/app/ingestion/adapters/ifcopenshell.py
@@ -44,6 +44,7 @@ from app.ingestion.contracts import (
 
 _PACKAGE_NAME = "ifcopenshell"
 _ADAPTER_KEY = "ifcopenshell"
+_SCHEMA_VERSION = "0.1"
 _SCHEMA_PATTERN = re.compile(r"FILE_SCHEMA\s*\(\s*\(\s*'([^']+)'", re.IGNORECASE)
 _SUPPORTED_SCHEMAS = frozenset({"IFC2X3", "IFC4", "IFC4X3"})
 _HEADER_READ_LIMIT_BYTES = 64 * 1024
@@ -58,6 +59,16 @@ _SCHEMA_ALIASES = {
     "IFC4X3ADD2": "IFC4X3",
     "IFC4X3ADD2TC1": "IFC4X3",
 }
+_NULLABLE_LINKAGE_KEYS = frozenset(
+    {
+        "drawing_revision_id",
+        "source_file_id",
+        "layout_ref",
+        "layer_ref",
+        "block_ref",
+        "parent_entity_ref",
+    }
+)
 
 _BASE_DESCRIPTOR = AdapterDescriptor(
     key=_ADAPTER_KEY,
@@ -260,6 +271,7 @@ class IfcOpenShellAdapter(IngestionAdapter):
                     entities=(),
                     layer_names=(),
                     units={"normalized": "meter", "source": "default", "assumed": True},
+                    empty_entities_reason="semantic_extract_skipped",
                 ),
                 provenance=tuple(provenance),
                 confidence=ConfidenceSummary(
@@ -298,11 +310,13 @@ class IfcOpenShellAdapter(IngestionAdapter):
         ]
         project = _first(_sequence(_model_by_type(model, "IfcProject")))
         util_element = _resolve_element_module(runtime)
+        units = _extract_units(project)
 
         raw_entities = [
             _extract_entity_payload(
                 product=product,
                 util_element=util_element,
+                units=units,
                 warnings=warnings,
             )
             for product in products
@@ -310,7 +324,6 @@ class IfcOpenShellAdapter(IngestionAdapter):
         entities = _finalize_entity_ids(raw_entities)
         layer_names = tuple(_unique_strings(entity.get("layer") for entity in entities))
         project_metadata = _extract_project_metadata(project)
-        units = _extract_units(project)
 
         if units.get("assumed") is True:
             warnings.append(
@@ -372,6 +385,7 @@ class IfcOpenShellAdapter(IngestionAdapter):
                 entities=tuple(entities),
                 layer_names=layer_names,
                 units=units,
+                empty_entities_reason="no_ifc_products" if not entities else None,
             ),
             provenance=tuple(provenance),
             confidence=ConfidenceSummary(
@@ -557,10 +571,15 @@ def _build_canonical(
     entities: Sequence[Mapping[str, JSONValue]],
     layer_names: Sequence[str],
     units: Mapping[str, JSONValue],
+    empty_entities_reason: str | None = None,
 ) -> dict[str, JSONValue]:
     project_payload = dict(project_metadata)
     metadata: dict[str, JSONValue] = {"project": project_payload}
+    if empty_entities_reason is not None:
+        metadata["empty_entities_reason"] = empty_entities_reason
     canonical: dict[str, JSONValue] = {
+        "schema_version": _SCHEMA_VERSION,
+        "canonical_entity_schema_version": _SCHEMA_VERSION,
         "units": dict(units),
         "coordinate_system": {"name": "local", "source": "semantic_ifc_metadata"},
         "layouts": (),
@@ -600,6 +619,7 @@ def _extract_entity_payload(
     *,
     product: object,
     util_element: object | None,
+    units: Mapping[str, JSONValue],
     warnings: list[AdapterWarning],
 ) -> _RawEntity:
     ifc_type = _entity_type(product)
@@ -654,9 +674,13 @@ def _extract_entity_payload(
         )
     payload: dict[str, JSONValue] = {
         "id": preferred_id,
+        "entity_id": preferred_id,
+        "entity_type": "ifc_product",
+        "entity_schema_version": _SCHEMA_VERSION,
         "kind": "ifc_product",
         "ifc_type": ifc_type,
         "layer": ifc_type,
+        "layout": None,
         "name": _string_or_none(getattr(product, "Name", None)),
         "description": _string_or_none(getattr(product, "Description", None)),
         "object_type": _string_or_none(getattr(product, "ObjectType", None)),
@@ -671,9 +695,35 @@ def _extract_entity_payload(
         "psets": psets,
         "qtos": qtos,
         "material_refs": material_refs,
+        "geometry": _entity_geometry(units=units),
+        "properties": _entity_properties(
+            ifc_type=ifc_type,
+            global_id=global_id,
+            step_id_token=step_id_token,
+        ),
+        "provenance": _entity_provenance(
+            entity_id=preferred_id,
+            ifc_type=ifc_type,
+            global_id=global_id,
+            step_id_token=step_id_token,
+        ),
+        "confidence": {
+            "score": 0.4,
+            "basis": "semantic_ifc_metadata_only",
+        },
+        "drawing_revision_id": None,
+        "source_file_id": None,
+        "layout_ref": None,
+        "layer_ref": ifc_type,
+        "block_ref": None,
+        "parent_entity_ref": None,
     }
     return _RawEntity(
-        payload={key: value for key, value in payload.items() if value is not None},
+        payload={
+            key: value
+            for key, value in payload.items()
+            if value is not None or key in _NULLABLE_LINKAGE_KEYS
+        },
         preferred_id=preferred_id,
         has_global_id=global_id is not None,
         step_id_value=step_id_value,
@@ -708,9 +758,62 @@ def _finalize_entity_ids(raw_entities: Sequence[_RawEntity]) -> tuple[dict[str, 
         count = seen.get(entity.preferred_id, 0) + 1
         seen[entity.preferred_id] = count
         payload = dict(entity.payload)
-        payload["id"] = entity.preferred_id if count == 1 else f"{entity.preferred_id}-{count}"
+        finalized_id = entity.preferred_id if count == 1 else f"{entity.preferred_id}-{count}"
+        payload["id"] = finalized_id
+        payload["entity_id"] = finalized_id
+        provenance = payload.get("provenance")
+        if isinstance(provenance, dict):
+            provenance["source_entity_ref"] = f"entities.{finalized_id}"
         finalized.append(payload)
     return tuple(finalized)
+
+
+def _entity_geometry(*, units: Mapping[str, JSONValue]) -> dict[str, JSONValue]:
+    return {
+        "bbox": None,
+        "units": dict(units),
+        "status": "absent",
+        "reason": "semantic_metadata_only",
+        "geometry_summary": {
+            "kind": "none",
+            "reason": "semantic_metadata_only",
+        },
+    }
+
+
+def _entity_properties(
+    *,
+    ifc_type: str,
+    global_id: str | None,
+    step_id_token: str | None,
+) -> dict[str, JSONValue]:
+    return {
+        "source_type": ifc_type,
+        "source_handle": step_id_token,
+        "quantity_hints": None,
+        "adapter_native": {
+            "ifcopenshell": {
+                "ifc_type": ifc_type,
+                "ifc_global_id": global_id,
+                "ifc_step_id": step_id_token,
+            }
+        },
+    }
+
+
+def _entity_provenance(
+    *,
+    entity_id: str,
+    ifc_type: str,
+    global_id: str | None,
+    step_id_token: str | None,
+) -> dict[str, JSONValue]:
+    return {
+        "source_entity_ref": f"entities.{entity_id}",
+        "native_entity_type": ifc_type,
+        "ifc_global_id": global_id,
+        "ifc_step_id": step_id_token,
+    }
 
 
 def _extract_project_metadata(project: object | None) -> dict[str, JSONValue]:

--- a/app/ingestion/adapters/libredwg.py
+++ b/app/ingestion/adapters/libredwg.py
@@ -498,6 +498,7 @@ def _build_placeholder_canonical(
     metadata: dict[str, JSONValue] = {
         "source_format": source.upload_format.value,
         "adapter_mode": "placeholder",
+        "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
         "dwgread": {
             "output_kind": run_result.output_kind,
             "output_size_bytes": run_result.output_size_bytes,

--- a/app/ingestion/adapters/pymupdf.py
+++ b/app/ingestion/adapters/pymupdf.py
@@ -400,6 +400,8 @@ def _extract_document_canonical(
         },
         "text_blocks": tuple(text_blocks),
     }
+    if not entities:
+        metadata["empty_entities_reason"] = "no_vector_entities_detected"
 
     return {
         "schema_version": _SCHEMA_VERSION,
@@ -738,6 +740,12 @@ def _build_lineish_entity(
             "score": _VECTOR_CONFIDENCE_SCORE,
             "basis": "vector_path_segment",
         },
+        "drawing_revision_id": None,
+        "source_file_id": None,
+        "layout_ref": layout_name,
+        "layer_ref": layer_name,
+        "block_ref": None,
+        "parent_entity_ref": None,
     }
     if entity_type == "line":
         start, end = normalized_points

--- a/app/ingestion/adapters/vtracer_tesseract.py
+++ b/app/ingestion/adapters/vtracer_tesseract.py
@@ -88,6 +88,7 @@ class VTracerTesseractAdapter(IngestionAdapter):
                 "geometry_mode": "raster",
                 "page_count": page_count,
                 "default_layer": _DEFAULT_LAYER,
+                "empty_entities_reason": "raster_vectorization_deferred",
                 "text_blocks": [],
                 "pdf_scale": {
                     "status": "unconfirmed",

--- a/tests/ingestion_contract_harness.py
+++ b/tests/ingestion_contract_harness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -35,6 +36,15 @@ from app.ingestion.finalization import (
 
 _DEFAULT_CONTRACT_TIMEOUT = AdapterTimeout(seconds=0.5)
 _DEFAULT_FAILURE_TIMEOUT = AdapterTimeout(seconds=0.01)
+_CONTRACT_ENTITY_SCHEMA_VERSION = "0.1"
+_NULLABLE_LINKAGE_FIELDS = (
+    "drawing_revision_id",
+    "source_file_id",
+    "layout_ref",
+    "layer_ref",
+    "block_ref",
+    "parent_entity_ref",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,6 +99,8 @@ def build_complete_canonical(*, include_pdf_scale: bool = False) -> dict[str, JS
     """Return a canonical payload that satisfies baseline validator checks."""
 
     canonical: dict[str, JSONValue] = {
+        "schema_version": _CONTRACT_ENTITY_SCHEMA_VERSION,
+        "canonical_entity_schema_version": _CONTRACT_ENTITY_SCHEMA_VERSION,
         "units": {"normalized": "meter"},
         "coordinate_system": {"name": "local"},
         "layouts": ({"name": "Model"},),
@@ -96,10 +108,43 @@ def build_complete_canonical(*, include_pdf_scale: bool = False) -> dict[str, JS
         "blocks": (),
         "entities": (
             {
+                "entity_id": "contract-entity-1",
+                "entity_type": "line",
+                "entity_schema_version": _CONTRACT_ENTITY_SCHEMA_VERSION,
+                "id": "contract-entity-1",
                 "kind": "line",
+                "layout": "Model",
                 "layer": "A-WALL",
                 "start": {"x": 0.0, "y": 0.0},
                 "end": {"x": 10.0, "y": 0.0},
+                "geometry": {
+                    "start": {"x": 0.0, "y": 0.0},
+                    "end": {"x": 10.0, "y": 0.0},
+                    "bbox": {"x_min": 0.0, "y_min": 0.0, "x_max": 10.0, "y_max": 0.0},
+                    "units": {"normalized": "meter"},
+                    "geometry_summary": {
+                        "kind": "line_segment",
+                        "length": 10.0,
+                        "vertex_count": 2,
+                    },
+                },
+                "properties": {
+                    "source_type": "LINE",
+                    "source_handle": "ABC",
+                    "quantity_hints": {"length": 10.0, "count": 1.0},
+                    "adapter_native": {"contract": {"layer": "A-WALL"}},
+                },
+                "provenance": {
+                    "source_entity_ref": "entities.contract-entity-1",
+                    "normalized_source_hash": "0" * 64,
+                },
+                "confidence": 0.99,
+                "drawing_revision_id": None,
+                "source_file_id": None,
+                "layout_ref": "Model",
+                "layer_ref": "A-WALL",
+                "block_ref": None,
+                "parent_entity_ref": None,
             },
         ),
         "xrefs": (),
@@ -151,10 +196,23 @@ def assert_adapter_result_contract(
 
     if "entities" not in result.canonical:
         raise AssertionError("Adapter canonical payload must include an entities collection.")
+    schema_version = result.canonical.get("canonical_entity_schema_version")
+    if not isinstance(schema_version, str) or not schema_version.strip():
+        raise AssertionError(
+            "Adapter canonical payload must include canonical_entity_schema_version."
+        )
     if not result.provenance:
         raise AssertionError("Adapter result must include provenance records.")
     if result.confidence is None:
         raise AssertionError("Adapter result must include confidence metadata.")
+
+    entities = result.canonical["entities"]
+    if not isinstance(entities, tuple):
+        raise AssertionError("Adapter canonical entities must be emitted as a tuple.")
+    if not entities:
+        _assert_empty_entity_collection_reason(result.canonical)
+    else:
+        _assert_entity_envelopes(entities, expected_schema_version=schema_version)
 
     for record in result.provenance:
         if not record.stage or not record.source_ref:
@@ -168,6 +226,165 @@ def assert_adapter_result_contract(
         raise AssertionError("Adapter warning codes did not match expected contract output.")
     if Counter(diagnostic_codes) != Counter(expected_diagnostic_codes):
         raise AssertionError("Adapter diagnostic codes did not match expected contract output.")
+
+
+def _assert_empty_entity_collection_reason(canonical: Mapping[str, JSONValue]) -> None:
+    metadata = canonical.get("metadata")
+    if not isinstance(metadata, dict):
+        raise AssertionError(
+            "Canonical payloads with empty entities must include metadata with a reason."
+        )
+    reason = metadata.get("empty_entities_reason")
+    if not isinstance(reason, str) or not reason.strip():
+        raise AssertionError(
+            "Canonical payloads with empty entities must include metadata.empty_entities_reason."
+        )
+
+
+def _assert_entity_envelopes(
+    entities: tuple[JSONValue, ...],
+    *,
+    expected_schema_version: str,
+) -> None:
+    seen_entity_ids: set[str] = set()
+    for entity_payload in entities:
+        if not isinstance(entity_payload, dict):
+            raise AssertionError("Canonical entities must be JSON object payloads.")
+
+        entity_id = entity_payload.get("entity_id")
+        if not isinstance(entity_id, str) or not entity_id.strip():
+            raise AssertionError("Canonical entities must include a stable entity_id.")
+        if entity_id in seen_entity_ids:
+            raise AssertionError("Canonical entity_ids must be unique within a payload.")
+        seen_entity_ids.add(entity_id)
+
+        entity_type = entity_payload.get("entity_type")
+        if not isinstance(entity_type, str) or not entity_type.strip():
+            raise AssertionError("Canonical entities must include a stable entity_type.")
+
+        entity_schema_version = entity_payload.get("entity_schema_version")
+        if entity_schema_version != expected_schema_version:
+            raise AssertionError(
+                "Canonical entity schema versions must match canonical_entity_schema_version."
+            )
+
+        provenance = entity_payload.get("provenance")
+        if not isinstance(provenance, dict) or not provenance:
+            raise AssertionError("Canonical entities must include provenance metadata.")
+        if not _has_stable_entity_provenance(provenance):
+            raise AssertionError(
+                "Canonical entity provenance must include a stable source locator."
+            )
+
+        _assert_required_nullable_linkage_fields(entity_payload)
+        _assert_entity_confidence(entity_payload.get("confidence"))
+        _assert_geometry_reason_if_required(entity_payload)
+
+
+def _has_stable_entity_provenance(provenance: dict[str, JSONValue]) -> bool:
+    stable_keys = (
+        "source_entity_ref",
+        "normalized_source_hash",
+        "ifc_step_id",
+        "ifc_global_id",
+        "page_number",
+        "drawing_index",
+        "source",
+    )
+    for key in stable_keys:
+        value = provenance.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return True
+    return False
+
+
+def _assert_entity_confidence(confidence: JSONValue) -> None:
+    if isinstance(confidence, (int, float)) and not isinstance(confidence, bool):
+        score = float(confidence)
+    elif isinstance(confidence, dict):
+        score_value = confidence.get("score")
+        if not isinstance(score_value, (int, float)) or isinstance(score_value, bool):
+            raise AssertionError(
+                "Canonical entity confidence objects must include a numeric score."
+            )
+        score = float(score_value)
+    else:
+        raise AssertionError("Canonical entities must include confidence metadata.")
+
+    if not 0.0 <= score <= 1.0:
+        raise AssertionError("Canonical entity confidence scores must be between 0.0 and 1.0.")
+
+
+def _assert_required_nullable_linkage_fields(entity_payload: dict[str, JSONValue]) -> None:
+    for field_name in _NULLABLE_LINKAGE_FIELDS:
+        if field_name not in entity_payload:
+            raise AssertionError(
+                f"Canonical entities must include nullable linkage field '{field_name}'."
+            )
+
+
+def _assert_geometry_reason_if_required(entity_payload: dict[str, JSONValue]) -> None:
+    geometry = entity_payload.get("geometry")
+    if not isinstance(geometry, dict):
+        reason = entity_payload.get("geometry_reason")
+        if not isinstance(reason, str) or not reason.strip():
+            raise AssertionError(
+                "Geometry-less canonical entities must include an explicit geometry reason."
+            )
+        return
+
+    if not _geometry_reason_required(geometry):
+        return
+
+    geometry_summary = geometry.get("geometry_summary")
+    reason_candidates = (
+        geometry.get("reason"),
+        geometry_summary.get("reason") if isinstance(geometry_summary, dict) else None,
+        entity_payload.get("geometry_reason"),
+    )
+    if not any(isinstance(reason, str) and reason.strip() for reason in reason_candidates):
+        raise AssertionError(
+            "Geometry-less canonical entities must include an explicit geometry reason."
+        )
+
+
+def _geometry_reason_required(geometry: dict[str, JSONValue]) -> bool:
+    status = geometry.get("status")
+    if status in {"absent", "missing", "placeholder"}:
+        return True
+
+    geometry_summary = geometry.get("geometry_summary")
+    if isinstance(geometry_summary, dict):
+        geometry_kind = geometry_summary.get("kind")
+        if geometry_kind in {"none", "placeholder", "unknown"}:
+            return True
+
+    return geometry.get("bbox") is None and not _has_concrete_geometry_payload(geometry)
+
+
+def _has_concrete_geometry_payload(geometry: dict[str, JSONValue]) -> bool:
+    metadata_keys = {
+        "bbox",
+        "units",
+        "status",
+        "reason",
+        "geometry_summary",
+        "summary",
+        "kind",
+        "coordinate_space",
+        "unit",
+    }
+    for key, value in geometry.items():
+        if key in metadata_keys:
+            continue
+        if value is None:
+            continue
+        if isinstance(value, (tuple, list, dict)) and not value:
+            continue
+        return True
+    return False
 
 
 async def exercise_adapter_contract(

--- a/tests/test_adapter_contract_harness.py
+++ b/tests/test_adapter_contract_harness.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml  # type: ignore[import-untyped]
@@ -196,6 +196,124 @@ async def test_contract_harness_rejects_missing_entities_key(tmp_path: Path) -> 
     )
 
     with pytest.raises(AssertionError):
+        await exercise_adapter_contract(
+            adapter,
+            source=source,
+            input_family=InputFamily.DXF,
+            adapter_key=adapter_key,
+            expectation=ContractFinalizationExpectation(
+                validation_status="valid",
+                review_state="approved",
+                quantity_gate="allowed",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_contract_harness_rejects_missing_entity_envelope_fields(tmp_path: Path) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter_key = "fake-dxf"
+    canonical = build_complete_canonical()
+    canonical["entities"] = (
+        {
+            "kind": "line",
+            "layer": "A-WALL",
+            "start": {"x": 0.0, "y": 0.0},
+            "end": {"x": 10.0, "y": 0.0},
+        },
+    )
+    adapter = _ResultAdapter(
+        result=build_result(
+            adapter_key=adapter_key,
+            score=0.97,
+            canonical=canonical,
+        ),
+        family=InputFamily.DXF,
+        key=adapter_key,
+    )
+
+    with pytest.raises(AssertionError, match="entity_id"):
+        await exercise_adapter_contract(
+            adapter,
+            source=source,
+            input_family=InputFamily.DXF,
+            adapter_key=adapter_key,
+            expectation=ContractFinalizationExpectation(
+                validation_status="valid",
+                review_state="approved",
+                quantity_gate="allowed",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_contract_harness_rejects_empty_entities_without_explicit_reason(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter_key = "fake-dxf"
+    canonical = build_complete_canonical()
+    canonical["entities"] = ()
+    adapter = _ResultAdapter(
+        result=build_result(
+            adapter_key=adapter_key,
+            score=0.97,
+            canonical=canonical,
+        ),
+        family=InputFamily.DXF,
+        key=adapter_key,
+    )
+
+    with pytest.raises(AssertionError, match="metadata with a reason"):
+        await exercise_adapter_contract(
+            adapter,
+            source=source,
+            input_family=InputFamily.DXF,
+            adapter_key=adapter_key,
+            expectation=ContractFinalizationExpectation(
+                validation_status="valid",
+                review_state="approved",
+                quantity_gate="allowed",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_contract_harness_rejects_absent_geometry_without_explicit_reason(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "source.dxf"
+    source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
+    source = build_contract_source(file_path=source_path)
+    adapter_key = "fake-dxf"
+    canonical = build_complete_canonical()
+    entity = cast(tuple[dict[str, Any], ...], canonical["entities"])[0]
+    canonical["entities"] = (
+        {
+            **entity,
+            "geometry": {
+                "bbox": None,
+                "units": {"normalized": "meter"},
+                "status": "absent",
+                "geometry_summary": {"kind": "line_segment"},
+            },
+        },
+    )
+    adapter = _ResultAdapter(
+        result=build_result(
+            adapter_key=adapter_key,
+            score=0.97,
+            canonical=canonical,
+        ),
+        family=InputFamily.DXF,
+        key=adapter_key,
+    )
+
+    with pytest.raises(AssertionError, match="geometry reason"):
         await exercise_adapter_contract(
             adapter,
             source=source,

--- a/tests/test_ezdxf_adapter.py
+++ b/tests/test_ezdxf_adapter.py
@@ -615,6 +615,31 @@ async def test_ezdxf_adapter_passes_shared_contract_harness_for_smoke_fixture() 
 
 
 @pytest.mark.asyncio
+async def test_ezdxf_adapter_empty_modelspace_passes_shared_contract_harness(
+    tmp_path: Path,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    source_path = tmp_path / "empty-modelspace.dxf"
+    cast(Any, ezdxf).new(units=6).saveas(source_path)
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=build_contract_source(file_path=source_path, original_name=source_path.name),
+        input_family=input_family(),
+        expectation=ContractFinalizationExpectation(
+            validation_status="needs_review",
+            review_state="review_required",
+            quantity_gate="review_gated",
+            diagnostic_codes=("dxf_document_loaded", "dxf_entities_extracted"),
+        ),
+        adapter_key="ezdxf",
+    )
+
+    assert payload.canonical_json["entities"] == []
+    assert payload.canonical_json["metadata"]["empty_entities_reason"] == "dxf_modelspace_empty"
+
+
+@pytest.mark.asyncio
 async def test_ezdxf_adapter_retains_unsupported_entities_as_unknown_with_warning(
     tmp_path: Path,
 ) -> None:
@@ -653,9 +678,11 @@ async def test_ezdxf_adapter_retains_unsupported_entities_as_unknown_with_warnin
     assert entity["entity_type"] == "unknown"
     assert entity["layer"] == "0"
     assert _mapping(entity["properties"])["source_type"] == "CIRCLE"
+    assert _mapping(entity["geometry"])["reason"] == "unsupported_or_invalid_geometry"
     assert _mapping(entity["geometry"])["geometry_summary"] == {
         "kind": "unknown",
         "source_type": "CIRCLE",
+        "reason": "unsupported_or_invalid_geometry",
     }
     assert result.warnings[0].details == {
         "entity_type": "CIRCLE",

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -262,12 +262,18 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
     canonical = payload.canonical_json
     assert canonical["ifc_schema"] == "IFC4"
     assert canonical["metadata"]["ifc_schema"] == "IFC4"
+    assert canonical["canonical_entity_schema_version"] == "0.1"
     assert canonical["project"]["name"] == "Demo Project"
     assert canonical["metadata"]["project"]["global_id"] == "PROJECT-1"
 
     entities = canonical["entities"]
     assert [entity["id"] for entity in entities] == ["DUPLICATE", "DUPLICATE-2", "#42"]
+    assert [entity["entity_id"] for entity in entities] == ["DUPLICATE", "DUPLICATE-2", "#42"]
     assert [entity["ifc_type"] for entity in entities] == ["IfcWall", "IfcWall", "IfcDoor"]
+    assert entities[0]["entity_type"] == "ifc_product"
+    assert entities[0]["entity_schema_version"] == "0.1"
+    assert entities[0]["geometry"]["reason"] == "semantic_metadata_only"
+    assert entities[0]["provenance"]["source_entity_ref"] == "entities.DUPLICATE"
     assert entities[0]["psets"][0]["name"] == "Pset_WallCommon"
     assert entities[0]["qtos"][0]["name"] == "Qto_WallBaseQuantities"
     assert entities[0]["material_refs"][0]["name"] == "Concrete"
@@ -604,6 +610,7 @@ async def test_ifcopenshell_adapter_short_circuits_invalid_schema_through_valida
         assert canonical["ifc_schema"] == expected_schema
         assert canonical["metadata"]["ifc_schema"] == expected_schema
     assert canonical["entities"] == []
+    assert canonical["metadata"]["empty_entities_reason"] == "semantic_extract_skipped"
 
 
 @pytest.mark.asyncio
@@ -630,6 +637,7 @@ async def test_ifcopenshell_adapter_capped_incomplete_header_continues_to_native
 
     runtime = SimpleNamespace(open=_open_runtime)
     monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+    monkeypatch.setattr(adapter_module, "_resolve_element_module", lambda _runtime: None)
 
     result = await adapter_module.create_adapter().ingest(
         build_contract_source(

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -868,6 +868,7 @@ async def test_pymupdf_vector_fixture_extracts_metadata_only_text() -> None:
             quantity_gate="review_gated",
             diagnostic_codes=("pymupdf.extract",),
         ),
+        timeout=AdapterTimeout(seconds=5),
     )
     result = await adapter.ingest(source, AdapterExecutionOptions())
 

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -47,6 +47,11 @@ from app.ingestion.registry import (
     get_registry,
     list_descriptors,
 )
+from tests.ingestion_contract_harness import (
+    ContractFinalizationExpectation,
+    build_contract_source,
+    exercise_adapter_contract,
+)
 
 
 class _FakePoint:
@@ -413,6 +418,7 @@ async def test_vtracer_tesseract_ingest_returns_raster_scaffold(
             "geometry_mode": "raster",
             "page_count": 2,
             "default_layer": "default",
+            "empty_entities_reason": "raster_vectorization_deferred",
             "text_blocks": [],
             "pdf_scale": {
                 "status": "unconfirmed",
@@ -488,6 +494,59 @@ async def test_vtracer_tesseract_ingest_returns_raster_scaffold(
             code="raster_scale_unconfirmed",
             message="Raster PDF scale remains unconfirmed in scaffold output.",
         ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_vtracer_tesseract_adapter_passes_shared_contract_harness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "raster.pdf"
+    source_path.write_bytes(
+        b"%PDF-1.4\n"
+        b"1 0 obj << /Type /Page >> endobj\n"
+        b"2 0 obj << /Type /Page >> endobj\n"
+        b"%%EOF\n"
+    )
+    adapter = vtracer_tesseract_adapter.create_adapter()
+
+    monkeypatch.setattr(adapter, "_runtime_for_ingest", lambda: object())
+    monkeypatch.setattr(vtracer_tesseract_adapter, "_vtracer_available", lambda: True)
+    monkeypatch.setattr(vtracer_tesseract_adapter, "_tesseract_binary_path", lambda: None)
+
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=build_contract_source(
+            file_path=source_path,
+            upload_format=UploadFormat.PDF,
+            input_family=InputFamily.PDF_RASTER,
+            original_name="raster.pdf",
+        ),
+        input_family=InputFamily.PDF_RASTER,
+        adapter_key="vtracer_tesseract",
+        expectation=ContractFinalizationExpectation(
+            validation_status="needs_review",
+            review_state="review_required",
+            quantity_gate="review_gated",
+            warning_codes=(
+                "RASTER_SCAFFOLD_ONLY",
+                "RASTER_SCALE_UNCONFIRMED",
+                "RASTER_GEOMETRY_REVIEW_REQUIRED",
+                "RASTER_OCR_DEFERRED",
+            ),
+            diagnostic_codes=(
+                "raster_scaffold_created",
+                "raster_dependency_probe",
+                "raster_vectorization_deferred",
+                "raster_ocr_deferred",
+                "raster_scale_unconfirmed",
+            ),
+        ),
+    )
+
+    assert payload.canonical_json["metadata"]["empty_entities_reason"] == (
+        "raster_vectorization_deferred"
     )
 
 
@@ -792,17 +851,29 @@ async def test_pymupdf_vector_fixture_extracts_metadata_only_text() -> None:
         pytest.skip("PyMuPDF runtime not installed for vector PDF smoke test.")
 
     fixture_path = Path(__file__).parent / "fixtures" / "pdf" / "vector-smoke.pdf"
-    result = await adapter.ingest(
-        AdapterSource(
-            file_path=fixture_path,
-            upload_format=UploadFormat.PDF,
-            input_family=InputFamily.PDF_VECTOR,
-        ),
-        AdapterExecutionOptions(),
+    source = build_contract_source(
+        file_path=fixture_path,
+        upload_format=UploadFormat.PDF,
+        input_family=InputFamily.PDF_VECTOR,
+        original_name=fixture_path.name,
     )
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=source,
+        input_family=InputFamily.PDF_VECTOR,
+        adapter_key="pymupdf",
+        expectation=ContractFinalizationExpectation(
+            validation_status="needs_review",
+            review_state="review_required",
+            quantity_gate="review_gated",
+            diagnostic_codes=("pymupdf.extract",),
+        ),
+    )
+    result = await adapter.ingest(source, AdapterExecutionOptions())
 
     assert result.confidence is not None
     assert result.confidence.review_required is True
+    assert payload.canonical_json["canonical_entity_schema_version"] == "0.1"
     assert result.canonical["schema_version"] == "0.1"
     assert result.canonical["canonical_entity_schema_version"] == "0.1"
     assert result.canonical["blocks"] == ()
@@ -830,6 +901,12 @@ async def test_pymupdf_vector_fixture_extracts_metadata_only_text() -> None:
     assert entity["kind"] == "polyline"
     assert entity["layout"] == "page-1"
     assert entity["layer"] == "default"
+    assert entity["drawing_revision_id"] is None
+    assert entity["source_file_id"] is None
+    assert entity["layout_ref"] == "page-1"
+    assert entity["layer_ref"] == "default"
+    assert entity["block_ref"] is None
+    assert entity["parent_entity_ref"] is None
     assert entity["points"] == (
         {"x": 10.0, "y": 90.0},
         {"x": 90.0, "y": 90.0},
@@ -890,8 +967,14 @@ async def test_pymupdf_ingest_uses_process_hook_instead_of_parent_parser_calls(
 ) -> None:
     source_path = tmp_path / "vector.pdf"
     source_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
-    adapter = cast(pymupdf_adapter.PyMuPDFAdapter, pymupdf_adapter.create_adapter())
+    adapter = cast(
+        pymupdf_adapter.PyMuPDFAdapter,
+        pymupdf_adapter.create_adapter(license_acknowledged=lambda: True),
+    )
 
+    monkeypatch.setattr(pymupdf_adapter, "_load_runtime_module", lambda: object())
+    monkeypatch.setattr(pymupdf_adapter, "_runtime_version", lambda _runtime: "1.26.0")
+    monkeypatch.setattr(pymupdf_adapter, "_package_version", lambda: "1.26.0")
     monkeypatch.setattr(adapter, "_runtime_for_ingest", lambda: None)
     monkeypatch.setattr(
         pymupdf_adapter,
@@ -927,6 +1010,7 @@ async def test_pymupdf_ingest_uses_process_hook_instead_of_parent_parser_calls(
                     "geometry_mode": "vector",
                     "page_count": 0,
                     "default_layer": "default",
+                    "empty_entities_reason": "no_vector_entities_detected",
                     "pdf_scale": {
                         "status": "unconfirmed",
                         "coordinate_space": "pdf_page_space_unrotated",
@@ -941,16 +1025,28 @@ async def test_pymupdf_ingest_uses_process_hook_instead_of_parent_parser_calls(
 
     monkeypatch.setattr(pymupdf_adapter, "_extract_with_process", _extract_with_process)
 
-    result = await adapter.ingest(
-        AdapterSource(
+    payload = await exercise_adapter_contract(
+        adapter,
+        source=build_contract_source(
             file_path=source_path,
             upload_format=UploadFormat.PDF,
             input_family=InputFamily.PDF_VECTOR,
+            original_name=source_path.name,
         ),
-        AdapterExecutionOptions(),
+        input_family=InputFamily.PDF_VECTOR,
+        adapter_key="pymupdf",
+        expectation=ContractFinalizationExpectation(
+            validation_status="needs_review",
+            review_state="review_required",
+            quantity_gate="review_gated",
+            diagnostic_codes=("pymupdf.extract",),
+        ),
     )
 
-    assert result.canonical["entities"] == ()
+    assert payload.canonical_json["entities"] == []
+    assert payload.canonical_json["metadata"]["empty_entities_reason"] == (
+        "no_vector_entities_detected"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -250,6 +250,9 @@ async def test_libredwg_adapter_emits_review_gated_placeholder_canonical_payload
     assert output_path.parent != _FIXTURE_PATH.parent
     assert payload.canonical_json["entities"] == []
     assert payload.canonical_json["metadata"]["adapter_mode"] == "placeholder"
+    assert payload.canonical_json["metadata"]["empty_entities_reason"] == (
+        "placeholder_canonical_no_entity_mapping"
+    )
 
     result = await adapter.ingest(
         source,


### PR DESCRIPTION
Closes #136

## Summary
- enforce canonical entity envelope requirements in the shared ingestion contract harness
- update supported adapters to emit explicit empty-entity and geometry-absence reasons where required
- extend contract coverage across DXF, DWG, IFC, and PDF adapter paths

## Test plan
- [x] uv run ruff check tests/ingestion_contract_harness.py tests app/ingestion/adapters
- [x] uv run mypy tests/ingestion_contract_harness.py app/ingestion/adapters
- [x] uv run pytest tests/test_adapter_contract_harness.py tests/test_ezdxf_adapter.py tests/test_ifcopenshell_adapter.py tests/test_libredwg_adapter.py tests/test_ingestion_contracts.py