### PR TITLE
fix(db): enforce project default constraints

### DIFF
--- a/alembic/versions/2026_05_10_0006_add_project_default_constraints.py
+++ b/alembic/versions/2026_05_10_0006_add_project_default_constraints.py
@@ -1,0 +1,70 @@
+"""Add project default currency and unit-system constraints.
+
+Legacy rows may still contain free-form defaults from before these checks
+existed. Canonicalize recognized values and clear everything else to NULL
+before adding the constraints so the migration can succeed on existing data.
+
+Revision ID: 2026_05_10_0006
+Revises: 2026_05_05_0005
+Create Date: 2026-05-10 07:45:00.000000
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_10_0006"
+down_revision: str | None = "2026_05_05_0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply migration changes."""
+    op.execute(
+        """
+        UPDATE projects
+        SET default_unit_system = CASE
+            WHEN lower(btrim(default_unit_system)) IN ('metric', 'imperial')
+                THEN lower(btrim(default_unit_system))
+            ELSE NULL
+        END
+        WHERE default_unit_system IS NOT NULL
+          AND (
+              default_unit_system <> lower(btrim(default_unit_system))
+              OR lower(btrim(default_unit_system)) NOT IN ('metric', 'imperial')
+          )
+        """
+    )
+    op.execute(
+        """
+        UPDATE projects
+        SET default_currency = CASE
+            WHEN upper(btrim(default_currency)) ~ '^[A-Z]{3}$'
+                THEN upper(btrim(default_currency))
+            ELSE NULL
+        END
+        WHERE default_currency IS NOT NULL
+          AND (
+              default_currency <> upper(btrim(default_currency))
+              OR upper(btrim(default_currency)) !~ '^[A-Z]{3}$'
+          )
+        """
+    )
+    op.create_check_constraint(
+        "ck_projects_default_unit_system",
+        "projects",
+        "default_unit_system IS NULL OR default_unit_system IN ('metric', 'imperial')",
+    )
+    op.create_check_constraint(
+        "ck_projects_default_currency",
+        "projects",
+        "default_currency IS NULL OR default_currency ~ '^[A-Z]{3}$'",
+    )
+
+
+def downgrade() -> None:
+    """Revert migration changes."""
+    op.drop_constraint("ck_projects_default_currency", "projects", type_="check")
+    op.drop_constraint("ck_projects_default_unit_system", "projects", type_="check")

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import CheckConstraint, DateTime, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -17,6 +17,16 @@ class Project(Base):
     """
 
     __tablename__ = "projects"
+    __table_args__ = (
+        CheckConstraint(
+            "default_unit_system IS NULL OR default_unit_system IN ('metric', 'imperial')",
+            name="ck_projects_default_unit_system",
+        ),
+        CheckConstraint(
+            "default_currency IS NULL OR default_currency ~ '^[A-Z]{3}$'",
+            name="ck_projects_default_currency",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         primary_key=True,
@@ -41,7 +51,7 @@ class Project(Base):
     default_currency: Mapped[str | None] = mapped_column(
         String(3),
         nullable=True,
-        comment="Default currency code (ISO 4217, e.g., 'USD', 'EUR')",
+        comment="Default 3-letter uppercase currency code (e.g., 'USD', 'EUR')",
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -2,8 +2,15 @@
 
 import uuid
 from datetime import datetime
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+ProjectUnitSystem = Literal["metric", "imperial"]
+CurrencyCode = Annotated[
+    str,
+    StringConstraints(min_length=3, max_length=3, pattern=r"^[A-Z]{3}$"),
+]
 
 
 class ProjectCreate(BaseModel):
@@ -13,11 +20,14 @@ class ProjectCreate(BaseModel):
     description: str | None = Field(
         None, max_length=1024, description="Optional project description"
     )
-    default_unit_system: str | None = Field(
+    default_unit_system: ProjectUnitSystem | None = Field(
         None, max_length=64, description="Default unit system (e.g., 'metric', 'imperial')"
     )
-    default_currency: str | None = Field(
-        None, min_length=3, max_length=3, description="Default currency code (ISO 4217)"
+    default_currency: CurrencyCode | None = Field(
+        None,
+        min_length=3,
+        max_length=3,
+        description="Default 3-letter uppercase currency code",
     )
 
 
@@ -30,7 +40,9 @@ class ProjectRead(BaseModel):
     name: str = Field(..., description="Project name")
     description: str | None = Field(None, description="Optional project description")
     default_unit_system: str | None = Field(None, description="Default unit system")
-    default_currency: str | None = Field(None, description="Default currency code")
+    default_currency: str | None = Field(
+        None, description="Default 3-letter uppercase currency code"
+    )
     created_at: datetime = Field(..., description="Project creation timestamp")
     updated_at: datetime = Field(..., description="Project last update timestamp")
 
@@ -42,11 +54,14 @@ class ProjectUpdate(BaseModel):
     description: str | None = Field(
         None, max_length=1024, description="Optional project description"
     )
-    default_unit_system: str | None = Field(
+    default_unit_system: ProjectUnitSystem | None = Field(
         None, max_length=64, description="Default unit system"
     )
-    default_currency: str | None = Field(
-        None, min_length=3, max_length=3, description="Default currency code"
+    default_currency: CurrencyCode | None = Field(
+        None,
+        min_length=3,
+        max_length=3,
+        description="Default 3-letter uppercase currency code",
     )
 
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -7,8 +7,12 @@ import uuid
 from typing import Any
 
 import httpx
+import pytest
 import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
 
+from app.db.session import AsyncSessionLocal
+from app.models.project import Project
 from tests.conftest import requires_database
 
 
@@ -129,6 +133,48 @@ class TestCreateProject:
         assert response.status_code == 422
         data = response.json()
 
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert data["error"]["message"] == "Request validation failed"
+        assert isinstance(data["error"]["details"], list)
+
+    async def test_create_project_validation_error_invalid_unit_system(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should reject unsupported default unit systems."""
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.post(
+            "/v1/projects",
+            json={"name": "Bad Unit", "default_unit_system": "si"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert data["error"]["message"] == "Request validation failed"
+        assert isinstance(data["error"]["details"], list)
+
+    async def test_create_project_validation_error_invalid_currency(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should reject malformed default currency codes."""
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.post(
+            "/v1/projects",
+            json={"name": "Bad Currency", "default_currency": "usd"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
         assert "error" in data
         assert data["error"]["code"] == "VALIDATION_ERROR"
         assert data["error"]["message"] == "Request validation failed"
@@ -487,6 +533,76 @@ class TestUpdateProject:
         assert data["name"] == update_data["name"]
         assert data["description"] == original_description  # Unchanged
 
+    async def test_update_project_accepts_valid_defaults_and_nulls(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should allow valid default values and clearing them back to null."""
+        _ = self
+
+        project_id = created_project["id"]
+
+        set_defaults_response = await async_client.patch(
+            f"/v1/projects/{project_id}",
+            json={"default_unit_system": "imperial", "default_currency": "EUR"},
+        )
+
+        assert set_defaults_response.status_code == 200
+        set_defaults_data = set_defaults_response.json()
+        assert set_defaults_data["default_unit_system"] == "imperial"
+        assert set_defaults_data["default_currency"] == "EUR"
+
+        clear_defaults_response = await async_client.patch(
+            f"/v1/projects/{project_id}",
+            json={"default_unit_system": None, "default_currency": None},
+        )
+
+        assert clear_defaults_response.status_code == 200
+        clear_defaults_data = clear_defaults_response.json()
+        assert clear_defaults_data["default_unit_system"] is None
+        assert clear_defaults_data["default_currency"] is None
+
+    async def test_update_project_validation_error_invalid_unit_system(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should reject unsupported unit systems on update."""
+        _ = self
+
+        response = await async_client.patch(
+            f"/v1/projects/{created_project['id']}",
+            json={"default_unit_system": "meters"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert data["error"]["message"] == "Request validation failed"
+        assert isinstance(data["error"]["details"], list)
+
+    async def test_update_project_validation_error_invalid_currency(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should reject malformed currency codes on update."""
+        _ = self
+
+        response = await async_client.patch(
+            f"/v1/projects/{created_project['id']}",
+            json={"default_currency": "US1"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "error" in data
+        assert data["error"]["code"] == "VALIDATION_ERROR"
+        assert data["error"]["message"] == "Request validation failed"
+        assert isinstance(data["error"]["details"], list)
+
     async def test_update_project_not_found(
         self,
         async_client: httpx.AsyncClient,
@@ -569,3 +685,105 @@ class TestDeleteProject:
 
         assert "error" in data
         assert data["error"]["code"] == "NOT_FOUND"
+
+
+def test_project_model_defines_default_value_check_constraints() -> None:
+    """Project ORM metadata should include DB-level default value constraints."""
+    project_table = typing.cast(Any, Project.__table__)
+    check_constraints = {
+        constraint.name: str(constraint.sqltext)
+        for constraint in project_table.constraints
+        if getattr(constraint, "sqltext", None) is not None
+    }
+
+    assert check_constraints["ck_projects_default_unit_system"] == (
+        "default_unit_system IS NULL OR default_unit_system IN ('metric', 'imperial')"
+    )
+    assert check_constraints["ck_projects_default_currency"] == (
+        "default_currency IS NULL OR default_currency ~ '^[A-Z]{3}$'"
+    )
+
+
+@requires_database
+class TestProjectDatabaseConstraints:
+    """DB-level constraint tests that bypass request/schema validation."""
+
+    async def test_insert_rejects_invalid_default_unit_system(
+        self,
+        cleanup_projects: None,
+    ) -> None:
+        """Database should reject invalid unit systems on insert."""
+        _ = self
+        _ = cleanup_projects
+
+        assert AsyncSessionLocal is not None
+
+        async with AsyncSessionLocal() as session:
+            session.add(Project(name="Invalid unit insert", default_unit_system="si"))
+
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+            await session.rollback()
+
+    async def test_update_rejects_invalid_default_unit_system(
+        self,
+        cleanup_projects: None,
+    ) -> None:
+        """Database should reject invalid unit systems on update."""
+        _ = self
+        _ = cleanup_projects
+
+        assert AsyncSessionLocal is not None
+
+        async with AsyncSessionLocal() as session:
+            project = Project(name="Invalid unit update", default_unit_system="metric")
+            session.add(project)
+            await session.commit()
+
+            project.default_unit_system = "meters"
+
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+            await session.rollback()
+
+    async def test_insert_rejects_invalid_default_currency(
+        self,
+        cleanup_projects: None,
+    ) -> None:
+        """Database should reject invalid currency codes on insert."""
+        _ = self
+        _ = cleanup_projects
+
+        assert AsyncSessionLocal is not None
+
+        async with AsyncSessionLocal() as session:
+            session.add(Project(name="Invalid currency insert", default_currency="usd"))
+
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+            await session.rollback()
+
+    async def test_update_rejects_invalid_default_currency(
+        self,
+        cleanup_projects: None,
+    ) -> None:
+        """Database should reject invalid currency codes on update."""
+        _ = self
+        _ = cleanup_projects
+
+        assert AsyncSessionLocal is not None
+
+        async with AsyncSessionLocal() as session:
+            project = Project(name="Invalid currency update", default_currency="USD")
+            session.add(project)
+            await session.commit()
+
+            project.default_currency = "US1"
+
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+            await session.rollback()

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -11,7 +11,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy.exc import IntegrityError
 
-from app.db.session import AsyncSessionLocal
+import app.db.session as session_module
 from app.models.project import Project
 from tests.conftest import requires_database
 
@@ -716,9 +716,10 @@ class TestProjectDatabaseConstraints:
         _ = self
         _ = cleanup_projects
 
-        assert AsyncSessionLocal is not None
+        session_local = session_module.AsyncSessionLocal
+        assert session_local is not None
 
-        async with AsyncSessionLocal() as session:
+        async with session_local() as session:
             session.add(Project(name="Invalid unit insert", default_unit_system="si"))
 
             with pytest.raises(IntegrityError):
@@ -734,9 +735,10 @@ class TestProjectDatabaseConstraints:
         _ = self
         _ = cleanup_projects
 
-        assert AsyncSessionLocal is not None
+        session_local = session_module.AsyncSessionLocal
+        assert session_local is not None
 
-        async with AsyncSessionLocal() as session:
+        async with session_local() as session:
             project = Project(name="Invalid unit update", default_unit_system="metric")
             session.add(project)
             await session.commit()
@@ -756,9 +758,10 @@ class TestProjectDatabaseConstraints:
         _ = self
         _ = cleanup_projects
 
-        assert AsyncSessionLocal is not None
+        session_local = session_module.AsyncSessionLocal
+        assert session_local is not None
 
-        async with AsyncSessionLocal() as session:
+        async with session_local() as session:
             session.add(Project(name="Invalid currency insert", default_currency="usd"))
 
             with pytest.raises(IntegrityError):
@@ -774,9 +777,10 @@ class TestProjectDatabaseConstraints:
         _ = self
         _ = cleanup_projects
 
-        assert AsyncSessionLocal is not None
+        session_local = session_module.AsyncSessionLocal
+        assert session_local is not None
 
-        async with AsyncSessionLocal() as session:
+        async with session_local() as session:
             project = Project(name="Invalid currency update", default_currency="USD")
             session.add(project)
             await session.commit()


### PR DESCRIPTION
Closes #143

## Summary
- enforce project default unit-system and currency-code contracts in schemas and database constraints
- add an Alembic migration that cleans legacy invalid defaults before applying checks
- cover accepted and rejected project-default cases in API and DB-layer tests

## Test plan
- [x] uv run ruff check app/models/project.py app/schemas/project.py app/api/v1/projects.py tests/test_projects.py alembic/versions
- [x] uv run mypy app/models/project.py app/schemas/project.py app/api/v1/projects.py
- [x] uv run pytest tests/test_projects.py (1 passed, 25 skipped because DATABASE_URL is unset)
- [x] uv run python -c "import app.db.session, app.models.project, app.schemas.project, app.api.v1.projects"

## Notes
- Reviewer follow-up: DB constraint tests should resolve `AsyncSessionLocal` via `app.db.session` at runtime when DATABASE_URL-backed tests run