### PR TITLE
fix(retention): add soft-delete retention semantics

### DIFF
--- a/alembic/versions/2026_05_10_0006_add_soft_delete_columns.py
+++ b/alembic/versions/2026_05_10_0006_add_soft_delete_columns.py
@@ -1,0 +1,62 @@
+"""add soft-delete columns for retention
+
+Revision ID: 2026_05_10_0006
+Revises: 2026_05_05_0005
+Create Date: 2026-05-10 12:20:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_10_0006"
+down_revision: str | None = "2026_05_05_0005"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add nullable soft-delete timestamps for retained resources."""
+    op.add_column(
+        "projects",
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Soft deletion timestamp for retention workflows",
+        ),
+    )
+    op.add_column(
+        "files",
+        sa.Column(
+            "deleted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Soft deletion timestamp for retention workflows",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove soft-delete timestamps only when no retained markers exist."""
+    bind = op.get_bind()
+    project_markers_exist = bool(
+        bind.execute(
+            sa.text("SELECT EXISTS (SELECT 1 FROM projects WHERE deleted_at IS NOT NULL)")
+        ).scalar()
+    )
+    file_markers_exist = bool(
+        bind.execute(
+            sa.text("SELECT EXISTS (SELECT 1 FROM files WHERE deleted_at IS NOT NULL)")
+        ).scalar()
+    )
+    if project_markers_exist or file_markers_exist:
+        raise RuntimeError(
+            "Manual data-preserving rollback is required before dropping soft-delete markers."
+        )
+
+    op.drop_column("files", "deleted_at")
+    op.drop_column("projects", "deleted_at")

--- a/alembic/versions/2026_05_10_0008_add_soft_delete_columns.py
+++ b/alembic/versions/2026_05_10_0008_add_soft_delete_columns.py
@@ -1,7 +1,7 @@
 """add soft-delete columns for retention
 
-Revision ID: 2026_05_10_0006
-Revises: 2026_05_05_0005
+Revision ID: 2026_05_10_0008
+Revises: 2026_05_10_0007
 Create Date: 2026-05-10 12:20:00
 """
 
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "2026_05_10_0006"
-down_revision: str | None = "2026_05_05_0005"
+revision: str = "2026_05_10_0008"
+down_revision: str | None = "2026_05_10_0007"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -220,16 +220,47 @@ async def _get_project_file_or_404(
     db: AsyncSession,
     project_id: UUID,
     file_id: UUID,
+    *,
+    for_update: bool = False,
 ) -> FileModel:
     """Return a project-scoped file row or raise not found."""
-    query = select(FileModel).where(
-        (FileModel.project_id == project_id) & (FileModel.id == file_id)
+    query = (
+        select(FileModel)
+        .join(Project, Project.id == FileModel.project_id)
+        .where(
+            (FileModel.project_id == project_id)
+            & (FileModel.id == file_id)
+            & (FileModel.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
     )
+    if for_update:
+        query = query.with_for_update()
     file_row = (await db.execute(query)).scalar_one_or_none()
     if file_row is None:
         raise_not_found("File", str(file_id))
     assert file_row is not None
     return file_row
+
+
+async def _get_active_project_or_404(
+    db: AsyncSession,
+    project_id: UUID,
+    *,
+    for_update: bool = False,
+) -> Project:
+    """Return an active project row or raise not found."""
+    query = select(Project).where(
+        (Project.id == project_id) & (Project.deleted_at.is_(None))
+    )
+    if for_update:
+        query = query.with_for_update()
+    project = (await db.execute(query)).scalar_one_or_none()
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    assert project is not None
+    return project
 
 
 async def _resolve_project_extraction_profile(
@@ -307,9 +338,7 @@ async def upload_project_file(
     storage: Annotated[Storage, Depends(get_storage)],
 ) -> FileModel:
     """Upload immutable source file bytes for a project and create ingest job."""
-    project = await db.get(Project, project_id)
-    if project is None:
-        raise_not_found("Project", str(project_id))
+    await _get_active_project_or_404(db, project_id)
 
     original_filename = file.filename or "upload.bin"
     media_type = file.content_type or "application/octet-stream"
@@ -430,6 +459,13 @@ async def upload_project_file(
     assert storage_key is not None
     assert storage_uri is not None
 
+    try:
+        await _get_active_project_or_404(db, project_id, for_update=True)
+    except Exception:
+        await db.rollback()
+        await _cleanup_persisted_upload(storage, storage_key, storage_uri)
+        raise
+
     extraction_profile = _build_extraction_profile(project_id)
     db.add(extraction_profile)
 
@@ -486,11 +522,11 @@ async def reprocess_project_file(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Job:
     """Create a new pending ingest job for an existing file and profile selection."""
-    project = await db.get(Project, project_id)
-    if project is None:
-        raise_not_found("Project", str(project_id))
+    await _get_active_project_or_404(db, project_id)
 
     await _get_project_file_or_404(db, project_id, file_id)
+    await _get_active_project_or_404(db, project_id, for_update=True)
+    await _get_project_file_or_404(db, project_id, file_id, for_update=True)
     extraction_profile = await _resolve_project_extraction_profile(db, project_id, request)
 
     ingest_job = Job(
@@ -534,13 +570,13 @@ async def list_project_files(
     limit: Annotated[int, Query(ge=1, le=200, description="Number of items to return")] = 50,
 ) -> FileListResponse:
     """List files for a project with cursor pagination."""
-    project = await db.get(Project, project_id)
-    if project is None:
-        raise_not_found("Project", str(project_id))
+    await _get_active_project_or_404(db, project_id)
 
     query = (
         select(FileModel)
-        .where(FileModel.project_id == project_id)
+        .where(
+            (FileModel.project_id == project_id) & (FileModel.deleted_at.is_(None))
+        )
         .order_by(FileModel.created_at.desc(), FileModel.id.desc())
     )
 

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -14,8 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
-from app.models.file import File
 from app.jobs.worker import enqueue_ingest_job
+from app.models.file import File
 from app.models.job import Job
 from app.models.job_event import JobEvent
 from app.models.project import Project

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -14,9 +14,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
+from app.models.file import File
 from app.jobs.worker import enqueue_ingest_job
 from app.models.job import Job
 from app.models.job_event import JobEvent
+from app.models.project import Project
 from app.schemas.job import JobEventPage, JobEventRead, JobRead
 
 jobs_router = APIRouter()
@@ -42,6 +44,30 @@ async def _get_job_or_404(db: AsyncSession, job_id: UUID) -> Job:
 async def _get_job_for_update_or_404(db: AsyncSession, job_id: UUID) -> Job:
     """Return a persisted job with a row lock or raise not found."""
     result = await db.execute(select(Job).where(Job.id == job_id).with_for_update())
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise_not_found("Job", str(job_id))
+    assert job is not None
+
+    return job
+
+
+async def _get_active_job_for_retry_or_404(db: AsyncSession, job_id: UUID) -> Job:
+    """Return a job row with active project/file visibility for retries."""
+    result = await db.execute(
+        select(Job)
+        .join(
+            File,
+            (File.id == Job.file_id) & (File.project_id == Job.project_id),
+        )
+        .join(Project, Project.id == Job.project_id)
+        .where(
+            (Job.id == job_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+        .with_for_update()
+    )
     job = result.scalar_one_or_none()
     if job is None:
         raise_not_found("Job", str(job_id))
@@ -195,7 +221,7 @@ async def retry_job(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Job:
     """Requeue a failed persisted job when attempts remain."""
-    job = await _get_job_for_update_or_404(db, job_id)
+    job = await _get_active_job_for_retry_or_404(db, job_id)
     if job.status != "failed" or job.attempts >= job.max_attempts:
         return job
 

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -3,17 +3,20 @@
 import base64
 import binascii
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
+from app.models.file import File
+from app.models.generated_artifact import GeneratedArtifact
+from app.models.job import Job
 from app.models.project import Project
 from app.schemas.project import (
     ProjectCreate,
@@ -23,6 +26,26 @@ from app.schemas.project import (
 )
 
 project_router = APIRouter()
+
+
+async def _get_active_project_or_404(
+    db: AsyncSession,
+    project_id: UUID,
+    *,
+    for_update: bool = False,
+) -> Project:
+    """Return an active project row or raise not found."""
+    query = select(Project).where(
+        (Project.id == project_id) & (Project.deleted_at.is_(None))
+    )
+    if for_update:
+        query = query.with_for_update()
+    project = (await db.execute(query)).scalar_one_or_none()
+    if project is None:
+        raise_not_found("Project", str(project_id))
+
+    assert project is not None
+    return project
 
 
 def _encode_cursor(created_at: datetime, project_id: UUID) -> str:
@@ -107,7 +130,11 @@ async def list_projects(
     Cursor should be the next_cursor value from a previous response.
     """
     # Build query ordered by created_at DESC, id DESC
-    query = select(Project).order_by(Project.created_at.desc(), Project.id.desc())
+    query = (
+        select(Project)
+        .where(Project.deleted_at.is_(None))
+        .order_by(Project.created_at.desc(), Project.id.desc())
+    )
 
     # Apply cursor filter if provided
     if cursor:
@@ -151,14 +178,7 @@ async def get_project(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Project:
     """Get a project by ID."""
-    result = await db.execute(select(Project).where(Project.id == project_id))
-    project = result.scalar_one_or_none()
-
-    if project is None:
-        raise_not_found("Project", str(project_id))
-
-    assert project is not None
-    return project
+    return await _get_active_project_or_404(db, project_id)
 
 
 @project_router.patch(
@@ -171,13 +191,7 @@ async def update_project(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Project:
     """Update an existing project."""
-    result = await db.execute(select(Project).where(Project.id == project_id))
-    project = result.scalar_one_or_none()
-
-    if project is None:
-        raise_not_found("Project", str(project_id))
-
-    assert project is not None
+    project = await _get_active_project_or_404(db, project_id)
 
     # Update only provided fields
     update_data = project_in.model_dump(exclude_unset=True)
@@ -198,11 +212,34 @@ async def delete_project(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     """Delete a project."""
-    result = await db.execute(select(Project).where(Project.id == project_id))
-    project = result.scalar_one_or_none()
-
-    if project is None:
-        raise_not_found("Project", str(project_id))
-
-    await db.delete(project)
+    project = await _get_active_project_or_404(db, project_id, for_update=True)
+    deleted_at = datetime.now(UTC)
+    project.deleted_at = deleted_at
+    await db.execute(
+        update(Job)
+        .where(
+            (Job.project_id == project_id)
+            & (Job.status.in_(("pending", "running")))
+        )
+        .values(
+            status="cancelled",
+            cancel_requested=True,
+            error_code=ErrorCode.JOB_CANCELLED.value,
+            error_message=None,
+            finished_at=deleted_at,
+        )
+    )
+    await db.execute(
+        update(File)
+        .where((File.project_id == project_id) & (File.deleted_at.is_(None)))
+        .values(deleted_at=deleted_at)
+    )
+    await db.execute(
+        update(GeneratedArtifact)
+        .where(
+            (GeneratedArtifact.project_id == project_id)
+            & (GeneratedArtifact.deleted_at.is_(None))
+        )
+        .values(deleted_at=deleted_at)
+    )
     await db.commit()

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -10,6 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.exceptions import raise_not_found
 from app.db.session import get_db
 from app.models.drawing_revision import DrawingRevision
+from app.models.file import File
+from app.models.project import Project
 from app.models.validation_report import ValidationReport
 from app.schemas.validation_report import (
     ValidationReportResponse,
@@ -29,11 +31,40 @@ async def get_validation_report(
 ) -> ValidationReportResponse:
     """Return the persisted canonical validation report for a drawing revision."""
     result = await db.execute(
-        select(ValidationReport).where(ValidationReport.drawing_revision_id == revision_id)
+        select(ValidationReport)
+        .join(
+            DrawingRevision,
+            DrawingRevision.id == ValidationReport.drawing_revision_id,
+        )
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (ValidationReport.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
     )
     report = result.scalar_one_or_none()
     if report is None:
-        revision = await db.get(DrawingRevision, revision_id)
+        revision_result = await db.execute(
+            select(DrawingRevision)
+            .join(
+                File,
+                (File.id == DrawingRevision.source_file_id)
+                & (File.project_id == DrawingRevision.project_id),
+            )
+            .join(Project, Project.id == DrawingRevision.project_id)
+            .where(
+                (DrawingRevision.id == revision_id)
+                & (File.deleted_at.is_(None))
+                & (Project.deleted_at.is_(None))
+            )
+        )
+        revision = revision_result.scalar_one_or_none()
         if revision is None:
             raise_not_found("Drawing revision", str(revision_id))
         raise_not_found("Validation report", str(revision_id))

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -28,6 +28,7 @@ from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job
 from app.models.job_event import JobEvent
+from app.models.project import Project
 from app.models.validation_report import ValidationReport
 from app.storage import get_storage
 from app.storage.keys import build_generated_artifact_storage_key
@@ -57,6 +58,10 @@ _SAFE_RUNNER_ERROR_DETAIL_KEYS = (
     "detected_format",
     "media_type",
 )
+
+
+class _InactiveSourceError(Exception):
+    """Raised when a job source project or file is no longer active."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,7 +183,16 @@ async def _get_source_file(
     for_update: bool = False,
 ) -> File | None:
     """Load a source file row, optionally under a row lock."""
-    statement = select(File).where((File.project_id == project_id) & (File.id == file_id))
+    statement = (
+        select(File)
+        .join(Project, Project.id == File.project_id)
+        .where(
+            (File.project_id == project_id)
+            & (File.id == file_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
     if for_update:
         statement = statement.with_for_update()
 
@@ -432,8 +446,7 @@ async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as session:
-        result = await session.execute(select(Job).where(Job.id == job_id))
-        job = result.scalar_one_or_none()
+        job = await _get_job_for_update(session, job_id)
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
@@ -441,10 +454,16 @@ async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
             session,
             project_id=job.project_id,
             file_id=job.file_id,
+            for_update=True,
         )
         if source_file is None:
-            raise LookupError(
-                f"File with identifier '{job.file_id}' for job '{job_id}' not found"
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            raise _InactiveSourceError(
+                f"File with identifier '{job.file_id}' for job '{job_id}' is no longer active"
             )
 
         return IngestionRunRequest(
@@ -518,9 +537,13 @@ async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPaylo
             for_update=True,
         )
         if source_file is None:
-            raise LookupError(
-                f"File with identifier '{job.file_id}' for job '{job_id}' not found"
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
             )
+            logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
+            return False
 
         predecessor_revision = await _get_latest_drawing_revision(
             session,
@@ -947,6 +970,28 @@ def _finalize_job_cancelled(job: Job) -> None:
     job.finished_at = _utcnow()
 
 
+async def _cancel_job_for_inactive_source(
+    session: AsyncSession,
+    job: Job,
+    *,
+    reason: str,
+) -> None:
+    """Persist cancellation when a job source project/file is no longer active."""
+    if job.status in _TERMINAL_JOB_STATUSES:
+        return
+
+    job.cancel_requested = True
+    _finalize_job_cancelled(job)
+    await emit_job_event(
+        job.id,
+        level="warning",
+        message="Job cancelled",
+        data_json={"status": "cancelled", "reason": reason},
+        session=session,
+    )
+    await session.commit()
+
+
 async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
     """Claim, resume, or cancel a persisted ingest job under a row lock."""
     session_maker = get_session_maker()
@@ -966,6 +1011,21 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
                 job_id=str(job_id),
                 status=job.status,
             )
+            return False
+
+        source_file = await _get_source_file(
+            session,
+            project_id=job.project_id,
+            file_id=job.file_id,
+            for_update=True,
+        )
+        if source_file is None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
             return False
 
         if not job.cancel_requested:
@@ -1070,6 +1130,9 @@ async def process_ingest_job(job_id: UUID) -> None:
                 stop_event=stop_event,
                 cancellation_task=cancellation_task,
             )
+    except _InactiveSourceError:
+        logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
+        return
     except IngestionRunnerError as exc:
         if exc.error_code is ErrorCode.JOB_CANCELLED:
             await _mark_job_cancelled(job_id)

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -94,3 +94,8 @@ class File(Base):
         nullable=False,
         comment="File creation timestamp",
     )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Soft deletion timestamp for retention workflows",
+    )

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -54,3 +54,8 @@ class Project(Base):
         onupdate=func.now(),
         comment="Project last update timestamp",
     )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Soft deletion timestamp for retention workflows",
+    )

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -17,8 +17,10 @@ from sqlalchemy import select
 import app.api.v1.files as files_api
 import app.db.session as session_module
 from app.core.config import settings
+from app.core.exceptions import raise_not_found
 from app.models.file import File as FileModel
 from app.models.job import Job
+from app.models.project import Project
 from app.storage import LocalFilesystemStorage, StoredObjectMeta, get_storage
 from tests.conftest import requires_database
 
@@ -54,6 +56,32 @@ async def _upload_file(
     )
     assert response.status_code == 201
     return cast(dict[str, Any], response.json())
+
+
+async def _mark_file_deleted(file_id: str) -> None:
+    """Mark a file row as soft-deleted for read-path tests."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        file_row = (
+            await session.execute(select(FileModel).where(FileModel.id == uuid.UUID(file_id)))
+        ).scalar_one()
+        file_row.deleted_at = file_row.created_at
+        await session.commit()
+
+
+async def _mark_project_deleted(project_id: str) -> None:
+    """Mark a project row as soft-deleted for project-scoped file tests."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        project = (
+            await session.execute(select(Project).where(Project.id == uuid.UUID(project_id)))
+        ).scalar_one()
+        project.deleted_at = project.updated_at
+        await session.commit()
 
 
 def _make_get_db_override_with_commit_error(
@@ -477,6 +505,38 @@ class TestProjectFiles:
         assert item["initial_job_id"] == uploaded["initial_job_id"]
         assert item["initial_extraction_profile_id"] == uploaded["initial_extraction_profile_id"]
 
+    async def test_list_project_files_excludes_soft_deleted_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET list should hide files with deleted_at set."""
+        _ = self
+
+        visible = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="visible.pdf",
+            content=b"%PDF-1.7\nvisible",
+            media_type="application/pdf",
+        )
+        deleted = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="deleted.pdf",
+            content=b"%PDF-1.7\ndeleted",
+            media_type="application/pdf",
+        )
+
+        await _mark_file_deleted(deleted["id"])
+
+        response = await async_client.get(f"/v1/projects/{created_project['id']}/files")
+        assert response.status_code == 200
+
+        returned_ids = {item["id"] for item in response.json()["items"]}
+        assert visible["id"] in returned_ids
+        assert deleted["id"] not in returned_ids
+
     async def test_list_project_files_pagination(
         self,
         async_client: httpx.AsyncClient,
@@ -639,6 +699,52 @@ class TestProjectFiles:
         assert "File" in data["error"]["message"]
         assert data["error"]["details"] is None
 
+    async def test_get_project_file_soft_deleted_returns_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET detail should hide files with deleted_at set."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="deleted-detail.pdf",
+            content=b"%PDF-1.7\ndeleted-detail",
+            media_type="application/pdf",
+        )
+
+        await _mark_file_deleted(uploaded["id"])
+
+        response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}"
+        )
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_get_project_file_soft_deleted_parent_project_returns_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """GET detail should hide files whose parent project is soft-deleted."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="deleted-project-detail.pdf",
+            content=b"%PDF-1.7\ndeleted-project-detail",
+            media_type="application/pdf",
+        )
+
+        await _mark_project_deleted(created_project["id"])
+
+        response = await async_client.get(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}"
+        )
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
     async def test_get_project_file_cross_project_returns_file_not_found(
         self,
         async_client: httpx.AsyncClient,
@@ -697,6 +803,82 @@ class TestProjectFiles:
         assert data["error"]["code"] == "NOT_FOUND"
         assert "Project" in data["error"]["message"]
 
+    async def test_upload_file_soft_deleted_project_returns_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST should treat soft-deleted parent projects as missing."""
+        _ = self
+        await _mark_project_deleted(created_project["id"])
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files",
+            files={"file": ("missing.pdf", b"%PDF-1.7\nx", "application/pdf")},
+        )
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_upload_file_cleans_persisted_upload_when_locked_project_recheck_fails(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        app: FastAPI,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POST should cleanup persisted bytes when the locked project recheck loses the race."""
+        _ = self
+        payload = b"%PDF-1.7\nrace-delete"
+        storage = RecordingStorage()
+        app.dependency_overrides[get_storage] = lambda: storage
+        original_get_active_project = files_api._get_active_project_or_404
+        active_project_checks: list[bool] = []
+
+        async def _race_active_project_check(
+            db: Any,
+            project_id: uuid.UUID,
+            *,
+            for_update: bool = False,
+        ) -> Project:
+            active_project_checks.append(for_update)
+            if for_update:
+                raise_not_found("Project", str(project_id))
+            return await original_get_active_project(db, project_id, for_update=for_update)
+
+        monkeypatch.setattr(
+            files_api,
+            "_get_active_project_or_404",
+            _race_active_project_check,
+        )
+
+        try:
+            response = await async_client.post(
+                f"/v1/projects/{created_project['id']}/files",
+                files={"file": ("race.pdf", payload, "application/pdf")},
+            )
+        finally:
+            app.dependency_overrides.pop(get_storage, None)
+
+        assert response.status_code == 404
+        assert active_project_checks == [False, True]
+        assert len(storage.put_calls) == 1
+        assert storage.delete_calls == [storage.put_calls[0][0]]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
     async def test_list_project_files_project_not_found(
         self,
         async_client: httpx.AsyncClient,
@@ -711,6 +893,54 @@ class TestProjectFiles:
         data = response.json()
         assert data["error"]["code"] == "NOT_FOUND"
         assert "Project" in data["error"]["message"]
+
+    async def test_reprocess_soft_deleted_file_returns_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST reprocess should hide files with deleted_at set."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="reprocess.pdf",
+            content=b"%PDF-1.7\nreprocess",
+            media_type="application/pdf",
+        )
+
+        await _mark_file_deleted(uploaded["id"])
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile": {}},
+        )
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_reprocess_soft_deleted_project_returns_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """POST reprocess should hide files under a soft-deleted project."""
+        _ = self
+        uploaded = await _upload_file(
+            async_client=async_client,
+            project_id=created_project["id"],
+            filename="reprocess-project.pdf",
+            content=b"%PDF-1.7\nreprocess-project",
+            media_type="application/pdf",
+        )
+
+        await _mark_project_deleted(created_project["id"])
+
+        response = await async_client.post(
+            f"/v1/projects/{created_project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile": {}},
+        )
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
 
     async def test_upload_file_rejects_payload_over_size_limit(
         self,

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -17,8 +17,8 @@ from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
 from app.jobs.worker import process_ingest_job
 from app.models.adapter_run_output import AdapterRunOutput
-from app.models.file import File as FileModel
 from app.models.drawing_revision import DrawingRevision
+from app.models.file import File as FileModel
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job
 from app.models.job_event import JobEvent

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -17,10 +17,12 @@ from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
 from app.jobs.worker import process_ingest_job
 from app.models.adapter_run_output import AdapterRunOutput
+from app.models.file import File as FileModel
 from app.models.drawing_revision import DrawingRevision
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job
 from app.models.job_event import JobEvent
+from app.models.project import Project
 from app.models.validation_report import ValidationReport
 from app.storage.keys import build_generated_artifact_storage_key
 from tests.conftest import requires_database
@@ -384,6 +386,48 @@ class TestIngestOutputPersistence:
             adapter_output=adapter_output,
             predecessor_artifact_id=None,
         )
+
+    async def test_delete_project_soft_deletes_generated_artifacts_without_removing_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Project deletion should retain rows while marking files/artifacts deleted."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        delete_response = await async_client.delete(f"/v1/projects/{project['id']}")
+        assert delete_response.status_code == 204
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            project_row = await session.get(Project, _as_uuid(project["id"]))
+            file_row = await session.get(FileModel, _as_uuid(uploaded["id"]))
+            artifact_rows = list(
+                (
+                    await session.execute(
+                        select(GeneratedArtifact)
+                        .where(GeneratedArtifact.project_id == _as_uuid(project["id"]))
+                        .order_by(GeneratedArtifact.created_at, GeneratedArtifact.id)
+                    )
+                ).scalars()
+            )
+
+        assert project_row is not None
+        assert project_row.deleted_at is not None
+        assert file_row is not None
+        assert file_row.deleted_at is not None
+        assert len(artifact_rows) == 1
+        assert artifact_rows[0].deleted_at is not None
 
     async def test_process_ingest_job_persists_payload_provenance_and_confidence_precedence(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1928,7 +1928,9 @@ class TestJobs:
 
         runner_calls: list[IngestionRunRequest] = []
 
-        async def _unexpected_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+        async def _unexpected_run_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
             runner_calls.append(request)
             return _build_fake_ingest_payload(request)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -32,6 +32,7 @@ from app.ingestion.runner import (
 from app.models.file import File
 from app.models.job import Job
 from app.models.job_event import JobEvent
+from app.models.project import Project
 from tests.conftest import requires_database
 
 _FAKE_RUNNER_ADAPTER_KEY = "tests.fake_ingestion_runner"
@@ -293,6 +294,29 @@ async def _update_source_file(
         await session.commit()
 
     return source_file
+
+
+async def _mark_source_deleted(
+    project_id: uuid.UUID,
+    file_id: uuid.UUID,
+    *,
+    delete_project: bool,
+    delete_file: bool,
+) -> None:
+    """Soft-delete the source project and/or file for worker visibility tests."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        if delete_project:
+            project = await session.get(Project, project_id)
+            assert project is not None
+            project.deleted_at = datetime.now(UTC)
+        if delete_file:
+            source_file = await session.get(File, file_id)
+            assert source_file is not None
+            source_file.deleted_at = datetime.now(UTC)
+        await session.commit()
 
 
 async def _create_job_event(
@@ -1737,6 +1761,67 @@ class TestJobs:
             }
         }
 
+    @pytest.mark.parametrize(
+        ("delete_project", "delete_file"),
+        [(True, False), (False, True)],
+    )
+    async def test_retry_job_returns_404_for_soft_deleted_source(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        delete_project: bool,
+        delete_file: bool,
+    ) -> None:
+        """Retry should hide jobs whose backing project or file is soft-deleted."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+            retried_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            jobs_api,
+            "enqueue_ingest_job",
+            _fake_retry_enqueue,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            error_message="previous failure",
+        )
+        await _mark_source_deleted(
+            uuid.UUID(project["id"]),
+            uuid.UUID(uploaded["id"]),
+            delete_project=delete_project,
+            delete_file=delete_file,
+        )
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"Job with identifier '{job.id}' not found",
+                "details": None,
+            }
+        }
+        assert retried_job_ids == []
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "failed"
+
     async def test_process_ingest_job_finalizes_cancel_requested_job_as_cancelled(
         self,
         async_client: httpx.AsyncClient,
@@ -1761,6 +1846,87 @@ class TestJobs:
         assert updated.error_code == ErrorCode.JOB_CANCELLED.value
         assert updated.finished_at is not None
         assert updated.error_message is None
+
+    async def test_process_ingest_job_cancels_soft_deleted_source_before_runner(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker should not start ingestion when the source project is already soft-deleted."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        runner_calls: list[IngestionRunRequest] = []
+
+        async def _unexpected_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+            runner_calls.append(request)
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _unexpected_run_ingestion)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _mark_source_deleted(
+            uuid.UUID(project["id"]),
+            uuid.UUID(uploaded["id"]),
+            delete_project=True,
+            delete_file=False,
+        )
+
+        await worker_module.process_ingest_job(job.id)
+
+        updated = await _get_job(job.id)
+        assert runner_calls == []
+        assert updated.status == "cancelled"
+        assert updated.cancel_requested is True
+        assert updated.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated.finished_at is not None
+
+    async def test_process_ingest_job_skips_finalization_storage_for_soft_deleted_source(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker should cancel before storage writes if the source is deleted mid-run."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        class _UnexpectedStorage:
+            async def put(self, *_: Any, **__: Any) -> Any:
+                raise AssertionError("storage.put should not be called for deleted sources")
+
+        async def _delete_source_during_run(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            await _mark_source_deleted(
+                uuid.UUID(project["id"]),
+                uuid.UUID(uploaded["id"]),
+                delete_project=False,
+                delete_file=True,
+            )
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "get_storage", lambda: _UnexpectedStorage())
+        monkeypatch.setattr(worker_module, "run_ingestion", _delete_source_during_run)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await worker_module.process_ingest_job(job.id)
+
+        updated = await _get_job(job.id)
+        assert updated.status == "cancelled"
+        assert updated.cancel_requested is True
+        assert updated.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated.finished_at is not None
 
     async def test_process_ingest_job_finalizes_cancelled_when_requested_during_completion_race(
         self,

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -8,7 +8,10 @@ from typing import Any
 
 import httpx
 import pytest_asyncio
+from sqlalchemy import select
 
+import app.db.session as session_module
+from app.models.project import Project
 from tests.conftest import requires_database
 
 
@@ -24,6 +27,19 @@ async def created_project(
     )
     assert response.status_code == 201
     return typing.cast(dict[str, Any], response.json())
+
+
+async def _mark_project_deleted(project_id: str) -> None:
+    """Mark a project row as soft-deleted for read-path tests."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        project = (
+            await session.execute(select(Project).where(Project.id == uuid.UUID(project_id)))
+        ).scalar_one()
+        project.deleted_at = project.updated_at
+        await session.commit()
 
 
 @requires_database
@@ -217,6 +233,20 @@ class TestGetProject:
         assert data["error"]["message"] == "Request validation failed"
         assert isinstance(data["error"]["details"], list)
 
+    async def test_get_project_soft_deleted_returns_not_found(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+    ) -> None:
+        """Should hide soft-deleted projects from detail reads."""
+        _ = self
+
+        await _mark_project_deleted(created_project["id"])
+
+        response = await async_client.get(f"/v1/projects/{created_project['id']}")
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
 
 @requires_database
 class TestListProjects:
@@ -271,6 +301,35 @@ class TestListProjects:
         # Verify the created project is in the list
         project_ids = [item["id"] for item in data["items"]]
         assert created_project["id"] in project_ids
+
+    async def test_list_projects_excludes_soft_deleted_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        """Should exclude projects with deleted_at set from list results."""
+        _ = self
+        _ = cleanup_projects
+
+        visible_response = await async_client.post(
+            "/v1/projects",
+            json={"name": "Visible Project"},
+        )
+        deleted_response = await async_client.post(
+            "/v1/projects",
+            json={"name": "Deleted Project"},
+        )
+        assert visible_response.status_code == 201
+        assert deleted_response.status_code == 201
+
+        await _mark_project_deleted(deleted_response.json()["id"])
+
+        response = await async_client.get("/v1/projects")
+        assert response.status_code == 200
+
+        project_ids = {item["id"] for item in response.json()["items"]}
+        assert visible_response.json()["id"] in project_ids
+        assert deleted_response.json()["id"] not in project_ids
 
     async def test_list_projects_pagination(
         self,
@@ -544,6 +603,18 @@ class TestDeleteProject:
 
         # Assert project no longer exists
         assert response.status_code == 404
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            project = (
+                await session.execute(
+                    select(Project).where(Project.id == uuid.UUID(created_project["id"]))
+                )
+            ).scalar_one_or_none()
+
+        assert project is not None
+        assert project.deleted_at is not None
 
     async def test_delete_project_not_found(
         self,

--- a/tests/test_soft_delete_retention_migration.py
+++ b/tests/test_soft_delete_retention_migration.py
@@ -15,10 +15,10 @@ def _load_soft_delete_migration() -> Any:
         Path(__file__).resolve().parents[1]
         / "alembic"
         / "versions"
-        / "2026_05_10_0006_add_soft_delete_columns.py"
+        / "2026_05_10_0008_add_soft_delete_columns.py"
     )
     spec = importlib.util.spec_from_file_location(
-        "migration_2026_05_10_0006_add_soft_delete_columns",
+        "migration_2026_05_10_0008_add_soft_delete_columns",
         migration_path,
     )
     assert spec is not None

--- a/tests/test_soft_delete_retention_migration.py
+++ b/tests/test_soft_delete_retention_migration.py
@@ -1,0 +1,103 @@
+"""Guard tests for the soft-delete retention migration rollback path."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_soft_delete_migration() -> Any:
+    """Load the soft-delete migration module directly from disk."""
+    migration_path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "2026_05_10_0006_add_soft_delete_columns.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_10_0006_add_soft_delete_columns",
+        migration_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeScalarResult:
+    """Small scalar result stand-in for migration guard tests."""
+
+    def __init__(self, value: bool) -> None:
+        self._value = value
+
+    def scalar(self) -> bool:
+        """Return the configured scalar value."""
+        return self._value
+
+
+class _FakeBind:
+    """Minimal Alembic bind double for downgrade guard tests."""
+
+    def __init__(self, *, project_markers_exist: bool, file_markers_exist: bool) -> None:
+        self.project_markers_exist = project_markers_exist
+        self.file_markers_exist = file_markers_exist
+
+    def execute(self, statement: Any, *_: Any, **__: Any) -> _FakeScalarResult:
+        """Return the configured marker-existence result for each table query."""
+        sql = str(statement)
+        if "FROM projects" in sql:
+            return _FakeScalarResult(self.project_markers_exist)
+        if "FROM files" in sql:
+            return _FakeScalarResult(self.file_markers_exist)
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+
+class _FakeOp:
+    """Minimal Alembic op double for downgrade guard tests."""
+
+    def __init__(self, *, project_markers_exist: bool, file_markers_exist: bool) -> None:
+        self._bind = _FakeBind(
+            project_markers_exist=project_markers_exist,
+            file_markers_exist=file_markers_exist,
+        )
+        self.drop_calls: list[tuple[str, str]] = []
+
+    def get_bind(self) -> _FakeBind:
+        """Return the fake bind used by the downgrade guard."""
+        return self._bind
+
+    def drop_column(self, table_name: str, column_name: str) -> None:
+        """Record drop column calls."""
+        self.drop_calls.append((table_name, column_name))
+
+
+def test_soft_delete_migration_downgrade_raises_when_markers_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Downgrade should refuse to drop soft-delete columns with retained markers."""
+    migration = _load_soft_delete_migration()
+    fake_op = _FakeOp(project_markers_exist=False, file_markers_exist=True)
+    monkeypatch.setattr(migration, "op", fake_op)
+
+    with pytest.raises(RuntimeError, match="Manual data-preserving rollback is required"):
+        migration.downgrade()
+
+    assert fake_op.drop_calls == []
+
+
+def test_soft_delete_migration_downgrade_drops_columns_without_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Downgrade should remain rollback-safe when no deletion markers are present."""
+    migration = _load_soft_delete_migration()
+    fake_op = _FakeOp(project_markers_exist=False, file_markers_exist=False)
+    monkeypatch.setattr(migration, "op", fake_op)
+
+    migration.downgrade()
+
+    assert fake_op.drop_calls == [("files", "deleted_at"), ("projects", "deleted_at")]

--- a/tests/test_validation_report_api.py
+++ b/tests/test_validation_report_api.py
@@ -292,3 +292,41 @@ class TestValidationReportApi:
             _generated_artifacts,
         ) = await _load_project_outputs(project["id"])
         assert validation_reports_after == []
+
+    async def test_get_validation_report_returns_404_for_soft_deleted_project_data(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Validation report reads should hide revisions under soft-deleted project/file data."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+
+        delete_response = await async_client.delete(f"/v1/projects/{project['id']}")
+        assert delete_response.status_code == 204
+
+        response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/validation-report"
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": f"Drawing revision with identifier '{drawing_revision.id}' not found",
+                "details": None,
+            }
+        }


### PR DESCRIPTION
Closes #126

## Summary
- add soft-delete retention semantics for projects and files, plus migration coverage for retained visibility markers
- block deleted projects/files from creating or exposing active ingest jobs, validation reports, and derived outputs
- harden worker and retry paths around deleted sources while preserving append-only artifact retention

## Test plan
- [x] uv run mypy app tests
- [x] uv build
- [x] uv run pytest

## Notes
- Follow-up issue for lock-order/deadlock hardening: #155