### PR TITLE
fix(api): surface upload enqueue failure consistently

### DIFF
--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -267,11 +267,13 @@ async def _mark_job_enqueue_failed(db: AsyncSession, job: Job, exc: Exception) -
 
 
 def _enqueue_failure_details(job: Job) -> dict[str, str]:
-    """Return safe durable identifiers for a failed enqueue response."""
+    """Return safe durable identifiers and status for a failed enqueue response."""
     assert job.extraction_profile_id is not None
     return {
+        "file_id": str(job.file_id),
         "job_id": str(job.id),
         "extraction_profile_id": str(job.extraction_profile_id),
+        "status": job.status,
     }
 
 
@@ -470,6 +472,14 @@ async def upload_project_file(
         enqueue_ingest_job(ingest_job.id)
     except Exception as exc:
         await _mark_job_enqueue_failed(db, ingest_job, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=create_error_response(
+                code=ErrorCode.INTERNAL_ERROR,
+                message=_PUBLIC_ENQUEUE_FAILURE_MESSAGE,
+                details=_enqueue_failure_details(ingest_job),
+            ),
+        ) from exc
 
     return _attach_initial_upload_metadata(file_row)
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -628,9 +628,9 @@ prior one.
 - Idempotent mutating endpoints accept `Idempotency-Key` headers and return the
   prior response on replay within a documented retention window.
 - When job enqueue fails after durable records are created, the public error must
-  stay sanitized and may include only safe identifiers already assigned by the
-  system, such as `file_id`, `job_id`, or `extraction_profile_id` where
-  applicable.
+  stay sanitized and may include only safe system-assigned identifiers and
+  workflow metadata, such as `file_id`, `job_id`, `extraction_profile_id`, or
+  `status` where applicable.
 
 ## Error Taxonomy
 

--- a/tests/test_extraction_profiles.py
+++ b/tests/test_extraction_profiles.py
@@ -385,8 +385,10 @@ class TestExtractionProfiles:
 
         failed_job = jobs[1]
         assert details == {
+            "file_id": str(failed_job.file_id),
             "job_id": str(failed_job.id),
             "extraction_profile_id": str(failed_job.extraction_profile_id),
+            "status": "failed",
         }
         assert failed_job.status == "failed"
         assert failed_job.error_code == "INTERNAL_ERROR"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -405,7 +405,7 @@ class TestJobs:
         cleanup_projects: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Uploading should leave a visible failed job when broker publish fails."""
+        """Uploading should expose safe failed-job identifiers when broker publish fails."""
         _ = self
         _ = cleanup_projects
 
@@ -415,8 +415,27 @@ class TestJobs:
         monkeypatch.setattr(files_api, "enqueue_ingest_job", _fail_enqueue)
 
         project = await _create_project(async_client)
-        uploaded = await _upload_file(async_client, project["id"])
-        job = await _get_job_for_file(str(uploaded["id"]))
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files",
+            files={"file": ("plan.pdf", _TEST_UPLOAD_BODY, "application/pdf")},
+        )
+
+        assert response.status_code == 500
+        payload = response.json()
+        assert payload["error"]["code"] == "INTERNAL_ERROR"
+        assert payload["error"]["message"] == "Failed to enqueue ingest job"
+        assert payload["error"]["details"] is not None
+        assert "broker unavailable" not in response.text
+
+        details = cast(dict[str, str], payload["error"]["details"])
+        job = await _get_job_for_file(details["file_id"])
+
+        assert details == {
+            "file_id": str(job.file_id),
+            "job_id": str(job.id),
+            "extraction_profile_id": str(job.extraction_profile_id),
+            "status": "failed",
+        }
 
         assert job.status == "failed"
         assert job.attempts == 0


### PR DESCRIPTION
Closes #129

## Summary
- align initial upload and reprocess so broker enqueue failures both return the same sanitized failed-job envelope
- keep durable identifiers and safe status metadata visible without leaking broker/runtime details
- update tests and TRD contract text to match the shared failure behavior

## Test plan
- [x] uv run mypy app tests
- [x] uv build
- [x] uv run pytest