### PR TITLE
docs(scope): codify API-only MVP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ service.
 
 ## Current MVP Scope
 
+- Product surface is API-only for MVP. Do not assume or document a shipped
+  product CLI, TUI, or web UI unless a scoped task explicitly adds one.
 - Accept DWG, vector PDF, and raster PDF inputs.
 - Treat DXF and IFC as first-class normalized/open inputs where available.
 - Preserve original uploads immutably.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ focuses on accepting common real-world drawing inputs, extracting structured
 geometry and semantic data, producing deterministic quantities and estimates,
 and exposing everything through a UI-agnostic API.
 
+The MVP product surface is API-only. Future clients may include a web UI, TUI,
+CLI, or other services, but this repository does not imply that a product CLI
+exists today.
+
 ## Current Status
 
 Docker Compose development stack is available. See "Local Development" below for setup instructions.
@@ -143,7 +147,8 @@ shapes.
 
 ## MVP Direction
 
-- Backend API that any web UI, TUI, CLI, or service can consume.
+- API-only MVP product surface.
+- Backend API that future web UIs, TUIs, CLIs, or services can consume.
 - Primary starting inputs: DWG, vector PDF, and raster PDF.
 - Direct normalized/open inputs: DXF and IFC where available.
 - Outputs: JSON, CSV, PDF estimate/report, and editable CAD revisions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## High-Level Shape
 
 ```text
-Client UI / CLI / TUI
+Future client UI / CLI / TUI
   -> FastAPI backend
       -> Postgres
       -> local/object storage
@@ -15,6 +15,10 @@ Client UI / CLI / TUI
 ```
 
 ## Main Components
+
+MVP delivery is API-only. Client applications such as a web UI, CLI, or TUI are
+downstream consumers of the backend contract and are not themselves MVP product
+requirements in this repository.
 
 ### API Service
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -3,8 +3,13 @@
 ## System Overview
 
 Draupnir is a backend service for CAD/BIM ingestion, quantity extraction,
-estimation, and revision generation. It exposes a stable API for multiple future
-clients, including web apps, TUIs, CLIs, and other backend services.
+estimation, and revision generation. MVP delivery is API-only. It exposes a
+stable API for future clients, including web apps, TUIs, CLIs, and other
+backend services.
+
+The MVP must not require or imply a separate product CLI. Command-line usage in
+development is operational only (for example, local server, worker, or
+migration commands), not an end-user product surface.
 
 ## Architecture Principles
 


### PR DESCRIPTION
Closes #146

## Summary
- clarify that the MVP ships an API-only backend surface rather than a product CLI
- keep CLI, TUI, and web clients positioned as future consumers of the backend API
- align README, AGENTS, TRD, and architecture docs around the same scope statement

## Test plan
- [x] Re-read changed docs for consistency