### PR TITLE
fix(db): constrain job and extraction-profile invariants

### DIFF
--- a/alembic/versions/2026_05_10_0006_add_project_default_constraints.py
+++ b/alembic/versions/2026_05_10_0006_add_project_default_constraints.py
@@ -1,0 +1,70 @@
+"""Add project default currency and unit-system constraints.
+
+Legacy rows may still contain free-form defaults from before these checks
+existed. Canonicalize recognized values and clear everything else to NULL
+before adding the constraints so the migration can succeed on existing data.
+
+Revision ID: 2026_05_10_0006
+Revises: 2026_05_05_0005
+Create Date: 2026-05-10 07:45:00.000000
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_10_0006"
+down_revision: str | None = "2026_05_05_0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply migration changes."""
+    op.execute(
+        """
+        UPDATE projects
+        SET default_unit_system = CASE
+            WHEN lower(btrim(default_unit_system)) IN ('metric', 'imperial')
+                THEN lower(btrim(default_unit_system))
+            ELSE NULL
+        END
+        WHERE default_unit_system IS NOT NULL
+          AND (
+              default_unit_system <> lower(btrim(default_unit_system))
+              OR lower(btrim(default_unit_system)) NOT IN ('metric', 'imperial')
+          )
+        """
+    )
+    op.execute(
+        """
+        UPDATE projects
+        SET default_currency = CASE
+            WHEN upper(btrim(default_currency)) ~ '^[A-Z]{3}$'
+                THEN upper(btrim(default_currency))
+            ELSE NULL
+        END
+        WHERE default_currency IS NOT NULL
+          AND (
+              default_currency <> upper(btrim(default_currency))
+              OR upper(btrim(default_currency)) !~ '^[A-Z]{3}$'
+          )
+        """
+    )
+    op.create_check_constraint(
+        "ck_projects_default_unit_system",
+        "projects",
+        "default_unit_system IS NULL OR default_unit_system IN ('metric', 'imperial')",
+    )
+    op.create_check_constraint(
+        "ck_projects_default_currency",
+        "projects",
+        "default_currency IS NULL OR default_currency ~ '^[A-Z]{3}$'",
+    )
+
+
+def downgrade() -> None:
+    """Revert migration changes."""
+    op.drop_constraint("ck_projects_default_currency", "projects", type_="check")
+    op.drop_constraint("ck_projects_default_unit_system", "projects", type_="check")

--- a/alembic/versions/2026_05_10_0006_constrain_job_fields_and_ingest_profile.py
+++ b/alembic/versions/2026_05_10_0006_constrain_job_fields_and_ingest_profile.py
@@ -1,0 +1,142 @@
+"""constrain job fields and ingest profile invariant
+
+Revision ID: 2026_05_10_0006
+Revises: 2026_05_05_0005
+Create Date: 2026-05-10 12:30:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_10_0006"
+down_revision: str | None = "2026_05_05_0005"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+_JOB_TYPE_VALUES = ("ingest", "reprocess")
+_JOB_STATUS_VALUES = ("pending", "running", "succeeded", "failed", "cancelled")
+_JOB_ERROR_CODE_VALUES = (
+    "NOT_FOUND",
+    "INVALID_CURSOR",
+    "VALIDATION_ERROR",
+    "INPUT_INVALID",
+    "INPUT_UNSUPPORTED_FORMAT",
+    "ADAPTER_UNAVAILABLE",
+    "ADAPTER_TIMEOUT",
+    "ADAPTER_FAILED",
+    "STORAGE_FAILED",
+    "DB_CONFLICT",
+    "REVISION_CONFLICT",
+    "JOB_CANCELLED",
+    "INTERNAL_ERROR",
+)
+_PROFILE_REQUIRED_JOB_TYPE_VALUES = ("ingest", "reprocess")
+
+
+def _sql_in_list(values: tuple[str, ...]) -> str:
+    """Render a SQL string list for check constraints."""
+
+    return ", ".join(f"'{value}'" for value in values)
+
+
+def _profile_required_constraint_sql() -> str:
+    """Render the extraction-profile invariant for persisted ingestion jobs."""
+
+    return (
+        "job_type NOT IN "
+        f"({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)}) OR extraction_profile_id IS NOT NULL"
+    )
+
+
+def upgrade() -> None:
+    """Constrain persisted job strings and ingest profile writes."""
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE jobs AS jobs
+            SET extraction_profile_id = files.initial_extraction_profile_id
+            FROM files
+            WHERE jobs.file_id = files.id
+              AND jobs.project_id = files.project_id
+              AND jobs.job_type = 'ingest'
+              AND jobs.extraction_profile_id IS NULL
+              AND files.initial_extraction_profile_id IS NOT NULL
+            """
+        )
+    )
+
+    op.create_check_constraint(
+        "ck_jobs_job_type_valid",
+        "jobs",
+        f"job_type IN ({_sql_in_list(_JOB_TYPE_VALUES)})",
+    )
+    op.create_check_constraint(
+        "ck_jobs_status_valid",
+        "jobs",
+        f"status IN ({_sql_in_list(_JOB_STATUS_VALUES)})",
+    )
+    op.create_check_constraint(
+        "ck_jobs_error_code_valid",
+        "jobs",
+        "error_code IS NULL "
+        f"OR error_code IN ({_sql_in_list(_JOB_ERROR_CODE_VALUES)})",
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE jobs
+            ADD CONSTRAINT ck_jobs_ingest_extraction_profile_required
+            CHECK ({constraint_sql})
+            NOT VALID
+            """
+            .format(constraint_sql=_profile_required_constraint_sql())
+        )
+    )
+
+    invalid_profile_required_jobs = bind.execute(
+        sa.text(
+            """
+            SELECT COUNT(*)
+            FROM jobs
+            WHERE job_type IN ({job_type_values})
+              AND extraction_profile_id IS NULL
+            """
+            .format(job_type_values=_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES))
+        )
+    ).scalar_one()
+    if invalid_profile_required_jobs != 0:
+        raise RuntimeError(
+            "Migration 2026_05_10_0006 requires extraction_profile_id for persisted "
+            "ingest/reprocess jobs, but "
+            f"{invalid_profile_required_jobs} row(s) still have NULL extraction_profile_id "
+            "after backfill. Populate jobs.extraction_profile_id (for ingest jobs, "
+            "typically from files.initial_extraction_profile_id) before rerunning this "
+            "migration."
+        )
+
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE jobs
+            VALIDATE CONSTRAINT ck_jobs_ingest_extraction_profile_required
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Drop job field and ingest profile constraints."""
+    op.drop_constraint(
+        "ck_jobs_ingest_extraction_profile_required",
+        "jobs",
+        type_="check",
+    )
+    op.drop_constraint("ck_jobs_error_code_valid", "jobs", type_="check")
+    op.drop_constraint("ck_jobs_status_valid", "jobs", type_="check")
+    op.drop_constraint("ck_jobs_job_type_valid", "jobs", type_="check")

--- a/alembic/versions/2026_05_10_0007_constrain_job_fields_and_ingest_profile.py
+++ b/alembic/versions/2026_05_10_0007_constrain_job_fields_and_ingest_profile.py
@@ -1,7 +1,7 @@
 """constrain job fields and ingest profile invariant
 
-Revision ID: 2026_05_10_0006
-Revises: 2026_05_05_0005
+Revision ID: 2026_05_10_0007
+Revises: 2026_05_10_0006
 Create Date: 2026-05-10 12:30:00
 """
 
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "2026_05_10_0006"
-down_revision: str | None = "2026_05_05_0005"
+revision: str = "2026_05_10_0007"
+down_revision: str | None = "2026_05_10_0006"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
@@ -48,7 +48,8 @@ def _profile_required_constraint_sql() -> str:
 
     return (
         "job_type NOT IN "
-        f"({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)}) OR extraction_profile_id IS NOT NULL"
+        f"({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)}) "
+        "OR extraction_profile_id IS NOT NULL"
     )
 
 
@@ -112,7 +113,7 @@ def upgrade() -> None:
     ).scalar_one()
     if invalid_profile_required_jobs != 0:
         raise RuntimeError(
-            "Migration 2026_05_10_0006 requires extraction_profile_id for persisted "
+            "Migration 2026_05_10_0007 requires extraction_profile_id for persisted "
             "ingest/reprocess jobs, but "
             f"{invalid_profile_required_jobs} row(s) still have NULL extraction_profile_id "
             "after backfill. Populate jobs.extraction_profile_id (for ingest jobs, "

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -26,7 +26,7 @@ from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
-from app.models.job import Job
+from app.models.job import Job, JobType
 from app.models.job_event import JobEvent
 from app.models.validation_report import ValidationReport
 from app.storage import get_storage
@@ -35,6 +35,7 @@ from app.storage.keys import build_generated_artifact_storage_key
 logger = get_logger(__name__)
 
 _INCOMPLETE_JOB_STATUSES = ("pending", "running")
+_RECOVERABLE_INGEST_JOB_TYPES = (JobType.INGEST.value, JobType.REPROCESS.value)
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
 _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
@@ -1119,7 +1120,7 @@ async def process_ingest_job(job_id: UUID) -> None:
 
 
 async def recover_incomplete_ingest_jobs() -> list[UUID]:
-    """Requeue incomplete persisted ingest jobs on worker startup."""
+    """Requeue incomplete persisted ingest/reprocess jobs on worker startup."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -1130,7 +1131,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
         result = await session.execute(
             select(Job)
             .where(
-                (Job.job_type == "ingest")
+                (Job.job_type.in_(_RECOVERABLE_INGEST_JOB_TYPES))
                 & (Job.status.in_(_INCOMPLETE_JOB_STATUSES))
             )
             .order_by(Job.created_at.asc(), Job.id.asc())
@@ -1164,7 +1165,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
 
 
 def recover_incomplete_ingest_jobs_on_worker_start(**_: object) -> None:
-    """Requeue incomplete ingest jobs when a worker starts."""
+    """Requeue incomplete ingest/reprocess jobs when a worker starts."""
     try:
         recovered_job_ids = asyncio.run(recover_incomplete_ingest_jobs())
     except Exception as exc:

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -2,9 +2,11 @@
 
 import uuid
 from datetime import datetime
+from enum import StrEnum
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -14,7 +16,37 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.errors import ErrorCode
 from app.db.base import Base
+
+
+class JobType(StrEnum):
+    """Supported persisted job types."""
+
+    INGEST = "ingest"
+    REPROCESS = "reprocess"
+
+
+class JobStatus(StrEnum):
+    """Supported persisted job lifecycle states."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+_JOB_TYPE_VALUES = tuple(job_type.value for job_type in JobType)
+_JOB_STATUS_VALUES = tuple(status.value for status in JobStatus)
+_JOB_ERROR_CODE_VALUES = tuple(error_code.value for error_code in ErrorCode)
+_PROFILE_REQUIRED_JOB_TYPE_VALUES = (JobType.INGEST.value, JobType.REPROCESS.value)
+
+
+def _sql_in_list(values: tuple[str, ...]) -> str:
+    """Render a SQL string list for check constraints."""
+
+    return ", ".join(f"'{value}'" for value in values)
 
 
 class Job(Base):
@@ -33,6 +65,24 @@ class Job(Base):
             ["extraction_profiles.id", "extraction_profiles.project_id"],
             ondelete="CASCADE",
             name="fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+        ),
+        CheckConstraint(
+            f"job_type IN ({_sql_in_list(_JOB_TYPE_VALUES)})",
+            name="ck_jobs_job_type_valid",
+        ),
+        CheckConstraint(
+            f"status IN ({_sql_in_list(_JOB_STATUS_VALUES)})",
+            name="ck_jobs_status_valid",
+        ),
+        CheckConstraint(
+            "error_code IS NULL "
+            f"OR error_code IN ({_sql_in_list(_JOB_ERROR_CODE_VALUES)})",
+            name="ck_jobs_error_code_valid",
+        ),
+        CheckConstraint(
+            "job_type NOT IN "
+            f"({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)}) OR extraction_profile_id IS NOT NULL",
+            name="ck_jobs_ingest_extraction_profile_required",
         ),
     )
 
@@ -57,7 +107,8 @@ class Job(Base):
         index=True,
         comment=(
             "Immutable extraction profile identifier. Nullable only during the "
-            "expand/rollback window; a future contract migration can enforce NOT NULL."
+            "expand/rollback window; persisted ingest/reprocess jobs require a "
+            "profile and a future contract migration can enforce NOT NULL."
         ),
     )
     job_type: Mapped[str] = mapped_column(

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -81,7 +81,8 @@ class Job(Base):
         ),
         CheckConstraint(
             "job_type NOT IN "
-            f"({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)}) OR extraction_profile_id IS NOT NULL",
+            f"({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)}) "
+            "OR extraction_profile_id IS NOT NULL",
             name="ck_jobs_ingest_extraction_profile_required",
         ),
     )

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.core.errors import ErrorCode
+from app.models.job import JobStatus, JobType
 
 
 class JobRead(BaseModel):
@@ -21,12 +22,12 @@ class JobRead(BaseModel):
         default=None,
         description=(
             "Immutable extraction profile identifier. Nullable for historical jobs "
-            "during the migration rollback window; future contract migration can "
-            "enforce non-null."
+            "during the migration rollback window; persisted ingest/reprocess jobs "
+            "require a profile and a future contract migration can enforce non-null."
         ),
     )
-    job_type: str = Field(..., description="Job type")
-    status: str = Field(..., description="Job status")
+    job_type: JobType = Field(..., description="Job type")
+    status: JobStatus = Field(..., description="Job status")
     attempts: int = Field(..., ge=0, description="Current attempt count")
     max_attempts: int = Field(..., ge=1, description="Maximum retry attempts")
     cancel_requested: bool = Field(..., description="Whether cancellation was requested")

--- a/tests/test_extraction_profiles.py
+++ b/tests/test_extraction_profiles.py
@@ -423,7 +423,7 @@ class TestExtractionProfiles:
 
             async with engine.begin() as conn:
                 await conn.execute(text(f'SET search_path TO "{schema_name}"'))
-                await conn.run_sync(_install_pre_0006_jobs_schema)
+                await conn.run_sync(_install_pre_0007_jobs_schema)
 
                 await conn.execute(
                     text("INSERT INTO projects (id) VALUES (:id)"),
@@ -492,7 +492,9 @@ class TestExtractionProfiles:
                     ],
                 )
 
-                await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+                await conn.run_sync(
+                    lambda sync_conn: _run_migration_upgrade(sync_conn, migration)
+                )
 
                 jobs = (
                     (
@@ -552,10 +554,13 @@ class TestExtractionProfiles:
             async with engine.begin() as conn:
                 await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
 
-            with pytest.raises(RuntimeError, match="still have NULL extraction_profile_id after backfill"):
+            with pytest.raises(
+                RuntimeError,
+                match="still have NULL extraction_profile_id after backfill",
+            ):
                 async with engine.begin() as conn:
                     await conn.execute(text(f'SET search_path TO "{schema_name}"'))
-                    await conn.run_sync(_install_pre_0006_jobs_schema)
+                    await conn.run_sync(_install_pre_0007_jobs_schema)
 
                     await conn.execute(
                         text("INSERT INTO projects (id) VALUES (:id)"),
@@ -606,7 +611,12 @@ class TestExtractionProfiles:
                         },
                     )
 
-                    await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+                    await conn.run_sync(
+                        lambda sync_conn: _run_migration_upgrade(
+                            sync_conn,
+                            migration,
+                        )
+                    )
         finally:
             async with engine.begin() as conn:
                 await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
@@ -614,7 +624,7 @@ class TestExtractionProfiles:
     async def test_job_constraints_migration_downgrade_drops_constraints(
         self,
     ) -> None:
-        """Downgrade should remove the 0006 job check constraints."""
+        """Downgrade should remove the 0007 job check constraints."""
         _ = self
 
         engine = session_module.get_engine()
@@ -633,7 +643,7 @@ class TestExtractionProfiles:
 
             async with engine.begin() as conn:
                 await conn.execute(text(f'SET search_path TO "{schema_name}"'))
-                await conn.run_sync(_install_pre_0006_jobs_schema)
+                await conn.run_sync(_install_pre_0007_jobs_schema)
 
                 await conn.execute(
                     text("INSERT INTO projects (id) VALUES (:id)"),
@@ -688,7 +698,9 @@ class TestExtractionProfiles:
                     },
                 )
 
-                await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+                await conn.run_sync(
+                    lambda sync_conn: _run_migration_upgrade(sync_conn, migration)
+                )
                 assert await _get_job_check_constraints(conn, schema_name) == {
                     "ck_jobs_error_code_valid": True,
                     "ck_jobs_ingest_extraction_profile_required": True,
@@ -696,7 +708,12 @@ class TestExtractionProfiles:
                     "ck_jobs_status_valid": True,
                 }
 
-                await conn.run_sync(lambda sync_conn: _run_migration_downgrade(sync_conn, migration))
+                await conn.run_sync(
+                    lambda sync_conn: _run_migration_downgrade(
+                        sync_conn,
+                        migration,
+                    )
+                )
                 assert await _get_job_check_constraints(conn, schema_name) == {}
         finally:
             async with engine.begin() as conn:
@@ -892,10 +909,10 @@ def _load_job_constraints_migration() -> Any:
         Path(__file__).resolve().parents[1]
         / "alembic"
         / "versions"
-        / "2026_05_10_0006_constrain_job_fields_and_ingest_profile.py"
+        / "2026_05_10_0007_constrain_job_fields_and_ingest_profile.py"
     )
     spec = importlib.util.spec_from_file_location(
-        "migration_2026_05_10_0006_constrain_job_fields_and_ingest_profile",
+        "migration_2026_05_10_0007_constrain_job_fields_and_ingest_profile",
         migration_path,
     )
     assert spec is not None
@@ -950,8 +967,8 @@ def _install_pre_0004_schema(sync_conn: sa.Connection) -> None:
     metadata.create_all(sync_conn)
 
 
-def _install_pre_0006_jobs_schema(sync_conn: sa.Connection) -> None:
-    """Create the minimal pre-0006 schema needed to exercise job constraints."""
+def _install_pre_0007_jobs_schema(sync_conn: sa.Connection) -> None:
+    """Create the minimal pre-0007 schema needed to exercise job constraints."""
     metadata = sa.MetaData()
     sa.Table(
         "projects",

--- a/tests/test_extraction_profiles.py
+++ b/tests/test_extraction_profiles.py
@@ -400,65 +400,307 @@ class TestExtractionProfiles:
         assert failed_profile.units_override == "metric"
         assert failed_profile.layout_mode == "paper_space"
 
-    async def test_jobs_column_stays_nullable_for_expand_contract_rollback_window(
+    async def test_job_constraints_migration_upgrade_backfills_and_validates_profiles(
         self,
-        async_client: httpx.AsyncClient,
-        cleanup_projects: None,
-        stub_enqueue_ingest_job: None,
     ) -> None:
-        """Head schema must still allow legacy inserts without extraction_profile_id."""
+        """Upgrade should backfill required profiles and validate all new job constraints."""
         _ = self
-        _ = cleanup_projects
-        _ = stub_enqueue_ingest_job
 
-        project = await _create_project(async_client)
-        uploaded = await _upload_file(async_client, project["id"])
-        legacy_job_id = uuid.uuid4()
+        engine = session_module.get_engine()
+        assert engine is not None
 
-        session_maker = session_module.AsyncSessionLocal
-        assert session_maker is not None
+        schema_name = f"test_job_constraints_{uuid.uuid4().hex}"
+        migration = _load_job_constraints_migration()
+        project_id = uuid.uuid4()
+        file_id = uuid.uuid4()
+        profile_id = uuid.uuid4()
+        ingest_job_id = uuid.uuid4()
+        reprocess_job_id = uuid.uuid4()
 
-        async with session_maker() as session:
-            await session.execute(
-                text(
-                    """
-                    INSERT INTO jobs (
-                        id,
-                        project_id,
-                        file_id,
-                        job_type,
-                        status,
-                        attempts,
-                        max_attempts,
-                        cancel_requested
-                    ) VALUES (
-                        :id,
-                        :project_id,
-                        :file_id,
-                        :job_type,
-                        :status,
-                        :attempts,
-                        :max_attempts,
-                        :cancel_requested
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(_install_pre_0006_jobs_schema)
+
+                await conn.execute(
+                    text("INSERT INTO projects (id) VALUES (:id)"),
+                    {"id": project_id},
+                )
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO files (id, project_id, initial_extraction_profile_id)
+                        VALUES (:id, :project_id, :initial_extraction_profile_id)
+                        """
+                    ),
+                    {
+                        "id": file_id,
+                        "project_id": project_id,
+                        "initial_extraction_profile_id": profile_id,
+                    },
+                )
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO jobs (
+                            id,
+                            project_id,
+                            file_id,
+                            extraction_profile_id,
+                            job_type,
+                            status,
+                            attempts,
+                            max_attempts,
+                            cancel_requested,
+                            created_at
+                        ) VALUES (
+                            :id,
+                            :project_id,
+                            :file_id,
+                            :extraction_profile_id,
+                            :job_type,
+                            :status,
+                            0,
+                            3,
+                            false,
+                            :created_at
+                        )
+                        """
+                    ),
+                    [
+                        {
+                            "id": ingest_job_id,
+                            "project_id": project_id,
+                            "file_id": file_id,
+                            "extraction_profile_id": None,
+                            "job_type": "ingest",
+                            "status": "pending",
+                            "created_at": datetime(2026, 5, 10, tzinfo=UTC),
+                        },
+                        {
+                            "id": reprocess_job_id,
+                            "project_id": project_id,
+                            "file_id": file_id,
+                            "extraction_profile_id": profile_id,
+                            "job_type": "reprocess",
+                            "status": "running",
+                            "created_at": datetime(2026, 5, 11, tzinfo=UTC),
+                        },
+                    ],
+                )
+
+                await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+                jobs = (
+                    (
+                        await conn.execute(
+                            text(
+                                """
+                                SELECT id, job_type, extraction_profile_id
+                                FROM jobs
+                                ORDER BY created_at ASC, id ASC
+                                """
+                            )
+                        )
                     )
-                    """
-                ),
-                {
-                    "id": legacy_job_id,
-                    "project_id": uuid.UUID(project["id"]),
-                    "file_id": uuid.UUID(uploaded["id"]),
-                    "job_type": "ingest",
-                    "status": "pending",
-                    "attempts": 0,
-                    "max_attempts": 3,
-                    "cancel_requested": False,
-                },
-            )
-            await session.commit()
+                    .mappings()
+                    .all()
+                )
+                assert [dict(row) for row in jobs] == [
+                    {
+                        "id": ingest_job_id,
+                        "job_type": "ingest",
+                        "extraction_profile_id": profile_id,
+                    },
+                    {
+                        "id": reprocess_job_id,
+                        "job_type": "reprocess",
+                        "extraction_profile_id": profile_id,
+                    },
+                ]
 
-        jobs = await _get_jobs_for_file(str(uploaded["id"]))
-        legacy_job = next(job for job in jobs if job.id == legacy_job_id)
-        assert legacy_job.extraction_profile_id is None
+                constraints = await _get_job_check_constraints(conn, schema_name)
+                assert constraints == {
+                    "ck_jobs_error_code_valid": True,
+                    "ck_jobs_ingest_extraction_profile_required": True,
+                    "ck_jobs_job_type_valid": True,
+                    "ck_jobs_status_valid": True,
+                }
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+    async def test_job_constraints_migration_upgrade_fails_when_backfill_leaves_null_profiles(
+        self,
+    ) -> None:
+        """Upgrade should fail loudly when legacy required-profile jobs cannot be backfilled."""
+        _ = self
+
+        engine = session_module.get_engine()
+        assert engine is not None
+
+        schema_name = f"test_job_constraints_fail_{uuid.uuid4().hex}"
+        migration = _load_job_constraints_migration()
+        project_id = uuid.uuid4()
+        file_id = uuid.uuid4()
+        ingest_job_id = uuid.uuid4()
+
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+            with pytest.raises(RuntimeError, match="still have NULL extraction_profile_id after backfill"):
+                async with engine.begin() as conn:
+                    await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                    await conn.run_sync(_install_pre_0006_jobs_schema)
+
+                    await conn.execute(
+                        text("INSERT INTO projects (id) VALUES (:id)"),
+                        {"id": project_id},
+                    )
+                    await conn.execute(
+                        text(
+                            """
+                            INSERT INTO files (id, project_id, initial_extraction_profile_id)
+                            VALUES (:id, :project_id, NULL)
+                            """
+                        ),
+                        {"id": file_id, "project_id": project_id},
+                    )
+                    await conn.execute(
+                        text(
+                            """
+                            INSERT INTO jobs (
+                                id,
+                                project_id,
+                                file_id,
+                                extraction_profile_id,
+                                job_type,
+                                status,
+                                attempts,
+                                max_attempts,
+                                cancel_requested,
+                                created_at
+                            ) VALUES (
+                                :id,
+                                :project_id,
+                                :file_id,
+                                NULL,
+                                'ingest',
+                                'pending',
+                                0,
+                                3,
+                                false,
+                                :created_at
+                            )
+                            """
+                        ),
+                        {
+                            "id": ingest_job_id,
+                            "project_id": project_id,
+                            "file_id": file_id,
+                            "created_at": datetime(2026, 5, 12, tzinfo=UTC),
+                        },
+                    )
+
+                    await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+    async def test_job_constraints_migration_downgrade_drops_constraints(
+        self,
+    ) -> None:
+        """Downgrade should remove the 0006 job check constraints."""
+        _ = self
+
+        engine = session_module.get_engine()
+        assert engine is not None
+
+        schema_name = f"test_job_constraints_down_{uuid.uuid4().hex}"
+        migration = _load_job_constraints_migration()
+        project_id = uuid.uuid4()
+        file_id = uuid.uuid4()
+        profile_id = uuid.uuid4()
+        ingest_job_id = uuid.uuid4()
+
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(_install_pre_0006_jobs_schema)
+
+                await conn.execute(
+                    text("INSERT INTO projects (id) VALUES (:id)"),
+                    {"id": project_id},
+                )
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO files (id, project_id, initial_extraction_profile_id)
+                        VALUES (:id, :project_id, :initial_extraction_profile_id)
+                        """
+                    ),
+                    {
+                        "id": file_id,
+                        "project_id": project_id,
+                        "initial_extraction_profile_id": profile_id,
+                    },
+                )
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO jobs (
+                            id,
+                            project_id,
+                            file_id,
+                            extraction_profile_id,
+                            job_type,
+                            status,
+                            attempts,
+                            max_attempts,
+                            cancel_requested,
+                            created_at
+                        ) VALUES (
+                            :id,
+                            :project_id,
+                            :file_id,
+                            NULL,
+                            'ingest',
+                            'pending',
+                            0,
+                            3,
+                            false,
+                            :created_at
+                        )
+                        """
+                    ),
+                    {
+                        "id": ingest_job_id,
+                        "project_id": project_id,
+                        "file_id": file_id,
+                        "created_at": datetime(2026, 5, 13, tzinfo=UTC),
+                    },
+                )
+
+                await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+                assert await _get_job_check_constraints(conn, schema_name) == {
+                    "ck_jobs_error_code_valid": True,
+                    "ck_jobs_ingest_extraction_profile_required": True,
+                    "ck_jobs_job_type_valid": True,
+                    "ck_jobs_status_valid": True,
+                }
+
+                await conn.run_sync(lambda sync_conn: _run_migration_downgrade(sync_conn, migration))
+                assert await _get_job_check_constraints(conn, schema_name) == {}
+        finally:
+            async with engine.begin() as conn:
+                await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
 
     async def test_migration_upgrade_backfills_profiles_and_initial_lineage(
         self,
@@ -644,6 +886,26 @@ def _load_extraction_profiles_migration() -> Any:
     return module
 
 
+def _load_job_constraints_migration() -> Any:
+    """Load the job-constraint migration module directly from disk."""
+    migration_path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "2026_05_10_0006_constrain_job_fields_and_ingest_profile.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_10_0006_constrain_job_fields_and_ingest_profile",
+        migration_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _install_pre_0004_schema(sync_conn: sa.Connection) -> None:
     """Create the minimal pre-0004 schema needed to exercise the migration."""
     metadata = sa.MetaData()
@@ -688,11 +950,95 @@ def _install_pre_0004_schema(sync_conn: sa.Connection) -> None:
     metadata.create_all(sync_conn)
 
 
+def _install_pre_0006_jobs_schema(sync_conn: sa.Connection) -> None:
+    """Create the minimal pre-0006 schema needed to exercise job constraints."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "projects",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+    )
+    sa.Table(
+        "files",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("initial_extraction_profile_id", sa.Uuid(), nullable=True),
+    )
+    sa.Table(
+        "jobs",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("file_id", sa.Uuid(), nullable=False),
+        sa.Column("extraction_profile_id", sa.Uuid(), nullable=True),
+        sa.Column("job_type", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("max_attempts", sa.Integer(), nullable=False, server_default=sa.text("3")),
+        sa.Column(
+            "cancel_requested",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("error_code", sa.String(length=128), nullable=True),
+        sa.Column("error_message", sa.String(length=2048), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    metadata.create_all(sync_conn)
+
+
 def _run_migration_upgrade(sync_conn: sa.Connection, migration: Any) -> None:
     """Run the extraction-profile upgrade against a live connection."""
     migration_context = MigrationContext.configure(sync_conn)
     migration.op = Operations(migration_context)
     migration.upgrade()
+
+
+def _run_migration_downgrade(sync_conn: sa.Connection, migration: Any) -> None:
+    """Run the corresponding downgrade against a live connection."""
+    migration_context = MigrationContext.configure(sync_conn)
+    migration.op = Operations(migration_context)
+    migration.downgrade()
+
+
+async def _get_job_check_constraints(conn: Any, schema_name: str) -> dict[str, bool]:
+    """Return job-table check constraints and validation state for a schema."""
+    rows = (
+        (
+            await conn.execute(
+                text(
+                    """
+                    SELECT con.conname, con.convalidated
+                    FROM pg_constraint AS con
+                    JOIN pg_class AS rel
+                      ON rel.oid = con.conrelid
+                    JOIN pg_namespace AS nsp
+                      ON nsp.oid = rel.relnamespace
+                    WHERE nsp.nspname = :schema_name
+                      AND rel.relname = 'jobs'
+                      AND con.contype = 'c'
+                    ORDER BY con.conname ASC
+                    """
+                ),
+                {"schema_name": schema_name},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return {
+        cast(str, row["conname"]): cast(bool, row["convalidated"])
+        for row in rows
+    }
 
 
 class _FakeScalarResult:

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -238,23 +238,6 @@ async def _load_job_events(job_id: uuid.UUID) -> list[JobEvent]:
         )
 
 
-async def _set_job_extraction_profile_id(
-    job_id: uuid.UUID,
-    extraction_profile_id: uuid.UUID | None,
-) -> Job:
-    """Update a job extraction profile for failure-path setup."""
-    session_maker = session_module.AsyncSessionLocal
-    assert session_maker is not None
-
-    async with session_maker() as session:
-        job = await session.get(Job, job_id)
-        assert job is not None
-        job.extraction_profile_id = extraction_profile_id
-        await session.commit()
-
-    return await _get_job(job_id)
-
-
 @requires_database
 class TestIngestOutputPersistence:
     """Tests for durable ingest output persistence and finalization guards."""
@@ -834,52 +817,6 @@ class TestIngestOutputPersistence:
         assert [row.id for row in second_outputs[1]] == [row.id for row in first_outputs[1]]
         assert [row.id for row in second_outputs[2]] == [row.id for row in first_outputs[2]]
         assert [row.id for row in second_outputs[3]] == [row.id for row in first_outputs[3]]
-
-    async def test_process_ingest_job_missing_profile_fails_without_outputs(
-        self,
-        async_client: httpx.AsyncClient,
-        cleanup_projects: None,
-        enqueued_job_ids: list[str],
-    ) -> None:
-        """Missing extraction profile should fail finalization without partial outputs."""
-        _ = self
-        _ = cleanup_projects
-        _ = enqueued_job_ids
-
-        project = await _create_project(async_client)
-        uploaded = await _upload_file(async_client, project["id"])
-        job = await _get_job_for_file(str(uploaded["id"]))
-
-        await _set_job_extraction_profile_id(job.id, None)
-
-        with pytest.raises(ValueError, match="Ingest job missing extraction profile"):
-            await process_ingest_job(job.id)
-
-        updated_job = await _get_job(job.id)
-        assert updated_job.status == "failed"
-        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert updated_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
-
-        events = await _load_job_events(job.id)
-        assert events[-1].level == "error"
-        assert events[-1].message == "Job failed"
-        assert events[-1].data_json == {
-            "status": "failed",
-            "error_code": ErrorCode.INTERNAL_ERROR.value,
-            "error_message": worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE,
-        }
-
-        (
-            adapter_outputs,
-            drawing_revisions,
-            validation_reports,
-            generated_artifacts,
-        ) = await _load_project_outputs(project["id"])
-
-        assert adapter_outputs == []
-        assert drawing_revisions == []
-        assert validation_reports == []
-        assert generated_artifacts == []
 
     async def test_process_ingest_job_precommit_overlay_failure_cleans_storage_without_outputs(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 import httpx
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 import app.api.v1.files as files_api
 import app.api.v1.jobs as jobs_api
@@ -1282,6 +1283,49 @@ class TestJobs:
         assert updated_job.status == "pending"
         assert updated_job.attempts == 0
 
+    async def test_recover_incomplete_ingest_jobs_requeues_pending_reprocess_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker startup recovery should requeue pending reprocess jobs."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        enqueued_job_ids.clear()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.job_type = "reprocess"
+            await session.commit()
+
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
+
+        assert recovered_job_ids == [str(job.id)]
+        assert requeued == [job.id]
+
+        await worker_module.process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.job_type == "reprocess"
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1
+
     async def test_recover_incomplete_ingest_jobs_requeues_orphaned_running_jobs(
         self,
         async_client: httpx.AsyncClient,
@@ -1820,3 +1864,108 @@ class TestJobs:
         assert after.attempts == 1
         assert after.cancel_requested is True
         assert after.finished_at == before_finished_at
+
+    async def test_job_constraints_accept_valid_type_status_error_writes(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Valid constrained job writes should still commit."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+
+            persisted_job.job_type = "reprocess"
+            persisted_job.status = "failed"
+            persisted_job.error_code = ErrorCode.ADAPTER_FAILED.value
+            persisted_job.error_message = "Adapter execution failed."
+
+            await session.commit()
+
+        updated = await _get_job(job.id)
+        assert updated.job_type == "reprocess"
+        assert updated.status == "failed"
+        assert updated.error_code == ErrorCode.ADAPTER_FAILED.value
+
+    @pytest.mark.parametrize(
+        ("field_name", "invalid_value"),
+        [
+            ("job_type", "not-a-job-type"),
+            ("status", "queued"),
+            ("error_code", "NOT_A_REAL_ERROR_CODE"),
+        ],
+    )
+    async def test_job_constraints_reject_invalid_string_writes(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        field_name: str,
+        invalid_value: str,
+    ) -> None:
+        """Invalid constrained string writes should fail at the database."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+
+            setattr(persisted_job, field_name, invalid_value)
+
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+            await session.rollback()
+
+    @pytest.mark.parametrize("job_type", ["ingest", "reprocess"])
+    async def test_job_constraints_reject_profile_required_job_without_extraction_profile(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        job_type: str,
+    ) -> None:
+        """Persisted ingest/reprocess jobs must retain an extraction profile identifier."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+
+            persisted_job.job_type = job_type
+            persisted_job.extraction_profile_id = None
+
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+            await session.rollback()


### PR DESCRIPTION
Closes #131

## Summary
- enforce job type, status, and error-code invariants at the database boundary
- require extraction profiles for profile-bound job types and align recovery behavior with those constraints
- add migration/backfill coverage and remove stale tests that depended on the old nullable-profile contract

## Test plan
- [x] uv run mypy app tests
- [x] uv build
- [x] uv run pytest