### PR TITLE
feat(api): add revision and artifact discoverability endpoints

### DIFF
--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -1,24 +1,394 @@
 """Revision API routes."""
 
+import base64
+import binascii
+from datetime import datetime
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import raise_not_found
 from app.db.session import get_db
+from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.file import File
+from app.models.generated_artifact import GeneratedArtifact
 from app.models.project import Project
 from app.models.validation_report import ValidationReport
+from app.schemas.revision import (
+    AdapterRunOutputRead,
+    DrawingRevisionListResponse,
+    DrawingRevisionRead,
+    GeneratedArtifactListResponse,
+    GeneratedArtifactRead,
+)
 from app.schemas.validation_report import (
     ValidationReportResponse,
     build_validation_report_response,
 )
 
 revisions_router = APIRouter()
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+
+
+class _DrawingRevisionCursor(BaseModel):
+    """Opaque cursor payload for drawing revision pagination."""
+
+    revision_sequence: int
+    created_at: datetime
+    id: UUID
+
+
+class _GeneratedArtifactCursor(BaseModel):
+    """Opaque cursor payload for generated artifact pagination."""
+
+    created_at: datetime
+    id: UUID
+
+
+def _encode_cursor(payload: BaseModel) -> str:
+    """Encode a pagination cursor payload as an opaque token."""
+
+    return base64.urlsafe_b64encode(payload.model_dump_json().encode("utf-8")).decode(
+        "utf-8"
+    ).rstrip("=")
+
+
+def _decode_revision_cursor(cursor: str) -> _DrawingRevisionCursor:
+    """Decode and validate an opaque drawing revision cursor."""
+
+    try:
+        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
+        return _DrawingRevisionCursor.model_validate_json(decoded)
+    except (ValueError, ValidationError, binascii.Error) as exc:
+        raise HTTPException(status_code=422, detail="Invalid cursor") from exc
+
+
+def _decode_artifact_cursor(cursor: str) -> _GeneratedArtifactCursor:
+    """Decode and validate an opaque generated artifact cursor."""
+
+    try:
+        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
+        return _GeneratedArtifactCursor.model_validate_json(decoded)
+    except (ValueError, ValidationError, binascii.Error) as exc:
+        raise HTTPException(status_code=422, detail="Invalid cursor") from exc
+
+
+async def _get_active_file(file_id: UUID, db: AsyncSession) -> File | None:
+    """Return an active file visible through a non-deleted project."""
+
+    result = await db.execute(
+        select(File)
+        .join(Project, Project.id == File.project_id)
+        .where(
+            (File.id == file_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_active_revision(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> DrawingRevision | None:
+    """Return an active revision visible through a non-deleted file and project."""
+
+    result = await db.execute(
+        select(DrawingRevision)
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (DrawingRevision.id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+@revisions_router.get("/files/{file_id}/revisions", response_model=DrawingRevisionListResponse)
+async def list_file_revisions(
+    file_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> DrawingRevisionListResponse:
+    """List active drawing revisions for a file."""
+
+    file = await _get_active_file(file_id, db)
+    if file is None:
+        raise_not_found("File", str(file_id))
+
+    pagination_cursor = _decode_revision_cursor(cursor) if cursor else None
+
+    query = (
+        select(DrawingRevision)
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (DrawingRevision.source_file_id == file_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+
+    if pagination_cursor is not None:
+        query = query.where(
+            (DrawingRevision.revision_sequence > pagination_cursor.revision_sequence)
+            | (
+                (DrawingRevision.revision_sequence == pagination_cursor.revision_sequence)
+                & (DrawingRevision.created_at > pagination_cursor.created_at)
+            )
+            | (
+                (DrawingRevision.revision_sequence == pagination_cursor.revision_sequence)
+                & (DrawingRevision.created_at == pagination_cursor.created_at)
+                & (DrawingRevision.id > pagination_cursor.id)
+            )
+        )
+
+    result = await db.execute(
+        query
+        .order_by(
+            DrawingRevision.revision_sequence.asc(),
+            DrawingRevision.created_at.asc(),
+            DrawingRevision.id.asc(),
+        )
+        .limit(limit + 1)
+    )
+    revisions = result.scalars().all()
+    page = revisions[:limit]
+    next_cursor = None
+
+    if len(revisions) > limit and page:
+        last_revision = page[-1]
+        next_cursor = _encode_cursor(
+            _DrawingRevisionCursor(
+                revision_sequence=last_revision.revision_sequence,
+                created_at=last_revision.created_at,
+                id=last_revision.id,
+            )
+        )
+
+    return DrawingRevisionListResponse(
+        items=[DrawingRevisionRead.model_validate(revision) for revision in page],
+        next_cursor=next_cursor,
+    )
+
+
+@revisions_router.get(
+    "/revisions/{revision_id}/adapter-output",
+    response_model=AdapterRunOutputRead,
+)
+async def get_revision_adapter_output(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> AdapterRunOutputRead:
+    """Return adapter output metadata for an active drawing revision."""
+
+    result = await db.execute(
+        select(AdapterRunOutput)
+        .join(DrawingRevision, DrawingRevision.adapter_run_output_id == AdapterRunOutput.id)
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (DrawingRevision.id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    adapter_output = result.scalar_one_or_none()
+    if adapter_output is None:
+        revision = await _get_active_revision(revision_id, db)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+        raise_not_found("Adapter run output", str(revision_id))
+
+    return AdapterRunOutputRead.model_validate(adapter_output)
+
+
+@revisions_router.get(
+    "/adapter-outputs/{adapter_output_id}",
+    response_model=AdapterRunOutputRead,
+)
+async def get_adapter_output(
+    adapter_output_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> AdapterRunOutputRead:
+    """Return adapter output metadata by identifier."""
+
+    result = await db.execute(
+        select(AdapterRunOutput)
+        .join(
+            File,
+            (File.id == AdapterRunOutput.source_file_id)
+            & (File.project_id == AdapterRunOutput.project_id),
+        )
+        .join(Project, Project.id == AdapterRunOutput.project_id)
+        .where(
+            (AdapterRunOutput.id == adapter_output_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    adapter_output = result.scalar_one_or_none()
+    if adapter_output is None:
+        raise_not_found("Adapter run output", str(adapter_output_id))
+
+    return AdapterRunOutputRead.model_validate(adapter_output)
+
+
+@revisions_router.get(
+    "/files/{file_id}/generated-artifacts",
+    response_model=GeneratedArtifactListResponse,
+)
+async def list_file_generated_artifacts(
+    file_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> GeneratedArtifactListResponse:
+    """List active generated artifacts for a file."""
+
+    file = await _get_active_file(file_id, db)
+    if file is None:
+        raise_not_found("File", str(file_id))
+
+    pagination_cursor = _decode_artifact_cursor(cursor) if cursor else None
+
+    query = (
+        select(GeneratedArtifact)
+        .join(
+            File,
+            (File.id == GeneratedArtifact.source_file_id)
+            & (File.project_id == GeneratedArtifact.project_id),
+        )
+        .join(Project, Project.id == GeneratedArtifact.project_id)
+        .where(
+            (GeneratedArtifact.source_file_id == file_id)
+            & (GeneratedArtifact.deleted_at.is_(None))
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+
+    if pagination_cursor is not None:
+        query = query.where(
+            (GeneratedArtifact.created_at > pagination_cursor.created_at)
+            | (
+                (GeneratedArtifact.created_at == pagination_cursor.created_at)
+                & (GeneratedArtifact.id > pagination_cursor.id)
+            )
+        )
+
+    result = await db.execute(
+        query.order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc()).limit(
+            limit + 1
+        )
+    )
+    artifacts = result.scalars().all()
+    page = artifacts[:limit]
+    next_cursor = None
+
+    if len(artifacts) > limit and page:
+        last_artifact = page[-1]
+        next_cursor = _encode_cursor(
+            _GeneratedArtifactCursor(
+                created_at=last_artifact.created_at,
+                id=last_artifact.id,
+            )
+        )
+
+    return GeneratedArtifactListResponse(
+        items=[GeneratedArtifactRead.model_validate(artifact) for artifact in page],
+        next_cursor=next_cursor,
+    )
+
+
+@revisions_router.get(
+    "/revisions/{revision_id}/generated-artifacts",
+    response_model=GeneratedArtifactListResponse,
+)
+async def list_revision_generated_artifacts(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> GeneratedArtifactListResponse:
+    """List active generated artifacts associated with a drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    pagination_cursor = _decode_artifact_cursor(cursor) if cursor else None
+
+    query = (
+        select(GeneratedArtifact)
+        .join(
+            File,
+            (File.id == GeneratedArtifact.source_file_id)
+            & (File.project_id == GeneratedArtifact.project_id),
+        )
+        .join(Project, Project.id == GeneratedArtifact.project_id)
+        .where(
+            (GeneratedArtifact.drawing_revision_id == revision_id)
+            & (GeneratedArtifact.deleted_at.is_(None))
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+
+    if pagination_cursor is not None:
+        query = query.where(
+            (GeneratedArtifact.created_at > pagination_cursor.created_at)
+            | (
+                (GeneratedArtifact.created_at == pagination_cursor.created_at)
+                & (GeneratedArtifact.id > pagination_cursor.id)
+            )
+        )
+
+    result = await db.execute(
+        query.order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc()).limit(
+            limit + 1
+        )
+    )
+    artifacts = result.scalars().all()
+    page = artifacts[:limit]
+    next_cursor = None
+
+    if len(artifacts) > limit and page:
+        last_artifact = page[-1]
+        next_cursor = _encode_cursor(
+            _GeneratedArtifactCursor(
+                created_at=last_artifact.created_at,
+                id=last_artifact.id,
+            )
+        )
+
+    return GeneratedArtifactListResponse(
+        items=[GeneratedArtifactRead.model_validate(artifact) for artifact in page],
+        next_cursor=next_cursor,
+    )
 
 
 @revisions_router.get(

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -3,10 +3,22 @@
 from app.schemas.file import FileListResponse, FileRead
 from app.schemas.job import JobRead
 from app.schemas.project import ProjectCreate, ProjectListResponse, ProjectRead, ProjectUpdate
+from app.schemas.revision import (
+    AdapterRunOutputRead,
+    DrawingRevisionListResponse,
+    DrawingRevisionRead,
+    GeneratedArtifactListResponse,
+    GeneratedArtifactRead,
+)
 
 __all__ = [
+    "AdapterRunOutputRead",
+    "DrawingRevisionListResponse",
+    "DrawingRevisionRead",
     "FileListResponse",
     "FileRead",
+    "GeneratedArtifactListResponse",
+    "GeneratedArtifactRead",
     "JobRead",
     "ProjectCreate",
     "ProjectListResponse",

--- a/app/schemas/revision.py
+++ b/app/schemas/revision.py
@@ -1,0 +1,122 @@
+"""Pydantic schemas for revision discoverability endpoints."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DrawingRevisionRead(BaseModel):
+    """Schema for reading drawing revision metadata."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(..., description="Unique drawing revision identifier")
+    project_id: UUID = Field(..., description="Owning project identifier")
+    source_file_id: UUID = Field(..., description="Source file identifier")
+    extraction_profile_id: UUID = Field(..., description="Extraction profile identifier")
+    source_job_id: UUID = Field(..., description="Source ingest or reprocess job identifier")
+    adapter_run_output_id: UUID = Field(..., description="Associated adapter output identifier")
+    predecessor_revision_id: UUID | None = Field(
+        None,
+        description="Previous revision identifier when this revision descends from another",
+    )
+    revision_sequence: int = Field(..., ge=1, description="Monotonic revision sequence")
+    revision_kind: str = Field(..., description="Revision lifecycle kind")
+    review_state: str = Field(..., description="Revision review state")
+    canonical_entity_schema_version: str = Field(
+        ...,
+        description="Canonical entity schema version used by the revision",
+    )
+    confidence_score: float = Field(..., description="Effective revision confidence score")
+    created_at: datetime = Field(..., description="Revision creation timestamp")
+
+
+class DrawingRevisionListResponse(BaseModel):
+    """Schema for file revision list responses."""
+
+    items: list[DrawingRevisionRead] = Field(
+        default_factory=list,
+        description="Ordered drawing revisions for the requested file",
+    )
+    next_cursor: str | None = Field(
+        None,
+        description="Opaque pagination cursor for the next revision page when more results exist",
+    )
+
+
+class AdapterRunOutputRead(BaseModel):
+    """Schema for reading adapter output metadata."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(..., description="Unique adapter output identifier")
+    project_id: UUID = Field(..., description="Owning project identifier")
+    source_file_id: UUID = Field(..., description="Source file identifier")
+    extraction_profile_id: UUID = Field(..., description="Extraction profile identifier")
+    source_job_id: UUID = Field(..., description="Source ingest or reprocess job identifier")
+    adapter_key: str = Field(..., description="Adapter implementation key")
+    adapter_version: str = Field(..., description="Adapter implementation version")
+    input_family: str = Field(..., description="Normalized source input family")
+    canonical_entity_schema_version: str = Field(
+        ...,
+        description="Canonical entity schema version emitted by the adapter",
+    )
+    confidence_score: float = Field(..., description="Adapter output confidence score")
+    result_checksum_sha256: str = Field(
+        ...,
+        min_length=64,
+        max_length=64,
+        description="Checksum for the persisted adapter result payload",
+    )
+    created_at: datetime = Field(..., description="Adapter output creation timestamp")
+
+
+class GeneratedArtifactRead(BaseModel):
+    """Schema for reading generated artifact metadata."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID = Field(..., description="Unique generated artifact identifier")
+    project_id: UUID = Field(..., description="Owning project identifier")
+    source_file_id: UUID = Field(..., description="Source file identifier")
+    job_id: UUID = Field(..., description="Source job identifier")
+    drawing_revision_id: UUID | None = Field(
+        None,
+        description="Associated drawing revision identifier when applicable",
+    )
+    adapter_run_output_id: UUID | None = Field(
+        None,
+        description="Associated adapter output identifier when applicable",
+    )
+    artifact_kind: str = Field(..., description="Artifact kind")
+    name: str = Field(..., description="Artifact display name")
+    format: str = Field(..., description="Artifact output format")
+    media_type: str = Field(..., description="Artifact media type")
+    size_bytes: int = Field(..., ge=0, description="Artifact size in bytes")
+    checksum_sha256: str = Field(
+        ...,
+        min_length=64,
+        max_length=64,
+        description="Artifact checksum",
+    )
+    generator_name: str = Field(..., description="Artifact generator name")
+    generator_version: str = Field(..., description="Artifact generator version")
+    predecessor_artifact_id: UUID | None = Field(
+        None,
+        description="Previous artifact identifier when this artifact supersedes another",
+    )
+    created_at: datetime = Field(..., description="Artifact creation timestamp")
+
+
+class GeneratedArtifactListResponse(BaseModel):
+    """Schema for generated artifact list responses."""
+
+    items: list[GeneratedArtifactRead] = Field(
+        default_factory=list,
+        description="Generated artifacts visible for the requested resource",
+    )
+    next_cursor: str | None = Field(
+        None,
+        description="Opaque pagination cursor for the next artifact page when more results exist",
+    )

--- a/tests/test_validation_report_api.py
+++ b/tests/test_validation_report_api.py
@@ -1,7 +1,8 @@
 """Integration tests for validation report API responses."""
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import httpx
 import pytest
@@ -12,6 +13,7 @@ from app.core.errors import ErrorCode
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
 from app.jobs.worker import process_ingest_job
+from app.models.generated_artifact import GeneratedArtifact
 from app.models.validation_report import ValidationReport
 from tests.conftest import requires_database
 from tests.test_ingest_output_persistence import (
@@ -44,6 +46,20 @@ def fake_ingestion_runner(
 def _parse_timestamp(value: str) -> datetime:
     """Parse API timestamps while accepting UTC Z suffix serialization."""
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _artifact_ids(items: list[dict[str, Any]]) -> list[str]:
+    """Return artifact identifiers from a JSON list response."""
+
+    return [item["id"] for item in items]
+
+
+def _clone_model(instance: Any, **overrides: Any) -> Any:
+    """Clone a persisted SQLAlchemy model instance with selected overrides."""
+
+    data = {column.name: getattr(instance, column.name) for column in instance.__table__.columns}
+    data.update(overrides)
+    return instance.__class__(**data)
 
 
 @requires_database
@@ -324,6 +340,455 @@ class TestValidationReportApi:
 
         assert response.status_code == 404
         assert response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": f"Drawing revision with identifier '{drawing_revision.id}' not found",
+                "details": None,
+            }
+        }
+
+    async def test_list_file_revisions_returns_revision_metadata(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """File revision listing should expose active revision metadata."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+
+        response = await async_client.get(f"/v1/files/{uploaded['id']}/revisions")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [item["id"] for item in body["items"]] == [str(drawing_revision.id)]
+        assert body["next_cursor"] is None
+
+        item = body["items"][0]
+        assert item["project_id"] == str(drawing_revision.project_id)
+        assert item["source_file_id"] == str(drawing_revision.source_file_id)
+        assert item["extraction_profile_id"] == str(drawing_revision.extraction_profile_id)
+        assert item["source_job_id"] == str(drawing_revision.source_job_id)
+        assert item["adapter_run_output_id"] == str(drawing_revision.adapter_run_output_id)
+        assert item["predecessor_revision_id"] is None
+        assert item["revision_sequence"] == drawing_revision.revision_sequence
+        assert item["revision_kind"] == drawing_revision.revision_kind
+        assert item["review_state"] == drawing_revision.review_state
+        assert (
+            item["canonical_entity_schema_version"]
+            == drawing_revision.canonical_entity_schema_version
+        )
+        assert item["confidence_score"] == drawing_revision.confidence_score
+        assert _parse_timestamp(item["created_at"]) == drawing_revision.created_at.astimezone(UTC)
+
+    async def test_list_file_revisions_supports_limit_cursor_and_invalid_cursor(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """File revision listing should provide bounded cursor pagination."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        adapter_output = adapter_outputs[0]
+        drawing_revision = drawing_revisions[0]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        next_created_at = drawing_revision.created_at + timedelta(seconds=1)
+        next_job = _clone_model(
+            job,
+            id=uuid.uuid4(),
+            job_type="reprocess",
+            status="succeeded",
+            started_at=next_created_at,
+            finished_at=next_created_at,
+            created_at=next_created_at,
+        )
+        next_adapter_output = _clone_model(
+            adapter_output,
+            id=uuid.uuid4(),
+            source_job_id=next_job.id,
+            result_checksum_sha256=uuid.uuid4().hex * 2,
+            created_at=next_created_at,
+        )
+        next_revision = _clone_model(
+            drawing_revision,
+            id=uuid.uuid4(),
+            source_job_id=next_job.id,
+            adapter_run_output_id=next_adapter_output.id,
+            predecessor_revision_id=drawing_revision.id,
+            revision_sequence=drawing_revision.revision_sequence + 1,
+            created_at=next_created_at,
+        )
+
+        async with session_maker() as session:
+            session.add(next_job)
+            await session.commit()
+
+        async with session_maker() as session:
+            session.add(next_adapter_output)
+            session.add(next_revision)
+            await session.commit()
+
+        first_page_response = await async_client.get(
+            f"/v1/files/{uploaded['id']}/revisions",
+            params={"limit": 1},
+        )
+
+        assert first_page_response.status_code == 200
+        first_page = first_page_response.json()
+        assert [item["id"] for item in first_page["items"]] == [str(drawing_revision.id)]
+        assert first_page["next_cursor"] is not None
+
+        second_page_response = await async_client.get(
+            f"/v1/files/{uploaded['id']}/revisions",
+            params={"limit": 1, "cursor": first_page["next_cursor"]},
+        )
+
+        assert second_page_response.status_code == 200
+        second_page = second_page_response.json()
+        assert [item["id"] for item in second_page["items"]] == [str(next_revision.id)]
+        assert second_page["next_cursor"] is None
+
+        invalid_cursor_response = await async_client.get(
+            f"/v1/files/{uploaded['id']}/revisions",
+            params={"cursor": "not-a-valid-cursor"},
+        )
+
+        assert invalid_cursor_response.status_code == 422
+        assert invalid_cursor_response.json() == {
+            "error": {
+                "code": ErrorCode.VALIDATION_ERROR.value,
+                "message": "Invalid cursor",
+                "details": None,
+            }
+        }
+
+    async def test_get_adapter_output_returns_safe_metadata_for_revision_and_output(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Adapter output discoverability should expose metadata without raw payloads."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        adapter_output = adapter_outputs[0]
+        drawing_revision = drawing_revisions[0]
+
+        by_revision_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/adapter-output"
+        )
+        by_id_response = await async_client.get(f"/v1/adapter-outputs/{adapter_output.id}")
+
+        assert by_revision_response.status_code == 200
+        assert by_id_response.status_code == 200
+
+        by_revision_body = by_revision_response.json()
+        by_id_body = by_id_response.json()
+        assert by_revision_body == by_id_body
+        assert by_revision_body["id"] == str(adapter_output.id)
+        assert by_revision_body["project_id"] == str(adapter_output.project_id)
+        assert by_revision_body["source_file_id"] == str(adapter_output.source_file_id)
+        assert (
+            by_revision_body["extraction_profile_id"]
+            == str(adapter_output.extraction_profile_id)
+        )
+        assert by_revision_body["source_job_id"] == str(adapter_output.source_job_id)
+        assert by_revision_body["adapter_key"] == adapter_output.adapter_key
+        assert by_revision_body["adapter_version"] == adapter_output.adapter_version
+        assert by_revision_body["input_family"] == adapter_output.input_family
+        assert (
+            by_revision_body["canonical_entity_schema_version"]
+            == adapter_output.canonical_entity_schema_version
+        )
+        assert by_revision_body["confidence_score"] == adapter_output.confidence_score
+        assert (
+            by_revision_body["result_checksum_sha256"]
+            == adapter_output.result_checksum_sha256
+        )
+        assert _parse_timestamp(by_revision_body["created_at"]) == (
+            adapter_output.created_at.astimezone(UTC)
+        )
+        assert "canonical_json" not in by_revision_body
+        assert "provenance_json" not in by_revision_body
+        assert "confidence_json" not in by_revision_body
+        assert "warnings_json" not in by_revision_body
+        assert "diagnostics_json" not in by_revision_body
+
+    async def test_generated_artifact_lists_filter_deleted_rows_and_hide_storage_fields(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Generated artifact discoverability should exclude deleted rows and storage paths."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, _validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+
+        file_response = await async_client.get(f"/v1/files/{uploaded['id']}/generated-artifacts")
+        revision_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/generated-artifacts"
+        )
+
+        assert file_response.status_code == 200
+        assert revision_response.status_code == 200
+
+        file_body = file_response.json()
+        revision_body = revision_response.json()
+        expected_revision_artifacts = [
+            artifact
+            for artifact in generated_artifacts
+            if artifact.drawing_revision_id == drawing_revision.id
+        ]
+        assert _artifact_ids(file_body["items"]) == [
+            str(artifact.id) for artifact in generated_artifacts
+        ]
+        assert _artifact_ids(revision_body["items"]) == [
+            str(artifact.id) for artifact in expected_revision_artifacts
+        ]
+        assert file_body["next_cursor"] is None
+        assert revision_body["next_cursor"] is None
+
+        first_item = file_body["items"][0]
+        first_artifact = generated_artifacts[0]
+        assert first_item["project_id"] == str(first_artifact.project_id)
+        assert first_item["source_file_id"] == str(first_artifact.source_file_id)
+        assert first_item["job_id"] == str(first_artifact.job_id)
+        assert first_item["drawing_revision_id"] == str(first_artifact.drawing_revision_id)
+        assert (
+            first_item["adapter_run_output_id"]
+            == str(first_artifact.adapter_run_output_id)
+        )
+        assert first_item["artifact_kind"] == first_artifact.artifact_kind
+        assert first_item["name"] == first_artifact.name
+        assert first_item["format"] == first_artifact.format
+        assert first_item["media_type"] == first_artifact.media_type
+        assert first_item["size_bytes"] == first_artifact.size_bytes
+        assert first_item["checksum_sha256"] == first_artifact.checksum_sha256
+        assert first_item["generator_name"] == first_artifact.generator_name
+        assert first_item["generator_version"] == first_artifact.generator_version
+        assert first_item["predecessor_artifact_id"] is None
+        assert _parse_timestamp(first_item["created_at"]) == first_artifact.created_at.astimezone(
+            UTC
+        )
+        assert "storage_key" not in first_item
+        assert "storage_uri" not in first_item
+        assert "generator_config_json" not in first_item
+        assert "lineage_json" not in first_item
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        deleted_artifact_id = generated_artifacts[0].id
+        async with session_maker() as session:
+            persisted_artifact = await session.get(
+                GeneratedArtifact,
+                deleted_artifact_id,
+            )
+            assert persisted_artifact is not None
+            persisted_artifact.deleted_at = datetime.now(UTC)
+            await session.commit()
+
+        filtered_file_response = await async_client.get(
+            f"/v1/files/{uploaded['id']}/generated-artifacts"
+        )
+        filtered_revision_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/generated-artifacts"
+        )
+
+        assert filtered_file_response.status_code == 200
+        assert filtered_revision_response.status_code == 200
+        assert str(deleted_artifact_id) not in _artifact_ids(filtered_file_response.json()["items"])
+        assert str(deleted_artifact_id) not in _artifact_ids(
+            filtered_revision_response.json()["items"]
+        )
+
+    async def test_generated_artifact_lists_support_limit_and_cursor(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Generated artifact listing should provide bounded cursor pagination."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, _validation_reports, generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        next_created_at = generated_artifacts[0].created_at + timedelta(seconds=1)
+        next_artifact = _clone_model(
+            generated_artifacts[0],
+            id=uuid.uuid4(),
+            name=f"{generated_artifacts[0].name}-page-2",
+            checksum_sha256=uuid.uuid4().hex * 2,
+            storage_key=f"generated/{uuid.uuid4()}",
+            storage_uri=f"file:///tmp/{uuid.uuid4()}",
+            predecessor_artifact_id=generated_artifacts[0].id,
+            created_at=next_created_at,
+        )
+
+        async with session_maker() as session:
+            session.add(next_artifact)
+            await session.commit()
+
+        generated_artifacts = [generated_artifacts[0], next_artifact]
+
+        file_first_page_response = await async_client.get(
+            f"/v1/files/{uploaded['id']}/generated-artifacts",
+            params={"limit": 1},
+        )
+        assert file_first_page_response.status_code == 200
+        file_first_page = file_first_page_response.json()
+        assert _artifact_ids(file_first_page["items"]) == [str(generated_artifacts[0].id)]
+        assert file_first_page["next_cursor"] is not None
+
+        file_second_page_response = await async_client.get(
+            f"/v1/files/{uploaded['id']}/generated-artifacts",
+            params={"limit": 1, "cursor": file_first_page["next_cursor"]},
+        )
+        assert file_second_page_response.status_code == 200
+        file_second_page = file_second_page_response.json()
+        assert _artifact_ids(file_second_page["items"]) == [str(generated_artifacts[1].id)]
+
+        revision_artifacts = [
+            artifact
+            for artifact in generated_artifacts
+            if artifact.drawing_revision_id == drawing_revision.id
+        ]
+        assert len(revision_artifacts) >= 2
+
+        revision_first_page_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/generated-artifacts",
+            params={"limit": 1},
+        )
+        assert revision_first_page_response.status_code == 200
+        revision_first_page = revision_first_page_response.json()
+        assert _artifact_ids(revision_first_page["items"]) == [str(revision_artifacts[0].id)]
+        assert revision_first_page["next_cursor"] is not None
+
+        revision_second_page_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/generated-artifacts",
+            params={"limit": 1, "cursor": revision_first_page["next_cursor"]},
+        )
+        assert revision_second_page_response.status_code == 200
+        revision_second_page = revision_second_page_response.json()
+        assert _artifact_ids(revision_second_page["items"]) == [str(revision_artifacts[1].id)]
+
+    async def test_discoverability_endpoints_hide_soft_deleted_project_data(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Revision and adapter output reads should hide soft-deleted project/file data."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+        adapter_output = adapter_outputs[0]
+
+        delete_response = await async_client.delete(f"/v1/projects/{project['id']}")
+        assert delete_response.status_code == 204
+
+        revisions_response = await async_client.get(f"/v1/files/{uploaded['id']}/revisions")
+        adapter_output_response = await async_client.get(
+            f"/v1/adapter-outputs/{adapter_output.id}"
+        )
+
+        assert revisions_response.status_code == 404
+        assert revisions_response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": f"File with identifier '{uploaded['id']}' not found",
+                "details": None,
+            }
+        }
+        assert adapter_output_response.status_code == 404
+        assert adapter_output_response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": f"Adapter run output with identifier '{adapter_output.id}' not found",
+                "details": None,
+            }
+        }
+
+        revision_artifacts_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/generated-artifacts"
+        )
+        assert revision_artifacts_response.status_code == 404
+        assert revision_artifacts_response.json() == {
             "error": {
                 "code": ErrorCode.NOT_FOUND.value,
                 "message": f"Drawing revision with identifier '{drawing_revision.id}' not found",


### PR DESCRIPTION
Closes #139

## Summary
- add revision, adapter-output, and generated-artifact discoverability endpoints for active files and revisions
- preserve soft-delete visibility rules and omit raw adapter/storage payload fields from public responses
- add cursor pagination and DB-backed API coverage for revision and artifact listing flows

## Test plan
- [x] uv run ruff check app/api/v1/revisions.py app/schemas/revision.py app/schemas/__init__.py tests/test_validation_report_api.py
- [x] uv run mypy app tests
- [x] DATABASE_URL=<fresh throwaway db> uv run alembic upgrade head
- [x] DATABASE_URL=<fresh throwaway db> uv run pytest tests/test_validation_report_api.py

## Notes
- malformed cursors currently surface as `422 VALIDATION_ERROR`; follow-up can align these endpoints with existing `400 INVALID_CURSOR` list semantics if we want strict consistency