### PR TITLE
refactor(api): extract shared cursor pagination helpers

### DIFF
--- a/app/api/pagination.py
+++ b/app/api/pagination.py
@@ -1,0 +1,50 @@
+"""Shared cursor pagination helpers for API routers."""
+
+import base64
+import binascii
+import json
+from collections.abc import Mapping
+from typing import Any, Never, cast
+
+from fastapi import HTTPException, status
+
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response
+
+
+def encode_cursor_payload(
+    payload: Mapping[str, object],
+    *,
+    compact: bool = False,
+) -> str:
+    """Encode a JSON cursor payload as URL-safe base64 without padding."""
+    json_payload = json.dumps(
+        payload,
+        separators=(",", ":"),
+    ) if compact else json.dumps(payload)
+    return base64.urlsafe_b64encode(json_payload.encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+def decode_cursor_payload(cursor: str) -> dict[str, Any]:
+    """Decode a URL-safe base64 JSON cursor payload."""
+    try:
+        padded_cursor = cursor + ("=" * (-len(cursor) % 4))
+        decoded = base64.urlsafe_b64decode(padded_cursor.encode("utf-8"))
+        payload_raw = json.loads(decoded.decode("utf-8"))
+        if not isinstance(payload_raw, dict):
+            raise TypeError("Cursor payload must be a JSON object")
+        return cast(dict[str, Any], payload_raw)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def raise_invalid_cursor(exc: Exception) -> Never:
+    """Raise the standard invalid-cursor HTTP error envelope."""
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INVALID_CURSOR,
+            message="Invalid cursor format",
+            details=None,
+        ),
+    ) from exc

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -1,9 +1,6 @@
 """Project-scoped file upload and retrieval endpoints."""
 
-import base64
-import binascii
 import hashlib
-import json
 import uuid
 from collections.abc import Sequence
 from contextlib import suppress
@@ -17,6 +14,11 @@ from fastapi import File as FilePart
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.pagination import (
+    decode_cursor_payload,
+    encode_cursor_payload,
+    raise_invalid_cursor,
+)
 from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
@@ -55,45 +57,23 @@ _MAX_MEDIA_TYPE_LENGTH = 255
 
 def _encode_cursor(created_at: datetime, file_id: UUID) -> str:
     """Encode cursor from created_at and file_id."""
-    cursor_data = {
-        "created_at": created_at.isoformat(),
-        "id": str(file_id),
-    }
-    return base64.urlsafe_b64encode(json.dumps(cursor_data).encode()).decode().rstrip("=")
+    return encode_cursor_payload(
+        {
+            "created_at": created_at.isoformat(),
+            "id": str(file_id),
+        }
+    )
 
 
-def _decode_cursor(cursor: str) -> dict[str, Any]:
-    """Decode cursor to dict with created_at and id."""
+def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
+    """Decode cursor to typed created_at and id values."""
     try:
-        padding = 4 - (len(cursor) % 4)
-        if padding != 4:
-            cursor += "=" * padding
-
-        decoded = base64.urlsafe_b64decode(cursor)
-        cursor_data_raw = json.loads(decoded.decode("utf-8"))
-        if not isinstance(cursor_data_raw, dict):
-            raise TypeError("Cursor payload must be a JSON object")
-        cursor_data = cast(dict[str, Any], cursor_data_raw)
-
-        _ = datetime.fromisoformat(str(cursor_data["created_at"]))
-        _ = UUID(str(cursor_data["id"]))
-        return cursor_data
-    except (
-        binascii.Error,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-        KeyError,
-        TypeError,
-        ValueError,
-    ) as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=create_error_response(
-                code=ErrorCode.INVALID_CURSOR,
-                message="Invalid cursor format",
-                details=None,
-            ),
-        ) from e
+        cursor_data = decode_cursor_payload(cursor)
+        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(
+            str(cursor_data["id"])
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
 
 
 def _sniff_format(initial_bytes: bytes) -> str | None:
@@ -591,9 +571,7 @@ async def list_project_files(
     )
 
     if cursor:
-        cursor_data = _decode_cursor(cursor)
-        created_at = datetime.fromisoformat(str(cursor_data["created_at"]))
-        file_id = UUID(str(cursor_data["id"]))
+        created_at, file_id = _decode_cursor(cursor)
         query = query.filter(
             (FileModel.created_at < created_at)
             | ((FileModel.created_at == created_at) & (FileModel.id < file_id))

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -1,8 +1,5 @@
 """Job status endpoints."""
 
-import base64
-import binascii
-import json
 from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
@@ -11,6 +8,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.pagination import (
+    decode_cursor_payload,
+    encode_cursor_payload,
+    raise_invalid_cursor,
+)
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
@@ -82,38 +84,28 @@ def _encode_job_events_cursor(event: JobEvent) -> str:
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=UTC)
 
-    payload = json.dumps(
+    return encode_cursor_payload(
         {
             "created_at": created_at.astimezone(UTC).isoformat(),
             "sequence_id": event.sequence_id,
             "id": str(event.id),
         },
-        separators=(",", ":"),
+        compact=True,
     )
-    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("utf-8").rstrip("=")
 
 
 def _decode_job_events_cursor(cursor: str) -> tuple[datetime, int | None, UUID]:
     """Decode a pagination cursor into its sort key values."""
     try:
-        padded_cursor = cursor + ("=" * (-len(cursor) % 4))
-        decoded = base64.urlsafe_b64decode(padded_cursor.encode("utf-8")).decode("utf-8")
-        payload = json.loads(decoded)
-        created_at = datetime.fromisoformat(payload["created_at"])
+        payload = decode_cursor_payload(cursor)
+        created_at = datetime.fromisoformat(str(payload["created_at"]))
         sequence_id_raw = payload.get("sequence_id")
         sequence_id = int(sequence_id_raw) if sequence_id_raw is not None else None
         if sequence_id is not None and sequence_id < 0:
             raise ValueError("sequence_id must be non-negative")
-        cursor_id = UUID(payload["id"])
-    except (ValueError, TypeError, KeyError, json.JSONDecodeError, binascii.Error) as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=create_error_response(
-                code=ErrorCode.INVALID_CURSOR,
-                message="Invalid cursor format",
-                details=None,
-            ),
-        ) from exc
+        cursor_id = UUID(str(payload["id"]))
+    except (ValueError, TypeError, KeyError) as exc:
+        raise_invalid_cursor(exc)
 
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=UTC)

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -1,18 +1,20 @@
 """Project CRUD endpoints."""
 
-import base64
-import binascii
-import json
 from datetime import UTC, datetime
-from typing import Annotated, Any, cast
+from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.pagination import (
+    decode_cursor_payload,
+    encode_cursor_payload,
+    raise_invalid_cursor,
+)
 from app.core.errors import ErrorCode
-from app.core.exceptions import create_error_response, raise_not_found
+from app.core.exceptions import raise_not_found
 from app.db.session import get_db
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
@@ -50,47 +52,23 @@ async def _get_active_project_or_404(
 
 def _encode_cursor(created_at: datetime, project_id: UUID) -> str:
     """Encode cursor from created_at and project_id."""
-    cursor_data = {
-        "created_at": created_at.isoformat(),
-        "id": str(project_id),
-    }
-    return base64.urlsafe_b64encode(json.dumps(cursor_data).encode()).decode().rstrip("=")
+    return encode_cursor_payload(
+        {
+            "created_at": created_at.isoformat(),
+            "id": str(project_id),
+        }
+    )
 
 
-def _decode_cursor(cursor: str) -> dict[str, Any]:
-    """Decode cursor to dict with created_at and id."""
+def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
+    """Decode cursor to typed created_at and id values."""
     try:
-        # Add padding if needed
-        padding = 4 - (len(cursor) % 4)
-        if padding != 4:
-            cursor += "=" * padding
-
-        decoded = base64.urlsafe_b64decode(cursor)
-        cursor_data_raw = json.loads(decoded.decode("utf-8"))
-        if not isinstance(cursor_data_raw, dict):
-            raise TypeError("Cursor payload must be a JSON object")
-        cursor_data = cast(dict[str, Any], cursor_data_raw)
-
-        # Validate required keys and value formats.
-        _ = datetime.fromisoformat(str(cursor_data["created_at"]))
-        _ = UUID(str(cursor_data["id"]))
-        return cursor_data
-    except (
-        binascii.Error,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-        KeyError,
-        TypeError,
-        ValueError,
-    ) as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=create_error_response(
-                code=ErrorCode.INVALID_CURSOR,
-                message="Invalid cursor format",
-                details=None,
-            ),
-        ) from e
+        cursor_data = decode_cursor_payload(cursor)
+        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(
+            str(cursor_data["id"])
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
 
 
 @project_router.post(
@@ -138,9 +116,7 @@ async def list_projects(
 
     # Apply cursor filter if provided
     if cursor:
-        cursor_data = _decode_cursor(cursor)
-        created_at = datetime.fromisoformat(str(cursor_data["created_at"]))
-        project_id = UUID(str(cursor_data["id"]))
+        created_at, project_id = _decode_cursor(cursor)
         # Filter for items after the cursor position
         query = query.filter(
             (Project.created_at < created_at)


### PR DESCRIPTION
Closes #142

## Summary
- extract shared URL-safe base64 JSON cursor helpers into `app/api/pagination.py`
- keep project, file, and job cursor payload shapes and ordering behavior unchanged while removing duplicated decode logic
- preserve the existing `400 INVALID_CURSOR` contract across paginated API endpoints

## Test plan
- [x] uv run ruff check app/api/pagination.py app/api/v1/projects.py app/api/v1/files.py app/api/v1/jobs.py
- [x] uv run mypy app tests
- [x] uv build
- [x] uv run pytest tests/test_projects.py tests/test_files.py tests/test_jobs.py

## Notes
- pytest ran without `DATABASE_URL`, so DB-gated cases skipped in this validation pass