### PR TITLE
fix(db): restrict lineage foreign keys to preserve history

### DIFF
--- a/alembic/versions/2026_05_10_0007_constrain_job_fields_and_ingest_profile.py
+++ b/alembic/versions/2026_05_10_0007_constrain_job_fields_and_ingest_profile.py
@@ -90,25 +90,23 @@ def upgrade() -> None:
     )
     op.execute(
         sa.text(
-            """
+            f"""
             ALTER TABLE jobs
             ADD CONSTRAINT ck_jobs_ingest_extraction_profile_required
-            CHECK ({constraint_sql})
+            CHECK ({_profile_required_constraint_sql()})
             NOT VALID
             """
-            .format(constraint_sql=_profile_required_constraint_sql())
         )
     )
 
     invalid_profile_required_jobs = bind.execute(
         sa.text(
-            """
+            f"""
             SELECT COUNT(*)
             FROM jobs
-            WHERE job_type IN ({job_type_values})
+            WHERE job_type IN ({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)})
               AND extraction_profile_id IS NULL
             """
-            .format(job_type_values=_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES))
         )
     ).scalar_one()
     if invalid_profile_required_jobs != 0:

--- a/alembic/versions/2026_05_11_0010_replace_lineage_fk_cascades_with_restrict.py
+++ b/alembic/versions/2026_05_11_0010_replace_lineage_fk_cascades_with_restrict.py
@@ -1,0 +1,276 @@
+"""replace lineage fk cascades with restrict
+
+Revision ID: 2026_05_11_0010
+Revises: 2026_05_10_0009
+Create Date: 2026-05-11 08:45:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import NamedTuple
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_11_0010"
+down_revision: str | None = "2026_05_10_0009"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+class _ForeignKeySpec(NamedTuple):
+    table_name: str
+    constrained_columns: tuple[str, ...]
+    referred_table: str
+    referred_columns: tuple[str, ...]
+    name: str
+
+
+_LINEAGE_FOREIGN_KEYS: tuple[_ForeignKeySpec, ...] = (
+    _ForeignKeySpec(
+        table_name="files",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_files_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="extraction_profiles",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_extraction_profiles_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="jobs",
+        constrained_columns=("file_id", "project_id"),
+        referred_table="files",
+        referred_columns=("id", "project_id"),
+        name="fk_jobs_file_id_project_id_files",
+    ),
+    _ForeignKeySpec(
+        table_name="jobs",
+        constrained_columns=("extraction_profile_id", "project_id"),
+        referred_table="extraction_profiles",
+        referred_columns=("id", "project_id"),
+        name="fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+    ),
+    _ForeignKeySpec(
+        table_name="jobs",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_jobs_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="job_events",
+        constrained_columns=("job_id",),
+        referred_table="jobs",
+        referred_columns=("id",),
+        name="fk_job_events_job_id_jobs",
+    ),
+    _ForeignKeySpec(
+        table_name="adapter_run_outputs",
+        constrained_columns=("source_file_id", "project_id"),
+        referred_table="files",
+        referred_columns=("id", "project_id"),
+        name="fk_adapter_run_outputs_source_file_id_project_id_files",
+    ),
+    _ForeignKeySpec(
+        table_name="adapter_run_outputs",
+        constrained_columns=("extraction_profile_id", "project_id"),
+        referred_table="extraction_profiles",
+        referred_columns=("id", "project_id"),
+        name="fk_adapter_run_outputs_extraction_profile_proj_profiles",
+    ),
+    _ForeignKeySpec(
+        table_name="adapter_run_outputs",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_adapter_run_outputs_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="adapter_run_outputs",
+        constrained_columns=("source_job_id",),
+        referred_table="jobs",
+        referred_columns=("id",),
+        name="fk_adapter_run_outputs_source_job_id_jobs",
+    ),
+    _ForeignKeySpec(
+        table_name="drawing_revisions",
+        constrained_columns=("source_file_id", "project_id"),
+        referred_table="files",
+        referred_columns=("id", "project_id"),
+        name="fk_drawing_revisions_source_file_id_project_id_files",
+    ),
+    _ForeignKeySpec(
+        table_name="drawing_revisions",
+        constrained_columns=("extraction_profile_id", "project_id"),
+        referred_table="extraction_profiles",
+        referred_columns=("id", "project_id"),
+        name="fk_drawing_revisions_extraction_profile_proj_profiles",
+    ),
+    _ForeignKeySpec(
+        table_name="drawing_revisions",
+        constrained_columns=("adapter_run_output_id", "project_id"),
+        referred_table="adapter_run_outputs",
+        referred_columns=("id", "project_id"),
+        name="fk_drawing_revisions_adapter_run_output_id_project_id_outputs",
+    ),
+    _ForeignKeySpec(
+        table_name="drawing_revisions",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_drawing_revisions_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="drawing_revisions",
+        constrained_columns=("source_job_id",),
+        referred_table="jobs",
+        referred_columns=("id",),
+        name="fk_drawing_revisions_source_job_id_jobs",
+    ),
+    _ForeignKeySpec(
+        table_name="validation_reports",
+        constrained_columns=("drawing_revision_id", "project_id"),
+        referred_table="drawing_revisions",
+        referred_columns=("id", "project_id"),
+        name="fk_validation_reports_drawing_revision_id_project_id_revisions",
+    ),
+    _ForeignKeySpec(
+        table_name="validation_reports",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_validation_reports_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="validation_reports",
+        constrained_columns=("source_job_id",),
+        referred_table="jobs",
+        referred_columns=("id",),
+        name="fk_validation_reports_source_job_id_jobs",
+    ),
+    _ForeignKeySpec(
+        table_name="generated_artifacts",
+        constrained_columns=("source_file_id", "project_id"),
+        referred_table="files",
+        referred_columns=("id", "project_id"),
+        name="fk_generated_artifacts_source_file_id_project_id_files",
+    ),
+    _ForeignKeySpec(
+        table_name="generated_artifacts",
+        constrained_columns=("drawing_revision_id", "project_id"),
+        referred_table="drawing_revisions",
+        referred_columns=("id", "project_id"),
+        name="fk_generated_artifacts_drawing_revision_id_project_id_revisions",
+    ),
+    _ForeignKeySpec(
+        table_name="generated_artifacts",
+        constrained_columns=("adapter_run_output_id", "project_id"),
+        referred_table="adapter_run_outputs",
+        referred_columns=("id", "project_id"),
+        name="fk_generated_artifacts_adapter_run_output_id_project_id_outputs",
+    ),
+    _ForeignKeySpec(
+        table_name="generated_artifacts",
+        constrained_columns=("project_id",),
+        referred_table="projects",
+        referred_columns=("id",),
+        name="fk_generated_artifacts_project_id_projects",
+    ),
+    _ForeignKeySpec(
+        table_name="generated_artifacts",
+        constrained_columns=("job_id",),
+        referred_table="jobs",
+        referred_columns=("id",),
+        name="fk_generated_artifacts_job_id_jobs",
+    ),
+)
+
+_DOWNGRADE_GUARD_TABLES: tuple[str, ...] = tuple(
+    sorted(
+        {spec.table_name for spec in _LINEAGE_FOREIGN_KEYS}
+        | {spec.referred_table for spec in _LINEAGE_FOREIGN_KEYS}
+    )
+)
+
+
+def _find_fk_name(spec: _ForeignKeySpec) -> str:
+    """Resolve the currently installed foreign key name for a spec."""
+
+    inspector = sa.inspect(op.get_bind())
+    for foreign_key in inspector.get_foreign_keys(spec.table_name):
+        if (
+            tuple(foreign_key["constrained_columns"]) == spec.constrained_columns
+            and foreign_key["referred_table"] == spec.referred_table
+            and tuple(foreign_key["referred_columns"]) == spec.referred_columns
+        ):
+            foreign_key_name = foreign_key.get("name")
+            if foreign_key_name is None:
+                raise RuntimeError(
+                    "Cannot replace foreign key without a name for "
+                    f"{spec.table_name}({', '.join(spec.constrained_columns)})"
+                )
+            return foreign_key_name
+
+    raise RuntimeError(
+        "Expected foreign key not found for "
+        f"{spec.table_name}({', '.join(spec.constrained_columns)}) -> "
+        f"{spec.referred_table}({', '.join(spec.referred_columns)})"
+    )
+
+
+def _replace_foreign_keys(*, ondelete: str) -> None:
+    """Recreate configured lineage foreign keys with the given delete action."""
+
+    for spec in _LINEAGE_FOREIGN_KEYS:
+        op.drop_constraint(_find_fk_name(spec), spec.table_name, type_="foreignkey")
+        op.create_foreign_key(
+            spec.name,
+            spec.table_name,
+            spec.referred_table,
+            list(spec.constrained_columns),
+            list(spec.referred_columns),
+            ondelete=ondelete,
+        )
+
+
+def _assert_lineage_tables_empty_for_downgrade() -> None:
+    """Refuse to restore destructive cascades while lineage data exists."""
+
+    bind = op.get_bind()
+    non_empty_tables: list[str] = []
+
+    for table_name in _DOWNGRADE_GUARD_TABLES:
+        has_rows = bind.execute(
+            sa.select(sa.literal(1)).select_from(sa.table(table_name)).limit(1)
+        ).first()
+        if has_rows is not None:
+            non_empty_tables.append(table_name)
+
+    if non_empty_tables:
+        joined_tables = ", ".join(non_empty_tables)
+        raise RuntimeError(
+            "Refusing to downgrade migration 2026_05_11_0010: restoring CASCADE "
+            "lineage foreign keys can destroy persisted lineage data. Empty the "
+            f"following tables before retrying: {joined_tables}."
+        )
+
+
+def upgrade() -> None:
+    """Replace destructive lineage cascades with restrictive delete policies."""
+
+    _replace_foreign_keys(ondelete="RESTRICT")
+
+
+def downgrade() -> None:
+    """Restore lineage foreign keys to cascading deletes."""
+
+    _assert_lineage_tables_empty_for_downgrade()
+    _replace_foreign_keys(ondelete="CASCADE")

--- a/app/models/adapter_run_output.py
+++ b/app/models/adapter_run_output.py
@@ -30,13 +30,13 @@ class AdapterRunOutput(Base):
         ForeignKeyConstraint(
             ["source_file_id", "project_id"],
             ["files.id", "files.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_adapter_run_outputs_source_file_id_project_id_files",
         ),
         ForeignKeyConstraint(
             ["extraction_profile_id", "project_id"],
             ["extraction_profiles.id", "extraction_profiles.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_adapter_run_outputs_extraction_profile_proj_profiles",
         ),
         UniqueConstraint(
@@ -65,7 +65,11 @@ class AdapterRunOutput(Base):
         comment="Unique adapter run output identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_adapter_run_outputs_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",
@@ -81,7 +85,11 @@ class AdapterRunOutput(Base):
         comment="Immutable extraction profile identifier used for this adapter run",
     )
     source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("jobs.id", ondelete="CASCADE"),
+        ForeignKey(
+            "jobs.id",
+            name="fk_adapter_run_outputs_source_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         comment="Job identifier that produced this committed adapter output",
     )

--- a/app/models/drawing_revision.py
+++ b/app/models/drawing_revision.py
@@ -29,19 +29,19 @@ class DrawingRevision(Base):
         ForeignKeyConstraint(
             ["source_file_id", "project_id"],
             ["files.id", "files.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_drawing_revisions_source_file_id_project_id_files",
         ),
         ForeignKeyConstraint(
             ["extraction_profile_id", "project_id"],
             ["extraction_profiles.id", "extraction_profiles.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_drawing_revisions_extraction_profile_proj_profiles",
         ),
         ForeignKeyConstraint(
             ["adapter_run_output_id", "project_id"],
             ["adapter_run_outputs.id", "adapter_run_outputs.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_drawing_revisions_adapter_run_output_id_project_id_outputs",
         ),
         UniqueConstraint(
@@ -88,7 +88,11 @@ class DrawingRevision(Base):
         comment="Unique drawing revision identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_drawing_revisions_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",
@@ -104,7 +108,11 @@ class DrawingRevision(Base):
         comment="Immutable extraction profile identifier used to derive this revision",
     )
     source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("jobs.id", ondelete="CASCADE"),
+        ForeignKey(
+            "jobs.id",
+            name="fk_drawing_revisions_source_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Job identifier that committed this drawing revision",

--- a/app/models/extraction_profile.py
+++ b/app/models/extraction_profile.py
@@ -37,7 +37,11 @@ class ExtractionProfile(Base):
         comment="Unique extraction profile identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_extraction_profiles_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",

--- a/app/models/file.py
+++ b/app/models/file.py
@@ -39,7 +39,11 @@ class File(Base):
         comment="Unique file identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_files_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",

--- a/app/models/generated_artifact.py
+++ b/app/models/generated_artifact.py
@@ -29,19 +29,19 @@ class GeneratedArtifact(Base):
         ForeignKeyConstraint(
             ["source_file_id", "project_id"],
             ["files.id", "files.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_generated_artifacts_source_file_id_project_id_files",
         ),
         ForeignKeyConstraint(
             ["drawing_revision_id", "project_id"],
             ["drawing_revisions.id", "drawing_revisions.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_generated_artifacts_drawing_revision_id_project_id_revisions",
         ),
         ForeignKeyConstraint(
             ["adapter_run_output_id", "project_id"],
             ["adapter_run_outputs.id", "adapter_run_outputs.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_generated_artifacts_adapter_run_output_id_project_id_outputs",
         ),
         ForeignKeyConstraint(
@@ -75,7 +75,11 @@ class GeneratedArtifact(Base):
         comment="Unique generated artifact identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_generated_artifacts_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",
@@ -86,7 +90,11 @@ class GeneratedArtifact(Base):
         comment="Source file identifier for artifact lineage",
     )
     job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("jobs.id", ondelete="CASCADE"),
+        ForeignKey(
+            "jobs.id",
+            name="fk_generated_artifacts_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Job identifier that produced this generated artifact",

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -57,13 +57,13 @@ class Job(Base):
         ForeignKeyConstraint(
             ["file_id", "project_id"],
             ["files.id", "files.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_jobs_file_id_project_id_files",
         ),
         ForeignKeyConstraint(
             ["extraction_profile_id", "project_id"],
             ["extraction_profiles.id", "extraction_profiles.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_jobs_extraction_profile_id_project_id_extraction_profiles",
         ),
         CheckConstraint(
@@ -93,7 +93,11 @@ class Job(Base):
         comment="Unique job identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_jobs_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",

--- a/app/models/job_event.py
+++ b/app/models/job_event.py
@@ -30,7 +30,11 @@ class JobEvent(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     job_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
-        ForeignKey("jobs.id", ondelete="CASCADE"),
+        ForeignKey(
+            "jobs.id",
+            name="fk_job_events_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
     )
     level: Mapped[str] = mapped_column(String(length=32), nullable=False)

--- a/app/models/validation_report.py
+++ b/app/models/validation_report.py
@@ -30,7 +30,7 @@ class ValidationReport(Base):
         ForeignKeyConstraint(
             ["drawing_revision_id", "project_id"],
             ["drawing_revisions.id", "drawing_revisions.project_id"],
-            ondelete="CASCADE",
+            ondelete="RESTRICT",
             name="fk_validation_reports_drawing_revision_id_project_id_revisions",
         ),
         UniqueConstraint(
@@ -73,7 +73,11 @@ class ValidationReport(Base):
         comment="Unique validation report identifier (UUID v4)",
     )
     project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("projects.id", ondelete="CASCADE"),
+        ForeignKey(
+            "projects.id",
+            name="fk_validation_reports_project_id_projects",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Owning project identifier",
@@ -83,7 +87,11 @@ class ValidationReport(Base):
         comment="Drawing revision identifier addressed by this canonical validation report",
     )
     source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey("jobs.id", ondelete="CASCADE"),
+        ForeignKey(
+            "jobs.id",
+            name="fk_validation_reports_source_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
         nullable=False,
         index=True,
         comment="Job identifier that produced this validation report",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -296,6 +296,9 @@ Soft deletion is a database visibility flag, not a storage mutation.
 - Soft deletion never rewrites lineage. References from artifacts to source
   files, drawing revisions, jobs, changesets, takeoffs, or estimates remain
   intact even when one of those records is hidden from default views.
+- Database-level delete behavior must match that policy: restrictive foreign
+  keys should block physical deletion while lineage, audit, or history children
+  still exist, rather than cascading through append-only records.
 
 MVP does not perform automatic physical deletion. In particular:
 
@@ -306,6 +309,8 @@ MVP does not perform automatic physical deletion. In particular:
 - superseded or soft-deleted artifacts may be filtered from default product
   views, but they remain restorable from retained metadata/object storage during
   MVP
+- physical deletes are exceptional/manual and should fail until dependent
+  lineage-bearing rows are handled in a way that preserves audit history
 
 ## Job Pipeline Orchestration
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -620,10 +620,19 @@ For MVP, retention is conservative:
 - prefer soft-delete or hidden metadata state before physical deletion
 - require manual/administrative action for physical artifact deletion
 - do not auto-delete superseded artifacts in MVP
+- destructive database cascades must not remove lineage, audit, or append-only
+  history rows
+- physical delete paths should be restrictive by default and fail while lineage
+  children still reference the target record
 
 Any physical deletion flow must preserve at least the metadata needed to explain
 what was produced and must not imply that a replacement artifact overwrote the
 prior one.
+
+Soft deletion is the normal MVP deletion path. Hiding a project, file, or
+artifact must not rewrite lineage, and database constraints should prevent
+parent-row deletion from cascading through retained revisions, jobs, artifacts,
+or other historical children.
 
 ## API Conventions
 

--- a/tests/test_lineage_delete_restrictions.py
+++ b/tests/test_lineage_delete_restrictions.py
@@ -1,0 +1,430 @@
+"""Integration tests for restrictive lineage foreign keys."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+import app.db.session as session_module
+import app.jobs.worker as worker_module
+from app.ingestion.finalization import IngestFinalizationPayload
+from app.ingestion.runner import IngestionRunRequest
+from app.jobs.worker import process_ingest_job
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.drawing_revision import DrawingRevision
+from app.models.extraction_profile import ExtractionProfile
+from app.models.file import File as FileModel
+from app.models.generated_artifact import GeneratedArtifact
+from app.models.job import Job
+from app.models.project import Project
+from app.models.validation_report import ValidationReport
+from tests.conftest import requires_database
+from tests.test_ingest_output_persistence import _as_uuid, _load_project_outputs
+from tests.test_jobs import (
+    _build_fake_ingest_payload,
+    _create_project,
+    _get_job_for_file,
+    _upload_file,
+)
+
+
+@dataclass
+class _LineageSnapshot:
+    project: Project
+    source_file: FileModel
+    extraction_profile: ExtractionProfile
+    job: Job
+    adapter_output: AdapterRunOutput
+    drawing_revision: DrawingRevision
+    validation_report: ValidationReport
+    generated_artifact: GeneratedArtifact
+
+
+@dataclass(frozen=True)
+class _ForeignKeyDeleteRule:
+    table_name: str
+    constrained_columns: tuple[str, ...]
+    referred_table: str
+    referred_columns: tuple[str, ...]
+    ondelete: str
+
+
+_EXPECTED_LINEAGE_FOREIGN_KEYS: tuple[_ForeignKeyDeleteRule, ...] = (
+    _ForeignKeyDeleteRule("files", ("project_id",), "projects", ("id",), "RESTRICT"),
+    _ForeignKeyDeleteRule(
+        "extraction_profiles",
+        ("project_id",),
+        "projects",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "jobs",
+        ("file_id", "project_id"),
+        "files",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "jobs",
+        ("extraction_profile_id", "project_id"),
+        "extraction_profiles",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule("jobs", ("project_id",), "projects", ("id",), "RESTRICT"),
+    _ForeignKeyDeleteRule("job_events", ("job_id",), "jobs", ("id",), "RESTRICT"),
+    _ForeignKeyDeleteRule(
+        "adapter_run_outputs",
+        ("source_file_id", "project_id"),
+        "files",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "adapter_run_outputs",
+        ("extraction_profile_id", "project_id"),
+        "extraction_profiles",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "adapter_run_outputs",
+        ("project_id",),
+        "projects",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "adapter_run_outputs",
+        ("source_job_id",),
+        "jobs",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "drawing_revisions",
+        ("source_file_id", "project_id"),
+        "files",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "drawing_revisions",
+        ("extraction_profile_id", "project_id"),
+        "extraction_profiles",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "drawing_revisions",
+        ("adapter_run_output_id", "project_id"),
+        "adapter_run_outputs",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "drawing_revisions",
+        ("project_id",),
+        "projects",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "drawing_revisions",
+        ("source_job_id",),
+        "jobs",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "validation_reports",
+        ("drawing_revision_id", "project_id"),
+        "drawing_revisions",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "validation_reports",
+        ("project_id",),
+        "projects",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "validation_reports",
+        ("source_job_id",),
+        "jobs",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "generated_artifacts",
+        ("source_file_id", "project_id"),
+        "files",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "generated_artifacts",
+        ("drawing_revision_id", "project_id"),
+        "drawing_revisions",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "generated_artifacts",
+        ("adapter_run_output_id", "project_id"),
+        "adapter_run_outputs",
+        ("id", "project_id"),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "generated_artifacts",
+        ("project_id",),
+        "projects",
+        ("id",),
+        "RESTRICT",
+    ),
+    _ForeignKeyDeleteRule(
+        "generated_artifacts",
+        ("job_id",),
+        "jobs",
+        ("id",),
+        "RESTRICT",
+    ),
+)
+
+
+def _normalize_ondelete(raw_foreign_key: Mapping[str, Any]) -> str:
+    """Extract a normalized delete action from inspector output."""
+
+    options = raw_foreign_key.get("options")
+    if isinstance(options, dict):
+        return str(options.get("ondelete") or "").upper()
+    return ""
+
+
+def _inspect_lineage_foreign_keys(
+    sync_connection: sa.Connection,
+) -> dict[tuple[str, tuple[str, ...], str, tuple[str, ...]], str]:
+    """Load installed delete actions for lineage foreign keys from PostgreSQL."""
+
+    inspector = sa.inspect(sync_connection)
+    lineage_tables = sorted({rule.table_name for rule in _EXPECTED_LINEAGE_FOREIGN_KEYS})
+    installed_rules: dict[tuple[str, tuple[str, ...], str, tuple[str, ...]], str] = {}
+
+    for table_name in lineage_tables:
+        for foreign_key in inspector.get_foreign_keys(table_name):
+            installed_rules[
+                (
+                    table_name,
+                    tuple(foreign_key["constrained_columns"]),
+                    str(foreign_key["referred_table"]),
+                    tuple(foreign_key["referred_columns"]),
+                )
+            ] = _normalize_ondelete(foreign_key)
+
+    return installed_rules
+
+
+async def _load_installed_lineage_foreign_keys(
+) -> dict[tuple[str, tuple[str, ...], str, tuple[str, ...]], str]:
+    """Inspect the migrated database instead of ORM metadata."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        connection = await session.connection()
+        return await connection.run_sync(_inspect_lineage_foreign_keys)
+
+
+@pytest.fixture(autouse=True)
+def fake_ingestion_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[IngestionRunRequest]:
+    """Patch worker ingestion with deterministic persisted outputs."""
+
+    recorded_requests: list[IngestionRunRequest] = []
+
+    async def _fake_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+        recorded_requests.append(request)
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+    return recorded_requests
+
+
+async def _load_lineage_snapshot(
+    project_id: str,
+    file_id: str,
+    job_id: uuid.UUID,
+) -> _LineageSnapshot:
+    """Load a fully persisted ingest lineage for delete-policy assertions."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+        await _load_project_outputs(project_id)
+    )
+    assert len(adapter_outputs) == 1
+    assert len(drawing_revisions) == 1
+    assert len(validation_reports) == 1
+    assert len(generated_artifacts) == 1
+
+    async with session_maker() as session:
+        project = await session.get(Project, _as_uuid(project_id))
+        source_file = await session.get(FileModel, _as_uuid(file_id))
+        job = await session.get(Job, job_id)
+
+        assert project is not None
+        assert source_file is not None
+        assert job is not None
+        assert job.extraction_profile_id is not None
+
+        extraction_profile = await session.get(ExtractionProfile, job.extraction_profile_id)
+        assert extraction_profile is not None
+
+    return _LineageSnapshot(
+        project=project,
+        source_file=source_file,
+        extraction_profile=extraction_profile,
+        job=job,
+        adapter_output=adapter_outputs[0],
+        drawing_revision=drawing_revisions[0],
+        validation_report=validation_reports[0],
+        generated_artifact=generated_artifacts[0],
+    )
+
+
+async def _assert_hard_delete_fails(model: type[Any], object_id: uuid.UUID) -> None:
+    """Assert a physical delete is rejected and the row remains."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        row = await session.get(model, object_id)
+        assert row is not None
+
+        await session.delete(row)
+
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+        await session.rollback()
+
+    async with session_maker() as session:
+        assert await session.get(model, object_id) is not None
+
+
+@requires_database
+class TestLineageDeleteRestrictions:
+    """Tests for non-destructive foreign key delete policies."""
+
+    async def test_lineage_foreign_keys_are_restrict_in_upgraded_database(self) -> None:
+        """Lineage FKs should be restrictive in the migrated PostgreSQL schema."""
+        _ = self
+
+        installed_rules = await _load_installed_lineage_foreign_keys()
+
+        assert all(ondelete != "CASCADE" for ondelete in installed_rules.values())
+
+        for expected_rule in _EXPECTED_LINEAGE_FOREIGN_KEYS:
+            edge = (
+                expected_rule.table_name,
+                expected_rule.constrained_columns,
+                expected_rule.referred_table,
+                expected_rule.referred_columns,
+            )
+            assert edge in installed_rules
+            assert installed_rules[edge] == expected_rule.ondelete
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "project",
+            "source_file",
+            "extraction_profile",
+            "job",
+            "adapter_output",
+            "drawing_revision",
+        ],
+    )
+    async def test_hard_delete_of_lineage_parent_fails(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        model_name: str,
+    ) -> None:
+        """Physical deletes should fail instead of cascading through lineage."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        snapshot = await _load_lineage_snapshot(
+            project["id"],
+            str(uploaded["id"]),
+            job.id,
+        )
+        row_by_model_name: dict[str, tuple[type[Any], uuid.UUID]] = {
+            "project": (Project, snapshot.project.id),
+            "source_file": (FileModel, snapshot.source_file.id),
+            "extraction_profile": (ExtractionProfile, snapshot.extraction_profile.id),
+            "job": (Job, snapshot.job.id),
+            "adapter_output": (AdapterRunOutput, snapshot.adapter_output.id),
+            "drawing_revision": (DrawingRevision, snapshot.drawing_revision.id),
+        }
+
+        model, object_id = row_by_model_name[model_name]
+        await _assert_hard_delete_fails(model, object_id)
+
+    async def test_project_soft_delete_retains_lineage_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Soft-delete flows should keep lineage rows while marking retained resources."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        await process_ingest_job(job.id)
+
+        delete_response = await async_client.delete(f"/v1/projects/{project['id']}")
+        assert delete_response.status_code == 204
+
+        snapshot = await _load_lineage_snapshot(project["id"], str(uploaded["id"]), job.id)
+
+        assert snapshot.project.deleted_at is not None
+        assert snapshot.source_file.deleted_at is not None
+        assert snapshot.generated_artifact.deleted_at is not None
+        assert snapshot.job.project_id == snapshot.project.id
+        assert snapshot.job.file_id == snapshot.source_file.id
+        assert snapshot.job.extraction_profile_id == snapshot.extraction_profile.id
+        assert snapshot.adapter_output.source_file_id == snapshot.source_file.id
+        assert snapshot.adapter_output.source_job_id == snapshot.job.id
+        assert snapshot.drawing_revision.adapter_run_output_id == snapshot.adapter_output.id
+        assert snapshot.validation_report.drawing_revision_id == snapshot.drawing_revision.id
+        assert snapshot.generated_artifact.job_id == snapshot.job.id


### PR DESCRIPTION
Closes #127

## Summary
- replace lineage-bearing foreign keys with restrictive delete behavior so historical rows are preserved
- add an Alembic migration and upgraded-database tests that verify lineage foreign keys install as RESTRICT
- document soft-delete as the normal MVP deletion path and block unsafe downgrade when lineage data still exists

## Test plan
- [x] uv run ruff check
- [x] uv run mypy app tests
- [x] uv run alembic heads
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_fk_restrict_test uv run alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_fk_restrict_test uv run pytest tests/test_lineage_delete_restrictions.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_fk_restrict_test uv run pytest