### PR TITLE
fix(worker): add ingest job attempt ownership leases

### DIFF
--- a/alembic/versions/2026_05_10_0007_constrain_job_fields_and_ingest_profile.py
+++ b/alembic/versions/2026_05_10_0007_constrain_job_fields_and_ingest_profile.py
@@ -90,25 +90,23 @@ def upgrade() -> None:
     )
     op.execute(
         sa.text(
-            """
+            f"""
             ALTER TABLE jobs
             ADD CONSTRAINT ck_jobs_ingest_extraction_profile_required
-            CHECK ({constraint_sql})
+            CHECK ({_profile_required_constraint_sql()})
             NOT VALID
             """
-            .format(constraint_sql=_profile_required_constraint_sql())
         )
     )
 
     invalid_profile_required_jobs = bind.execute(
         sa.text(
-            """
+            f"""
             SELECT COUNT(*)
             FROM jobs
-            WHERE job_type IN ({job_type_values})
+            WHERE job_type IN ({_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES)})
               AND extraction_profile_id IS NULL
             """
-            .format(job_type_values=_sql_in_list(_PROFILE_REQUIRED_JOB_TYPE_VALUES))
         )
     ).scalar_one()
     if invalid_profile_required_jobs != 0:

--- a/alembic/versions/2026_05_11_0010_add_job_attempt_leases.py
+++ b/alembic/versions/2026_05_11_0010_add_job_attempt_leases.py
@@ -1,0 +1,48 @@
+"""add job attempt lease fencing
+
+Revision ID: 2026_05_11_0010
+Revises: 2026_05_10_0009
+Create Date: 2026-05-11 12:30:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_11_0010"
+down_revision: str | None = "2026_05_10_0009"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add persisted worker-attempt lease fencing to jobs."""
+
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "attempt_token",
+            sa.Uuid(),
+            nullable=True,
+            comment="Current running attempt ownership token fence",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "attempt_lease_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Current running attempt lease expiry used to reclaim stale deliveries",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop persisted worker-attempt lease fencing from jobs."""
+
+    op.drop_column("jobs", "attempt_lease_expires_at")
+    op.drop_column("jobs", "attempt_token")

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -65,6 +65,10 @@ class _InactiveSourceError(Exception):
     """Raised when a job source project or file is no longer active."""
 
 
+class _StaleJobAttemptError(Exception):
+    """Raised when a worker attempt no longer owns the job lease."""
+
+
 @dataclass(frozen=True, slots=True)
 class _QueuedJobEvent:
     """Buffered job event persisted by the progress drain."""
@@ -72,6 +76,14 @@ class _QueuedJobEvent:
     level: str
     message: str
     data_json: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _JobAttemptLease:
+    """Persisted ownership token for a claimed job attempt."""
+
+    token: UUID
+    lease_expires_at: datetime
 
 
 class _PersistedJobCancellationHandle:
@@ -92,8 +104,9 @@ class _JobProgressEventBridge:
 
     _STOP = object()
 
-    def __init__(self, job_id: UUID) -> None:
+    def __init__(self, job_id: UUID, *, attempt_token: UUID) -> None:
         self._job_id = job_id
+        self._attempt_token = attempt_token
         self._queue: asyncio.Queue[_QueuedJobEvent | object] = asyncio.Queue()
         self._drain_task = asyncio.create_task(self._drain())
         self._closed = False
@@ -132,6 +145,7 @@ class _JobProgressEventBridge:
                     level=queued.level,
                     message=queued.message,
                     data_json=queued.data_json,
+                    attempt_token=self._attempt_token,
                 )
             finally:
                 self._queue.task_done()
@@ -158,8 +172,58 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+def _clear_job_attempt_lease(job: Job) -> None:
+    """Clear persisted ownership fencing for a job attempt."""
+    job.attempt_token = None
+    job.attempt_lease_expires_at = None
+
+
+def _claim_job_attempt_lease(
+    job: Job,
+    *,
+    now: datetime,
+    increment_attempt: bool,
+) -> _JobAttemptLease:
+    """Mint and persist a fresh job-attempt ownership lease."""
+    attempt_token = uuid.uuid4()
+    lease_expires_at = now + _RUNNING_JOB_STALE_AFTER
+
+    if increment_attempt:
+        job.attempts += 1
+
+    job.status = "running"
+    job.started_at = now
+    job.finished_at = None
+    job.error_code = None
+    job.error_message = None
+    job.attempt_token = attempt_token
+    job.attempt_lease_expires_at = lease_expires_at
+
+    return _JobAttemptLease(token=attempt_token, lease_expires_at=lease_expires_at)
+
+
+def _job_attempt_is_current(job: Job, *, attempt_token: UUID) -> bool:
+    """Return whether a worker still owns the persisted job attempt lease."""
+    return job.status == "running" and job.attempt_token == attempt_token
+
+
+def _job_is_safe_recovery_failure_target(job: Job) -> bool:
+    """Return whether recovery can still safely mark the job failed."""
+    return (
+        job.status == "pending"
+        and job.attempt_token is None
+        and job.attempt_lease_expires_at is None
+    )
+
+
 def _is_stale_running_job(job: Job, *, now: datetime) -> bool:
     """Return whether a running job is old enough to treat as orphaned."""
+    lease_expires_at = job.attempt_lease_expires_at
+    if lease_expires_at is not None:
+        if lease_expires_at.tzinfo is None:
+            lease_expires_at = lease_expires_at.replace(tzinfo=UTC)
+        return lease_expires_at <= now
+
     if job.started_at is None:
         return True
 
@@ -440,7 +504,7 @@ async def _cleanup_failed_storage_writes(
             )
 
 
-async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
+async def _build_ingestion_run_request(job_id: UUID, *, attempt_token: UUID) -> IngestionRunRequest:
     """Load persisted job and file metadata for the ingestion runner."""
     session_maker = get_session_maker()
     if session_maker is None:
@@ -450,6 +514,8 @@ async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
         job = await _get_job_for_update(session, job_id)
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
 
         source_file = await _get_source_file(
             session,
@@ -458,11 +524,14 @@ async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
             for_update=True,
         )
         if source_file is None:
-            await _cancel_job_for_inactive_source(
+            cancelled = await _cancel_job_for_inactive_source(
                 session,
                 job,
                 reason="source_deleted",
+                attempt_token=attempt_token,
             )
+            if not cancelled:
+                raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
             raise _InactiveSourceError(
                 f"File with identifier '{job.file_id}' for job '{job_id}' is no longer active"
             )
@@ -479,7 +548,12 @@ async def _build_ingestion_run_request(job_id: UUID) -> IngestionRunRequest:
         )
 
 
-async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPayload) -> bool:
+async def _finalize_ingest_job(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    payload: IngestFinalizationPayload,
+) -> bool:
     """Atomically publish durable ingest outputs and terminal job success."""
     session_maker = get_session_maker()
     if session_maker is None:
@@ -493,6 +567,14 @@ async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPaylo
         if job.status in _TERMINAL_JOB_STATUSES:
             logger.info(
                 "ingest_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            logger.info(
+                "ingest_job_completion_skipped_stale_attempt",
                 job_id=str(job_id),
                 status=job.status,
             )
@@ -542,6 +624,7 @@ async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPaylo
                 session,
                 job,
                 reason="source_deleted",
+                attempt_token=attempt_token,
             )
             logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
             return False
@@ -708,6 +791,7 @@ async def _finalize_ingest_job(job_id: UUID, *, payload: IngestFinalizationPaylo
             job.finished_at = finished_at
             job.error_code = None
             job.error_message = None
+            _clear_job_attempt_lease(job)
             await emit_job_event(
                 job.id,
                 level="info",
@@ -752,8 +836,9 @@ async def emit_job_event(
     level: str,
     message: str,
     data_json: dict[str, Any] | None = None,
+    attempt_token: UUID | None = None,
     session: AsyncSession | None = None,
-) -> None:
+) -> bool:
     """Persist a job lifecycle event."""
     event = JobEvent(
         job_id=job_id,
@@ -762,16 +847,30 @@ async def emit_job_event(
         data_json=data_json,
     )
     if session is not None:
+        if attempt_token is not None:
+            job = await _get_job_for_update(session, job_id)
+            if job is None:
+                raise LookupError(f"Job with identifier '{job_id}' not found")
+            if not _job_attempt_is_current(job, attempt_token=attempt_token):
+                return False
         session.add(event)
-        return
+        return True
 
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as managed_session:
+        if attempt_token is not None:
+            job = await _get_job_for_update(managed_session, job_id)
+            if job is None:
+                raise LookupError(f"Job with identifier '{job_id}' not found")
+            if not _job_attempt_is_current(job, attempt_token=attempt_token):
+                return False
         managed_session.add(event)
         await managed_session.commit()
+
+    return True
 
 
 def _progress_event_data(update: ProgressUpdate) -> dict[str, Any]:
@@ -836,6 +935,7 @@ async def _invoke_ingestion_runner(
 async def _poll_job_cancellation(
     job_id: UUID,
     *,
+    attempt_token: UUID,
     cancellation: _PersistedJobCancellationHandle,
     run_task: asyncio.Task[IngestFinalizationPayload],
     stop_event: asyncio.Event,
@@ -847,13 +947,15 @@ async def _poll_job_cancellation(
 
     while not stop_event.is_set() and not cancellation.is_cancelled():
         async with session_maker() as session:
-            result = await session.execute(select(Job.cancel_requested).where(Job.id == job_id))
-            cancel_requested = result.scalar_one_or_none()
+            job = await session.get(Job, job_id)
 
-        if cancel_requested is None:
+        if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
-        if cancel_requested:
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            return
+
+        if job.cancel_requested:
             cancellation.mark_cancelled()
             run_task.cancel()
             return
@@ -881,12 +983,39 @@ async def _stop_job_execution_monitor(
         await progress_bridge.flush()
 
 
+async def _persist_job_failed(
+    session: AsyncSession,
+    job: Job,
+    *,
+    error_message: str,
+    error_code: ErrorCode,
+) -> None:
+    """Persist a failed job state and matching event within an active session."""
+    job.status = "failed"
+    job.error_code = error_code.value
+    job.error_message = error_message
+    job.finished_at = _utcnow()
+    _clear_job_attempt_lease(job)
+    await emit_job_event(
+        job.id,
+        level="error",
+        message="Job failed",
+        data_json={
+            "status": "failed",
+            "error_code": error_code.value,
+            "error_message": error_message,
+        },
+        session=session,
+    )
+
+
 async def _mark_job_failed(
     job_id: UUID,
     *,
     error_message: str,
     error_code: ErrorCode = ErrorCode.INTERNAL_ERROR,
-) -> None:
+    attempt_token: UUID | None = None,
+) -> bool:
     """Persist a failed job state with the supplied message."""
     session_maker = get_session_maker()
     if session_maker is None:
@@ -903,26 +1032,30 @@ async def _mark_job_failed(
                 job_id=str(job_id),
                 status=job.status,
             )
-            return
-        job.status = "failed"
-        job.error_code = error_code.value
-        job.error_message = error_message
-        job.finished_at = _utcnow()
-        await emit_job_event(
-            job_id,
-            level="error",
-            message="Job failed",
-            data_json={
-                "status": "failed",
-                "error_code": error_code.value,
-                "error_message": error_message,
-            },
-            session=session,
+            return False
+        if attempt_token is not None and not _job_attempt_is_current(
+            job,
+            attempt_token=attempt_token,
+        ):
+            logger.info(
+                "ingest_job_failure_mark_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        await _persist_job_failed(
+            session,
+            job,
+            error_message=error_message,
+            error_code=error_code,
         )
         await session.commit()
 
+    return True
 
-async def _mark_job_cancelled(job_id: UUID) -> None:
+
+async def _mark_job_cancelled(job_id: UUID, *, attempt_token: UUID | None = None) -> bool:
     """Persist a cancelled job state."""
     session_maker = get_session_maker()
     if session_maker is None:
@@ -939,7 +1072,18 @@ async def _mark_job_cancelled(job_id: UUID) -> None:
                 job_id=str(job_id),
                 status=job.status,
             )
-            return
+            return False
+
+        if attempt_token is not None and not _job_attempt_is_current(
+            job,
+            attempt_token=attempt_token,
+        ):
+            logger.info(
+                "ingest_job_cancel_mark_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
 
         _finalize_job_cancelled(job)
         await emit_job_event(
@@ -951,16 +1095,60 @@ async def _mark_job_cancelled(job_id: UUID) -> None:
         )
         await session.commit()
 
+    return True
 
-async def _mark_recovery_enqueue_failed(job_id: UUID) -> None:
+
+async def _mark_job_failed_if_recovery_safe(
+    job_id: UUID,
+    *,
+    error_message: str,
+    error_code: ErrorCode = ErrorCode.INTERNAL_ERROR,
+) -> bool:
+    """Fail a recovered job only if it is still pending and unowned."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if not _job_is_safe_recovery_failure_target(job):
+            logger.info(
+                "ingest_job_recovery_enqueue_failure_mark_skipped_changed_state",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        await _persist_job_failed(
+            session,
+            job,
+            error_message=error_message,
+            error_code=error_code,
+        )
+        await session.commit()
+
+    return True
+
+
+async def _mark_recovery_enqueue_failed(job_id: UUID) -> bool:
     """Persist and log a sanitized worker-recovery enqueue failure."""
-    await _mark_job_failed(job_id, error_message=_ENQUEUE_INGEST_JOB_ERROR_MESSAGE)
+    marked_failed = await _mark_job_failed_if_recovery_safe(
+        job_id,
+        error_message=_ENQUEUE_INGEST_JOB_ERROR_MESSAGE,
+    )
+    if not marked_failed:
+        return False
+
     logger.error(
         "ingest_job_recovery_enqueue_failed",
         job_id=str(job_id),
         error_code=ErrorCode.INTERNAL_ERROR.value,
         recovery_action="mark_failed",
     )
+    return True
 
 
 def _finalize_job_cancelled(job: Job) -> None:
@@ -969,6 +1157,7 @@ def _finalize_job_cancelled(job: Job) -> None:
     job.error_code = _JOB_CANCELLED_ERROR_CODE
     job.error_message = None
     job.finished_at = _utcnow()
+    _clear_job_attempt_lease(job)
 
 
 async def _cancel_job_for_inactive_source(
@@ -976,10 +1165,14 @@ async def _cancel_job_for_inactive_source(
     job: Job,
     *,
     reason: str,
-) -> None:
+    attempt_token: UUID | None = None,
+) -> bool:
     """Persist cancellation when a job source project/file is no longer active."""
     if job.status in _TERMINAL_JOB_STATUSES:
-        return
+        return False
+
+    if attempt_token is not None and not _job_attempt_is_current(job, attempt_token=attempt_token):
+        return False
 
     job.cancel_requested = True
     _finalize_job_cancelled(job)
@@ -992,8 +1185,10 @@ async def _cancel_job_for_inactive_source(
     )
     await session.commit()
 
+    return True
 
-async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
+
+async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
     """Claim, resume, or cancel a persisted ingest job under a row lock."""
     session_maker = get_session_maker()
     if session_maker is None:
@@ -1012,7 +1207,7 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
                 job_id=str(job_id),
                 status=job.status,
             )
-            return False
+            return None
 
         source_file = await _get_source_file(
             session,
@@ -1027,16 +1222,12 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
                 reason="source_deleted",
             )
             logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
-            return False
+            return None
 
         if not job.cancel_requested:
             if job.status == "running":
                 if _is_stale_running_job(job, now=now):
-                    job.attempts += 1
-                    job.started_at = now
-                    job.finished_at = None
-                    job.error_code = None
-                    job.error_message = None
+                    lease = _claim_job_attempt_lease(job, now=now, increment_attempt=True)
                     await emit_job_event(
                         job.id,
                         level="info",
@@ -1054,21 +1245,16 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
                         job_id=str(job_id),
                         status=job.status,
                     )
-                    return True
+                    return lease
 
                 logger.info(
-                    "ingest_job_continuing_running_status",
+                    "ingest_job_duplicate_delivery_skipped_running_attempt",
                     job_id=str(job_id),
                     status=job.status,
                 )
-                return True
+                return None
 
-            job.attempts += 1
-            job.status = "running"
-            job.started_at = now
-            job.finished_at = None
-            job.error_code = None
-            job.error_message = None
+            lease = _claim_job_attempt_lease(job, now=now, increment_attempt=True)
             await emit_job_event(
                 job.id,
                 level="info",
@@ -1077,7 +1263,7 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
                 session=session,
             )
             await session.commit()
-            return True
+            return lease
 
         _finalize_job_cancelled(job)
         await emit_job_event(
@@ -1090,7 +1276,7 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> bool:
         await session.commit()
 
     logger.info("ingest_job_cancelled", job_id=str(job_id))
-    return False
+    return None
 
 
 async def process_ingest_job(job_id: UUID) -> None:
@@ -1099,12 +1285,13 @@ async def process_ingest_job(job_id: UUID) -> None:
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
-    if not await _begin_or_resume_ingest_job(job_id):
+    lease = await _begin_or_resume_ingest_job(job_id)
+    if lease is None:
         return
 
     try:
-        request = await _build_ingestion_run_request(job_id)
-        progress_bridge = _JobProgressEventBridge(job_id)
+        request = await _build_ingestion_run_request(job_id, attempt_token=lease.token)
+        progress_bridge = _JobProgressEventBridge(job_id, attempt_token=lease.token)
         cancellation = _PersistedJobCancellationHandle()
         stop_event = asyncio.Event()
         run_task = asyncio.create_task(
@@ -1118,6 +1305,7 @@ async def process_ingest_job(job_id: UUID) -> None:
         cancellation_task = asyncio.create_task(
             _poll_job_cancellation(
                 job_id,
+                attempt_token=lease.token,
                 cancellation=cancellation,
                 run_task=run_task,
                 stop_event=stop_event,
@@ -1134,24 +1322,36 @@ async def process_ingest_job(job_id: UUID) -> None:
     except _InactiveSourceError:
         logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
         return
+    except _StaleJobAttemptError:
+        logger.info("ingest_job_stale_attempt_skipped", job_id=str(job_id))
+        return
     except IngestionRunnerError as exc:
         if exc.error_code is ErrorCode.JOB_CANCELLED:
-            await _mark_job_cancelled(job_id)
+            await _mark_job_cancelled(job_id, attempt_token=lease.token)
             logger.info(
                 "ingest_job_cancelled_during_execution",
                 job_id=str(job_id),
                 error_code=exc.error_code.value,
             )
         else:
-            await _mark_job_failed(job_id, error_message=exc.message, error_code=exc.error_code)
+            await _mark_job_failed(
+                job_id,
+                error_message=exc.message,
+                error_code=exc.error_code,
+                attempt_token=lease.token,
+            )
             logger.error("ingest_job_failed", job_id=str(job_id), **_runner_error_log_fields(exc))
         raise
     except asyncio.CancelledError:
-        await _mark_job_cancelled(job_id)
+        await _mark_job_cancelled(job_id, attempt_token=lease.token)
         logger.info("ingest_job_cancelled_during_execution", job_id=str(job_id))
         raise
     except Exception:
-        await _mark_job_failed(job_id, error_message=_PROCESS_INGEST_JOB_ERROR_MESSAGE)
+        await _mark_job_failed(
+            job_id,
+            error_message=_PROCESS_INGEST_JOB_ERROR_MESSAGE,
+            attempt_token=lease.token,
+        )
         logger.error(
             "ingest_job_failed",
             job_id=str(job_id),
@@ -1162,13 +1362,21 @@ async def process_ingest_job(job_id: UUID) -> None:
         raise
 
     try:
-        finalized = await _finalize_ingest_job(job_id, payload=payload)
+        finalized = await _finalize_ingest_job(
+            job_id,
+            attempt_token=lease.token,
+            payload=payload,
+        )
     except asyncio.CancelledError:
-        await _mark_job_cancelled(job_id)
+        await _mark_job_cancelled(job_id, attempt_token=lease.token)
         logger.info("ingest_job_cancelled_during_finalization", job_id=str(job_id))
         raise
     except Exception as exc:
-        await _mark_job_failed(job_id, error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE)
+        await _mark_job_failed(
+            job_id,
+            error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE,
+            attempt_token=lease.token,
+        )
         logger.error(
             "ingest_job_finalization_failed",
             job_id=str(job_id),
@@ -1198,6 +1406,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
                 & (Job.status.in_(_INCOMPLETE_JOB_STATUSES))
             )
             .order_by(Job.created_at.asc(), Job.id.asc())
+            .with_for_update(skip_locked=True)
         )
         jobs = result.scalars().all()
 
@@ -1211,6 +1420,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
                 job.finished_at = None
                 job.error_code = None
                 job.error_message = None
+                _clear_job_attempt_lease(job)
             recovered_job_ids.append(job.id)
 
         await session.commit()

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -134,6 +134,15 @@ class Job(Base):
         nullable=False,
         comment="Maximum retry attempts",
     )
+    attempt_token: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Current running attempt ownership token fence",
+    )
+    attempt_lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Current running attempt lease expiry used to reclaim stale deliveries",
+    )
     cancel_requested: Mapped[bool] = mapped_column(
         Boolean,
         default=False,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -371,24 +371,30 @@ async def test_mark_recovery_enqueue_failed_logs_only_safe_fields(
     logger_error_calls: list[tuple[str, dict[str, Any]]] = []
     marked_failed_job_ids: list[uuid.UUID] = []
 
-    async def _fake_mark_job_failed(
+    async def _fake_mark_job_failed_if_recovery_safe(
         failed_job_id: uuid.UUID,
         *,
         error_message: str,
         error_code: ErrorCode = ErrorCode.INTERNAL_ERROR,
-    ) -> None:
+    ) -> bool:
         marked_failed_job_ids.append(failed_job_id)
         assert error_message == "Failed to enqueue ingest job"
         assert error_code == ErrorCode.INTERNAL_ERROR
+        return True
 
     def _capture_logger_error(event: str, **kwargs: Any) -> None:
         logger_error_calls.append((event, kwargs))
 
-    monkeypatch.setattr(worker_module, "_mark_job_failed", _fake_mark_job_failed)
+    monkeypatch.setattr(
+        worker_module,
+        "_mark_job_failed_if_recovery_safe",
+        _fake_mark_job_failed_if_recovery_safe,
+    )
     monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
 
-    await worker_module._mark_recovery_enqueue_failed(job_id)
+    marked_failed = await worker_module._mark_recovery_enqueue_failed(job_id)
 
+    assert marked_failed is True
     assert marked_failed_job_ids == [job_id]
     assert logger_error_calls == [
         (
@@ -1266,20 +1272,33 @@ class TestJobs:
             "cancelled",
         ]
 
-    async def test_process_ingest_job_continues_redelivered_running_job(
+    async def test_process_ingest_job_skips_fresh_redelivered_running_job(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Redelivery should complete an already-running ingest attempt."""
+        """Fresh redelivery should not execute or mutate an already-running attempt."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
 
+        runner_calls: list[IngestionRunRequest] = []
+
+        async def _unexpected_run_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            runner_calls.append(request)
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _unexpected_run_ingestion)
+
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
+        attempt_token = uuid.uuid4()
+        lease_expires_at = datetime.now(UTC) + worker_module._RUNNING_JOB_STALE_AFTER
 
         session_maker = session_module.AsyncSessionLocal
         assert session_maker is not None
@@ -1289,15 +1308,199 @@ class TestJobs:
             persisted_job.status = "running"
             persisted_job.attempts = 1
             persisted_job.started_at = datetime.now(UTC)
+            persisted_job.attempt_token = attempt_token
+            persisted_job.attempt_lease_expires_at = lease_expires_at
             await session.commit()
 
         await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
-        assert updated_job.status == "succeeded"
+        assert runner_calls == []
+        assert updated_job.status == "running"
         assert updated_job.attempts == 1
         assert updated_job.started_at is not None
-        assert updated_job.finished_at is not None
+        assert updated_job.finished_at is None
+        assert updated_job.attempt_token == attempt_token
+        assert updated_job.attempt_lease_expires_at == lease_expires_at
+
+    async def test_begin_or_resume_ingest_job_reclaims_stale_running_attempt_with_new_token(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Stale running attempts should be reclaimed with a fresh ownership token."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        old_attempt_token = uuid.uuid4()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = (
+                datetime.now(UTC)
+                - worker_module._RUNNING_JOB_STALE_AFTER
+                - timedelta(seconds=1)
+            )
+            persisted_job.attempt_token = old_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        lease = await worker_module._begin_or_resume_ingest_job(job.id)
+
+        assert lease is not None
+        assert lease.token != old_attempt_token
+        reclaimed_job = await _get_job(job.id)
+        assert reclaimed_job.status == "running"
+        assert reclaimed_job.attempts == 2
+        assert reclaimed_job.attempt_token == lease.token
+        assert reclaimed_job.attempt_lease_expires_at == lease.lease_expires_at
+        assert reclaimed_job.attempt_lease_expires_at is not None
+        assert reclaimed_job.attempt_lease_expires_at > datetime.now(UTC)
+
+    async def test_stale_attempt_writes_noop_after_reclaim(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Stale attempt events and terminal writes should no-op after reclaim."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        old_attempt_token = uuid.uuid4()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = (
+                datetime.now(UTC)
+                - worker_module._RUNNING_JOB_STALE_AFTER
+                - timedelta(seconds=1)
+            )
+            persisted_job.attempt_token = old_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        new_lease = await worker_module._begin_or_resume_ingest_job(job.id)
+
+        assert new_lease is not None
+        event_written = await worker_module.emit_job_event(
+            job.id,
+            level="info",
+            message="Stale progress",
+            data_json={"status": "running", "event": "progress", "stage": "stale"},
+            attempt_token=old_attempt_token,
+        )
+        failed = await worker_module._mark_job_failed(
+            job.id,
+            error_message="stale failure",
+            attempt_token=old_attempt_token,
+        )
+        cancelled = await worker_module._mark_job_cancelled(
+            job.id,
+            attempt_token=old_attempt_token,
+        )
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            inactive_source_cancelled = await worker_module._cancel_job_for_inactive_source(
+                session,
+                persisted_job,
+                reason="source_deleted",
+                attempt_token=old_attempt_token,
+            )
+
+        finalize_request = IngestionRunRequest(
+            job_id=job.id,
+            file_id=job.file_id,
+            checksum_sha256=hashlib.sha256(_TEST_UPLOAD_BODY).hexdigest(),
+            detected_format="pdf",
+            media_type="application/pdf",
+            original_name="plan.pdf",
+            extraction_profile_id=job.extraction_profile_id,
+            initial_job_id=job.id,
+        )
+        finalized = await worker_module._finalize_ingest_job(
+            job.id,
+            attempt_token=old_attempt_token,
+            payload=_build_fake_ingest_payload(finalize_request),
+        )
+
+        assert event_written is False
+        assert failed is False
+        assert cancelled is False
+        assert inactive_source_cancelled is False
+        assert finalized is False
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "running"
+        assert updated_job.attempts == 2
+        assert updated_job.attempt_token == new_lease.token
+        assert updated_job.finished_at is None
+
+        response = await async_client.get(f"/v1/jobs/{job.id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert [event["message"] for event in data["items"]] == ["Job started"]
+
+    async def test_finalize_ingest_job_clears_owned_attempt_lease_on_success(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Owned terminal success should clear persisted attempt lease state."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        lease = await worker_module._begin_or_resume_ingest_job(job.id)
+
+        assert lease is not None
+        finalize_request = IngestionRunRequest(
+            job_id=job.id,
+            file_id=job.file_id,
+            checksum_sha256=hashlib.sha256(_TEST_UPLOAD_BODY).hexdigest(),
+            detected_format="pdf",
+            media_type="application/pdf",
+            original_name="plan.pdf",
+            extraction_profile_id=job.extraction_profile_id,
+            initial_job_id=job.id,
+        )
+
+        finalized = await worker_module._finalize_ingest_job(
+            job.id,
+            attempt_token=lease.token,
+            payload=_build_fake_ingest_payload(finalize_request),
+        )
+
+        assert finalized is True
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempt_token is None
+        assert updated_job.attempt_lease_expires_at is None
 
     async def test_recover_incomplete_ingest_jobs_requeues_pending_jobs(
         self,
@@ -1394,6 +1597,7 @@ class TestJobs:
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
+        old_attempt_token = uuid.uuid4()
         enqueued_job_ids.clear()
 
         session_maker = session_module.AsyncSessionLocal
@@ -1408,6 +1612,8 @@ class TestJobs:
                 - worker_module._RUNNING_JOB_STALE_AFTER
                 - timedelta(seconds=1)
             )
+            persisted_job.attempt_token = old_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
             await session.commit()
 
         requeued = await worker_module.recover_incomplete_ingest_jobs()
@@ -1420,12 +1626,86 @@ class TestJobs:
         assert recovered_job.attempts == 1
         assert recovered_job.started_at is None
         assert recovered_job.finished_at is None
+        assert recovered_job.attempt_token is None
+        assert recovered_job.attempt_lease_expires_at is None
 
         await worker_module.process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
         assert updated_job.status == "succeeded"
         assert updated_job.attempts == 2
+
+    async def test_recover_incomplete_ingest_jobs_skips_locked_reclaimed_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker startup recovery should not clobber a concurrently reclaimed live attempt."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        stale_attempt_token = uuid.uuid4()
+        fresh_attempt_token = uuid.uuid4()
+        enqueued_job_ids.clear()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = (
+                datetime.now(UTC)
+                - worker_module._RUNNING_JOB_STALE_AFTER
+                - timedelta(seconds=1)
+            )
+            persisted_job.attempt_token = stale_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        fresh_lease_expires_at = datetime.now(UTC) + worker_module._RUNNING_JOB_STALE_AFTER
+
+        async with session_maker() as reclaim_session:
+            reclaimed_job = await worker_module._get_job_for_update(reclaim_session, job.id)
+            assert reclaimed_job is not None
+            reclaimed_job.status = "running"
+            reclaimed_job.attempts = 2
+            reclaimed_job.started_at = datetime.now(UTC)
+            reclaimed_job.finished_at = None
+            reclaimed_job.error_code = None
+            reclaimed_job.error_message = None
+            reclaimed_job.attempt_token = fresh_attempt_token
+            reclaimed_job.attempt_lease_expires_at = fresh_lease_expires_at
+            await reclaim_session.flush()
+
+            requeued = await asyncio.wait_for(
+                worker_module.recover_incomplete_ingest_jobs(),
+                timeout=2,
+            )
+
+            assert requeued == []
+            assert recovered_job_ids == []
+
+            await reclaim_session.commit()
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "running"
+        assert updated_job.attempts == 2
+        assert updated_job.attempt_token == fresh_attempt_token
+        assert updated_job.attempt_lease_expires_at == fresh_lease_expires_at
 
     async def test_recover_incomplete_ingest_jobs_skips_fresh_running_jobs(
         self,
@@ -1531,6 +1811,81 @@ class TestJobs:
                 },
             )
         ]
+
+    async def test_mark_recovery_enqueue_failed_skips_owned_running_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Recovery enqueue failure should not fail a job reclaimed by a live attempt."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        attempt_token = uuid.uuid4()
+        lease_expires_at = datetime.now(UTC) + worker_module._RUNNING_JOB_STALE_AFTER
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = datetime.now(UTC)
+            persisted_job.finished_at = None
+            persisted_job.error_code = None
+            persisted_job.error_message = None
+            persisted_job.attempt_token = attempt_token
+            persisted_job.attempt_lease_expires_at = lease_expires_at
+            await session.commit()
+
+        marked_failed = await worker_module._mark_recovery_enqueue_failed(job.id)
+
+        assert marked_failed is False
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "running"
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
+        assert updated_job.finished_at is None
+        assert updated_job.attempt_token == attempt_token
+        assert updated_job.attempt_lease_expires_at == lease_expires_at
+
+    async def test_mark_recovery_enqueue_failed_skips_terminal_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Recovery enqueue failure should not rewrite a terminalized job."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.status = "succeeded"
+            persisted_job.finished_at = datetime.now(UTC)
+            await session.commit()
+
+        marked_failed = await worker_module._mark_recovery_enqueue_failed(job.id)
+
+        assert marked_failed is False
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
 
     async def test_process_ingest_job_ignores_duplicate_delivery_after_success(
         self,


### PR DESCRIPTION
Closes #132

## Summary
- add per-attempt lease token fields for ingest and reprocess jobs
- fence terminal writes, cancellation, progress events, and recovery paths by attempt ownership
- cover duplicate delivery, stale reclaim, and recovery safety with targeted concurrency tests

## Test plan
- [x] uv run ruff check
- [x] uv run mypy app tests
- [x] uv run alembic heads
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_job_attempt_leases_validation uv run alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_job_attempt_leases_validation uv run pytest tests/test_jobs.py -k "recover_incomplete_ingest_jobs or mark_recovery_enqueue_failed or skips_fresh_redelivered_running_job or reclaims_stale_running_attempt_with_new_token or stale_attempt_writes_noop_after_reclaim or finalize_ingest_job_clears_owned_attempt_lease_on_success"
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_132_recovery uv run pytest

## Notes
- this branch was cut from current main while #127 remains unmerged, so the Alembic revision will need rebasing/renumbering after #127 lands