### PR TITLE
fix(reprocess): capture base revision and reject stale finalization

### DIFF
--- a/alembic/versions/2026_05_11_0011_add_job_attempt_leases.py
+++ b/alembic/versions/2026_05_11_0011_add_job_attempt_leases.py
@@ -1,7 +1,7 @@
 """add job attempt lease fencing
 
-Revision ID: 2026_05_11_0010
-Revises: 2026_05_10_0009
+Revision ID: 2026_05_11_0011
+Revises: 2026_05_11_0010
 Create Date: 2026-05-11 12:30:00
 """
 
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "2026_05_11_0010"
-down_revision: str | None = "2026_05_10_0009"
+revision: str = "2026_05_11_0011"
+down_revision: str | None = "2026_05_11_0010"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 

--- a/alembic/versions/2026_05_11_0012_add_jobs_base_revision_id.py
+++ b/alembic/versions/2026_05_11_0012_add_jobs_base_revision_id.py
@@ -1,0 +1,143 @@
+"""add jobs base revision pin
+
+Revision ID: 2026_05_11_0012
+Revises: 2026_05_11_0011
+Create Date: 2026-05-11 15:45:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_11_0012"
+down_revision: str | None = "2026_05_11_0011"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def _require_no_pending_legacy_reprocess_jobs() -> None:
+    """Refuse upgrade when legacy queued reprocess jobs cannot be pinned safely."""
+
+    bind = op.get_bind()
+    legacy_job_count = int(
+        bind.execute(
+            sa.text(
+                """
+                SELECT COUNT(*)
+                FROM jobs
+                JOIN files
+                  ON files.id = jobs.file_id
+                WHERE jobs.job_type = 'ingest'
+                  AND jobs.id != files.initial_job_id
+                  AND jobs.status IN ('pending', 'running')
+                """
+            )
+        ).scalar()
+        or 0
+    )
+    if legacy_job_count:
+        raise RuntimeError(
+            "Drain or cancel pending/running legacy pre-#133 reprocess jobs before "
+            "upgrading; jobs.base_revision_id cannot be pinned safely for those rows."
+        )
+
+
+def _require_no_pending_reprocess_jobs_before_downgrade() -> None:
+    """Refuse downgrade while reprocess jobs still rely on stale-base fencing."""
+
+    bind = op.get_bind()
+    pending_reprocess_jobs_exist = bool(
+        bind.execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM jobs
+                    WHERE job_type = 'reprocess'
+                      AND status IN ('pending', 'running')
+                )
+                """
+            )
+        ).scalar()
+    )
+    if pending_reprocess_jobs_exist:
+        raise RuntimeError(
+            "Manual data-preserving rollback is required before dropping "
+            "jobs.base_revision_id; pending/running reprocess jobs still rely on "
+            "stale-base fencing."
+        )
+
+
+def upgrade() -> None:
+    """Persist the pinned finalized base revision for reprocess jobs."""
+
+    _require_no_pending_legacy_reprocess_jobs()
+
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "base_revision_id",
+            sa.Uuid(),
+            nullable=True,
+            comment=(
+                "Pinned latest finalized drawing revision captured when a reprocess "
+                "job was created. Null for initial ingest jobs."
+            ),
+        ),
+    )
+    op.create_index("ix_jobs_base_revision_id", "jobs", ["base_revision_id"], unique=False)
+    op.create_foreign_key(
+        "fk_jobs_base_revision_id_drawing_revisions",
+        "jobs",
+        "drawing_revisions",
+        ["base_revision_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE jobs
+            ADD CONSTRAINT ck_jobs_reprocess_base_revision_required
+            CHECK (job_type != 'reprocess' OR base_revision_id IS NOT NULL)
+            NOT VALID
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE jobs
+            ADD CONSTRAINT ck_jobs_ingest_base_revision_forbidden
+            CHECK (job_type != 'ingest' OR base_revision_id IS NULL)
+            NOT VALID
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Drop the persisted reprocess base revision pin."""
+
+    _require_no_pending_reprocess_jobs_before_downgrade()
+
+    op.drop_constraint(
+        "ck_jobs_ingest_base_revision_forbidden",
+        "jobs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_jobs_reprocess_base_revision_required",
+        "jobs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "fk_jobs_base_revision_id_drawing_revisions",
+        "jobs",
+        type_="foreignkey",
+    )
+    op.drop_index("ix_jobs_base_revision_id", table_name="jobs")
+    op.drop_column("jobs", "base_revision_id")

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -34,6 +34,7 @@ from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
 from app.jobs.worker import enqueue_ingest_job
+from app.models.drawing_revision import DrawingRevision
 from app.models.extraction_profile import ExtractionProfile
 from app.models.file import File as FileModel
 from app.models.job import Job
@@ -288,6 +289,38 @@ async def _get_existing_project_extraction_profile_or_404(
         raise_not_found("ExtractionProfile", str(extraction_profile_id))
     assert profile_row is not None
     return profile_row
+
+
+async def _get_latest_finalized_revision(
+    db: AsyncSession,
+    project_id: UUID,
+    file_id: UUID,
+) -> DrawingRevision | None:
+    """Return the latest finalized drawing revision for a file."""
+
+    query = (
+        select(DrawingRevision)
+        .where(
+            (DrawingRevision.project_id == project_id)
+            & (DrawingRevision.source_file_id == file_id)
+        )
+        .order_by(DrawingRevision.revision_sequence.desc())
+        .limit(1)
+    )
+    return (await db.execute(query)).scalar_one_or_none()
+
+
+def _raise_reprocess_base_revision_conflict() -> None:
+    """Raise the standardized missing-base revision conflict response."""
+
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=create_error_response(
+            code=ErrorCode.REVISION_CONFLICT,
+            message="Reprocess requires a finalized base revision.",
+            details=None,
+        ),
+    )
 
 
 async def _mark_job_enqueue_failed(db: AsyncSession, job: Job, exc: Exception) -> None:
@@ -643,7 +676,7 @@ async def reprocess_project_file(
     db: Annotated[AsyncSession, Depends(get_db)],
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> Job | Response:
-    """Create a new pending ingest job for an existing file and profile selection."""
+    """Create a new pending reprocess job for an existing file and profile selection."""
     reservation: IdempotencyReservation | None = None
     fingerprint: str | None = None
     if idempotency_key is not None:
@@ -667,6 +700,14 @@ async def reprocess_project_file(
             project_id,
             request.extraction_profile_id,
         )
+
+    if idempotency_key is not None:
+        await _get_active_project_or_404(db, project_id, for_update=True)
+        await _get_project_file_or_404(db, project_id, file_id, for_update=True)
+        if await _get_latest_finalized_revision(db, project_id, file_id) is None:
+            await db.rollback()
+            _raise_reprocess_base_revision_conflict()
+
     if idempotency_key is not None:
         assert fingerprint is not None
         claim = await claim_idempotency(
@@ -681,13 +722,20 @@ async def reprocess_project_file(
         reservation = claim
     await _get_active_project_or_404(db, project_id, for_update=True)
     await _get_project_file_or_404(db, project_id, file_id, for_update=True)
+    base_revision = await _get_latest_finalized_revision(db, project_id, file_id)
+    if base_revision is None:
+        await db.rollback()
+        _raise_reprocess_base_revision_conflict()
+    assert base_revision is not None
+
     extraction_profile = await _resolve_project_extraction_profile(db, project_id, request)
 
     ingest_job = Job(
         project_id=project_id,
         file_id=file_id,
         extraction_profile_id=extraction_profile.id,
-        job_type="ingest",
+        base_revision_id=base_revision.id,
+        job_type="reprocess",
         status="pending",
         attempts=0,
         max_attempts=3,

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -329,6 +329,19 @@ async def retry_job(
             return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
         return job
 
+    if job.error_code == ErrorCode.REVISION_CONFLICT.value:
+        if reservation is not None:
+            body = JobRead.model_validate(job).model_dump(mode="json")
+            await mark_idempotency_completed(
+                db,
+                reservation,
+                status_code=status.HTTP_202_ACCEPTED,
+                response_body=body,
+            )
+            await db.commit()
+            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+        return job
+
     job.status = "pending"
     job.cancel_requested = False
     job.error_code = None

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -70,6 +70,17 @@ class _StaleJobAttemptError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
+class _RevisionConflictError(Exception):
+    """Raised when a persisted ingest/reprocess revision base is invalid or stale."""
+
+    message: str
+    details: dict[str, Any]
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
 class _QueuedJobEvent:
     """Buffered job event persisted by the progress drain."""
 
@@ -296,6 +307,138 @@ async def _get_latest_drawing_revision(
     return result.scalar_one_or_none()
 
 
+async def _get_drawing_revision(
+    session: AsyncSession,
+    *,
+    revision_id: UUID,
+) -> DrawingRevision | None:
+    """Load a drawing revision row by identifier."""
+
+    return await session.get(DrawingRevision, revision_id)
+
+
+def _expected_revision_kind_for_job(job: Job) -> str:
+    """Return the expected persisted revision kind for a job type."""
+
+    if job.job_type == JobType.INGEST.value:
+        return _INITIAL_INGEST_REVISION_KIND
+    if job.job_type == JobType.REPROCESS.value:
+        return _REPROCESS_REVISION_KIND
+    raise ValueError(f"Unsupported ingest job type '{job.job_type}'")
+
+
+def _assert_job_base_revision_invariants(job: Job) -> None:
+    """Reject persisted jobs whose job_type/base_revision_id pairing is invalid."""
+
+    if job.job_type == JobType.INGEST.value:
+        if job.base_revision_id is not None:
+            raise ValueError("Initial ingest job cannot retain a base revision")
+        return
+
+    if job.job_type == JobType.REPROCESS.value:
+        if job.base_revision_id is None:
+            raise _RevisionConflictError(
+                message="Reprocess job is missing its finalized base revision.",
+                details={
+                    "base_revision_id": None,
+                    "base_revision_sequence": None,
+                    "current_revision_id": None,
+                    "current_revision_sequence": None,
+                },
+            )
+        return
+
+    raise ValueError(f"Unsupported ingest job type '{job.job_type}'")
+
+
+def _revision_reference(
+    revision: DrawingRevision | None,
+) -> tuple[str | None, int | None]:
+    """Return stable revision identifier/sequence details for conflict payloads."""
+
+    if revision is None:
+        return None, None
+
+    return str(revision.id), revision.revision_sequence
+
+
+def _build_revision_conflict_details(
+    *,
+    base_revision: DrawingRevision | None,
+    current_revision: DrawingRevision | None,
+) -> dict[str, str | int | None]:
+    """Build structured stale-base details for durable job events."""
+
+    base_revision_id, base_revision_sequence = _revision_reference(base_revision)
+    current_revision_id, current_revision_sequence = _revision_reference(current_revision)
+    return {
+        "base_revision_id": base_revision_id,
+        "base_revision_sequence": base_revision_sequence,
+        "current_revision_id": current_revision_id,
+        "current_revision_sequence": current_revision_sequence,
+    }
+
+
+async def _resolve_finalization_predecessor_revision(
+    session: AsyncSession,
+    *,
+    job: Job,
+    source_file: File,
+    payload_revision_kind: str,
+) -> DrawingRevision | None:
+    """Validate job lineage invariants and return the predecessor revision to append to."""
+
+    _assert_job_base_revision_invariants(job)
+    expected_revision_kind = _expected_revision_kind_for_job(job)
+    if payload_revision_kind != expected_revision_kind:
+        raise _RevisionConflictError(
+            message="Ingest job revision kind changed before finalization.",
+            details={
+                "expected_revision_kind": expected_revision_kind,
+                "payload_revision_kind": payload_revision_kind,
+            },
+        )
+
+    current_revision = await _get_latest_drawing_revision(
+        session,
+        project_id=job.project_id,
+        source_file_id=source_file.id,
+    )
+    if expected_revision_kind == _INITIAL_INGEST_REVISION_KIND:
+        if current_revision is not None:
+            raise _RevisionConflictError(
+                message="Initial ingest cannot finalize after another revision already exists.",
+                details=_build_revision_conflict_details(
+                    base_revision=None,
+                    current_revision=current_revision,
+                ),
+            )
+        return None
+
+    assert job.base_revision_id is not None
+    base_revision = await _get_drawing_revision(session, revision_id=job.base_revision_id)
+    if base_revision is None:
+        raise _RevisionConflictError(
+            message="Reprocess job base revision no longer exists.",
+            details=_build_revision_conflict_details(
+                base_revision=None,
+                current_revision=current_revision,
+            ),
+        )
+    if base_revision.project_id != job.project_id or base_revision.source_file_id != source_file.id:
+        raise ValueError("Reprocess job base revision does not belong to the source file")
+    if current_revision is None or current_revision.id != base_revision.id:
+        raise _RevisionConflictError(
+            message="Reprocess base revision became stale before finalization.",
+            details=_build_revision_conflict_details(
+                base_revision=base_revision,
+                current_revision=current_revision,
+            ),
+        )
+
+    return base_revision
+
+
 async def _get_generated_artifact_for_revision(
     session: AsyncSession,
     *,
@@ -315,40 +458,6 @@ async def _get_generated_artifact_for_revision(
         .limit(1)
     )
     return result.scalar_one_or_none()
-
-
-def _resolve_revision_kind(job_id: UUID, *, initial_job_id: UUID | None) -> str:
-    """Map file linkage to the correct ingest revision kind."""
-    if initial_job_id == job_id:
-        return _INITIAL_INGEST_REVISION_KIND
-
-    return _REPROCESS_REVISION_KIND
-
-
-def _assert_revision_invariants(
-    job_id: UUID,
-    *,
-    source_file: File,
-    predecessor_revision: DrawingRevision | None,
-    payload_revision_kind: str,
-) -> None:
-    """Reject finalization when revision lineage invariants are violated."""
-    expected_revision_kind = _resolve_revision_kind(
-        job_id,
-        initial_job_id=source_file.initial_job_id,
-    )
-    if payload_revision_kind != expected_revision_kind:
-        raise ValueError("Ingest job revision kind changed before finalization")
-
-    if expected_revision_kind == _INITIAL_INGEST_REVISION_KIND:
-        if predecessor_revision is not None:
-            raise ValueError("Initial ingest cannot finalize after a predecessor revision exists")
-        return
-
-    if predecessor_revision is None:
-        raise ValueError(
-            "Reprocess ingest job cannot finalize before a predecessor revision exists"
-        )
 
 
 def _build_persisted_validation_report_json(
@@ -516,6 +625,7 @@ async def _build_ingestion_run_request(job_id: UUID, *, attempt_token: UUID) -> 
             raise LookupError(f"Job with identifier '{job_id}' not found")
         if not _job_attempt_is_current(job, attempt_token=attempt_token):
             raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
+        _assert_job_base_revision_invariants(job)
 
         source_file = await _get_source_file(
             session,
@@ -629,15 +739,10 @@ async def _finalize_ingest_job(
             logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
             return False
 
-        predecessor_revision = await _get_latest_drawing_revision(
+        predecessor_revision = await _resolve_finalization_predecessor_revision(
             session,
-            project_id=job.project_id,
-            source_file_id=source_file.id,
-        )
-        _assert_revision_invariants(
-            job.id,
+            job=job,
             source_file=source_file,
-            predecessor_revision=predecessor_revision,
             payload_revision_kind=payload.revision_kind,
         )
         revision_sequence = 1
@@ -989,6 +1094,7 @@ async def _persist_job_failed(
     *,
     error_message: str,
     error_code: ErrorCode,
+    error_details: dict[str, Any] | None = None,
 ) -> None:
     """Persist a failed job state and matching event within an active session."""
     job.status = "failed"
@@ -1004,6 +1110,7 @@ async def _persist_job_failed(
             "status": "failed",
             "error_code": error_code.value,
             "error_message": error_message,
+            **({"details": error_details} if error_details is not None else {}),
         },
         session=session,
     )
@@ -1015,6 +1122,7 @@ async def _mark_job_failed(
     error_message: str,
     error_code: ErrorCode = ErrorCode.INTERNAL_ERROR,
     attempt_token: UUID | None = None,
+    error_details: dict[str, Any] | None = None,
 ) -> bool:
     """Persist a failed job state with the supplied message."""
     session_maker = get_session_maker()
@@ -1049,6 +1157,7 @@ async def _mark_job_failed(
             job,
             error_message=error_message,
             error_code=error_code,
+            error_details=error_details,
         )
         await session.commit()
 
@@ -1103,6 +1212,7 @@ async def _mark_job_failed_if_recovery_safe(
     *,
     error_message: str,
     error_code: ErrorCode = ErrorCode.INTERNAL_ERROR,
+    error_details: dict[str, Any] | None = None,
 ) -> bool:
     """Fail a recovered job only if it is still pending and unowned."""
     session_maker = get_session_maker()
@@ -1127,6 +1237,7 @@ async def _mark_job_failed_if_recovery_safe(
             job,
             error_message=error_message,
             error_code=error_code,
+            error_details=error_details,
         )
         await session.commit()
 
@@ -1325,6 +1436,21 @@ async def process_ingest_job(job_id: UUID) -> None:
     except _StaleJobAttemptError:
         logger.info("ingest_job_stale_attempt_skipped", job_id=str(job_id))
         return
+    except _RevisionConflictError as exc:
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=ErrorCode.REVISION_CONFLICT,
+            attempt_token=lease.token,
+            error_details=exc.details,
+        )
+        logger.warning(
+            "ingest_job_revision_conflict",
+            job_id=str(job_id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            **exc.details,
+        )
+        raise
     except IngestionRunnerError as exc:
         if exc.error_code is ErrorCode.JOB_CANCELLED:
             await _mark_job_cancelled(job_id, attempt_token=lease.token)
@@ -1371,6 +1497,21 @@ async def process_ingest_job(job_id: UUID) -> None:
         await _mark_job_cancelled(job_id, attempt_token=lease.token)
         logger.info("ingest_job_cancelled_during_finalization", job_id=str(job_id))
         raise
+    except _RevisionConflictError as exc:
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=ErrorCode.REVISION_CONFLICT,
+            attempt_token=lease.token,
+            error_details=exc.details,
+        )
+        logger.warning(
+            "ingest_job_revision_conflict",
+            job_id=str(job_id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            **exc.details,
+        )
+        raise
     except Exception as exc:
         await _mark_job_failed(
             job_id,
@@ -1387,7 +1528,6 @@ async def process_ingest_job(job_id: UUID) -> None:
 
     if finalized:
         logger.info("ingest_job_succeeded", job_id=str(job_id))
-
 
 
 async def recover_incomplete_ingest_jobs() -> list[UUID]:

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -41,6 +41,7 @@ _JOB_TYPE_VALUES = tuple(job_type.value for job_type in JobType)
 _JOB_STATUS_VALUES = tuple(status.value for status in JobStatus)
 _JOB_ERROR_CODE_VALUES = tuple(error_code.value for error_code in ErrorCode)
 _PROFILE_REQUIRED_JOB_TYPE_VALUES = (JobType.INGEST.value, JobType.REPROCESS.value)
+_BASE_REQUIRED_JOB_TYPE_VALUES = (JobType.REPROCESS.value,)
 
 
 def _sql_in_list(values: tuple[str, ...]) -> str:
@@ -85,6 +86,16 @@ class Job(Base):
             "OR extraction_profile_id IS NOT NULL",
             name="ck_jobs_ingest_extraction_profile_required",
         ),
+        CheckConstraint(
+            "job_type NOT IN "
+            f"({_sql_in_list(_BASE_REQUIRED_JOB_TYPE_VALUES)}) "
+            "OR base_revision_id IS NOT NULL",
+            name="ck_jobs_reprocess_base_revision_required",
+        ),
+        CheckConstraint(
+            f"job_type != '{JobType.INGEST.value}' OR base_revision_id IS NULL",
+            name="ck_jobs_ingest_base_revision_forbidden",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -114,6 +125,19 @@ class Job(Base):
             "Immutable extraction profile identifier. Nullable only during the "
             "expand/rollback window; persisted ingest/reprocess jobs require a "
             "profile and a future contract migration can enforce NOT NULL."
+        ),
+    )
+    base_revision_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "drawing_revisions.id",
+            name="fk_jobs_base_revision_id_drawing_revisions",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        index=True,
+        comment=(
+            "Pinned latest finalized drawing revision captured when a reprocess "
+            "job was created. Null for initial ingest jobs."
         ),
     )
     job_type: Mapped[str] = mapped_column(

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -26,6 +26,13 @@ class JobRead(BaseModel):
             "require a profile and a future contract migration can enforce non-null."
         ),
     )
+    base_revision_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Pinned latest finalized drawing revision captured when a reprocess "
+            "job was created. Null for initial ingest jobs."
+        ),
+    )
     job_type: JobType = Field(..., description="Job type")
     status: JobStatus = Field(..., description="Job status")
     attempts: int = Field(..., ge=0, description="Current attempt count")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -230,7 +230,20 @@ Reprocessing a file always creates a new drawing revision from the original
 immutable `file_id`; it never overwrites the previous revision. The new revision
 records the adapter version used for the run and the `extraction_profile_id`
 that defined the extraction settings so later jobs and audits can reproduce the
-result.
+result. Each reprocess job also captures the finalized base revision in
+`jobs.base_revision_id`.
+
+The reprocess path uses the same optimistic revision guardrail as changeset
+apply, but at request and finalization time instead of edit apply time:
+
+- if `POST /v1/projects/{project_id}/files/{file_id}/reprocess` finds no
+  finalized base revision, it returns `409 REVISION_CONFLICT`, creates no job,
+  and enqueues nothing
+- worker finalization re-checks that `jobs.base_revision_id` still matches the
+  current finalized revision; if not, the job fails with `REVISION_CONFLICT`
+  and commits no new revision, outputs, artifacts, or storage writes
+- retrying a `REVISION_CONFLICT` reprocess job returns the unchanged failed job
+  and does not enqueue a new attempt
 
 ## Original File Policy
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -684,7 +684,8 @@ codes:
 - `STORAGE_FAILED` - read/write/link/checksum failure
 - `DB_CONFLICT` - optimistic concurrency or unique violation
 - `IDEMPOTENCY_CONFLICT` - duplicate idempotency key is in progress or mapped to a different request fingerprint
-- `REVISION_CONFLICT` - changeset base revision is stale at apply time
+- `REVISION_CONFLICT` - changeset or reprocess base revision is stale at
+  apply/request/finalization time
 - `JOB_CANCELLED` - cancelled by user before completion
 - `INTERNAL_ERROR` - unhandled exception or internal publish/worker failure
 
@@ -718,6 +719,8 @@ New codes require a docs change in this file.
 - Retry is only for failed work. A retry attempt may replace staged attempt
   data, but it does not overwrite or mutate already committed artifacts from a
   different completed job path.
+- Retrying a job that failed with `REVISION_CONFLICT` must return the unchanged
+  failed job and must not enqueue a new attempt.
 - Attempt-local staging is mutable until commit, but staged rows/objects are not
   authoritative product records. Only the atomic finalization step may publish
   new append-only records, and cancellation before that step must leave no new
@@ -954,6 +957,8 @@ Probe rules:
 - Reprocessing is not an in-place rerun. Reprocessing creates a new drawing
   revision from an existing `file_id`, records the `extraction_profile_id` used
   for the run, and records the adapter name/version that produced the result.
+- Reprocess jobs also record the finalized base revision they were created
+  against in `jobs.base_revision_id`.
 - The prior revision remains available for lineage, comparison, and audit even
   when the newer reprocessed revision supersedes it.
 - Reprocess API contract: `POST /v1/projects/{project_id}/files/{file_id}/reprocess`
@@ -962,11 +967,18 @@ Probe rules:
   - when `extraction_profile_id` is provided, it must resolve within the
     project before the request claims idempotency or creates a new job
   - the server creates a new ingestion/reprocessing job bound to `project_id`,
-    `file_id`, and the resolved `extraction_profile_id`
+    `file_id`, the resolved `extraction_profile_id`, and the current finalized
+    base revision as `jobs.base_revision_id`
+  - if the file has no finalized base revision yet, the request fails with `409`
+    `REVISION_CONFLICT`, creates no job, and enqueues nothing
   - successful completion creates a new drawing revision rather than mutating
     the previous revision in place
   - the resulting revision must expose adapter version, extraction profile, and
     predecessor/superseded lineage metadata
+  - worker finalization must re-check that `jobs.base_revision_id` still matches
+    the current finalized revision; if stale, the job fails with
+    `REVISION_CONFLICT`, commits no outputs/artifacts/storage writes, and emits
+    conflict details including base/current revision ids and sequences
   - during the expand/rollback window for this contract, `jobs.extraction_profile_id`
     may remain nullable even though file initial lineage and resolved reprocess
     lineage are durable

--- a/tests/test_extraction_profiles.py
+++ b/tests/test_extraction_profiles.py
@@ -17,11 +17,23 @@ from sqlalchemy import select, text
 
 import app.api.v1.files as files_api
 import app.db.session as session_module
+import app.jobs.worker as worker_module
 from app.models.extraction_profile import ExtractionProfile
 from app.models.job import Job
 from app.schemas.extraction_profile import ExtractionProfileCreate
 from app.schemas.job import JobRead
 from tests.conftest import requires_database
+from tests.test_jobs import _build_fake_ingest_payload
+
+
+@pytest.fixture(autouse=True)
+def fake_ingestion_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch worker ingestion with a deterministic fake runner payload."""
+
+    async def _fake_run_ingestion(request: Any) -> Any:
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
 
 
 async def _create_project(async_client: httpx.AsyncClient) -> dict[str, Any]:
@@ -74,6 +86,16 @@ async def _get_extraction_profile(profile_id: uuid.UUID) -> ExtractionProfile:
 
     assert profile is not None
     return profile
+
+
+async def _finalize_initial_revision(file_id: str) -> Job:
+    """Process the initial ingest job so reprocess has a finalized base."""
+
+    initial_job = (await _get_jobs_for_file(file_id))[0]
+    await worker_module.process_ingest_job(initial_job.id)
+
+    refreshed_jobs = await _get_jobs_for_file(file_id)
+    return next(job for job in refreshed_jobs if job.id == initial_job.id)
 
 
 @pytest.fixture
@@ -136,8 +158,7 @@ class TestExtractionProfiles:
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
-        original_jobs = await _get_jobs_for_file(str(uploaded["id"]))
-        original_job = original_jobs[0]
+        original_job = await _finalize_initial_revision(str(uploaded["id"]))
 
         response = await async_client.post(
             f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
@@ -148,8 +169,9 @@ class TestExtractionProfiles:
         payload = response.json()
         assert payload["file_id"] == uploaded["id"]
         assert payload["project_id"] == project["id"]
-        assert payload["job_type"] == "ingest"
+        assert payload["job_type"] == "reprocess"
         assert payload["status"] == "pending"
+        assert payload["base_revision_id"] is not None
         assert payload["extraction_profile_id"] == str(original_job.extraction_profile_id)
 
         jobs = await _get_jobs_for_file(str(uploaded["id"]))
@@ -157,6 +179,7 @@ class TestExtractionProfiles:
         assert jobs[0].id == original_job.id
         assert jobs[0].extraction_profile_id == original_job.extraction_profile_id
         assert jobs[1].id != original_job.id
+        assert jobs[1].job_type == "reprocess"
         assert jobs[1].extraction_profile_id == original_job.extraction_profile_id
 
     async def test_reprocess_creates_new_profile_from_payload(
@@ -172,8 +195,7 @@ class TestExtractionProfiles:
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
-        original_jobs = await _get_jobs_for_file(str(uploaded["id"]))
-        original_job = original_jobs[0]
+        original_job = await _finalize_initial_revision(str(uploaded["id"]))
 
         response = await async_client.post(
             f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
@@ -195,6 +217,8 @@ class TestExtractionProfiles:
 
         assert response.status_code == 202
         payload = response.json()
+        assert payload["job_type"] == "reprocess"
+        assert payload["base_revision_id"] is not None
         assert payload["extraction_profile_id"] != str(original_job.extraction_profile_id)
 
         jobs = await _get_jobs_for_file(str(uploaded["id"]))
@@ -347,6 +371,7 @@ class TestExtractionProfiles:
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
+        await _finalize_initial_revision(str(uploaded["id"]))
 
         def _failing_enqueue(_: uuid.UUID) -> None:
             raise RuntimeError("broker exploded: amqp://user:secret@mq.internal/vhost")
@@ -390,6 +415,8 @@ class TestExtractionProfiles:
             "extraction_profile_id": str(failed_job.extraction_profile_id),
             "status": "failed",
         }
+        assert failed_job.job_type == "reprocess"
+        assert failed_job.base_revision_id is not None
         assert failed_job.status == "failed"
         assert failed_job.error_code == "INTERNAL_ERROR"
         assert failed_job.error_message == "Failed to enqueue ingest job"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 
 import app.api.v1.files as files_api
 import app.db.session as session_module
+import app.jobs.worker as worker_module
 from app.core.config import settings
 from app.core.exceptions import raise_not_found
 from app.models.file import File as FileModel
@@ -23,6 +24,7 @@ from app.models.job import Job
 from app.models.project import Project
 from app.storage import LocalFilesystemStorage, StoredObjectMeta, get_storage
 from tests.conftest import requires_database
+from tests.test_jobs import _build_fake_ingest_payload
 
 
 @pytest_asyncio.fixture
@@ -56,6 +58,26 @@ async def _upload_file(
     )
     assert response.status_code == 201
     return cast(dict[str, Any], response.json())
+
+
+async def _get_job_for_file(file_id: str) -> Job:
+    """Load the single current job for a newly uploaded file."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        return (
+            await session.execute(select(Job).where(Job.file_id == uuid.UUID(file_id)))
+        ).scalar_one()
+
+
+async def _finalize_initial_revision(file_id: str) -> Job:
+    """Process the initial ingest job so reprocess has a finalized base."""
+
+    initial_job = await _get_job_for_file(file_id)
+    await worker_module.process_ingest_job(initial_job.id)
+    return await _get_job_for_file(file_id)
 
 
 async def _mark_file_deleted(file_id: str) -> None:
@@ -203,6 +225,15 @@ class LocalChecksumMismatchStorage(LocalFilesystemStorage):
 @requires_database
 class TestProjectFiles:
     """Tests for project file upload and retrieval endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def _fake_ingestion_runner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch worker ingestion with a deterministic fake runner payload."""
+
+        async def _fake_run_ingestion(request: Any) -> Any:
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
 
     @pytest.fixture(autouse=True)
     def _stub_enqueue_ingest_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -456,6 +487,7 @@ class TestProjectFiles:
             content=b"%PDF-1.7\ninitial",
             media_type="application/pdf",
         )
+        await _finalize_initial_revision(str(uploaded["id"]))
 
         response = await async_client.post(
             f"/v1/projects/{created_project['id']}/files/{uploaded['id']}/reprocess",
@@ -649,6 +681,7 @@ class TestProjectFiles:
             content=b"%PDF-1.7\ndetail",
             media_type="application/pdf",
         )
+        await _finalize_initial_revision(str(uploaded["id"]))
 
         response = await async_client.post(
             f"/v1/projects/{created_project['id']}/files/{uploaded['id']}/reprocess",

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -15,6 +15,7 @@ from sqlalchemy import func, select
 import app.api.v1.files as files_api
 import app.api.v1.jobs as jobs_api
 import app.db.session as session_module
+import app.jobs.worker as worker_module
 from app.api.idempotency import (
     IdempotencyReservation,
     build_idempotency_fingerprint,
@@ -24,10 +25,14 @@ from app.api.idempotency import (
     replay_idempotency,
 )
 from app.core.config import settings
+from app.core.errors import ErrorCode
+from app.jobs.worker import process_ingest_job
+from app.models.drawing_revision import DrawingRevision
 from app.models.idempotency_key import IdempotencyKey, IdempotencyStatus
 from app.models.job import Job
 from app.models.project import Project
 from tests.conftest import requires_database
+from tests.test_jobs import _build_fake_ingest_payload
 
 
 def _headers(idempotency_key: str | None) -> dict[str, str]:
@@ -119,6 +124,16 @@ def _set_idempotency_hash_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "idempotency_key_hash_secret", "test-idempotency-secret")
 
 
+@pytest.fixture(autouse=True)
+def _fake_ingestion_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch worker ingestion with a deterministic fake runner payload."""
+
+    async def _fake_run_ingestion(request: Any) -> Any:
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+
+
 async def _create_project(
     async_client: httpx.AsyncClient,
     *,
@@ -190,6 +205,43 @@ async def _get_job_for_file(file_id: str) -> Job:
         ).scalar_one()
 
 
+async def _get_job(job_id: str | uuid.UUID) -> Job:
+    """Return the persisted job by identifier."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+    async with session_maker() as session:
+        job = await session.get(Job, uuid.UUID(str(job_id)))
+
+    assert job is not None
+    return job
+
+
+async def _get_file_revisions(file_id: str) -> list[DrawingRevision]:
+    """Return drawing revisions for a file in revision order."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+    async with session_maker() as session:
+        return list(
+            (
+                await session.execute(
+                    select(DrawingRevision)
+                    .where(DrawingRevision.source_file_id == uuid.UUID(file_id))
+                    .order_by(DrawingRevision.revision_sequence, DrawingRevision.id)
+                )
+            ).scalars()
+        )
+
+
+async def _finalize_initial_revision(file_id: str) -> Job:
+    """Process the initial ingest job so reprocess has a finalized base."""
+
+    initial_job = await _get_job_for_file(file_id)
+    await process_ingest_job(initial_job.id)
+    return await _get_job(initial_job.id)
+
+
 async def _update_job_status(job_id: str, *, status_value: str) -> None:
     """Mutate a persisted job status for replay assertions."""
 
@@ -202,7 +254,12 @@ async def _update_job_status(job_id: str, *, status_value: str) -> None:
         await session.commit()
 
 
-async def _mark_job_failed(job_id: str) -> None:
+async def _mark_job_failed(
+    job_id: str,
+    *,
+    error_code: str | None = None,
+    error_message: str = "failed",
+) -> None:
     """Place a persisted job into the failed state for retry tests."""
 
     session_maker = session_module.AsyncSessionLocal
@@ -211,7 +268,8 @@ async def _mark_job_failed(job_id: str) -> None:
         job = await session.get(Job, uuid.UUID(job_id))
         assert job is not None
         job.status = "failed"
-        job.error_message = "failed"
+        job.error_code = error_code
+        job.error_message = error_message
         await session.commit()
 
 
@@ -636,17 +694,26 @@ class TestEndpointIdempotency:
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """POST /reprocess should replay the original 202 job snapshot for the same key."""
 
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
+
+        async def _fake_run_ingestion(request: Any) -> Any:
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+
         project = cast(dict[str, Any], (await _create_project(async_client)).json())
         uploaded = cast(
             dict[str, Any],
             (await _upload_pdf(async_client, project_id=project["id"])).json(),
         )
+        initial_job = await _get_job_for_file(uploaded["id"])
+        await process_ingest_job(initial_job.id)
         key = "file-reprocess-1"
         payload = {"extraction_profile": {"profile_version": "v0.1"}}
 
@@ -656,7 +723,21 @@ class TestEndpointIdempotency:
             headers=_headers(key),
         )
         assert first.status_code == 202
-        await _update_job_status(first.json()["id"], status_value="running")
+        original_base_revision_id = first.json()["base_revision_id"]
+        assert first.json()["job_type"] == "reprocess"
+        assert original_base_revision_id is not None
+
+        reprocess_job = await _get_job(first.json()["id"])
+        assert reprocess_job.base_revision_id == uuid.UUID(original_base_revision_id)
+
+        await process_ingest_job(reprocess_job.id)
+
+        revisions = await _get_file_revisions(uploaded["id"])
+        assert [revision.revision_sequence for revision in revisions] == [1, 2]
+        assert str(revisions[-1].id) != original_base_revision_id
+
+        updated_reprocess_job = await _get_job(reprocess_job.id)
+        assert updated_reprocess_job.base_revision_id == uuid.UUID(original_base_revision_id)
 
         second = await async_client.post(
             f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
@@ -666,7 +747,50 @@ class TestEndpointIdempotency:
 
         assert second.status_code == 202
         assert second.json() == first.json()
+        assert second.json()["base_revision_id"] == original_base_revision_id
         assert await _job_count_for_file(uploaded["id"]) == 2
+
+    async def test_reprocess_missing_base_revision_returns_conflict_without_snapshot(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Missing base revisions should not persist a completed reprocess snapshot."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+        project = cast(dict[str, Any], (await _create_project(async_client)).json())
+        uploaded = cast(
+            dict[str, Any],
+            (await _upload_pdf(async_client, project_id=project["id"])).json(),
+        )
+        key = "file-reprocess-missing-base-1"
+        payload = {"extraction_profile": {"profile_version": "v0.1"}}
+
+        first = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json=payload,
+            headers=_headers(key),
+        )
+        second = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json=payload,
+            headers=_headers(key),
+        )
+
+        assert first.status_code == 409
+        assert first.json() == {
+            "error": {
+                "code": "REVISION_CONFLICT",
+                "message": "Reprocess requires a finalized base revision.",
+                "details": None,
+            }
+        }
+        assert second.status_code == 409
+        assert second.json() == first.json()
+        assert await _get_idempotency_record_or_none(key) is None
 
     async def test_reprocess_invalid_extraction_profile_replays_original_not_found(
         self,
@@ -720,6 +844,7 @@ class TestEndpointIdempotency:
             dict[str, Any],
             (await _upload_pdf(async_client, project_id=project["id"])).json(),
         )
+        await _finalize_initial_revision(uploaded["id"])
         key = "file-reprocess-enqueue-failure-1"
         payload = {"extraction_profile": {"profile_version": "v0.1"}}
 
@@ -813,6 +938,51 @@ class TestEndpointIdempotency:
         assert second.status_code == 202
         assert second.json() == first.json()
         assert len(enqueued_job_ids) == enqueued_before_retry + 1
+
+    async def test_retry_revision_conflict_replays_original_failed_snapshot_without_enqueue(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """REVISION_CONFLICT retries should replay the unchanged failed job snapshot."""
+
+        _ = self
+        _ = cleanup_projects
+        project = cast(dict[str, Any], (await _create_project(async_client)).json())
+        uploaded = cast(
+            dict[str, Any],
+            (await _upload_pdf(async_client, project_id=project["id"])).json(),
+        )
+
+        def _record_retry_enqueue(job_id: uuid.UUID) -> None:
+            enqueued_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(jobs_api, "enqueue_ingest_job", _record_retry_enqueue)
+
+        job = await _get_job_for_file(uploaded["id"])
+        await _mark_job_failed(
+            str(job.id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            error_message="Reprocess base revision became stale before finalization.",
+        )
+        key = "job-retry-revision-conflict-1"
+        enqueued_before_retry = len(enqueued_job_ids)
+
+        first = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=_headers(key))
+        second = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=_headers(key))
+        record = await _get_idempotency_record(key)
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json() == first.json()
+        assert first.json()["status"] == "failed"
+        assert first.json()["error_code"] == ErrorCode.REVISION_CONFLICT.value
+        assert len(enqueued_job_ids) == enqueued_before_retry
+        assert record.status == IdempotencyStatus.COMPLETED.value
+        assert record.response_status_code == 202
+        assert record.response_body_json == first.json()
 
     async def test_retry_enqueue_failure_replays_sanitized_error_snapshot(
         self,

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -635,7 +635,7 @@ class TestIngestOutputPersistence:
         cleanup_projects: None,
         enqueued_job_ids: list[str],
     ) -> None:
-        """Concurrent reprocess runs should still persist a linear revision chain."""
+        """Concurrent reprocess runs should leave one success and one stale conflict."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
@@ -661,9 +661,34 @@ class TestIngestOutputPersistence:
         second_job = await _get_job(_as_uuid(second_reprocess_response.json()["id"]))
         third_job = await _get_job(_as_uuid(third_reprocess_response.json()["id"]))
 
-        await asyncio.gather(
+        results = await asyncio.gather(
             process_ingest_job(second_job.id),
             process_ingest_job(third_job.id),
+            return_exceptions=True,
+        )
+
+        assert sum(result is None for result in results) == 1
+        assert (
+            sum(
+                isinstance(result, worker_module._RevisionConflictError)
+                for result in results
+            )
+            == 1
+        )
+
+        second_job = await _get_job(second_job.id)
+        third_job = await _get_job(third_job.id)
+        succeeded_reprocess_jobs = [
+            job for job in (second_job, third_job) if job.status == "succeeded"
+        ]
+        failed_reprocess_jobs = [job for job in (second_job, third_job) if job.status == "failed"]
+
+        assert len(succeeded_reprocess_jobs) == 1
+        assert len(failed_reprocess_jobs) == 1
+        assert failed_reprocess_jobs[0].error_code == ErrorCode.REVISION_CONFLICT.value
+        assert (
+            failed_reprocess_jobs[0].error_message
+            == "Reprocess base revision became stale before finalization."
         )
 
         (
@@ -673,45 +698,44 @@ class TestIngestOutputPersistence:
             generated_artifacts,
         ) = await _load_project_outputs(project["id"])
 
-        assert len(adapter_outputs) == 3
-        assert len(drawing_revisions) == 3
-        assert len(validation_reports) == 3
-        assert len(generated_artifacts) == 3
+        assert len(adapter_outputs) == 2
+        assert len(drawing_revisions) == 2
+        assert len(validation_reports) == 2
+        assert len(generated_artifacts) == 2
 
-        first_revision, second_revision, _third_revision = drawing_revisions
+        first_revision, second_revision = drawing_revisions
         artifacts_by_revision_id = {
             artifact.drawing_revision_id: artifact for artifact in generated_artifacts
         }
         first_artifact = artifacts_by_revision_id[first_revision.id]
         second_artifact = artifacts_by_revision_id[second_revision.id]
-        third_artifact = artifacts_by_revision_id[drawing_revisions[2].id]
-        assert [revision.revision_sequence for revision in drawing_revisions] == [1, 2, 3]
+        assert [revision.revision_sequence for revision in drawing_revisions] == [1, 2]
         assert [revision.predecessor_revision_id for revision in drawing_revisions] == [
             None,
             first_revision.id,
-            second_revision.id,
         ]
         assert [revision.revision_kind for revision in drawing_revisions] == [
             "ingest",
             "reprocess",
-            "reprocess",
         ]
 
-        expected_job_ids = {first_job.id, second_job.id, third_job.id}
+        expected_job_ids = {first_job.id, succeeded_reprocess_jobs[0].id}
         assert {output.source_job_id for output in adapter_outputs} == expected_job_ids
         assert {report.source_job_id for report in validation_reports} == expected_job_ids
         assert {artifact.job_id for artifact in generated_artifacts} == expected_job_ids
+        assert failed_reprocess_jobs[0].id not in {
+            output.source_job_id for output in adapter_outputs
+        }
         assert first_artifact.predecessor_artifact_id is None
         assert second_artifact.predecessor_artifact_id == first_artifact.id
-        assert third_artifact.predecessor_artifact_id == second_artifact.id
 
-    async def test_reprocess_before_initial_finalization_fails_without_outputs(
+    async def test_reprocess_without_finalized_base_returns_conflict_without_job(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
     ) -> None:
-        """A reprocess cannot finalize before the initial revision exists."""
+        """Reprocess creation should fail before enqueue when no finalized base exists."""
         _ = self
         _ = cleanup_projects
 
@@ -719,38 +743,33 @@ class TestIngestOutputPersistence:
         uploaded = await _upload_file(async_client, project["id"])
         initial_job = await _get_job_for_file(str(uploaded["id"]))
 
-        first_reprocess_response = await async_client.post(
+        reprocess_response = await async_client.post(
             f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
             json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
         )
-        assert first_reprocess_response.status_code == 202
+        assert reprocess_response.status_code == 409
+        assert reprocess_response.json() == {
+            "error": {
+                "code": "REVISION_CONFLICT",
+                "message": "Reprocess requires a finalized base revision.",
+                "details": None,
+            }
+        }
+        assert enqueued_job_ids == [str(initial_job.id)]
 
-        second_reprocess_response = await async_client.post(
-            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
-            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
-        )
-        assert second_reprocess_response.status_code == 202
-
-        blocked_reprocess_job = await _get_job(_as_uuid(first_reprocess_response.json()["id"]))
-        _unused_reprocess_job = await _get_job(_as_uuid(second_reprocess_response.json()["id"]))
-        assert enqueued_job_ids == [
-            str(initial_job.id),
-            str(blocked_reprocess_job.id),
-            str(_unused_reprocess_job.id),
-        ]
-
-        with pytest.raises(
-            ValueError,
-            match="Reprocess ingest job cannot finalize before a predecessor revision exists",
-        ):
-            await process_ingest_job(blocked_reprocess_job.id)
-
-        failed_reprocess_job = await _get_job(blocked_reprocess_job.id)
-        assert failed_reprocess_job.status == "failed"
-        assert failed_reprocess_job.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert (
-            failed_reprocess_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
-        )
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_jobs = list(
+                (
+                    await session.execute(
+                        select(Job)
+                        .where(Job.file_id == initial_job.file_id)
+                        .order_by(Job.created_at, Job.id)
+                    )
+                ).scalars()
+            )
+        assert [job.id for job in persisted_jobs] == [initial_job.id]
 
         (
             adapter_outputs,
@@ -763,8 +782,93 @@ class TestIngestOutputPersistence:
         assert validation_reports == []
         assert generated_artifacts == []
 
+    async def test_stale_reprocess_finalization_fails_without_storage_or_extra_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A stale reprocess base should fail before storage writes and append no outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        @dataclass(frozen=True, slots=True)
+        class _StoredOverlay:
+            key: str
+            storage_uri: str
+            size_bytes: int
+            checksum_sha256: str
+
+        class _RecordingStorage:
+            def __init__(self) -> None:
+                self.put_calls: list[str] = []
+                self.delete_calls: list[tuple[str, str]] = []
+
+            async def put(self, key: str, payload: bytes, *, immutable: bool) -> _StoredOverlay:
+                assert immutable is True
+                self.put_calls.append(key)
+                return _StoredOverlay(
+                    key=key,
+                    storage_uri=f"memory://{key}",
+                    size_bytes=len(payload),
+                    checksum_sha256="0" * 64,
+                )
+
+            async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+                self.delete_calls.append((key, storage_uri))
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        storage = _RecordingStorage()
+        monkeypatch.setattr(worker_module, "get_storage", lambda: storage)
+
         await process_ingest_job(initial_job.id)
-        initial_job = await _get_job(initial_job.id)
+
+        (
+            adapter_outputs,
+            drawing_revisions,
+            _validation_reports,
+            _generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+        base_revision = drawing_revisions[0]
+        assert len(adapter_outputs) == 1
+
+        first_reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        second_reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert first_reprocess_response.status_code == 202
+        assert second_reprocess_response.status_code == 202
+
+        first_reprocess_job = await _get_job(_as_uuid(first_reprocess_response.json()["id"]))
+        second_reprocess_job = await _get_job(_as_uuid(second_reprocess_response.json()["id"]))
+        assert first_reprocess_job.job_type == "reprocess"
+        assert second_reprocess_job.job_type == "reprocess"
+        assert first_reprocess_job.base_revision_id == base_revision.id
+        assert second_reprocess_job.base_revision_id == base_revision.id
+
+        await process_ingest_job(first_reprocess_job.id)
+
+        (
+            adapter_outputs_before_stale,
+            drawing_revisions_before_stale,
+            validation_reports_before_stale,
+            generated_artifacts_before_stale,
+        ) = await _load_project_outputs(project["id"])
+        storage_put_calls_before_stale = list(storage.put_calls)
+
+        with pytest.raises(
+            worker_module._RevisionConflictError,
+            match=r"Reprocess base revision became stale before finalization\.",
+        ):
+            await process_ingest_job(second_reprocess_job.id)
 
         (
             adapter_outputs,
@@ -772,22 +876,60 @@ class TestIngestOutputPersistence:
             validation_reports,
             generated_artifacts,
         ) = await _load_project_outputs(project["id"])
-        assert len(adapter_outputs) == 1
-        assert len(drawing_revisions) == 1
-        assert len(validation_reports) == 1
-        assert len(generated_artifacts) == 1
-        assert adapter_outputs[0].source_job_id == initial_job.id
-        assert drawing_revisions[0].source_job_id == initial_job.id
-        assert drawing_revisions[0].revision_sequence == 1
-        assert drawing_revisions[0].predecessor_revision_id is None
-        assert drawing_revisions[0].revision_kind == "ingest"
-        _assert_debug_overlay_artifact(
-            generated_artifacts[0],
-            job=initial_job,
-            drawing_revision=drawing_revisions[0],
-            adapter_output=adapter_outputs[0],
-            predecessor_artifact_id=None,
+        current_revision = next(
+            revision
+            for revision in drawing_revisions
+            if revision.source_job_id == first_reprocess_job.id
         )
+        assert [row.id for row in adapter_outputs] == [
+            row.id for row in adapter_outputs_before_stale
+        ]
+        assert [row.id for row in drawing_revisions] == [
+            row.id for row in drawing_revisions_before_stale
+        ]
+        assert [row.id for row in validation_reports] == [
+            row.id for row in validation_reports_before_stale
+        ]
+        assert [row.id for row in generated_artifacts] == [
+            row.id for row in generated_artifacts_before_stale
+        ]
+        assert second_reprocess_job.id not in {output.source_job_id for output in adapter_outputs}
+        assert second_reprocess_job.id not in {
+            revision.source_job_id for revision in drawing_revisions
+        }
+        assert second_reprocess_job.id not in {
+            report.source_job_id for report in validation_reports
+        }
+        assert second_reprocess_job.id not in {artifact.job_id for artifact in generated_artifacts}
+        failed_reprocess_job = await _get_job(second_reprocess_job.id)
+        assert failed_reprocess_job.status == "failed"
+        assert failed_reprocess_job.error_code == ErrorCode.REVISION_CONFLICT.value
+        assert (
+            failed_reprocess_job.error_message
+            == "Reprocess base revision became stale before finalization."
+        )
+        assert failed_reprocess_job.attempt_token is None
+        assert failed_reprocess_job.attempt_lease_expires_at is None
+
+        job_events = await _load_job_events(second_reprocess_job.id)
+        assert job_events[-1].data_json == {
+            "status": "failed",
+            "error_code": ErrorCode.REVISION_CONFLICT.value,
+            "error_message": "Reprocess base revision became stale before finalization.",
+            "details": {
+                "base_revision_id": str(base_revision.id),
+                "base_revision_sequence": 1,
+                "current_revision_id": str(current_revision.id),
+                "current_revision_sequence": 2,
+            },
+        }
+
+        assert len(adapter_outputs) == 2
+        assert len(drawing_revisions) == 2
+        assert len(validation_reports) == 2
+        assert len(generated_artifacts) == 2
+        assert storage.put_calls == storage_put_calls_before_stale
+        assert storage.delete_calls == []
 
     async def test_process_ingest_job_cancelled_before_finalization_creates_no_outputs(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,6 +6,7 @@ import types
 import uuid
 from collections.abc import Callable
 from contextlib import suppress
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -246,6 +247,7 @@ async def _update_job(
     attempts: int | None = None,
     max_attempts: int | None = None,
     cancel_requested: bool | None = None,
+    error_code: str | None = None,
     error_message: str | None = None,
 ) -> Job:
     """Update and return a persisted job for test setup."""
@@ -264,6 +266,8 @@ async def _update_job(
             job.max_attempts = max_attempts
         if cancel_requested is not None:
             job.cancel_requested = cancel_requested
+        if error_code is not None:
+            job.error_code = error_code
 
         if error_message is not None:
             job.error_message = error_message
@@ -1553,16 +1557,15 @@ class TestJobs:
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
-        job = await _get_job_for_file(str(uploaded["id"]))
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+        reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert reprocess_response.status_code == 202
+        job = await _get_job(uuid.UUID(reprocess_response.json()["id"]))
         enqueued_job_ids.clear()
-
-        session_maker = session_module.AsyncSessionLocal
-        assert session_maker is not None
-        async with session_maker() as session:
-            persisted_job = await session.get(Job, job.id)
-            assert persisted_job is not None
-            persisted_job.job_type = "reprocess"
-            await session.commit()
 
         requeued = await worker_module.recover_incomplete_ingest_jobs()
 
@@ -1575,6 +1578,77 @@ class TestJobs:
         assert updated_job.job_type == "reprocess"
         assert updated_job.status == "succeeded"
         assert updated_job.attempts == 1
+
+    async def test_reprocess_job_persists_base_revision_snapshot(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Reprocess creation should persist job_type and the latest finalized base revision."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+
+        assert response.status_code == 202
+        assert response.json()["job_type"] == "reprocess"
+        assert response.json()["base_revision_id"] is not None
+
+        reprocess_job = await _get_job(uuid.UUID(response.json()["id"]))
+        assert reprocess_job.job_type == "reprocess"
+        assert reprocess_job.base_revision_id == uuid.UUID(response.json()["base_revision_id"])
+
+    async def test_process_reprocess_job_rejects_payload_revision_kind_mismatch(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worker finalization should fail reprocess jobs whose payload kind drifts."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert response.status_code == 202
+        reprocess_job = await _get_job(uuid.UUID(response.json()["id"]))
+
+        async def _run_ingestion_with_wrong_kind(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return replace(_build_fake_ingest_payload(request), revision_kind="ingest")
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_ingestion_with_wrong_kind)
+
+        with pytest.raises(
+            worker_module._RevisionConflictError,
+            match=r"Ingest job revision kind changed before finalization\.",
+        ):
+            await worker_module.process_ingest_job(reprocess_job.id)
+
+        failed_job = await _get_job(reprocess_job.id)
+        assert failed_job.status == "failed"
+        assert failed_job.error_code == ErrorCode.REVISION_CONFLICT.value
+        assert failed_job.error_message == "Ingest job revision kind changed before finalization."
 
     async def test_recover_incomplete_ingest_jobs_requeues_orphaned_running_jobs(
         self,
@@ -2124,6 +2198,54 @@ class TestJobs:
         assert unchanged.attempts == 3
         assert unchanged.max_attempts == 3
 
+    async def test_retry_job_noops_for_revision_conflict_failure(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should not requeue jobs that already failed with REVISION_CONFLICT."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+            retried_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            jobs_api,
+            "enqueue_ingest_job",
+            _fake_retry_enqueue,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            error_message="Reprocess base revision became stale before finalization.",
+        )
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 202
+        assert retried_job_ids == []
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "failed"
+        assert unchanged.error_code == ErrorCode.REVISION_CONFLICT.value
+        assert (
+            unchanged.error_message
+            == "Reprocess base revision became stale before finalization."
+        )
+
     async def test_retry_job_is_terminal_no_op_for_cancelled_job(
         self,
         async_client: httpx.AsyncClient,
@@ -2424,7 +2546,14 @@ class TestJobs:
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
-        job = await _get_job_for_file(str(uploaded["id"]))
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+        reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert reprocess_response.status_code == 202
+        job = await _get_job(uuid.UUID(reprocess_response.json()["id"]))
 
         session_maker = session_module.AsyncSessionLocal
         assert session_maker is not None

--- a/tests/test_jobs_base_revision_migration.py
+++ b/tests/test_jobs_base_revision_migration.py
@@ -1,0 +1,514 @@
+"""Guard tests for the jobs base-revision pin migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import text
+
+import app.db.session as session_module
+from tests.conftest import requires_database
+
+
+def _load_jobs_base_revision_migration() -> Any:
+    """Load the jobs base-revision migration module directly from disk."""
+
+    migration_path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "2026_05_11_0012_add_jobs_base_revision_id.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_11_0012_add_jobs_base_revision_id",
+        migration_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_pre_0012_schema(sync_conn: sa.Connection) -> None:
+    """Create the minimal pre-0012 schema needed to exercise the migration."""
+
+    metadata = sa.MetaData()
+    sa.Table(
+        "files",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("initial_job_id", sa.Uuid(), nullable=False),
+    )
+    sa.Table(
+        "drawing_revisions",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("file_id", sa.Uuid(), nullable=False),
+    )
+    sa.Table(
+        "jobs",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column("file_id", sa.Uuid(), nullable=False),
+        sa.Column("job_type", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    metadata.create_all(sync_conn)
+
+
+def _run_migration_upgrade(sync_conn: sa.Connection, migration: Any) -> None:
+    """Run the migration upgrade against a live connection."""
+
+    migration_context = MigrationContext.configure(sync_conn)
+    migration.op = Operations(migration_context)
+    migration.upgrade()
+
+
+def _run_migration_downgrade(sync_conn: sa.Connection, migration: Any) -> None:
+    """Run the migration downgrade against a live connection."""
+
+    migration_context = MigrationContext.configure(sync_conn)
+    migration.op = Operations(migration_context)
+    migration.downgrade()
+
+
+async def _job_column_exists(conn: Any, schema_name: str, column_name: str) -> bool:
+    """Return whether the jobs table contains the requested column."""
+
+    result = await conn.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = :schema_name
+                  AND table_name = 'jobs'
+                  AND column_name = :column_name
+            )
+            """
+        ),
+        {"schema_name": schema_name, "column_name": column_name},
+    )
+    return cast(bool, result.scalar())
+
+
+async def _get_job_base_revision_constraints(conn: Any, schema_name: str) -> dict[str, bool]:
+    """Return base-revision check constraints and their validation state."""
+
+    rows = (
+        (
+            await conn.execute(
+                text(
+                    """
+                    SELECT con.conname, con.convalidated
+                    FROM pg_constraint AS con
+                    JOIN pg_class AS rel
+                      ON rel.oid = con.conrelid
+                    JOIN pg_namespace AS nsp
+                      ON nsp.oid = rel.relnamespace
+                    WHERE nsp.nspname = :schema_name
+                      AND rel.relname = 'jobs'
+                      AND con.conname IN (
+                          'ck_jobs_ingest_base_revision_forbidden',
+                          'ck_jobs_reprocess_base_revision_required'
+                      )
+                    ORDER BY con.conname ASC
+                    """
+                ),
+                {"schema_name": schema_name},
+            )
+        )
+        .mappings()
+        .all()
+    )
+    return {
+        cast(str, row["conname"]): cast(bool, row["convalidated"])
+        for row in rows
+    }
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_base_revision_migration_upgrade_allows_terminal_legacy_rows() -> None:
+    """Upgrade should preserve historical legacy rows while adding the new base-pin guards."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jbr_up_{uuid.uuid4().hex}"
+    migration = _load_jobs_base_revision_migration()
+    file_id = uuid.uuid4()
+    initial_job_id = uuid.uuid4()
+    legacy_terminal_job_id = uuid.uuid4()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0012_schema)
+
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO files (id, initial_job_id)
+                    VALUES (:id, :initial_job_id)
+                    """
+                ),
+                {"id": file_id, "initial_job_id": initial_job_id},
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (id, file_id, job_type, status, created_at)
+                    VALUES (:id, :file_id, :job_type, :status, :created_at)
+                    """
+                ),
+                [
+                    {
+                        "id": initial_job_id,
+                        "file_id": file_id,
+                        "job_type": "ingest",
+                        "status": "pending",
+                        "created_at": datetime(2026, 5, 11, tzinfo=UTC),
+                    },
+                    {
+                        "id": legacy_terminal_job_id,
+                        "file_id": file_id,
+                        "job_type": "ingest",
+                        "status": "succeeded",
+                        "created_at": datetime(2026, 5, 12, tzinfo=UTC),
+                    },
+                ],
+            )
+
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+            assert await _job_column_exists(conn, schema_name, "base_revision_id")
+            assert await _get_job_base_revision_constraints(conn, schema_name) == {
+                "ck_jobs_ingest_base_revision_forbidden": False,
+                "ck_jobs_reprocess_base_revision_required": False,
+            }
+
+            jobs = (
+                (
+                    await conn.execute(
+                        text(
+                            """
+                            SELECT id, job_type, status, base_revision_id
+                            FROM jobs
+                            ORDER BY created_at ASC, id ASC
+                            """
+                        )
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            assert [dict(row) for row in jobs] == [
+                {
+                    "id": initial_job_id,
+                    "job_type": "ingest",
+                    "status": "pending",
+                    "base_revision_id": None,
+                },
+                {
+                    "id": legacy_terminal_job_id,
+                    "job_type": "ingest",
+                    "status": "succeeded",
+                    "base_revision_id": None,
+                },
+            ]
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_base_revision_migration_upgrade_raises_for_pending_legacy_reprocess_rows(
+) -> None:
+    """Upgrade should refuse legacy queued reprocess rows that cannot be pinned safely."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jbr_guard_{uuid.uuid4().hex}"
+    migration = _load_jobs_base_revision_migration()
+    file_id = uuid.uuid4()
+    initial_job_id = uuid.uuid4()
+    legacy_pending_job_id = uuid.uuid4()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0012_schema)
+
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO files (id, initial_job_id)
+                    VALUES (:id, :initial_job_id)
+                    """
+                ),
+                {"id": file_id, "initial_job_id": initial_job_id},
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (id, file_id, job_type, status, created_at)
+                    VALUES (:id, :file_id, :job_type, :status, :created_at)
+                    """
+                ),
+                [
+                    {
+                        "id": initial_job_id,
+                        "file_id": file_id,
+                        "job_type": "ingest",
+                        "status": "pending",
+                        "created_at": datetime(2026, 5, 11, tzinfo=UTC),
+                    },
+                    {
+                        "id": legacy_pending_job_id,
+                        "file_id": file_id,
+                        "job_type": "ingest",
+                        "status": "running",
+                        "created_at": datetime(2026, 5, 12, tzinfo=UTC),
+                    },
+                ],
+            )
+
+        with pytest.raises(
+            RuntimeError,
+            match="legacy pre-#133 reprocess jobs",
+        ):
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+        async with engine.begin() as conn:
+            assert not await _job_column_exists(conn, schema_name, "base_revision_id")
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_base_revision_migration_downgrade_raises_for_pending_reprocess_jobs() -> None:
+    """Downgrade should refuse to drop stale-base fencing while reprocess work is active."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jbr_down_guard_{uuid.uuid4().hex}"
+    migration = _load_jobs_base_revision_migration()
+    file_id = uuid.uuid4()
+    initial_job_id = uuid.uuid4()
+    base_revision_id = uuid.uuid4()
+    reprocess_job_id = uuid.uuid4()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0012_schema)
+
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO files (id, initial_job_id)
+                    VALUES (:id, :initial_job_id)
+                    """
+                ),
+                {"id": file_id, "initial_job_id": initial_job_id},
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO drawing_revisions (id, file_id)
+                    VALUES (:id, :file_id)
+                    """
+                ),
+                {"id": base_revision_id, "file_id": file_id},
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (id, file_id, job_type, status, created_at)
+                    VALUES (:id, :file_id, :job_type, :status, :created_at)
+                    """
+                ),
+                {
+                    "id": initial_job_id,
+                    "file_id": file_id,
+                    "job_type": "ingest",
+                    "status": "succeeded",
+                    "created_at": datetime(2026, 5, 11, tzinfo=UTC),
+                },
+            )
+
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (
+                        id,
+                        file_id,
+                        job_type,
+                        status,
+                        created_at,
+                        base_revision_id
+                    ) VALUES (
+                        :id,
+                        :file_id,
+                        'reprocess',
+                        :status,
+                        :created_at,
+                        :base_revision_id
+                    )
+                    """
+                ),
+                {
+                    "id": reprocess_job_id,
+                    "file_id": file_id,
+                    "status": "pending",
+                    "created_at": datetime(2026, 5, 12, tzinfo=UTC),
+                    "base_revision_id": base_revision_id,
+                },
+            )
+
+        with pytest.raises(
+            RuntimeError,
+            match="Manual data-preserving rollback is required",
+        ):
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(
+                    lambda sync_conn: _run_migration_downgrade(sync_conn, migration)
+                )
+
+        async with engine.begin() as conn:
+            assert await _job_column_exists(conn, schema_name, "base_revision_id")
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_base_revision_migration_downgrade_drops_base_pin_without_active_reprocess_jobs(
+) -> None:
+    """Downgrade should remain rollback-safe after active reprocess work has drained."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jbr_down_{uuid.uuid4().hex}"
+    migration = _load_jobs_base_revision_migration()
+    file_id = uuid.uuid4()
+    initial_job_id = uuid.uuid4()
+    base_revision_id = uuid.uuid4()
+    reprocess_job_id = uuid.uuid4()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0012_schema)
+
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO files (id, initial_job_id)
+                    VALUES (:id, :initial_job_id)
+                    """
+                ),
+                {"id": file_id, "initial_job_id": initial_job_id},
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO drawing_revisions (id, file_id)
+                    VALUES (:id, :file_id)
+                    """
+                ),
+                {"id": base_revision_id, "file_id": file_id},
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (id, file_id, job_type, status, created_at)
+                    VALUES (:id, :file_id, :job_type, :status, :created_at)
+                    """
+                ),
+                {
+                    "id": initial_job_id,
+                    "file_id": file_id,
+                    "job_type": "ingest",
+                    "status": "succeeded",
+                    "created_at": datetime(2026, 5, 11, tzinfo=UTC),
+                },
+            )
+
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jobs (
+                        id,
+                        file_id,
+                        job_type,
+                        status,
+                        created_at,
+                        base_revision_id
+                    ) VALUES (
+                        :id,
+                        :file_id,
+                        'reprocess',
+                        :status,
+                        :created_at,
+                        :base_revision_id
+                    )
+                    """
+                ),
+                {
+                    "id": reprocess_job_id,
+                    "file_id": file_id,
+                    "status": "succeeded",
+                    "created_at": datetime(2026, 5, 12, tzinfo=UTC),
+                    "base_revision_id": base_revision_id,
+                },
+            )
+
+            await conn.run_sync(lambda sync_conn: _run_migration_downgrade(sync_conn, migration))
+
+            assert not await _job_column_exists(conn, schema_name, "base_revision_id")
+            assert await _get_job_base_revision_constraints(conn, schema_name) == {}
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))

--- a/tests/test_validation_report_api.py
+++ b/tests/test_validation_report_api.py
@@ -423,6 +423,7 @@ class TestValidationReportApi:
         next_job = _clone_model(
             job,
             id=uuid.uuid4(),
+            base_revision_id=drawing_revision.id,
             job_type="reprocess",
             status="succeeded",
             started_at=next_created_at,


### PR DESCRIPTION
Closes #133

## Summary
- persist `jobs.base_revision_id` for reprocess jobs and expose the captured base in job responses
- reject stale reprocess finalization with `REVISION_CONFLICT` before any outputs, artifacts, or storage writes commit
- repair the Alembic graph, add migration guards, and update idempotency/retry/docs coverage for the new contract

## Test plan
- [x] `uv run ruff check`
- [x] `uv run mypy app tests`
- [x] `uv run alembic heads`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_133_validation_20260511_180936_28603 uv run alembic upgrade head`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_133_validation_20260511_180936_28603 uv run pytest tests/test_jobs_base_revision_migration.py`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_133_validation_20260511_180936_28603 uv run pytest`

## Notes
- the old duplicate `2026_05_11_0010_add_job_attempt_leases.py` migration was renumbered to `2026_05_11_0011_add_job_attempt_leases.py` so #127/#132/#133 form a linear Alembic history