### PR TITLE
fix(ifc): normalize canonical entity envelope (#137)

### DIFF
--- a/app/ingestion/adapters/ifcopenshell.py
+++ b/app/ingestion/adapters/ifcopenshell.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib
 import importlib.metadata
 import importlib.util
@@ -702,15 +703,12 @@ def _extract_entity_payload(
             step_id_token=step_id_token,
         ),
         "provenance": _entity_provenance(
-            entity_id=preferred_id,
             ifc_type=ifc_type,
             global_id=global_id,
             step_id_token=step_id_token,
+            fallback_identity=preferred_id,
         ),
-        "confidence": {
-            "score": 0.4,
-            "basis": "semantic_ifc_metadata_only",
-        },
+        "confidence": _entity_confidence(),
         "drawing_revision_id": None,
         "source_file_id": None,
         "layout_ref": None,
@@ -763,7 +761,7 @@ def _finalize_entity_ids(raw_entities: Sequence[_RawEntity]) -> tuple[dict[str, 
         payload["entity_id"] = finalized_id
         provenance = payload.get("provenance")
         if isinstance(provenance, dict):
-            provenance["source_entity_ref"] = f"entities.{finalized_id}"
+            provenance["canonical_entity_ref"] = f"entities.{finalized_id}"
         finalized.append(payload)
     return tuple(finalized)
 
@@ -801,19 +799,95 @@ def _entity_properties(
     }
 
 
+def _entity_confidence() -> dict[str, JSONValue]:
+    return {
+        "score": 0.4,
+        "review_required": True,
+        "basis": "semantic_ifc_metadata_only",
+    }
+
+
 def _entity_provenance(
     *,
-    entity_id: str,
     ifc_type: str,
     global_id: str | None,
     step_id_token: str | None,
+    fallback_identity: str,
 ) -> dict[str, JSONValue]:
+    source_entity_ref = _entity_source_locator(
+        ifc_type=ifc_type,
+        global_id=global_id,
+        step_id_token=step_id_token,
+        fallback_identity=fallback_identity,
+    )
     return {
-        "source_entity_ref": f"entities.{entity_id}",
+        "origin": "adapter_normalized",
+        "adapter": _ADAPTER_KEY,
+        "source": source_entity_ref,
+        "source_entity_ref": source_entity_ref,
+        "source_identity": global_id or step_id_token or fallback_identity,
+        "normalized_source_hash": _normalized_source_hash(
+            ifc_type=ifc_type,
+            global_id=global_id,
+            step_id_token=step_id_token,
+            fallback_identity=fallback_identity,
+        ),
         "native_entity_type": ifc_type,
         "ifc_global_id": global_id,
         "ifc_step_id": step_id_token,
+        "extraction_path": ("semantic_extract",),
+        "notes": ("semantic_ifc_metadata_only",),
     }
+
+
+def _entity_source_locator(
+    *,
+    ifc_type: str,
+    global_id: str | None,
+    step_id_token: str | None,
+    fallback_identity: str,
+) -> str:
+    parts = [ifc_type]
+    if global_id is not None:
+        parts.append(f"global-id:{global_id}")
+    if step_id_token is not None:
+        parts.append(f"step-id:{step_id_token.removeprefix('#')}")
+    if len(parts) == 1:
+        parts.append(f"entity:{fallback_identity}")
+    return "ifc://" + "/".join(parts)
+
+
+def _normalized_source_hash(
+    *,
+    ifc_type: str,
+    global_id: str | None,
+    step_id_token: str | None,
+    fallback_identity: str,
+) -> str:
+    durable_source_ref = _normalized_source_locator(
+        ifc_type=ifc_type,
+        global_id=global_id,
+        step_id_token=step_id_token,
+        fallback_identity=fallback_identity,
+    )
+    return hashlib.sha256(durable_source_ref.encode("utf-8")).hexdigest()
+
+
+def _normalized_source_locator(
+    *,
+    ifc_type: str,
+    global_id: str | None,
+    step_id_token: str | None,
+    fallback_identity: str,
+) -> str:
+    parts = [ifc_type]
+    if global_id is not None:
+        parts.append(f"global-id:{global_id}")
+    elif step_id_token is not None:
+        parts.append(f"step-id:{step_id_token.removeprefix('#')}")
+    else:
+        parts.append(f"entity:{fallback_identity}")
+    return "ifc://" + "/".join(parts)
 
 
 def _extract_project_metadata(project: object | None) -> dict[str, JSONValue]:

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -129,7 +129,7 @@ Each entity record must include:
 - `geometry` - normalized geometry payload for the entity type
 - `properties` - normalized semantic properties and adapter-carried attributes
 - `provenance` - structured origin and extraction metadata
-- `confidence` - float in `[0, 1]`
+- `confidence` - float in `[0, 1]` or a structured object with at least `score`
 
 Version-field rule: `canonical_entity_schema_version` is revision-scoped and
 declares the canonical contract for the full revision payload. The
@@ -194,6 +194,12 @@ logic must not lose source identity.
 Entity identity must preserve source-native identity when available and also
 record a normalized source hash or equivalent fingerprint so dedup/re-ingestion
 logic can compare semantically identical entities across adapter passes.
+
+Entity provenance must carry a stable source locator or source-native identity
+when the adapter can provide one. Semantic-only envelopes such as IFC products
+may also include an adapter-normalized provenance object with fields like
+`source`, `source_entity_ref`, `source_identity`, and
+`normalized_source_hash`.
 
 For raster-derived entities, the canonical payload must also record page-scoped
 or view-scoped scale calibration metadata when used, because quantities are not

--- a/tests/ingestion_contract_harness.py
+++ b/tests/ingestion_contract_harness.py
@@ -310,6 +310,16 @@ def _assert_entity_confidence(confidence: JSONValue) -> None:
                 "Canonical entity confidence objects must include a numeric score."
             )
         score = float(score_value)
+        review_required = confidence.get("review_required")
+        if review_required is not None and not isinstance(review_required, bool):
+            raise AssertionError(
+                "Canonical entity confidence.review_required must be boolean when present."
+            )
+        basis = confidence.get("basis")
+        if basis is not None and (not isinstance(basis, str) or not basis.strip()):
+            raise AssertionError(
+                "Canonical entity confidence.basis must be non-empty when present."
+            )
     else:
         raise AssertionError("Canonical entities must include confidence metadata.")
 

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.machinery
 from collections.abc import Mapping
 from pathlib import Path
@@ -273,7 +274,24 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
     assert entities[0]["entity_type"] == "ifc_product"
     assert entities[0]["entity_schema_version"] == "0.1"
     assert entities[0]["geometry"]["reason"] == "semantic_metadata_only"
-    assert entities[0]["provenance"]["source_entity_ref"] == "entities.DUPLICATE"
+    assert entities[0]["provenance"]["origin"] == "adapter_normalized"
+    assert entities[0]["provenance"]["adapter"] == "ifcopenshell"
+    assert entities[0]["provenance"]["source"] == "ifc://IfcWall/global-id:DUPLICATE/step-id:10"
+    assert (
+        entities[0]["provenance"]["source_entity_ref"]
+        == "ifc://IfcWall/global-id:DUPLICATE/step-id:10"
+    )
+    assert entities[0]["provenance"]["source_identity"] == "DUPLICATE"
+    assert entities[0]["provenance"]["canonical_entity_ref"] == "entities.DUPLICATE"
+    assert entities[0]["provenance"]["normalized_source_hash"] == hashlib.sha256(
+        b"ifc://IfcWall/global-id:DUPLICATE"
+    ).hexdigest()
+    assert entities[0]["provenance"]["notes"] == ["semantic_ifc_metadata_only"]
+    assert entities[0]["confidence"] == {
+        "score": 0.4,
+        "review_required": True,
+        "basis": "semantic_ifc_metadata_only",
+    }
     assert entities[0]["psets"][0]["name"] == "Pset_WallCommon"
     assert entities[0]["qtos"][0]["name"] == "Qto_WallBaseQuantities"
     assert entities[0]["material_refs"][0]["name"] == "Concrete"
@@ -281,6 +299,13 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
         entities[0]["representation"]["representations"][0]["representation_identifier"]
         == "Body"
     )
+    assert entities[2]["provenance"]["source"] == "ifc://IfcDoor/step-id:42"
+    assert entities[2]["provenance"]["source_entity_ref"] == "ifc://IfcDoor/step-id:42"
+    assert entities[2]["provenance"]["source_identity"] == "#42"
+    assert entities[2]["provenance"]["canonical_entity_ref"] == "entities.#42"
+    assert entities[2]["provenance"]["normalized_source_hash"] == hashlib.sha256(
+        b"ifc://IfcDoor/step-id:42"
+    ).hexdigest()
     assert canonical["layers"] == [{"name": "IfcWall"}, {"name": "IfcDoor"}]
     assert payload.provenance_json["records"][1]["details"]["entity_count"] == 3
     assert {record["source_ref"] for record in payload.provenance_json["records"]} == {
@@ -705,6 +730,7 @@ async def test_ifcopenshell_adapter_quoted_endsec_in_capped_header_continues_nat
 
     runtime = SimpleNamespace(open=_open_runtime)
     monkeypatch.setattr(adapter_module, "_load_runtime_module", lambda: runtime)
+    monkeypatch.setattr(adapter_module, "_resolve_element_module", lambda _runtime: None)
 
     result = await adapter_module.create_adapter().ingest(
         build_contract_source(


### PR DESCRIPTION
Closes #137

## Summary
- normalize IFC semantic entities to the canonical envelope expected across the ingestion pipeline
- derive stable normalized source hashes from durable IFC identity while keeping STEP ids in diagnostic provenance
- extend IFC adapter tests and contract harness coverage for the canonical output shape

## Test plan
- [x] `uv run ruff check app/ingestion/adapters/ifcopenshell.py tests/test_ifcopenshell_adapter.py tests/ingestion_contract_harness.py`
- [x] `uv run mypy app tests`
- [x] `uv build`
- [x] `uv run pytest tests/test_ifcopenshell_adapter.py tests/test_adapter_contract_harness.py tests/test_ingestion_contracts.py -q`