### PR TITLE
fix(jobs): add transactional enqueue outbox recovery (#135)

### DIFF
--- a/alembic/versions/2026_05_11_0013_add_jobs_enqueue_outbox.py
+++ b/alembic/versions/2026_05_11_0013_add_jobs_enqueue_outbox.py
@@ -1,0 +1,119 @@
+"""add jobs enqueue outbox columns
+
+Revision ID: 2026_05_11_0013
+Revises: 2026_05_11_0012
+Create Date: 2026-05-11 19:15:00
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_11_0013"
+down_revision: str | None = "2026_05_11_0012"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Persist durable enqueue intent state for jobs."""
+
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "enqueue_status",
+            sa.String(length=32),
+            nullable=True,
+            server_default=sa.text("'pending'"),
+            comment="Durable enqueue intent state (pending, publishing, published)",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "enqueue_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+            comment="Broker publish attempts for the current durable enqueue intent",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "enqueue_owner_token",
+            sa.Uuid(),
+            nullable=True,
+            comment="Current enqueue publisher ownership token for stranded-intent recovery",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "enqueue_lease_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Current enqueue publisher lease expiry used to reclaim stranded intents",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "enqueue_last_attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Most recent broker publish attempt timestamp for the current intent",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "enqueue_published_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Timestamp when the current durable enqueue intent was last published",
+        ),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE jobs
+            SET enqueue_status = CASE
+                    WHEN status = 'pending' THEN 'pending'
+                    ELSE 'published'
+                END,
+                enqueue_published_at = CASE
+                    WHEN status = 'pending' THEN NULL
+                    ELSE created_at
+                END,
+                enqueue_attempts = 0,
+                enqueue_owner_token = NULL,
+                enqueue_lease_expires_at = NULL,
+                enqueue_last_attempted_at = NULL
+            """
+        )
+    )
+
+    op.alter_column("jobs", "enqueue_status", nullable=False, server_default=None)
+    op.alter_column("jobs", "enqueue_attempts", server_default=None)
+    op.create_check_constraint(
+        "ck_jobs_enqueue_status_valid",
+        "jobs",
+        "enqueue_status IN ('pending', 'publishing', 'published')",
+    )
+
+
+def downgrade() -> None:
+    """Drop durable enqueue intent state from jobs."""
+
+    op.drop_constraint("ck_jobs_enqueue_status_valid", "jobs", type_="check")
+    op.drop_column("jobs", "enqueue_published_at")
+    op.drop_column("jobs", "enqueue_last_attempted_at")
+    op.drop_column("jobs", "enqueue_lease_expires_at")
+    op.drop_column("jobs", "enqueue_owner_token")
+    op.drop_column("jobs", "enqueue_attempts")
+    op.drop_column("jobs", "enqueue_status")

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -4,7 +4,7 @@ import hashlib
 import uuid
 from collections.abc import Sequence
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Any, cast
 from uuid import UUID
@@ -33,7 +33,13 @@ from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
-from app.jobs.worker import enqueue_ingest_job
+from app.jobs.worker import (
+    enqueue_ingest_job as _enqueue_ingest_job,
+)
+from app.jobs.worker import (
+    prepare_job_enqueue_intent,
+    publish_job_enqueue_intent,
+)
 from app.models.drawing_revision import DrawingRevision
 from app.models.extraction_profile import ExtractionProfile
 from app.models.file import File as FileModel
@@ -48,8 +54,6 @@ from app.storage.keys import build_original_storage_key
 files_router = APIRouter()
 _UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
 _UPLOAD_SNIFF_BYTES = 4096
-_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH = 255
-_PUBLIC_ENQUEUE_FAILURE_MESSAGE = "Failed to enqueue ingest job"
 # UPLOAD_FORMAT_SIGNATURES:
 # _sniff_format accepts these leading-byte signatures for upload detection:
 # - PDF: b"%PDF-"
@@ -64,6 +68,11 @@ _UTF8_BOM = b"\xef\xbb\xbf"
 _SUPPORTED_FORMATS_MESSAGE = "Unsupported file format. Supported formats: pdf, dwg, dxf, ifc."
 _MAX_ORIGINAL_FILENAME_LENGTH = 512
 _MAX_MEDIA_TYPE_LENGTH = 255
+
+
+def enqueue_ingest_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+    _enqueue_ingest_job(job_id)
 
 
 def _encode_cursor(created_at: datetime, file_id: UUID) -> str:
@@ -323,48 +332,6 @@ def _raise_reprocess_base_revision_conflict() -> None:
     )
 
 
-async def _mark_job_enqueue_failed(db: AsyncSession, job: Job, exc: Exception) -> None:
-    """Persist a visible failed job after enqueue publish errors."""
-    _ = exc
-    job.status = "failed"
-    job.error_code = ErrorCode.INTERNAL_ERROR.value
-    job.error_message = _PUBLIC_ENQUEUE_FAILURE_MESSAGE[:_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH]
-    job.finished_at = datetime.now(UTC)
-    await db.commit()
-    await db.refresh(job)
-
-
-async def _mark_job_enqueue_failed_with_snapshot(
-    db: AsyncSession,
-    job: Job,
-    exc: Exception,
-    *,
-    reservation: IdempotencyReservation | None,
-) -> dict[str, Any]:
-    """Persist enqueue failure state and finalize a replay snapshot when present."""
-
-    _ = exc
-    job.status = "failed"
-    job.error_code = ErrorCode.INTERNAL_ERROR.value
-    job.error_message = _PUBLIC_ENQUEUE_FAILURE_MESSAGE[:_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH]
-    job.finished_at = datetime.now(UTC)
-    error_body = create_error_response(
-        code=ErrorCode.INTERNAL_ERROR,
-        message=_PUBLIC_ENQUEUE_FAILURE_MESSAGE,
-        details=_enqueue_failure_details(job),
-    )
-    if reservation is not None:
-        await mark_idempotency_completed(
-            db,
-            reservation,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            response_body=error_body,
-        )
-    await db.commit()
-    await db.refresh(job)
-    return error_body
-
-
 async def _raise_upload_storage_failure(
     db: AsyncSession,
     reservation: IdempotencyReservation | None,
@@ -397,17 +364,6 @@ async def _raise_upload_storage_failure(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail=error_body,
     ) from cause
-
-
-def _enqueue_failure_details(job: Job) -> dict[str, str]:
-    """Return safe durable identifiers and status for a failed enqueue response."""
-    assert job.extraction_profile_id is not None
-    return {
-        "file_id": str(job.file_id),
-        "job_id": str(job.id),
-        "extraction_profile_id": str(job.extraction_profile_id),
-        "status": job.status,
-    }
 
 
 def _attach_initial_upload_metadata(file_row: FileModel) -> FileModel:
@@ -628,26 +584,12 @@ async def upload_project_file(
     )
     db.add(file_row)
     db.add(ingest_job)
-
-    await db.commit()
-
+    prepare_job_enqueue_intent(ingest_job)
+    await db.flush()
     await db.refresh(file_row)
     await db.refresh(ingest_job)
 
-    try:
-        enqueue_ingest_job(ingest_job.id)
-    except Exception as exc:
-        error_body = await _mark_job_enqueue_failed_with_snapshot(
-            db,
-            ingest_job,
-            exc,
-            reservation=reservation,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_body,
-        ) from exc
-
+    success_body: dict[str, Any] | None = None
     if reservation is not None:
         success_body = FileRead.model_validate(
             _attach_initial_upload_metadata(file_row)
@@ -658,7 +600,16 @@ async def upload_project_file(
             status_code=status.HTTP_201_CREATED,
             response_body=success_body,
         )
-        await db.commit()
+
+    await db.commit()
+    await publish_job_enqueue_intent(
+        ingest_job.id,
+        publisher=enqueue_ingest_job,
+        suppress_exceptions=True,
+    )
+
+    if reservation is not None:
+        assert success_body is not None
         return JSONResponse(status_code=status.HTTP_201_CREATED, content=success_body)
 
     return _attach_initial_upload_metadata(file_row)
@@ -742,23 +693,11 @@ async def reprocess_project_file(
         cancel_requested=False,
     )
     db.add(ingest_job)
-    await db.commit()
+    prepare_job_enqueue_intent(ingest_job)
+    await db.flush()
     await db.refresh(ingest_job)
 
-    try:
-        enqueue_ingest_job(ingest_job.id)
-    except Exception as exc:
-        error_body = await _mark_job_enqueue_failed_with_snapshot(
-            db,
-            ingest_job,
-            exc,
-            reservation=reservation,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_body,
-        ) from exc
-
+    success_body: dict[str, Any] | None = None
     if reservation is not None:
         success_body = JobRead.model_validate(ingest_job).model_dump(mode="json")
         await mark_idempotency_completed(
@@ -767,7 +706,16 @@ async def reprocess_project_file(
             status_code=status.HTTP_202_ACCEPTED,
             response_body=success_body,
         )
-        await db.commit()
+
+    await db.commit()
+    await publish_job_enqueue_intent(
+        ingest_job.id,
+        publisher=enqueue_ingest_job,
+        suppress_exceptions=True,
+    )
+
+    if reservation is not None:
+        assert success_body is not None
         return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
 
     return ingest_job

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,9 +24,15 @@ from app.api.pagination import (
     raise_invalid_cursor,
 )
 from app.core.errors import ErrorCode
-from app.core.exceptions import create_error_response, raise_not_found
+from app.core.exceptions import raise_not_found
 from app.db.session import get_db
-from app.jobs.worker import enqueue_ingest_job
+from app.jobs.worker import (
+    enqueue_ingest_job as _enqueue_ingest_job,
+)
+from app.jobs.worker import (
+    prepare_job_enqueue_intent,
+    publish_job_enqueue_intent,
+)
 from app.models.file import File
 from app.models.job import Job
 from app.models.job_event import JobEvent
@@ -37,9 +43,12 @@ jobs_router = APIRouter()
 
 _DEFAULT_EVENTS_LIMIT = 50
 _MAX_EVENTS_LIMIT = 200
-_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH = 255
-_PUBLIC_ENQUEUE_FAILURE_MESSAGE = "Failed to enqueue ingest job"
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
+
+
+def enqueue_ingest_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+    _enqueue_ingest_job(job_id)
 
 
 async def _get_job_or_404(db: AsyncSession, job_id: UUID) -> Job:
@@ -348,34 +357,11 @@ async def retry_job(
     job.error_message = None
     job.started_at = None
     job.finished_at = None
-    await db.commit()
-
-    try:
-        enqueue_ingest_job(job.id)
-    except Exception as exc:
-        job.status = "failed"
-        job.error_code = ErrorCode.INTERNAL_ERROR.value
-        job.error_message = _PUBLIC_ENQUEUE_FAILURE_MESSAGE[:_MAX_PUBLIC_JOB_ERROR_MESSAGE_LENGTH]
-        job.finished_at = datetime.now(UTC)
-        error_body = create_error_response(
-            code=ErrorCode.INTERNAL_ERROR,
-            message=_PUBLIC_ENQUEUE_FAILURE_MESSAGE,
-            details=None,
-        )
-        if reservation is not None:
-            await mark_idempotency_completed(
-                db,
-                reservation,
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                response_body=error_body,
-            )
-        await db.commit()
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_body,
-        ) from exc
-
+    prepare_job_enqueue_intent(job)
+    await db.flush()
     await db.refresh(job)
+
+    success_body: dict[str, object] | None = None
     if reservation is not None:
         success_body = JobRead.model_validate(job).model_dump(mode="json")
         await mark_idempotency_completed(
@@ -384,7 +370,16 @@ async def retry_job(
             status_code=status.HTTP_202_ACCEPTED,
             response_body=success_body,
         )
-        await db.commit()
+
+    await db.commit()
+    await publish_job_enqueue_intent(
+        job.id,
+        publisher=enqueue_ingest_job,
+        suppress_exceptions=True,
+    )
+
+    if reservation is not None:
+        assert success_body is not None
         return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
 
     return job

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import uuid
+from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -35,11 +36,14 @@ from app.storage.keys import build_generated_artifact_storage_key
 
 logger = get_logger(__name__)
 
-_INCOMPLETE_JOB_STATUSES = ("pending", "running")
 _RECOVERABLE_INGEST_JOB_TYPES = (JobType.INGEST.value, JobType.REPROCESS.value)
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
+_ENQUEUE_STATUS_PENDING = "pending"
+_ENQUEUE_STATUS_PUBLISHING = "publishing"
+_ENQUEUE_STATUS_PUBLISHED = "published"
 _DEFAULT_ADAPTER_TIMEOUT = timedelta(minutes=5)
 _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
+_ENQUEUE_LEASE_DURATION = timedelta(minutes=1)
 _JOB_CANCELLATION_POLL_INTERVAL_SECONDS = 0.1
 _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
 _ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
@@ -92,6 +96,14 @@ class _QueuedJobEvent:
 @dataclass(frozen=True, slots=True)
 class _JobAttemptLease:
     """Persisted ownership token for a claimed job attempt."""
+
+    token: UUID
+    lease_expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class _EnqueueIntentLease:
+    """Persisted ownership token for a claimed durable enqueue intent."""
 
     token: UUID
     lease_expires_at: datetime
@@ -189,6 +201,21 @@ def _clear_job_attempt_lease(job: Job) -> None:
     job.attempt_lease_expires_at = None
 
 
+def _clear_enqueue_intent_lease(job: Job) -> None:
+    """Clear persisted ownership fencing for a durable enqueue intent."""
+    job.enqueue_owner_token = None
+    job.enqueue_lease_expires_at = None
+
+
+def prepare_job_enqueue_intent(job: Job) -> None:
+    """Reset a job's durable enqueue intent to the pending outbox state."""
+    job.enqueue_status = _ENQUEUE_STATUS_PENDING
+    job.enqueue_attempts = 0
+    job.enqueue_last_attempted_at = None
+    job.enqueue_published_at = None
+    _clear_enqueue_intent_lease(job)
+
+
 def _claim_job_attempt_lease(
     job: Job,
     *,
@@ -224,6 +251,9 @@ def _job_is_safe_recovery_failure_target(job: Job) -> bool:
         job.status == "pending"
         and job.attempt_token is None
         and job.attempt_lease_expires_at is None
+        and job.enqueue_status == _ENQUEUE_STATUS_PENDING
+        and job.enqueue_owner_token is None
+        and job.enqueue_lease_expires_at is None
     )
 
 
@@ -243,6 +273,28 @@ def _is_stale_running_job(job: Job, *, now: datetime) -> bool:
         started_at = started_at.replace(tzinfo=UTC)
 
     return started_at <= now - _RUNNING_JOB_STALE_AFTER
+
+
+def _is_stale_enqueue_intent(job: Job, *, now: datetime) -> bool:
+    """Return whether an in-flight enqueue publish claim can be reclaimed."""
+    lease_expires_at = job.enqueue_lease_expires_at
+    if lease_expires_at is None:
+        return True
+    if lease_expires_at.tzinfo is None:
+        lease_expires_at = lease_expires_at.replace(tzinfo=UTC)
+    return lease_expires_at <= now
+
+
+def _claim_enqueue_intent_lease(job: Job, *, now: datetime) -> _EnqueueIntentLease:
+    """Mint and persist a fresh ownership lease for broker publication."""
+    token = uuid.uuid4()
+    lease_expires_at = now + _ENQUEUE_LEASE_DURATION
+    job.enqueue_status = _ENQUEUE_STATUS_PUBLISHING
+    job.enqueue_attempts += 1
+    job.enqueue_owner_token = token
+    job.enqueue_lease_expires_at = lease_expires_at
+    job.enqueue_last_attempted_at = now
+    return _EnqueueIntentLease(token=token, lease_expires_at=lease_expires_at)
 
 
 async def _get_job_for_update(session: AsyncSession, job_id: UUID) -> Job | None:
@@ -1244,6 +1296,131 @@ async def _mark_job_failed_if_recovery_safe(
     return True
 
 
+async def _claim_job_enqueue_intent(job_id: UUID) -> _EnqueueIntentLease | None:
+    """Claim a durable enqueue intent for best-effort or recovery publication."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    now = _utcnow()
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.job_type not in _RECOVERABLE_INGEST_JOB_TYPES or job.status != "pending":
+            return None
+
+        if job.enqueue_status == _ENQUEUE_STATUS_PUBLISHED:
+            return None
+
+        if job.enqueue_status == _ENQUEUE_STATUS_PUBLISHING and not _is_stale_enqueue_intent(
+            job,
+            now=now,
+        ):
+            return None
+
+        lease = _claim_enqueue_intent_lease(job, now=now)
+        await session.commit()
+        return lease
+
+
+async def _release_job_enqueue_intent(job_id: UUID, *, lease_token: UUID) -> bool:
+    """Release a claimed durable enqueue intent after a publish failure."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if (
+            job.enqueue_status != _ENQUEUE_STATUS_PUBLISHING
+            or job.enqueue_owner_token != lease_token
+        ):
+            return False
+
+        if job.status == "pending":
+            job.enqueue_status = _ENQUEUE_STATUS_PENDING
+            _clear_enqueue_intent_lease(job)
+            await session.commit()
+            return True
+
+        job.enqueue_status = _ENQUEUE_STATUS_PUBLISHED
+        job.enqueue_published_at = _utcnow()
+        _clear_enqueue_intent_lease(job)
+        await session.commit()
+        return True
+
+
+async def _mark_job_enqueue_published(job_id: UUID, *, lease_token: UUID) -> bool:
+    """Finalize a claimed durable enqueue intent after broker publication."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await _get_job_for_update(session, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if (
+            job.enqueue_status != _ENQUEUE_STATUS_PUBLISHING
+            or job.enqueue_owner_token != lease_token
+        ):
+            return False
+
+        job.enqueue_status = _ENQUEUE_STATUS_PUBLISHED
+        job.enqueue_published_at = _utcnow()
+        _clear_enqueue_intent_lease(job)
+        await session.commit()
+        return True
+
+
+async def publish_job_enqueue_intent(
+    job_id: UUID,
+    *,
+    recovery: bool = False,
+    publisher: Callable[[UUID], None] | None = None,
+    suppress_exceptions: bool = False,
+) -> bool:
+    """Best-effort publish for a durable enqueue intent recorded in Postgres."""
+    try:
+        lease = await _claim_job_enqueue_intent(job_id)
+        if lease is None:
+            return False
+
+        publish = publisher or enqueue_ingest_job
+        try:
+            publish(job_id)
+        except Exception:
+            await _release_job_enqueue_intent(job_id, lease_token=lease.token)
+            if recovery:
+                await _mark_recovery_enqueue_failed(job_id)
+            else:
+                logger.warning(
+                    "ingest_job_enqueue_deferred",
+                    job_id=str(job_id),
+                    recovery_action="worker_start_recovery",
+                )
+            return False
+
+        await _mark_job_enqueue_published(job_id, lease_token=lease.token)
+        return True
+    except Exception:
+        if not suppress_exceptions:
+            raise
+
+        logger.warning(
+            "ingest_job_enqueue_deferred",
+            job_id=str(job_id),
+            recovery_action="worker_start_recovery",
+        )
+        return False
+
+
 async def _mark_recovery_enqueue_failed(job_id: UUID) -> bool:
     """Persist and log a sanitized worker-recovery enqueue failure."""
     marked_failed = await _mark_job_failed_if_recovery_safe(
@@ -1543,7 +1720,17 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
             select(Job)
             .where(
                 (Job.job_type.in_(_RECOVERABLE_INGEST_JOB_TYPES))
-                & (Job.status.in_(_INCOMPLETE_JOB_STATUSES))
+                & (
+                    (Job.status == "running")
+                    | (
+                        (Job.status == "pending")
+                        & (
+                            Job.enqueue_status.in_(
+                                (_ENQUEUE_STATUS_PENDING, _ENQUEUE_STATUS_PUBLISHING)
+                            )
+                        )
+                    )
+                )
             )
             .order_by(Job.created_at.asc(), Job.id.asc())
             .with_for_update(skip_locked=True)
@@ -1561,17 +1748,30 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
                 job.error_code = None
                 job.error_message = None
                 _clear_job_attempt_lease(job)
+                prepare_job_enqueue_intent(job)
+                recovered_job_ids.append(job.id)
+                continue
+
+            if job.enqueue_status == _ENQUEUE_STATUS_PUBLISHING and not _is_stale_enqueue_intent(
+                job,
+                now=now,
+            ):
+                continue
+
+            if job.enqueue_status == _ENQUEUE_STATUS_PUBLISHING:
+                job.enqueue_status = _ENQUEUE_STATUS_PENDING
+                _clear_enqueue_intent_lease(job)
+
+            if job.enqueue_status != _ENQUEUE_STATUS_PENDING:
+                continue
+
             recovered_job_ids.append(job.id)
 
         await session.commit()
 
     enqueued_job_ids: list[UUID] = []
     for job_id in recovered_job_ids:
-        try:
-            enqueue_ingest_job(job_id)
-        except Exception:
-            await _mark_recovery_enqueue_failed(job_id)
-        else:
+        if await publish_job_enqueue_intent(job_id, recovery=True):
             enqueued_job_ids.append(job_id)
 
     return enqueued_job_ids

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -40,6 +40,7 @@ class JobStatus(StrEnum):
 _JOB_TYPE_VALUES = tuple(job_type.value for job_type in JobType)
 _JOB_STATUS_VALUES = tuple(status.value for status in JobStatus)
 _JOB_ERROR_CODE_VALUES = tuple(error_code.value for error_code in ErrorCode)
+_ENQUEUE_STATUS_VALUES = ("pending", "publishing", "published")
 _PROFILE_REQUIRED_JOB_TYPE_VALUES = (JobType.INGEST.value, JobType.REPROCESS.value)
 _BASE_REQUIRED_JOB_TYPE_VALUES = (JobType.REPROCESS.value,)
 
@@ -79,6 +80,10 @@ class Job(Base):
             "error_code IS NULL "
             f"OR error_code IN ({_sql_in_list(_JOB_ERROR_CODE_VALUES)})",
             name="ck_jobs_error_code_valid",
+        ),
+        CheckConstraint(
+            f"enqueue_status IN ({_sql_in_list(_ENQUEUE_STATUS_VALUES)})",
+            name="ck_jobs_enqueue_status_valid",
         ),
         CheckConstraint(
             "job_type NOT IN "
@@ -170,6 +175,37 @@ class Job(Base):
         DateTime(timezone=True),
         nullable=True,
         comment="Current running attempt lease expiry used to reclaim stale deliveries",
+    )
+    enqueue_status: Mapped[str] = mapped_column(
+        String(32),
+        default="pending",
+        nullable=False,
+        comment="Durable enqueue intent state (pending, publishing, published)",
+    )
+    enqueue_attempts: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+        comment="Broker publish attempts for the current durable enqueue intent",
+    )
+    enqueue_owner_token: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Current enqueue publisher ownership token for stranded-intent recovery",
+    )
+    enqueue_lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Current enqueue publisher lease expiry used to reclaim stranded intents",
+    )
+    enqueue_last_attempted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Most recent broker publish attempt timestamp for the current intent",
+    )
+    enqueue_published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Timestamp when the current durable enqueue intent was last published",
     )
     cancel_requested: Mapped[bool] = mapped_column(
         Boolean,

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -655,18 +655,15 @@ or other historical children.
 - The replay contract applies to project create/update/delete, file upload,
   file reprocess, job cancel, and job retry.
 - A matching completed reservation replays the original response body/status
-  exactly, including the sanitized enqueue-failure `500` body when durable work
-  has already been recorded. Completed snapshots are write-once: the server must
-  not expose a completed success replay before the final enqueue outcome is
-  known, and later failures must not overwrite an already completed snapshot.
+  exactly. For upload, reprocess, and retry, the completed success snapshot is
+  committed atomically with the durable enqueue intent and is write-once; later
+  broker publish or recovery outcomes must not overwrite that snapshot.
 - A matching `in_progress` reservation returns `409 IDEMPOTENCY_CONFLICT` with
   `Retry-After: 1`. MVP does not reclaim stale `in_progress` reservations.
 - Reusing the same key for a different fingerprint returns
   `409 IDEMPOTENCY_CONFLICT` with `details.reason = "request_mismatch"`.
-- When job enqueue fails after durable records are created, the public error must
-  stay sanitized and may include only safe system-assigned identifiers and
-  workflow metadata, such as `file_id`, `job_id`, `extraction_profile_id`, or
-  `status` where applicable.
+- Upload, reprocess, and retry success depends on durably recording the enqueue
+  intent in Postgres, not on synchronous broker publish success.
 
 ## Error Taxonomy
 
@@ -695,6 +692,12 @@ New codes require a docs change in this file.
 
 - Default ingestion adapter timeout: 5 minutes. Override per-adapter via config.
 - Default max attempts: 3. Backoff is exponential with jitter.
+- Upload, reprocess, and retry commit the pending job state and a durable enqueue
+  intent atomically in Postgres before any broker publish attempt.
+- Broker publish is best-effort after commit. If the process crashes or publish
+  raises before the intent is marked published, worker-start recovery owns the
+  stranded intent and either re-enqueues it or marks the still-pending job
+  failed with a sanitized enqueue error.
 - Cancel is cooperative. Workers must check `cancel_requested` before starting
   work, between adapter steps, on every persisted progress event, and again
   before any terminal success commit.
@@ -968,7 +971,8 @@ Probe rules:
     project before the request claims idempotency or creates a new job
   - the server creates a new ingestion/reprocessing job bound to `project_id`,
     `file_id`, the resolved `extraction_profile_id`, and the current finalized
-    base revision as `jobs.base_revision_id`
+    base revision as `jobs.base_revision_id`, plus a durable enqueue intent in
+    the same transaction
   - if the file has no finalized base revision yet, the request fails with `409`
     `REVISION_CONFLICT`, creates no job, and enqueues nothing
   - successful completion creates a new drawing revision rather than mutating

--- a/tests/test_extraction_profiles.py
+++ b/tests/test_extraction_profiles.py
@@ -357,14 +357,14 @@ class TestExtractionProfiles:
         assert "yards" in response.text
         assert "literal_error" in response.text
 
-    async def test_reprocess_enqueue_failure_returns_durable_failed_job_details(
+    async def test_reprocess_publish_failure_returns_success_with_durable_job_details(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         stub_enqueue_ingest_job: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Reprocess enqueue failures should expose safe durable identifiers."""
+        """Reprocess publish failures after commit should still return success."""
         _ = self
         _ = cleanup_projects
         _ = stub_enqueue_ingest_job
@@ -373,7 +373,7 @@ class TestExtractionProfiles:
         uploaded = await _upload_file(async_client, project["id"])
         await _finalize_initial_revision(str(uploaded["id"]))
 
-        def _failing_enqueue(_: uuid.UUID) -> None:
+        def _failing_enqueue(_: uuid.UUID, **__: Any) -> None:
             raise RuntimeError("broker exploded: amqp://user:secret@mq.internal/vhost")
 
         monkeypatch.setattr(files_api, "enqueue_ingest_job", _failing_enqueue)
@@ -396,38 +396,34 @@ class TestExtractionProfiles:
             },
         )
 
-        assert response.status_code == 500
+        assert response.status_code == 202
         payload = response.json()
-        assert payload["error"]["code"] == "INTERNAL_ERROR"
-        assert payload["error"]["message"] == "Failed to enqueue ingest job"
-        assert payload["error"]["details"] is not None
+        assert payload["file_id"] == uploaded["id"]
+        assert payload["project_id"] == project["id"]
+        assert payload["job_type"] == "reprocess"
+        assert payload["status"] == "pending"
+        assert payload["base_revision_id"] is not None
         assert "broker exploded" not in response.text
         assert "amqp://user:secret@mq.internal/vhost" not in response.text
 
-        details = cast(dict[str, str], payload["error"]["details"])
         jobs = await _get_jobs_for_file(str(uploaded["id"]))
         assert len(jobs) == 2
 
-        failed_job = jobs[1]
-        assert details == {
-            "file_id": str(failed_job.file_id),
-            "job_id": str(failed_job.id),
-            "extraction_profile_id": str(failed_job.extraction_profile_id),
-            "status": "failed",
-        }
-        assert failed_job.job_type == "reprocess"
-        assert failed_job.base_revision_id is not None
-        assert failed_job.status == "failed"
-        assert failed_job.error_code == "INTERNAL_ERROR"
-        assert failed_job.error_message == "Failed to enqueue ingest job"
-        assert "broker exploded" not in failed_job.error_message
-        assert failed_job.extraction_profile_id is not None
+        reprocess_job = jobs[1]
+        assert payload["id"] == str(reprocess_job.id)
+        assert payload["extraction_profile_id"] == str(reprocess_job.extraction_profile_id)
+        assert reprocess_job.job_type == "reprocess"
+        assert reprocess_job.base_revision_id is not None
+        assert reprocess_job.status == "pending"
+        assert reprocess_job.error_code is None
+        assert reprocess_job.error_message is None
+        assert reprocess_job.extraction_profile_id is not None
 
-        failed_profile = await _get_extraction_profile(failed_job.extraction_profile_id)
-        assert str(failed_profile.id) == details["extraction_profile_id"]
-        assert failed_profile.project_id == uuid.UUID(project["id"])
-        assert failed_profile.units_override == "metric"
-        assert failed_profile.layout_mode == "paper_space"
+        reprocess_profile = await _get_extraction_profile(reprocess_job.extraction_profile_id)
+        assert str(reprocess_profile.id) == payload["extraction_profile_id"]
+        assert reprocess_profile.project_id == uuid.UUID(project["id"])
+        assert reprocess_profile.units_override == "metric"
+        assert reprocess_profile.layout_mode == "paper_space"
 
     async def test_job_constraints_migration_upgrade_backfills_and_validates_profiles(
         self,

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -557,20 +557,20 @@ class TestEndpointIdempotency:
             }
         }
 
-    async def test_upload_enqueue_failure_replays_sanitized_error_snapshot(
+    async def test_upload_publish_failure_replays_success_snapshot(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Enqueue failures must replay the original sanitized 500 after durable writes."""
+        """Publish failures after commit must replay the original success snapshot."""
 
         _ = self
         _ = cleanup_projects
         project = cast(dict[str, Any], (await _create_project(async_client)).json())
         key = "file-upload-enqueue-failure-1"
 
-        def _fail_enqueue(_: uuid.UUID) -> None:
+        def _fail_enqueue(_: uuid.UUID, **__: Any) -> None:
             raise RuntimeError("broker unavailable")
 
         monkeypatch.setattr(files_api, "enqueue_ingest_job", _fail_enqueue)
@@ -579,12 +579,12 @@ class TestEndpointIdempotency:
         second = await _upload_pdf(async_client, project_id=project["id"], idempotency_key=key)
         record = await _get_idempotency_record(key)
 
-        assert first.status_code == 500
-        assert first.json()["error"]["message"] == "Failed to enqueue ingest job"
-        assert second.status_code == 500
+        assert first.status_code == 201
+        assert second.status_code == 201
         assert second.json() == first.json()
+        assert await _job_count_for_file(first.json()["id"]) == 1
         assert record.status == IdempotencyStatus.COMPLETED.value
-        assert record.response_status_code == 500
+        assert record.response_status_code == 201
         assert record.response_body_json == first.json()
 
     async def test_upload_storage_failure_replays_sanitized_error_snapshot(
@@ -827,14 +827,14 @@ class TestEndpointIdempotency:
         assert second.json() == first.json()
         assert await _get_idempotency_record_or_none(key) is None
 
-    async def test_reprocess_enqueue_failure_replays_sanitized_error_snapshot(
+    async def test_reprocess_publish_failure_replays_success_snapshot(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Reprocess enqueue failures must finalize and replay the sanitized 500."""
+        """Reprocess publish failures after commit must replay success."""
 
         _ = self
         _ = cleanup_projects
@@ -848,7 +848,7 @@ class TestEndpointIdempotency:
         key = "file-reprocess-enqueue-failure-1"
         payload = {"extraction_profile": {"profile_version": "v0.1"}}
 
-        def _fail_enqueue(_: uuid.UUID) -> None:
+        def _fail_enqueue(_: uuid.UUID, **__: Any) -> None:
             raise RuntimeError("broker unavailable")
 
         monkeypatch.setattr(files_api, "enqueue_ingest_job", _fail_enqueue)
@@ -865,12 +865,14 @@ class TestEndpointIdempotency:
         )
         record = await _get_idempotency_record(key)
 
-        assert first.status_code == 500
-        assert first.json()["error"]["message"] == "Failed to enqueue ingest job"
-        assert second.status_code == 500
+        assert first.status_code == 202
+        assert first.json()["job_type"] == "reprocess"
+        assert first.json()["base_revision_id"] is not None
+        assert second.status_code == 202
         assert second.json() == first.json()
+        assert await _job_count_for_file(uploaded["id"]) == 2
         assert record.status == IdempotencyStatus.COMPLETED.value
-        assert record.response_status_code == 500
+        assert record.response_status_code == 202
         assert record.response_body_json == first.json()
 
     async def test_cancel_replays_original_job_snapshot(
@@ -984,14 +986,14 @@ class TestEndpointIdempotency:
         assert record.response_status_code == 202
         assert record.response_body_json == first.json()
 
-    async def test_retry_enqueue_failure_replays_sanitized_error_snapshot(
+    async def test_retry_publish_failure_replays_success_snapshot(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Retry enqueue failures must finalize and replay the sanitized 500."""
+        """Retry publish failures after commit must replay success."""
 
         _ = self
         _ = cleanup_projects
@@ -1005,7 +1007,7 @@ class TestEndpointIdempotency:
         await _mark_job_failed(str(job.id))
         key = "job-retry-enqueue-failure-1"
 
-        def _fail_enqueue(_: uuid.UUID) -> None:
+        def _fail_enqueue(_: uuid.UUID, **__: Any) -> None:
             raise RuntimeError("broker unavailable")
 
         monkeypatch.setattr(jobs_api, "enqueue_ingest_job", _fail_enqueue)
@@ -1014,10 +1016,10 @@ class TestEndpointIdempotency:
         second = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=_headers(key))
         record = await _get_idempotency_record(key)
 
-        assert first.status_code == 500
-        assert first.json()["error"]["message"] == "Failed to enqueue ingest job"
-        assert second.status_code == 500
+        assert first.status_code == 202
+        assert first.json()["status"] == "pending"
+        assert second.status_code == 202
         assert second.json() == first.json()
         assert record.status == IdempotencyStatus.COMPLETED.value
-        assert record.response_status_code == 500
+        assert record.response_status_code == 202
         assert record.response_body_json == first.json()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -48,6 +48,7 @@ _FAKE_RUNNER_QUANTITY_GATE = "allowed_provisional"
 _FAKE_RUNNER_VALIDATOR_NAME = "tests.fake_ingestion_runner"
 _FAKE_RUNNER_VALIDATOR_VERSION = "1.0"
 _TEST_UPLOAD_BODY = b"%PDF-1.7\njob-test\n"
+_UNSET = object()
 
 
 class _AdapterModule(types.ModuleType):
@@ -249,6 +250,12 @@ async def _update_job(
     cancel_requested: bool | None = None,
     error_code: str | None = None,
     error_message: str | None = None,
+    enqueue_status: str | None = None,
+    enqueue_attempts: int | None = None,
+    enqueue_owner_token: uuid.UUID | object = _UNSET,
+    enqueue_lease_expires_at: datetime | object = _UNSET,
+    enqueue_last_attempted_at: datetime | object = _UNSET,
+    enqueue_published_at: datetime | object = _UNSET,
 ) -> Job:
     """Update and return a persisted job for test setup."""
     session_maker = session_module.AsyncSessionLocal
@@ -271,6 +278,18 @@ async def _update_job(
 
         if error_message is not None:
             job.error_message = error_message
+        if enqueue_status is not None:
+            job.enqueue_status = enqueue_status
+        if enqueue_attempts is not None:
+            job.enqueue_attempts = enqueue_attempts
+        if enqueue_owner_token is not _UNSET:
+            job.enqueue_owner_token = cast(uuid.UUID | None, enqueue_owner_token)
+        if enqueue_lease_expires_at is not _UNSET:
+            job.enqueue_lease_expires_at = cast(datetime | None, enqueue_lease_expires_at)
+        if enqueue_last_attempted_at is not _UNSET:
+            job.enqueue_last_attempted_at = cast(datetime | None, enqueue_last_attempted_at)
+        if enqueue_published_at is not _UNSET:
+            job.enqueue_published_at = cast(datetime | None, enqueue_published_at)
 
         await session.commit()
 
@@ -433,21 +452,22 @@ class TestJobs:
         assert enqueued_job_ids == [str(job.id)]
         assert job.status == "pending"
         assert job.attempts == 0
+        assert job.enqueue_status == "published"
 
-    async def test_upload_file_marks_job_failed_when_enqueue_publish_fails(
+    async def test_upload_file_succeeds_when_publish_is_deferred(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Uploading should expose safe failed-job identifiers when broker publish fails."""
+        """Uploading should succeed once durable enqueue intent commits."""
         _ = self
         _ = cleanup_projects
 
-        def _fail_enqueue(_: uuid.UUID) -> None:
-            raise RuntimeError("broker unavailable")
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
 
-        monkeypatch.setattr(files_api, "enqueue_ingest_job", _fail_enqueue)
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
 
         project = await _create_project(async_client)
         response = await async_client.post(
@@ -455,31 +475,81 @@ class TestJobs:
             files={"file": ("plan.pdf", _TEST_UPLOAD_BODY, "application/pdf")},
         )
 
-        assert response.status_code == 500
+        assert response.status_code == 201
         payload = response.json()
-        assert payload["error"]["code"] == "INTERNAL_ERROR"
-        assert payload["error"]["message"] == "Failed to enqueue ingest job"
-        assert payload["error"]["details"] is not None
-        assert "broker unavailable" not in response.text
+        job = await _get_job_for_file(payload["id"])
 
-        details = cast(dict[str, str], payload["error"]["details"])
-        job = await _get_job_for_file(details["file_id"])
-
-        assert details == {
-            "file_id": str(job.file_id),
-            "job_id": str(job.id),
-            "extraction_profile_id": str(job.extraction_profile_id),
-            "status": "failed",
-        }
-
-        assert job.status == "failed"
+        assert job.status == "pending"
         assert job.attempts == 0
-        assert job.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert job.error_message == "Failed to enqueue ingest job"
-        assert "broker unavailable" not in job.error_message
-        assert len(job.error_message) <= 255
+        assert job.error_code is None
+        assert job.error_message is None
         assert job.started_at is None
-        assert job.finished_at is not None
+        assert job.finished_at is None
+        assert job.enqueue_status == "pending"
+        assert job.enqueue_attempts == 0
+
+    async def test_upload_file_replays_success_when_publish_is_deferred_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Upload idempotency should snapshot success before best-effort publish."""
+        _ = self
+        _ = cleanup_projects
+
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
+
+        project = await _create_project(async_client)
+        headers = {"Idempotency-Key": "upload-outbox-replay"}
+
+        first = await async_client.post(
+            f"/v1/projects/{project['id']}/files",
+            files={"file": ("plan.pdf", _TEST_UPLOAD_BODY, "application/pdf")},
+            headers=headers,
+        )
+        second = await async_client.post(
+            f"/v1/projects/{project['id']}/files",
+            files={"file": ("plan.pdf", _TEST_UPLOAD_BODY, "application/pdf")},
+            headers=headers,
+        )
+
+        assert first.status_code == 201
+        assert second.status_code == 201
+        assert second.json() == first.json()
+
+        job = await _get_job_for_file(first.json()["id"])
+        assert job.status == "pending"
+        assert job.enqueue_status == "pending"
+
+    async def test_upload_file_succeeds_when_enqueue_claim_raises_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Upload should not fail if post-commit enqueue bookkeeping raises before claim."""
+        _ = self
+        _ = cleanup_projects
+
+        async def _fail_claim(_: uuid.UUID) -> worker_module._EnqueueIntentLease | None:
+            raise RuntimeError("transient enqueue claim failure")
+
+        monkeypatch.setattr(worker_module, "_claim_job_enqueue_intent", _fail_claim)
+
+        project = await _create_project(async_client)
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files",
+            files={"file": ("plan.pdf", _TEST_UPLOAD_BODY, "application/pdf")},
+        )
+
+        assert response.status_code == 201
+        job = await _get_job_for_file(response.json()["id"])
+        assert job.status == "pending"
+        assert job.enqueue_status == "pending"
 
     async def test_process_ingest_job_marks_internal_error_code_on_failure(
         self,
@@ -1506,7 +1576,7 @@ class TestJobs:
         assert updated_job.attempt_token is None
         assert updated_job.attempt_lease_expires_at is None
 
-    async def test_recover_incomplete_ingest_jobs_requeues_pending_jobs(
+    async def test_recover_incomplete_ingest_jobs_requeues_stranded_pending_jobs(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
@@ -1522,6 +1592,10 @@ class TestJobs:
         def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
             recovered_job_ids.append(str(job_id))
 
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
         monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
 
         project = await _create_project(async_client)
@@ -1536,8 +1610,49 @@ class TestJobs:
         updated_job = await _get_job(job.id)
         assert updated_job.status == "pending"
         assert updated_job.attempts == 0
+        assert updated_job.enqueue_status == "published"
+        assert updated_job.enqueue_attempts == 1
 
-    async def test_recover_incomplete_ingest_jobs_requeues_pending_reprocess_jobs(
+    async def test_recover_incomplete_ingest_jobs_does_not_duplicate_requeue_after_publish(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Recovery should not requeue the same pending job twice once publish state is durable."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        enqueued_job_ids.clear()
+
+        first_requeued = await worker_module.recover_incomplete_ingest_jobs()
+        second_requeued = await worker_module.recover_incomplete_ingest_jobs()
+
+        assert recovered_job_ids == [str(job.id)]
+        assert first_requeued == [job.id]
+        assert second_requeued == []
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "pending"
+        assert updated_job.enqueue_status == "published"
+        assert updated_job.enqueue_attempts == 1
+
+    async def test_recover_incomplete_ingest_jobs_requeues_stranded_pending_reprocess_jobs(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
@@ -1559,6 +1674,11 @@ class TestJobs:
         uploaded = await _upload_file(async_client, project["id"])
         initial_job = await _get_job_for_file(str(uploaded["id"]))
         await worker_module.process_ingest_job(initial_job.id)
+
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
         reprocess_response = await async_client.post(
             f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
             json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
@@ -1607,6 +1727,81 @@ class TestJobs:
         reprocess_job = await _get_job(uuid.UUID(response.json()["id"]))
         assert reprocess_job.job_type == "reprocess"
         assert reprocess_job.base_revision_id == uuid.UUID(response.json()["base_revision_id"])
+
+    async def test_reprocess_job_replays_success_when_publish_is_deferred_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reprocess idempotency should snapshot success before best-effort publish."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
+
+        headers = {"Idempotency-Key": "reprocess-outbox-replay"}
+        first = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+            headers=headers,
+        )
+        second = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+            headers=headers,
+        )
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json() == first.json()
+
+        reprocess_job = await _get_job(uuid.UUID(first.json()["id"]))
+        assert reprocess_job.status == "pending"
+        assert reprocess_job.enqueue_status == "pending"
+
+    async def test_reprocess_job_succeeds_when_enqueue_finalize_raises_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reprocess should not fail if post-commit enqueue bookkeeping raises after publish."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+
+        async def _fail_finalize(_: uuid.UUID, *, lease_token: uuid.UUID) -> bool:
+            _ = lease_token
+            raise RuntimeError("transient enqueue finalize failure")
+
+        monkeypatch.setattr(worker_module, "_mark_job_enqueue_published", _fail_finalize)
+
+        response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+
+        assert response.status_code == 202
+        job = await _get_job(uuid.UUID(response.json()["id"]))
+        assert job.status == "pending"
+        assert job.enqueue_status == "publishing"
 
     async def test_process_reprocess_job_rejects_payload_revision_kind_mismatch(
         self,
@@ -1844,6 +2039,10 @@ class TestJobs:
         def _capture_logger_error(event: str, **kwargs: Any) -> None:
             logger_error_calls.append((event, kwargs))
 
+        async def _skip_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
         monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fail_recovery_enqueue)
         monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
 
@@ -2073,13 +2272,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
             retried_job_ids.append(str(job_id))
+            return True
 
         monkeypatch.setattr(
             jobs_api,
-            "enqueue_ingest_job",
-            _fake_retry_enqueue,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
             raising=False,
         )
 
@@ -2100,26 +2300,28 @@ class TestJobs:
         assert retried_job_ids == [str(job.id)]
         updated = await _get_job(job.id)
         assert updated.status == "pending"
+        assert updated.error_code is None
+        assert updated.error_message is None
 
-    async def test_retry_job_returns_error_envelope_when_enqueue_fails(
+    async def test_retry_job_succeeds_when_publish_is_deferred(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Retry should standardize broker enqueue failures and persist job failure."""
+        """Retry should succeed once durable enqueue intent commits."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
 
-        def _fail_retry_enqueue(_: uuid.UUID) -> None:
-            raise RuntimeError("broker unavailable")
+        async def _skip_retry_publish(_: uuid.UUID) -> bool:
+            return False
 
         monkeypatch.setattr(
             jobs_api,
-            "enqueue_ingest_job",
-            _fail_retry_enqueue,
+            "publish_job_enqueue_intent",
+            _skip_retry_publish,
             raising=False,
         )
 
@@ -2136,23 +2338,94 @@ class TestJobs:
 
         response = await async_client.post(f"/v1/jobs/{job.id}/retry")
 
-        assert response.status_code == 500
-        assert response.json() == {
-            "error": {
-                "code": "INTERNAL_ERROR",
-                "message": "Failed to enqueue ingest job",
-                "details": None,
-            }
-        }
-        assert "broker unavailable" not in response.text
+        assert response.status_code == 202
 
         updated = await _get_job(job.id)
-        assert updated.status == "failed"
-        assert updated.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert updated.error_message == "Failed to enqueue ingest job"
-        assert "broker unavailable" not in updated.error_message
-        assert len(updated.error_message) <= 255
-        assert updated.finished_at is not None
+        assert updated.status == "pending"
+        assert updated.error_code is None
+        assert updated.error_message is None
+        assert updated.finished_at is None
+        assert updated.enqueue_status == "pending"
+
+    async def test_retry_job_replays_success_when_publish_is_deferred_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry idempotency should snapshot success before best-effort publish."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _skip_retry_publish(_: uuid.UUID) -> bool:
+            return False
+
+        monkeypatch.setattr(
+            jobs_api,
+            "publish_job_enqueue_intent",
+            _skip_retry_publish,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            error_message="previous failure",
+        )
+
+        headers = {"Idempotency-Key": "retry-outbox-replay"}
+        first = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=headers)
+        second = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=headers)
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json() == first.json()
+
+        updated = await _get_job(job.id)
+        assert updated.status == "pending"
+        assert updated.enqueue_status == "pending"
+
+    async def test_retry_job_succeeds_when_enqueue_claim_raises_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should not fail if post-commit enqueue bookkeeping raises before claim."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _fail_claim(_: uuid.UUID) -> worker_module._EnqueueIntentLease | None:
+            raise RuntimeError("transient enqueue claim failure")
+
+        monkeypatch.setattr(worker_module, "_claim_job_enqueue_intent", _fail_claim)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            error_message="previous failure",
+        )
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 202
+        updated = await _get_job(job.id)
+        assert updated.status == "pending"
+        assert updated.enqueue_status == "pending"
 
     async def test_retry_job_noops_when_attempt_limit_reached(
         self,
@@ -2168,13 +2441,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
             retried_job_ids.append(str(job_id))
+            return True
 
         monkeypatch.setattr(
             jobs_api,
-            "enqueue_ingest_job",
-            _fake_retry_enqueue,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
             raising=False,
         )
 
@@ -2212,13 +2486,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
             retried_job_ids.append(str(job_id))
+            return True
 
         monkeypatch.setattr(
             jobs_api,
-            "enqueue_ingest_job",
-            _fake_retry_enqueue,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
             raising=False,
         )
 
@@ -2260,13 +2535,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
             retried_job_ids.append(str(job_id))
+            return True
 
         monkeypatch.setattr(
             jobs_api,
-            "enqueue_ingest_job",
-            _fake_retry_enqueue,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
             raising=False,
         )
 
@@ -2325,13 +2601,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        def _fake_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
             retried_job_ids.append(str(job_id))
+            return True
 
         monkeypatch.setattr(
             jobs_api,
-            "enqueue_ingest_job",
-            _fake_retry_enqueue,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
             raising=False,
         )
 
@@ -2566,6 +2843,7 @@ class TestJobs:
             persisted_job.status = "failed"
             persisted_job.error_code = ErrorCode.ADAPTER_FAILED.value
             persisted_job.error_message = "Adapter execution failed."
+            persisted_job.enqueue_status = "published"
 
             await session.commit()
 
@@ -2580,6 +2858,7 @@ class TestJobs:
             ("job_type", "not-a-job-type"),
             ("status", "queued"),
             ("error_code", "NOT_A_REAL_ERROR_CODE"),
+            ("enqueue_status", "queued"),
         ],
     )
     async def test_job_constraints_reject_invalid_string_writes(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -464,7 +464,14 @@ class TestJobs:
         _ = self
         _ = cleanup_projects
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -498,7 +505,14 @@ class TestJobs:
         _ = self
         _ = cleanup_projects
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -1592,7 +1606,14 @@ class TestJobs:
         def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
             recovered_job_ids.append(str(job_id))
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -1629,7 +1650,14 @@ class TestJobs:
         def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
             recovered_job_ids.append(str(job_id))
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -1675,7 +1703,14 @@ class TestJobs:
         initial_job = await _get_job_for_file(str(uploaded["id"]))
         await worker_module.process_ingest_job(initial_job.id)
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -1745,7 +1780,14 @@ class TestJobs:
         initial_job = await _get_job_for_file(str(uploaded["id"]))
         await worker_module.process_ingest_job(initial_job.id)
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -2039,7 +2081,14 @@ class TestJobs:
         def _capture_logger_error(event: str, **kwargs: Any) -> None:
             logger_error_calls.append((event, kwargs))
 
-        async def _skip_publish(_: uuid.UUID) -> bool:
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
@@ -2272,7 +2321,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             retried_job_ids.append(str(job_id))
             return True
 
@@ -2315,7 +2371,14 @@ class TestJobs:
         _ = cleanup_projects
         _ = enqueued_job_ids
 
-        async def _skip_retry_publish(_: uuid.UUID) -> bool:
+        async def _skip_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(
@@ -2359,7 +2422,14 @@ class TestJobs:
         _ = cleanup_projects
         _ = enqueued_job_ids
 
-        async def _skip_retry_publish(_: uuid.UUID) -> bool:
+        async def _skip_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
             return False
 
         monkeypatch.setattr(
@@ -2441,7 +2511,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             retried_job_ids.append(str(job_id))
             return True
 
@@ -2486,7 +2563,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             retried_job_ids.append(str(job_id))
             return True
 
@@ -2535,7 +2619,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             retried_job_ids.append(str(job_id))
             return True
 
@@ -2601,7 +2692,14 @@ class TestJobs:
 
         retried_job_ids: list[str] = []
 
-        async def _fake_retry_publish(job_id: uuid.UUID) -> bool:
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             retried_job_ids.append(str(job_id))
             return True
 


### PR DESCRIPTION
Closes #135

## Summary
- persist a durable enqueue intent on jobs so upload, reprocess, and retry no longer depend on synchronous broker publish success
- add worker-side claim, publish, and recovery fencing for stranded enqueue intents
- cover deferred publish and idempotent replay behavior with focused job tests

## Test plan
- [x] `uv run ruff check app/api/v1/files.py app/api/v1/jobs.py app/jobs/worker.py app/models/job.py tests/test_jobs.py alembic/versions/2026_05_11_0013_add_jobs_enqueue_outbox.py`
- [x] `uv run mypy app tests`
- [x] `uv build`
- [x] `uv run pytest -rs tests/test_jobs.py -k "enqueue or outbox or idempotency or recovery"`

## Notes
- Database-gated job tests were skipped locally because `DATABASE_URL` was not set in this session.