### PR TITLE
fix(ingestion): review-gate placeholder adapters (#138)

### DIFF
--- a/app/ingestion/adapters/libredwg.py
+++ b/app/ingestion/adapters/libredwg.py
@@ -46,6 +46,7 @@ _MAX_STDOUT_BYTES = 8 * 1024
 _MAX_STDERR_BYTES = 16 * 1024
 _MAX_OUTPUT_BYTES = 1 * 1024 * 1024
 _PLACEHOLDER_CONFIDENCE_SCORE = 0.4
+_PLACEHOLDER_EMPTY_ENTITIES_REASON = "placeholder_canonical_no_entity_mapping"
 
 
 @dataclass(frozen=True, slots=True)
@@ -495,10 +496,14 @@ def _build_placeholder_canonical(
     source: AdapterSource,
     run_result: _DwgreadRunResult,
 ) -> dict[str, JSONValue]:
+    empty_entities_reason = _PLACEHOLDER_EMPTY_ENTITIES_REASON
     metadata: dict[str, JSONValue] = {
         "source_format": source.upload_format.value,
         "adapter_mode": "placeholder",
-        "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
+        "empty_entities_reason": empty_entities_reason,
+        "placeholder_semantics": _build_placeholder_semantics(
+            empty_entities_reason=empty_entities_reason,
+        ),
         "dwgread": {
             "output_kind": run_result.output_kind,
             "output_size_bytes": run_result.output_size_bytes,
@@ -525,6 +530,23 @@ def _build_placeholder_canonical(
         "entities": (),
         "xrefs": (),
         "metadata": metadata,
+    }
+
+
+def _build_placeholder_semantics(*, empty_entities_reason: str) -> dict[str, JSONValue]:
+    return {
+        "status": "placeholder",
+        "review_required": True,
+        "quantity_gate": "review_gated",
+        "reason": empty_entities_reason,
+        "coverage": {
+            "entities": "none",
+            "geometry": "none",
+            "layers": "none",
+            "blocks": "none",
+            "text": "none",
+            "quantity_hints": "none",
+        },
     }
 
 

--- a/app/ingestion/adapters/vtracer_tesseract.py
+++ b/app/ingestion/adapters/vtracer_tesseract.py
@@ -37,6 +37,7 @@ _PAGE_PATTERN: Final[re.Pattern[bytes]] = re.compile(rb"/Type\s*/Page\b")
 _PAGE_SCAN_CHUNK_SIZE: Final[int] = 64 * 1024
 _PAGE_SCAN_OVERLAP: Final[int] = 64
 _MAX_PAGES: Final[int] = 1024
+_RASTER_EMPTY_ENTITIES_REASON: Final[str] = "raster_vectorization_deferred"
 
 
 class VTracerTesseractAdapter(IngestionAdapter):
@@ -63,45 +64,51 @@ class VTracerTesseractAdapter(IngestionAdapter):
             page_cap=_MAX_PAGES,
             cancellation=options.cancellation,
         )
+        empty_entities_reason = _RASTER_EMPTY_ENTITIES_REASON
+        metadata: dict[str, JSONValue] = {
+            "source_format": UploadFormat.PDF.value,
+            "adapter_mode": "sparse_placeholder",
+            "geometry_mode": "raster",
+            "page_count": page_count,
+            "default_layer": _DEFAULT_LAYER,
+            "empty_entities_reason": empty_entities_reason,
+            "placeholder_semantics": _build_placeholder_semantics(
+                empty_entities_reason=empty_entities_reason,
+            ),
+            "text_blocks": (),
+            "pdf_scale": {
+                "status": "unconfirmed",
+                "coordinate_space": "pdf_page_space_unrotated",
+                "unit": "point",
+                "real_world_units": False,
+                "calibration": {
+                    "provided": False,
+                    "source": "not_supported_in_adapter_options",
+                    "requires_extraction_profile_pass_through": True,
+                },
+            },
+        }
         canonical = cast(
             dict[str, JSONValue],
             {
-            "schema_version": _SCHEMA_VERSION,
-            "canonical_entity_schema_version": _SCHEMA_VERSION,
-            "units": {"normalized": "unknown"},
-            "coordinate_system": {
-                "name": "pdf_page_space_unrotated",
-                "origin": "top_left",
-                "x_axis": "right",
-                "y_axis": "down",
-            },
-            "layouts": tuple(
-                {"name": f"page-{page_number}", "page_number": page_number}
-                for page_number in range(1, page_count + 1)
-            ),
-            "layers": ({"name": _DEFAULT_LAYER},),
-            "blocks": (),
-            "entities": (),
-            "xrefs": (),
-            "metadata": {
-                "source_format": UploadFormat.PDF.value,
-                "geometry_mode": "raster",
-                "page_count": page_count,
-                "default_layer": _DEFAULT_LAYER,
-                "empty_entities_reason": "raster_vectorization_deferred",
-                "text_blocks": [],
-                "pdf_scale": {
-                    "status": "unconfirmed",
-                    "coordinate_space": "pdf_page_space_unrotated",
-                    "unit": "point",
-                    "real_world_units": False,
-                    "calibration": {
-                        "provided": False,
-                        "source": "not_supported_in_adapter_options",
-                        "requires_extraction_profile_pass_through": True,
-                    },
+                "schema_version": _SCHEMA_VERSION,
+                "canonical_entity_schema_version": _SCHEMA_VERSION,
+                "units": {"normalized": "unknown"},
+                "coordinate_system": {
+                    "name": "pdf_page_space_unrotated",
+                    "origin": "top_left",
+                    "x_axis": "right",
+                    "y_axis": "down",
                 },
-            },
+                "layouts": tuple(
+                    {"name": f"page-{page_number}", "page_number": page_number}
+                    for page_number in range(1, page_count + 1)
+                ),
+                "layers": ({"name": _DEFAULT_LAYER},),
+                "blocks": (),
+                "entities": (),
+                "xrefs": (),
+                "metadata": metadata,
             },
         )
 
@@ -298,3 +305,19 @@ def _durable_source_ref(source: AdapterSource) -> str:
     if not sanitized_name:
         return "originals/source.pdf"
     return f"originals/{sanitized_name}"
+
+
+def _build_placeholder_semantics(*, empty_entities_reason: str) -> dict[str, JSONValue]:
+    return {
+        "status": "sparse",
+        "review_required": True,
+        "quantity_gate": "review_gated",
+        "reason": empty_entities_reason,
+        "coverage": {
+            "entities": "none",
+            "geometry": "none",
+            "text": "deferred",
+            "ocr": "deferred",
+            "scale": "unconfirmed",
+        },
+    }

--- a/app/ingestion/registry.py
+++ b/app/ingestion/registry.py
@@ -47,13 +47,6 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
         module="app.ingestion.adapters.libredwg",
         license_name="GPL-3.0-or-later",
         capabilities=AdapterCapabilities(
-            extracts_geometry=True,
-            extracts_layers=True,
-            extracts_blocks=True,
-            extracts_text=True,
-            supports_quantity_hints=True,
-            supports_layout_selection=True,
-            supports_xref_resolution=True,
         ),
         confidence_range=(0.95, 1.0),
         probes=(
@@ -70,7 +63,11 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
                 detail="Distribution or on-prem bundling requires GPL review.",
             ),
         ),
-        notes=("Primary DWG adapter is isolated behind the ingestion contract.",),
+        notes=(
+            "Primary DWG adapter is isolated behind the ingestion contract.",
+            "Current Phase 2 output is placeholder-only and does not expose "
+            "real DWG extraction coverage yet.",
+        ),
     ),
     AdapterDescriptor(
         key="ezdxf",
@@ -157,11 +154,7 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
         display_name="VTracer + Tesseract",
         module="app.ingestion.adapters.vtracer_tesseract",
         license_name="MIT + Apache-2.0",
-        capabilities=AdapterCapabilities(
-            extracts_geometry=True,
-            extracts_text=True,
-            supports_quantity_hints=True,
-        ),
+        capabilities=AdapterCapabilities(),
         experimental=True,
         confidence_range=(0.3, 0.6),
         probes=(
@@ -177,6 +170,10 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
                 failure_status=AdapterStatus.DEGRADED,
                 detail="Tesseract enables OCR and confidence scoring for raster PDFs.",
             ),
+        ),
+        notes=(
+            "Experimental raster scaffold only; vectorization, OCR, and "
+            "quantity hints remain deferred.",
         ),
     ),
 )

--- a/app/ingestion/validation.py
+++ b/app/ingestion/validation.py
@@ -54,6 +54,15 @@ _PASS_STATUS_VALUES: Final[frozenset[str]] = frozenset(
 _PDF_SCALE_UNCONFIRMED_VALUES: Final[frozenset[str]] = frozenset(
     {"manual_required", "pending", "placeholder", "tbd", "unconfirmed", "unknown"}
 )
+_PLACEHOLDER_ADAPTER_MODE_VALUES: Final[frozenset[str]] = frozenset(
+    {"placeholder", "sparse_placeholder"}
+)
+_PLACEHOLDER_STATUS_VALUES: Final[frozenset[str]] = frozenset(
+    {"placeholder", "scaffold", "sparse", "synthetic"}
+)
+_PLACEHOLDER_EMPTY_ENTITY_REASONS: Final[frozenset[str]] = frozenset(
+    {"placeholder_canonical_no_entity_mapping", "raster_vectorization_deferred"}
+)
 _CENTER_RADIUS_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"arc", "circle"})
 _LINE_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"line"})
 _POINT_ENTITY_KINDS: Final[frozenset[str]] = frozenset({"point"})
@@ -88,6 +97,19 @@ class ValidationOutcome:
     confidence_json: dict[str, Any]
     adapter_warnings_json: list[Any]
     report_json: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _PlaceholderReviewPolicy:
+    requires_review: bool
+    status: str
+    quantity_gate: str
+    reason: str | None
+    placeholder_semantics: Mapping[str, Any] | None
+    adapter_mode: str | None
+    empty_entities_reason: str | None
+    derived_from: tuple[str, ...]
+    contract_violation_codes: tuple[str, ...]
 
 
 def build_validation_outcome(
@@ -178,6 +200,13 @@ def build_validation_outcome(
             details={"reported_confidence": confidence_score},
         )
 
+    placeholder_requires_review = _apply_placeholder_review_policy(
+        canonical_json=canonical_json,
+        add_finding=add_finding,
+    )
+    if placeholder_requires_review:
+        effective_confidence = min(effective_confidence, _REVIEW_CAPPED_CONFIDENCE)
+
     checks, required_checks_require_review, required_checks_invalid = _build_required_checks(
         canonical_json=canonical_json,
         add_finding=add_finding,
@@ -227,6 +256,7 @@ def build_validation_outcome(
             input_family == InputFamily.PDF_RASTER
             or confidence_score < _REVIEW_THRESHOLD
             or adapter_review_required
+            or placeholder_requires_review
             or required_checks_require_review
             or pdf_scale_requires_review
         ),
@@ -238,6 +268,7 @@ def build_validation_outcome(
             input_family == InputFamily.PDF_RASTER
             or confidence_score < _REVIEW_THRESHOLD
             or adapter_review_required
+            or placeholder_requires_review
             or required_checks_require_review
             or pdf_scale_requires_review
         ),
@@ -347,6 +378,154 @@ def _build_required_checks(
         invalid = invalid or check_invalid
 
     return checks, requires_review, invalid
+
+
+def _apply_placeholder_review_policy(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> bool:
+    placeholder_policy = _derive_placeholder_review_policy(canonical_json)
+    if placeholder_policy is None or not placeholder_policy.requires_review:
+        return False
+
+    add_finding(
+        check_key="placeholder_semantics",
+        severity="warning",
+        message=(
+            "Adapter reported or implied placeholder/scaffold extraction semantics; "
+            "quantities remain review-gated until non-placeholder coverage is available."
+        ),
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={
+            "status": placeholder_policy.status,
+            "quantity_gate": placeholder_policy.quantity_gate,
+            "reason": placeholder_policy.reason,
+            "adapter_mode": placeholder_policy.adapter_mode,
+            "empty_entities_reason": placeholder_policy.empty_entities_reason,
+            "derived_from": list(placeholder_policy.derived_from),
+            "placeholder_semantics": (
+                None
+                if placeholder_policy.placeholder_semantics is None
+                else _json_compatible(dict(placeholder_policy.placeholder_semantics))
+            ),
+        },
+    )
+
+    if placeholder_policy.contract_violation_codes:
+        add_finding(
+            check_key="placeholder_semantics_contract_violation",
+            severity="warning",
+            message=(
+                "Placeholder/scaffold output metadata was missing or inconsistent; "
+                "validator forced review-gated quantities from adapter metadata."
+            ),
+            target_type="revision",
+            target_ref=_SOURCE_DOCUMENT_REF,
+            quantity_effect="blocks_quantity",
+            source="validator",
+            details={
+                "contract_violation_codes": list(placeholder_policy.contract_violation_codes),
+                "status": placeholder_policy.status,
+                "quantity_gate": placeholder_policy.quantity_gate,
+                "reason": placeholder_policy.reason,
+                "adapter_mode": placeholder_policy.adapter_mode,
+                "empty_entities_reason": placeholder_policy.empty_entities_reason,
+                "placeholder_semantics": (
+                    None
+                    if placeholder_policy.placeholder_semantics is None
+                    else _json_compatible(dict(placeholder_policy.placeholder_semantics))
+                ),
+            },
+        )
+
+    return True
+
+
+def _derive_placeholder_review_policy(
+    canonical_json: Mapping[str, Any],
+) -> _PlaceholderReviewPolicy | None:
+    placeholder_semantics = _extract_placeholder_semantics(canonical_json)
+    adapter_mode = _normalized_string(_metadata_candidate(canonical_json, "adapter_mode"))
+    empty_entities_reason = _normalized_string(
+        _metadata_candidate(canonical_json, "empty_entities_reason")
+    )
+
+    derived_from: list[str] = []
+    if placeholder_semantics is not None:
+        derived_from.append("placeholder_semantics")
+    if adapter_mode in _PLACEHOLDER_ADAPTER_MODE_VALUES:
+        derived_from.append("adapter_mode")
+    if empty_entities_reason in _PLACEHOLDER_EMPTY_ENTITY_REASONS:
+        derived_from.append("empty_entities_reason")
+
+    if not derived_from:
+        return None
+
+    status = _placeholder_status(
+        placeholder_semantics=placeholder_semantics,
+        adapter_mode=adapter_mode,
+    )
+    reason = _placeholder_reason(
+        placeholder_semantics=placeholder_semantics,
+        empty_entities_reason=empty_entities_reason,
+    )
+
+    contract_violation_codes: list[str] = []
+    if placeholder_semantics is None:
+        contract_violation_codes.append("missing_placeholder_semantics")
+    else:
+        if _normalized_string(placeholder_semantics.get("status")) not in (
+            _PLACEHOLDER_STATUS_VALUES
+        ):
+            contract_violation_codes.append("placeholder_status_not_recognized")
+        if placeholder_semantics.get("review_required") is not True:
+            contract_violation_codes.append("review_required_not_true")
+        if _normalized_string(placeholder_semantics.get("quantity_gate")) != "review_gated":
+            contract_violation_codes.append("quantity_gate_not_review_gated")
+        if (
+            empty_entities_reason is not None
+            and _normalized_string(placeholder_semantics.get("reason")) != empty_entities_reason
+        ):
+            contract_violation_codes.append("reason_mismatch")
+
+    return _PlaceholderReviewPolicy(
+        requires_review=True,
+        status=status,
+        quantity_gate="review_gated",
+        reason=reason,
+        placeholder_semantics=placeholder_semantics,
+        adapter_mode=adapter_mode,
+        empty_entities_reason=empty_entities_reason,
+        derived_from=tuple(derived_from),
+        contract_violation_codes=tuple(contract_violation_codes),
+    )
+
+
+def _placeholder_status(
+    *, placeholder_semantics: Mapping[str, Any] | None, adapter_mode: str | None
+) -> str:
+    if placeholder_semantics is not None:
+        status = _normalized_string(placeholder_semantics.get("status"))
+        if status in _PLACEHOLDER_STATUS_VALUES:
+            return status
+
+    if adapter_mode == "sparse_placeholder":
+        return "sparse"
+    return "placeholder"
+
+
+def _placeholder_reason(
+    *,
+    placeholder_semantics: Mapping[str, Any] | None,
+    empty_entities_reason: str | None,
+) -> str | None:
+    if placeholder_semantics is not None:
+        reason = _normalized_string(placeholder_semantics.get("reason"))
+        if reason is not None:
+            return reason
+    return empty_entities_reason
 
 
 def _build_units_check(
@@ -1200,6 +1379,36 @@ def _mapping_value(value: Any, key: str) -> Any | None:
         return value.get(key)
 
     return None
+
+
+def _normalized_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _extract_placeholder_semantics(canonical_json: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    candidates: tuple[Any | None, ...] = (
+        canonical_json.get("placeholder_semantics"),
+        _mapping_value(canonical_json.get("metadata"), "placeholder_semantics"),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            return candidate
+
+    return None
+
+
+def _placeholder_semantics_requires_review(placeholder_semantics: Mapping[str, Any]) -> bool:
+    if placeholder_semantics.get("review_required") is True:
+        return True
+
+    if _normalized_string(placeholder_semantics.get("quantity_gate")) == "review_gated":
+        return True
+
+    return _normalized_string(placeholder_semantics.get("status")) in _PLACEHOLDER_STATUS_VALUES
 
 
 def _metadata_candidate(canonical_json: Mapping[str, Any], *keys: str) -> Any | None:

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -115,6 +115,17 @@ Minimum top-level canonical revision payload requirements:
 `layouts`, `layers`, `blocks`, and `entities` are required keys and may be
 empty lists when extraction finds none.
 
+If an adapter emits an explicit placeholder or sparse scaffold instead of real
+canonical entities, the payload must also include
+`metadata.placeholder_semantics` with at minimum:
+
+- `status` - placeholder posture such as `placeholder` or `sparse`
+- `review_required` - must be `true`
+- `quantity_gate` - must be `review_gated`
+- `reason` - must align with `metadata.empty_entities_reason`
+- `coverage` - structured extraction limitations so operators do not infer real
+  DWG/raster entity coverage where none exists yet
+
 ### Canonical Entity Schema v0.1
 
 Canonical entity schema v0.1 is a JSON-first strict contract for normalized
@@ -1030,6 +1041,9 @@ Probe rules:
   review, even when individual heuristics score above the normal provisional
   band. Raster confidence may guide prioritization, but it cannot auto-approve
   trusted quantity input.
+- Placeholder or sparse adapter outputs are also a hard exception: explicit
+  placeholder semantics must keep the revision `review_required` and
+  `review_gated` until a non-placeholder extraction pass replaces it.
 - Human review may promote a revision from `review_required` or `provisional` to
   `approved`, keep it `provisional`, mark it `rejected`, or leave it
   `review_required` pending more information. A revision replaced by a later

--- a/tests/ingestion_contract_harness.py
+++ b/tests/ingestion_contract_harness.py
@@ -239,6 +239,49 @@ def _assert_empty_entity_collection_reason(canonical: Mapping[str, JSONValue]) -
         raise AssertionError(
             "Canonical payloads with empty entities must include metadata.empty_entities_reason."
         )
+    if _requires_placeholder_semantics(metadata, reason=reason):
+        _assert_placeholder_semantics(metadata, reason=reason)
+
+
+def _requires_placeholder_semantics(metadata: dict[str, JSONValue], *, reason: str) -> bool:
+    adapter_mode = metadata.get("adapter_mode")
+    if adapter_mode in {"placeholder", "sparse_placeholder"}:
+        return True
+
+    return reason in {
+        "placeholder_canonical_no_entity_mapping",
+        "raster_vectorization_deferred",
+    }
+
+
+def _assert_placeholder_semantics(metadata: dict[str, JSONValue], *, reason: str) -> None:
+    placeholder_semantics = metadata.get("placeholder_semantics")
+    if not isinstance(placeholder_semantics, dict):
+        raise AssertionError(
+            "Placeholder or sparse canonical payloads must include metadata.placeholder_semantics."
+        )
+
+    status = placeholder_semantics.get("status")
+    if not isinstance(status, str) or not status.strip():
+        raise AssertionError(
+            "Placeholder semantics must include a non-empty placeholder status."
+        )
+    if placeholder_semantics.get("review_required") is not True:
+        raise AssertionError("Placeholder semantics must explicitly require review.")
+    if placeholder_semantics.get("quantity_gate") != "review_gated":
+        raise AssertionError(
+            "Placeholder semantics must explicitly publish quantity_gate='review_gated'."
+        )
+    if placeholder_semantics.get("reason") != reason:
+        raise AssertionError(
+            "Placeholder semantics reason must match metadata.empty_entities_reason."
+        )
+
+    coverage = placeholder_semantics.get("coverage")
+    if not isinstance(coverage, dict) or not coverage:
+        raise AssertionError(
+            "Placeholder semantics must describe extraction coverage limitations."
+        )
 
 
 def _assert_entity_envelopes(

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -6,6 +6,7 @@ import asyncio
 import math
 from collections.abc import Callable
 from dataclasses import fields
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -47,9 +48,12 @@ from app.ingestion.registry import (
     get_registry,
     list_descriptors,
 )
+from app.ingestion.validation import build_validation_outcome
 from tests.ingestion_contract_harness import (
     ContractFinalizationExpectation,
+    assert_adapter_result_contract,
     build_contract_source,
+    build_result,
     exercise_adapter_contract,
 )
 
@@ -227,10 +231,25 @@ def test_registry_is_static_and_covers_every_family() -> None:
     assert registry[InputFamily.PDF_RASTER].experimental is True
     assert registry[InputFamily.DWG].capabilities.can_read is True
     assert registry[InputFamily.DWG].capabilities.can_write is False
-    assert registry[InputFamily.DWG].capabilities.extracts_geometry is True
-    assert registry[InputFamily.DWG].capabilities.supports_quantity_hints is True
-    assert registry[InputFamily.DWG].capabilities.supports_layout_selection is True
-    assert registry[InputFamily.DWG].capabilities.supports_xref_resolution is True
+    assert registry[InputFamily.DWG].capabilities.extracts_geometry is False
+    assert registry[InputFamily.DWG].capabilities.extracts_layers is False
+    assert registry[InputFamily.DWG].capabilities.extracts_blocks is False
+    assert registry[InputFamily.DWG].capabilities.extracts_text is False
+    assert registry[InputFamily.DWG].capabilities.supports_quantity_hints is False
+    assert registry[InputFamily.DWG].capabilities.supports_layout_selection is False
+    assert registry[InputFamily.DWG].capabilities.supports_xref_resolution is False
+    assert registry[InputFamily.DWG].notes == (
+        "Primary DWG adapter is isolated behind the ingestion contract.",
+        "Current Phase 2 output is placeholder-only and does not expose "
+        "real DWG extraction coverage yet.",
+    )
+    assert registry[InputFamily.PDF_RASTER].capabilities.extracts_geometry is False
+    assert registry[InputFamily.PDF_RASTER].capabilities.extracts_text is False
+    assert registry[InputFamily.PDF_RASTER].capabilities.supports_quantity_hints is False
+    assert registry[InputFamily.PDF_RASTER].notes == (
+        "Experimental raster scaffold only; vectorization, OCR, and "
+        "quantity hints remain deferred.",
+    )
     assert registry[InputFamily.IFC].capabilities.extracts_materials is True
 
     dwg_license_probe = next(
@@ -415,11 +434,25 @@ async def test_vtracer_tesseract_ingest_returns_raster_scaffold(
         "xrefs": (),
         "metadata": {
             "source_format": "pdf",
+            "adapter_mode": "sparse_placeholder",
             "geometry_mode": "raster",
             "page_count": 2,
             "default_layer": "default",
             "empty_entities_reason": "raster_vectorization_deferred",
-            "text_blocks": [],
+            "placeholder_semantics": {
+                "status": "sparse",
+                "review_required": True,
+                "quantity_gate": "review_gated",
+                "reason": "raster_vectorization_deferred",
+                "coverage": {
+                    "entities": "none",
+                    "geometry": "none",
+                    "text": "deferred",
+                    "ocr": "deferred",
+                    "scale": "unconfirmed",
+                },
+            },
+            "text_blocks": (),
             "pdf_scale": {
                 "status": "unconfirmed",
                 "coordinate_space": "pdf_page_space_unrotated",
@@ -494,6 +527,26 @@ async def test_vtracer_tesseract_ingest_returns_raster_scaffold(
             code="raster_scale_unconfirmed",
             message="Raster PDF scale remains unconfirmed in scaffold output.",
         ),
+    )
+
+    validation = build_validation_outcome(
+        input_family=InputFamily.PDF_RASTER,
+        canonical_json=result.canonical,
+        canonical_entity_schema_version=cast(
+            str,
+            result.canonical["canonical_entity_schema_version"],
+        ),
+        result=result,
+        generated_at=datetime.now(UTC),
+    )
+    findings = cast(list[dict[str, object]], validation.report_json["findings"])
+    assert validation.review_state == "review_required"
+    assert validation.quantity_gate == "review_gated"
+    assert any(
+        finding.get("check_key") == "placeholder_semantics"
+        and cast(dict[str, object], finding["details"]).get("reason")
+        == "raster_vectorization_deferred"
+        for finding in findings
     )
 
 
@@ -1709,3 +1762,42 @@ def test_adapter_source_rejects_invalid_upload_family_pairing() -> None:
         assert "is not valid" in str(exc)
     else:
         raise AssertionError("Expected invalid upload/family pairing to fail.")
+
+
+def test_contract_rejects_placeholder_semantics_with_non_review_gated_quantity_gate() -> None:
+    result = build_result(
+        adapter_key="contract",
+        score=0.3,
+        review_required=True,
+        canonical={
+            "schema_version": "0.1",
+            "canonical_entity_schema_version": "0.1",
+            "entities": (),
+            "metadata": {
+                "adapter_mode": "placeholder",
+                "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
+                "placeholder_semantics": {
+                    "status": "placeholder",
+                    "review_required": True,
+                    "quantity_gate": "allowed",
+                    "reason": "placeholder_canonical_no_entity_mapping",
+                    "coverage": {"entities": "none"},
+                },
+            },
+        },
+    )
+
+    with pytest.raises(AssertionError, match="quantity_gate='review_gated'"):
+        assert_adapter_result_contract(
+            result,
+            expected_adapter_key="contract",
+            expected_warning_codes=(),
+            expected_diagnostic_codes=(),
+        )
+
+
+def test_registry_placeholder_adapters_do_not_advertise_real_extraction_coverage() -> None:
+    registry = get_registry()
+
+    assert registry[InputFamily.DWG].capabilities == AdapterCapabilities()
+    assert registry[InputFamily.PDF_RASTER].capabilities == AdapterCapabilities()

--- a/tests/test_ingestion_validation.py
+++ b/tests/test_ingestion_validation.py
@@ -575,6 +575,127 @@ def test_build_validation_outcome_rejects_invalid_or_unconfirmed_pdf_scale_value
     assert outcome.quantity_gate == quantity_gate
 
 
+def test_build_validation_outcome_review_gates_placeholder_mode_without_placeholder_semantics(
+) -> None:
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DWG,
+        canonical_json={
+            "entities": (),
+            "metadata": {
+                "adapter_mode": "placeholder",
+                "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
+            },
+        },
+        canonical_entity_schema_version="0.1",
+        result=_build_result(
+            score=0.99,
+            input_family=InputFamily.DWG,
+            canonical={
+                "entities": (),
+                "metadata": {
+                    "adapter_mode": "placeholder",
+                    "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
+                },
+            },
+        ),
+        generated_at=_GENERATED_AT,
+    )
+
+    findings = {finding["check_key"]: finding for finding in outcome.report_json["findings"]}
+
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+    assert findings["placeholder_semantics"]["details"] == {
+        "status": "placeholder",
+        "quantity_gate": "review_gated",
+        "reason": "placeholder_canonical_no_entity_mapping",
+        "adapter_mode": "placeholder",
+        "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
+        "derived_from": ["adapter_mode", "empty_entities_reason"],
+        "placeholder_semantics": None,
+    }
+    assert findings["placeholder_semantics_contract_violation"]["details"] == {
+        "contract_violation_codes": ["missing_placeholder_semantics"],
+        "status": "placeholder",
+        "quantity_gate": "review_gated",
+        "reason": "placeholder_canonical_no_entity_mapping",
+        "adapter_mode": "placeholder",
+        "empty_entities_reason": "placeholder_canonical_no_entity_mapping",
+        "placeholder_semantics": None,
+    }
+
+
+def test_build_validation_outcome_forces_review_gated_placeholder_semantics_when_inconsistent(
+) -> None:
+    canonical_json: dict[str, JSONValue] = {
+        "entities": (),
+        "metadata": {
+            "adapter_mode": "sparse_placeholder",
+            "empty_entities_reason": "raster_vectorization_deferred",
+            "placeholder_semantics": {
+                "status": "complete",
+                "review_required": False,
+                "quantity_gate": "allowed",
+                "reason": "wrong_reason",
+                "coverage": {"entities": "none"},
+            },
+        },
+    }
+    outcome = build_validation_outcome(
+        input_family=InputFamily.PDF_RASTER,
+        canonical_json=canonical_json,
+        canonical_entity_schema_version="0.1",
+        result=_build_result(
+            score=0.99,
+            input_family=InputFamily.PDF_RASTER,
+            canonical=canonical_json,
+        ),
+        generated_at=_GENERATED_AT,
+    )
+
+    findings = {finding["check_key"]: finding for finding in outcome.report_json["findings"]}
+
+    assert outcome.validation_status == "needs_review"
+    assert outcome.review_state == "review_required"
+    assert outcome.quantity_gate == "review_gated"
+    assert findings["placeholder_semantics"]["details"] == {
+        "status": "sparse",
+        "quantity_gate": "review_gated",
+        "reason": "wrong_reason",
+        "adapter_mode": "sparse_placeholder",
+        "empty_entities_reason": "raster_vectorization_deferred",
+        "derived_from": ["placeholder_semantics", "adapter_mode", "empty_entities_reason"],
+        "placeholder_semantics": {
+            "status": "complete",
+            "review_required": False,
+            "quantity_gate": "allowed",
+            "reason": "wrong_reason",
+            "coverage": {"entities": "none"},
+        },
+    }
+    assert findings["placeholder_semantics_contract_violation"]["details"] == {
+        "contract_violation_codes": [
+            "placeholder_status_not_recognized",
+            "review_required_not_true",
+            "quantity_gate_not_review_gated",
+            "reason_mismatch",
+        ],
+        "status": "sparse",
+        "quantity_gate": "review_gated",
+        "reason": "wrong_reason",
+        "adapter_mode": "sparse_placeholder",
+        "empty_entities_reason": "raster_vectorization_deferred",
+        "placeholder_semantics": {
+            "status": "complete",
+            "review_required": False,
+            "quantity_gate": "allowed",
+            "reason": "wrong_reason",
+            "coverage": {"entities": "none"},
+        },
+    }
+
+
 def test_build_validation_outcome_includes_raw_provenance_in_report_json() -> None:
     result = _build_result(score=0.95)
 

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -21,6 +22,7 @@ from app.ingestion.contracts import (
     InputFamily,
     UploadFormat,
 )
+from app.ingestion.validation import build_validation_outcome
 from tests.ingestion_contract_harness import (
     ContractFinalizationExpectation,
     build_contract_source,
@@ -253,6 +255,20 @@ async def test_libredwg_adapter_emits_review_gated_placeholder_canonical_payload
     assert payload.canonical_json["metadata"]["empty_entities_reason"] == (
         "placeholder_canonical_no_entity_mapping"
     )
+    assert payload.canonical_json["metadata"]["placeholder_semantics"] == {
+        "status": "placeholder",
+        "review_required": True,
+        "quantity_gate": "review_gated",
+        "reason": "placeholder_canonical_no_entity_mapping",
+        "coverage": {
+            "entities": "none",
+            "geometry": "none",
+            "layers": "none",
+            "blocks": "none",
+            "text": "none",
+            "quantity_hints": "none",
+        },
+    }
 
     result = await adapter.ingest(
         source,
@@ -267,6 +283,26 @@ async def test_libredwg_adapter_emits_review_gated_placeholder_canonical_payload
     assert str(second_output_path.parent) not in stderr_excerpt
     assert "<source>" in stdout_excerpt
     assert "<tempdir>" in stderr_excerpt
+
+    validation = build_validation_outcome(
+        input_family=InputFamily.DWG,
+        canonical_json=result.canonical,
+        canonical_entity_schema_version=cast(
+            str,
+            result.canonical["canonical_entity_schema_version"],
+        ),
+        result=result,
+        generated_at=datetime.now(UTC),
+    )
+    findings = cast(list[Mapping[str, object]], validation.report_json["findings"])
+    assert validation.review_state == "review_required"
+    assert validation.quantity_gate == "review_gated"
+    assert any(
+        finding.get("check_key") == "placeholder_semantics"
+        and cast(Mapping[str, object], finding["details"]).get("reason")
+        == "placeholder_canonical_no_entity_mapping"
+        for finding in findings
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #138

## Summary
- make placeholder review-gate semantics explicit for DWG and raster outputs in adapter contracts and runtime validation
- align published ingestion capabilities with placeholder-phase extraction limits so clients do not infer real coverage too early
- add validation and contract tests for fallback placeholder markers, contract violations, and capability reporting

## Test plan
- [x] `uv run ruff check app/ingestion/adapters/libredwg.py app/ingestion/adapters/vtracer_tesseract.py app/ingestion/registry.py app/ingestion/validation.py tests/ingestion_contract_harness.py tests/test_ingestion_contracts.py tests/test_ingestion_validation.py tests/test_libredwg_adapter.py`
- [x] `uv run mypy app tests`
- [x] `uv build`
- [x] `uv run pytest tests/test_libredwg_adapter.py tests/test_ingestion_contracts.py tests/test_adapter_contract_harness.py tests/test_ingestion_validation.py -q`

## Notes
- Follow-up: #166 tracks the remaining DWG capability confidence-range alignment noted in review.