### PR TITLE
feat(ingestion): expand DXF and vector PDF entity coverage

### DIFF
--- a/app/ingestion/adapters/ezdxf.py
+++ b/app/ingestion/adapters/ezdxf.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import time
 from dataclasses import dataclass
+from itertools import pairwise
 from math import isfinite, sqrt
 from pathlib import Path
 from typing import Any
@@ -37,6 +38,7 @@ _DESCRIPTOR = get_descriptor(InputFamily.DXF)
 _CANONICAL_SCHEMA_VERSION = "0.1"
 _METER_UNITS = 6
 _MODEL_LAYOUT_NAME = "Model"
+_MAX_POLYLINE_VERTICES = 10_000
 _UNIT_NAMES: dict[int, str] = {
     0: "unitless",
     1: "inch",
@@ -97,6 +99,14 @@ class _CheckpointBudget:
         elapsed_seconds = time.monotonic() - self.started_at
         if elapsed_seconds >= self.timeout.seconds:
             raise TimeoutError("DXF ingestion exceeded the adapter timeout budget.")
+
+
+class _UnsupportedPolylineError(ValueError):
+    """Raised when a DXF polyline uses unsupported simple-geometry semantics."""
+
+
+class _PolylineLimitError(ValueError):
+    """Raised when a DXF polyline exceeds supported adapter limits."""
 
 
 class EzdxfAdapter:
@@ -186,6 +196,85 @@ class EzdxfAdapter:
                         layout_name=layout_name,
                         units=units_payload,
                     )
+                except ValueError as exc:
+                    canonical_entity = _unknown_entity_payload(
+                        entity,
+                        layout_name=layout_name,
+                        units=units_payload,
+                    )
+                    warnings.append(
+                        AdapterWarning(
+                            code="malformed_coordinates",
+                            message=(
+                                "DXF entity coordinates were invalid and the entity "
+                                "was retained as unknown."
+                            ),
+                            details={
+                                "entity_type": entity_type,
+                                "handle": _entity_handle(entity),
+                                "layer": _entity_layer(entity),
+                                "layout": layout_name,
+                                "reason": str(exc),
+                            },
+                        )
+                    )
+                    invalid_geometry_entities += 1
+                else:
+                    supported_entities += 1
+            elif entity_type in {"LWPOLYLINE", "POLYLINE"}:
+                try:
+                    canonical_entity = _polyline_entity_payload(
+                        entity,
+                        layout_name=layout_name,
+                        units=units_payload,
+                        budget=budget,
+                    )
+                except _PolylineLimitError as exc:
+                    canonical_entity = _unknown_entity_payload(
+                        entity,
+                        layout_name=layout_name,
+                        units=units_payload,
+                    )
+                    warnings.append(
+                        AdapterWarning(
+                            code="polyline_vertex_limit_exceeded",
+                            message=(
+                                "DXF polyline exceeded the supported vertex limit and "
+                                "was retained as unknown."
+                            ),
+                            details={
+                                "entity_type": entity_type,
+                                "handle": _entity_handle(entity),
+                                "layer": _entity_layer(entity),
+                                "layout": layout_name,
+                                "reason": str(exc),
+                            },
+                        )
+                    )
+                    unsupported_entities += 1
+                except _UnsupportedPolylineError as exc:
+                    canonical_entity = _unknown_entity_payload(
+                        entity,
+                        layout_name=layout_name,
+                        units=units_payload,
+                    )
+                    warnings.append(
+                        AdapterWarning(
+                            code="unsupported_entity",
+                            message=(
+                                f"DXF polyline entity type '{entity_type}' uses unsupported "
+                                "semantics and was retained as unknown."
+                            ),
+                            details={
+                                "entity_type": entity_type,
+                                "handle": _entity_handle(entity),
+                                "layer": _entity_layer(entity),
+                                "layout": layout_name,
+                                "reason": str(exc),
+                            },
+                        )
+                    )
+                    unsupported_entities += 1
                 except ValueError as exc:
                     canonical_entity = _unknown_entity_payload(
                         entity,
@@ -667,6 +756,284 @@ def _unknown_entity_payload(
         "layer": layer_name,
         "layout": layout_name,
     }
+
+
+def _polyline_entity_payload(
+    entity: Any,
+    *,
+    layout_name: str,
+    units: dict[str, JSONValue],
+    budget: _CheckpointBudget,
+) -> dict[str, JSONValue]:
+    native_type = str(entity.dxftype()).upper()
+    handle = _entity_handle(entity)
+    layer_name = _entity_layer(entity)
+    native_points, closed, adapter_native = _polyline_native_geometry(entity, budget=budget)
+    points = _scaled_points_payload(native_points, units=units)
+    metric_name = "perimeter" if closed else "length"
+    native_measure = _polyline_measure(native_points, closed=closed, budget=budget)
+    measure = _polyline_measure(points, closed=closed, budget=budget)
+    geometry_payload: dict[str, JSONValue] = {
+        "points": points,
+        "closed": closed,
+    }
+    entity_id = _entity_id(
+        native_type=native_type,
+        handle=handle,
+        layout_name=layout_name,
+        layer_name=layer_name,
+        geometry=geometry_payload,
+    )
+
+    if _native_geometry_should_be_preserved(units):
+        adapter_native["geometry"] = {
+            "points": native_points,
+            "closed": closed,
+            metric_name: native_measure,
+            "units": {
+                "normalized": _normalized_unit_name(_source_unit_value(units)),
+                "source_value": _source_unit_value(units),
+            },
+        }
+
+    return {
+        "entity_id": entity_id,
+        "entity_type": "polyline",
+        "entity_schema_version": _CANONICAL_SCHEMA_VERSION,
+        "geometry": {
+            "vertices": points,
+            "points": points,
+            "closed": closed,
+            "bbox": _points_bbox_payload(points),
+            "units": dict(units),
+            "geometry_summary": {
+                "kind": "polyline",
+                "vertex_count": len(points),
+                "closed": closed,
+                "dimensionality": _polyline_dimensionality(points, budget=budget),
+                metric_name: measure,
+            },
+        },
+        "properties": {
+            "source_type": native_type,
+            "source_handle": handle or None,
+            "quantity_hints": {
+                metric_name: measure,
+                "count": 1.0,
+            },
+            "adapter_native": {
+                "ezdxf": adapter_native,
+            },
+        },
+        "provenance": _entity_provenance(
+            native_type=native_type,
+            handle=handle,
+            layout_name=layout_name,
+            layer_name=layer_name,
+            entity_id=entity_id,
+            geometry=geometry_payload,
+        ),
+        "confidence": 0.99,
+        "drawing_revision_id": None,
+        "source_file_id": None,
+        "layout_ref": layout_name,
+        "layer_ref": layer_name,
+        "block_ref": None,
+        "parent_entity_ref": None,
+        "kind": "polyline",
+        "handle": handle,
+        "layer": layer_name,
+        "layout": layout_name,
+        "vertices": points,
+        "points": points,
+        "closed": closed,
+        metric_name: measure,
+    }
+
+
+def _polyline_native_geometry(
+    entity: Any,
+    *,
+    budget: _CheckpointBudget,
+) -> tuple[tuple[dict[str, JSONValue], ...], bool, dict[str, JSONValue]]:
+    native_type = str(entity.dxftype()).upper()
+    layer_name = _entity_layer(entity)
+    linetype = _optional_string(getattr(entity.dxf, "linetype", None))
+
+    if native_type == "LWPOLYLINE":
+        if bool(getattr(entity, "has_arc", False)):
+            raise _UnsupportedPolylineError("Polyline bulge arcs are not supported.")
+        if _polyline_width_is_nonzero(getattr(entity.dxf, "const_width", 0.0)):
+            raise _UnsupportedPolylineError("Polyline widths are not supported.")
+        if bool(getattr(entity, "has_width", False)):
+            for vertex_count, vertex in enumerate(entity, start=1):
+                budget.check()
+                _enforce_polyline_vertex_limit(vertex_count)
+                if _lwpolyline_vertex_has_width(vertex):
+                    raise _UnsupportedPolylineError("Polyline widths are not supported.")
+        closed = bool(getattr(entity, "is_closed", False))
+        points = _points_payload(entity.vertices_in_wcs(), budget=budget)
+        if len(points) < 2:
+            raise _UnsupportedPolylineError("Polyline must contain at least 2 vertices.")
+        return (
+            points,
+            closed,
+            {
+                "layer": layer_name,
+                "linetype": linetype,
+                "flags": int(getattr(entity.dxf, "flags", 0)),
+                "closed": closed,
+            },
+        )
+
+    if native_type != "POLYLINE":
+        raise _UnsupportedPolylineError(f"Unsupported polyline entity type '{native_type}'.")
+
+    flags = int(getattr(entity.dxf, "flags", 0))
+    if flags & 2:
+        raise _UnsupportedPolylineError("Polyline curve-fit vertices are not supported.")
+    if flags & 4:
+        raise _UnsupportedPolylineError("Polyline spline-fit vertices are not supported.")
+    if bool(getattr(entity, "is_polygon_mesh", False)):
+        raise _UnsupportedPolylineError("Polyline mesh entities are not supported.")
+    if bool(getattr(entity, "is_poly_face_mesh", False)):
+        raise _UnsupportedPolylineError("Polyline polyface entities are not supported.")
+    if not bool(getattr(entity, "is_2d_polyline", False)) and not bool(
+        getattr(entity, "is_3d_polyline", False)
+    ):
+        raise _UnsupportedPolylineError("Polyline semantics are not supported.")
+    if bool(getattr(entity, "has_arc", False)):
+        raise _UnsupportedPolylineError("Polyline bulge arcs are not supported.")
+
+    unsupported_vertex_mask = 1 | 2 | 8 | 16 | 64 | 128
+    point_payloads: list[dict[str, JSONValue]] = []
+    for vertex_count, vertex in enumerate(entity.vertices, start=1):
+        budget.check()
+        _enforce_polyline_vertex_limit(vertex_count)
+        vertex_flags = int(getattr(vertex.dxf, "flags", 0))
+        if vertex_flags & unsupported_vertex_mask:
+            raise _UnsupportedPolylineError("Polyline vertex semantics are not supported.")
+        if _polyline_width_is_nonzero(getattr(vertex.dxf, "start_width", 0.0)) or (
+            _polyline_width_is_nonzero(getattr(vertex.dxf, "end_width", 0.0))
+        ):
+            raise _UnsupportedPolylineError("Polyline widths are not supported.")
+        point_payloads.append(_point_payload(vertex.dxf.location))
+
+    native_points = tuple(point_payloads)
+    if len(native_points) < 2:
+        raise _UnsupportedPolylineError("Polyline must contain at least 2 vertices.")
+
+    closed = bool(getattr(entity, "is_closed", False))
+    mode = "3d" if bool(getattr(entity, "is_3d_polyline", False)) else "2d"
+    return (
+        native_points,
+        closed,
+        {
+            "layer": layer_name,
+            "linetype": linetype,
+            "flags": flags,
+            "closed": closed,
+            "mode": mode,
+        },
+    )
+
+
+def _points_payload(
+    points: Any,
+    *,
+    budget: _CheckpointBudget,
+) -> tuple[dict[str, JSONValue], ...]:
+    payloads: list[dict[str, JSONValue]] = []
+    for vertex_count, point in enumerate(points, start=1):
+        budget.check()
+        _enforce_polyline_vertex_limit(vertex_count)
+        payloads.append(_point_payload(point))
+    if len(payloads) < 2:
+        raise _UnsupportedPolylineError("Polyline must contain at least 2 vertices.")
+    return tuple(payloads)
+
+
+def _enforce_polyline_vertex_limit(vertex_count: int) -> None:
+    if vertex_count > _MAX_POLYLINE_VERTICES:
+        raise _PolylineLimitError(
+            f"Polyline vertex count exceeds supported limit of {_MAX_POLYLINE_VERTICES}."
+        )
+
+
+def _polyline_width_is_nonzero(value: Any) -> bool:
+    try:
+        width = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Polyline width must be finite.") from exc
+    if not isfinite(width):
+        raise ValueError("Polyline width must be finite.")
+    return width != 0.0
+
+
+def _lwpolyline_vertex_has_width(vertex: Any) -> bool:
+    if not hasattr(vertex, "__len__") or not hasattr(vertex, "__getitem__") or len(vertex) < 4:
+        return False
+    return _polyline_width_is_nonzero(vertex[2]) or _polyline_width_is_nonzero(vertex[3])
+
+
+def _scaled_points_payload(
+    points: tuple[dict[str, JSONValue], ...],
+    *,
+    units: dict[str, JSONValue],
+) -> tuple[dict[str, JSONValue], ...]:
+    return tuple(_scaled_point_payload(point, units=units, point_payload=point) for point in points)
+
+
+def _points_bbox_payload(points: tuple[dict[str, JSONValue], ...]) -> dict[str, JSONValue]:
+    x_values = tuple(_point_component(point, "x") for point in points)
+    y_values = tuple(_point_component(point, "y") for point in points)
+    z_values = tuple(_point_component(point, "z") for point in points)
+    return {
+        "min": {
+            "x": min(x_values),
+            "y": min(y_values),
+            "z": min(z_values),
+        },
+        "max": {
+            "x": max(x_values),
+            "y": max(y_values),
+            "z": max(z_values),
+        },
+    }
+
+
+def _polyline_measure(
+    points: tuple[dict[str, JSONValue], ...],
+    *,
+    closed: bool,
+    budget: _CheckpointBudget,
+) -> float:
+    metric_name = "perimeter" if closed else "length"
+    total = 0.0
+    for start, end in pairwise(points):
+        budget.check()
+        total += _line_length(start, end)
+        if not isfinite(total):
+            raise ValueError(f"Polyline {metric_name} must be finite.")
+    if closed:
+        budget.check()
+        total += _line_length(points[-1], points[0])
+        if not isfinite(total):
+            raise ValueError("Polyline perimeter must be finite.")
+    return total
+
+
+def _polyline_dimensionality(
+    points: tuple[dict[str, JSONValue], ...],
+    *,
+    budget: _CheckpointBudget,
+) -> int:
+    first_z = _point_component(points[0], "z")
+    for point in points[1:]:
+        budget.check()
+        if _point_component(point, "z") != first_z:
+            return 3
+    return 2
 
 
 def _entity_provenance(

--- a/app/ingestion/adapters/pymupdf.py
+++ b/app/ingestion/adapters/pymupdf.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib
 import importlib.metadata
+import json
 import math
 import multiprocessing
 from collections.abc import Callable
@@ -596,10 +598,52 @@ def _extract_page_entities(
             )
             if warning is not None:
                 warnings.append(warning)
+            try:
+                _append_entity(
+                    entities,
+                    _build_unknown_entity(
+                        item=item,
+                        page_number=page_number,
+                        layout_name=layout_name,
+                        layer_name=layer_name,
+                        drawing_index=drawing_index,
+                        entity_index=emitted_count,
+                        item_index=item_index,
+                        drawing=drawing,
+                    ),
+                    entity_limit=entity_limit,
+                )
+            except PyMuPDFNonFiniteValueError:
+                warnings.append(
+                    AdapterWarning(
+                        code="pymupdf_entity_non_finite",
+                        message="Skipping PyMuPDF entity with non-finite numeric values.",
+                        details={
+                            "page_number": page_number,
+                            "drawing_index": drawing_index,
+                            "item_index": item_index,
+                            "operator": str(operator),
+                        },
+                    )
+                )
+                warnings.append(
+                    AdapterWarning(
+                        code="pymupdf_path_operator_unsupported",
+                        message="Skipping unsupported PyMuPDF path operator.",
+                        details={
+                            "page_number": page_number,
+                            "drawing_index": drawing_index,
+                            "item_index": item_index,
+                            "operator": str(operator),
+                        },
+                    )
+                )
+                continue
+            emitted_count += 1
             warnings.append(
                 AdapterWarning(
                     code="pymupdf_path_operator_unsupported",
-                    message="Skipping unsupported PyMuPDF path operator.",
+                    message="Retained unsupported PyMuPDF path operator as unknown entity.",
                     details={
                         "page_number": page_number,
                         "drawing_index": drawing_index,
@@ -608,6 +652,7 @@ def _extract_page_entities(
                     },
                 )
             )
+            continue
 
         _, warning = _flush_pending_entity(
             entities=entities,
@@ -818,6 +863,71 @@ def _build_rect_entity(
     return entity
 
 
+def _build_unknown_entity(
+    *,
+    item: tuple[Any, ...],
+    page_number: int,
+    layout_name: str,
+    layer_name: str,
+    drawing_index: int,
+    entity_index: int,
+    item_index: int,
+    drawing: dict[str, Any],
+) -> dict[str, JSONValue]:
+    operator = str(item[0])
+    entity_id = _entity_id(
+        page_number=page_number,
+        drawing_index=drawing_index,
+        entity_index=entity_index,
+    )
+    bbox = _bbox_from_unsupported_item(item)
+    provenance: dict[str, JSONValue] = {
+        "page_number": page_number,
+        "drawing_index": drawing_index,
+        "item_index": item_index,
+        "operator": operator,
+        "source": "pymupdf.get_drawings",
+    }
+    normalized_source_hash = _normalized_source_hash(item)
+    if normalized_source_hash is not None:
+        provenance["normalized_source_hash"] = normalized_source_hash
+
+    return {
+        "entity_id": entity_id,
+        "entity_type": "unknown",
+        "entity_schema_version": _SCHEMA_VERSION,
+        "id": entity_id,
+        "kind": "unknown",
+        "layout": layout_name,
+        "layer": layer_name,
+        "bbox": bbox,
+        "properties": {
+            **_entity_properties(drawing, closed=False, rect_like=False),
+            "unsupported_operator": operator,
+        },
+        "provenance": provenance,
+        "confidence": {
+            "score": _VECTOR_CONFIDENCE_SCORE,
+            "review_required": True,
+            "basis": "vector_pdf_unconfirmed_scale",
+        },
+        "geometry": {
+            "kind": "unknown",
+            "coordinate_space": "pdf_page_space_unrotated",
+            "units": "unknown",
+            "bbox": bbox,
+            "status": "unsupported",
+            "reason": "unsupported_path_operator",
+        },
+        "drawing_revision_id": None,
+        "source_file_id": None,
+        "layout_ref": layout_name,
+        "layer_ref": layer_name,
+        "block_ref": None,
+        "parent_entity_ref": None,
+    }
+
+
 def _flush_pending_entity(
     *,
     entities: list[dict[str, JSONValue]],
@@ -894,6 +1004,101 @@ def _entity_properties(
         "rect_like": rect_like,
         "sequence_number": int(drawing.get("seqno", 0)),
     }
+
+
+def _normalized_source_hash(value: Any) -> str | None:
+    normalized, representable = _normalize_source_value(value)
+    if not representable:
+        return None
+    payload = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _normalize_source_value(value: Any) -> tuple[JSONValue, bool]:
+    if value is None or isinstance(value, (str, bool)):
+        return value, True
+    if isinstance(value, int):
+        return value, True
+    if isinstance(value, float):
+        return _round_float(value), True
+    if _looks_like_point(value):
+        return {
+            "x": _round_float(float(value.x)),
+            "y": _round_float(float(value.y)),
+        }, True
+    if _looks_like_rect(value):
+        return {
+            "x0": _round_float(float(value.x0)),
+            "y0": _round_float(float(value.y0)),
+            "x1": _round_float(float(value.x1)),
+            "y1": _round_float(float(value.y1)),
+        }, True
+    if isinstance(value, dict):
+        normalized: dict[str, JSONValue] = {}
+        for key in sorted(value, key=str):
+            child, representable = _normalize_source_value(value[key])
+            if not representable:
+                return None, False
+            normalized[str(key)] = child
+        return normalized, True
+    if isinstance(value, (list, tuple)):
+        normalized_items: list[JSONValue] = []
+        for child_value in value:
+            child, representable = _normalize_source_value(child_value)
+            if not representable:
+                return None, False
+            normalized_items.append(child)
+        return tuple(normalized_items), True
+    return None, False
+
+
+def _bbox_from_unsupported_item(item: tuple[Any, ...]) -> dict[str, JSONValue] | None:
+    points = _bbox_points_from_value(item[1:])
+    if not points:
+        return None
+    return _bbox_from_points(tuple(points))
+
+
+def _bbox_points_from_value(value: Any) -> list[tuple[float, float]]:
+    if _looks_like_point(value):
+        return [_point_tuple(value)]
+    if _looks_like_rect(value):
+        return [
+            (_round_float(float(value.x0)), _round_float(float(value.y0))),
+            (_round_float(float(value.x1)), _round_float(float(value.y1))),
+        ]
+    if isinstance(value, tuple) and len(value) == 2 and all(
+        isinstance(component, int | float) for component in value
+    ):
+        x, y = value
+        return [(_round_float(float(x)), _round_float(float(y)))]
+    if isinstance(value, tuple) and len(value) == 4 and all(
+        isinstance(component, int | float) for component in value
+    ):
+        x0, y0, x1, y1 = value
+        return [
+            (_round_float(float(x0)), _round_float(float(y0))),
+            (_round_float(float(x1)), _round_float(float(y1))),
+        ]
+    if isinstance(value, dict):
+        points: list[tuple[float, float]] = []
+        for child in value.values():
+            points.extend(_bbox_points_from_value(child))
+        return points
+    if isinstance(value, (list, tuple)):
+        nested_points: list[tuple[float, float]] = []
+        for child in value:
+            nested_points.extend(_bbox_points_from_value(child))
+        return nested_points
+    return []
+
+
+def _looks_like_point(value: Any) -> bool:
+    return hasattr(value, "x") and hasattr(value, "y")
+
+
+def _looks_like_rect(value: Any) -> bool:
+    return all(hasattr(value, attr) for attr in ("x0", "y0", "x1", "y1"))
 
 
 def _line_geometry(

--- a/tests/test_ezdxf_adapter.py
+++ b/tests/test_ezdxf_adapter.py
@@ -73,6 +73,129 @@ class _FakeEntity:
         return self._layout
 
 
+class _FakePolylineVertex:
+    def __init__(
+        self,
+        location: Any,
+        *,
+        flags: int = 0,
+        start_width: float = 0.0,
+        end_width: float = 0.0,
+    ) -> None:
+        self.dxf = types.SimpleNamespace(
+            location=location,
+            flags=flags,
+            start_width=start_width,
+            end_width=end_width,
+        )
+
+
+class _FakePolylineEntity:
+    def __init__(
+        self,
+        *,
+        handle: str,
+        layer: str,
+        layout_name: str,
+        points: tuple[Any, ...],
+        vertex_flags: tuple[int, ...] | None = None,
+        closed: bool = False,
+        flags: int = 0,
+        vertex_widths: tuple[tuple[float, float], ...] | None = None,
+        is_2d_polyline: bool = True,
+        is_3d_polyline: bool = False,
+        is_polygon_mesh: bool = False,
+        is_poly_face_mesh: bool = False,
+        has_arc: bool = False,
+    ) -> None:
+        self._layout = types.SimpleNamespace(name=layout_name)
+        self._points = points
+        self.is_closed = closed
+        self.is_2d_polyline = is_2d_polyline
+        self.is_3d_polyline = is_3d_polyline
+        self.is_polygon_mesh = is_polygon_mesh
+        self.is_poly_face_mesh = is_poly_face_mesh
+        self.has_arc = has_arc
+        flags_by_vertex = vertex_flags or tuple(0 for _ in points)
+        widths_by_vertex = vertex_widths or tuple((0.0, 0.0) for _ in points)
+        self.vertices = tuple(
+            _FakePolylineVertex(
+                point,
+                flags=vertex_flag,
+                start_width=vertex_width[0],
+                end_width=vertex_width[1],
+            )
+            for point, vertex_flag, vertex_width in zip(
+                points,
+                flags_by_vertex,
+                widths_by_vertex,
+                strict=True,
+            )
+        )
+        self.dxf = types.SimpleNamespace(
+            handle=handle,
+            layer=layer,
+            linetype="Continuous",
+            flags=flags,
+        )
+
+    def dxftype(self) -> str:
+        return "POLYLINE"
+
+    def get_layout(self) -> Any:
+        return self._layout
+
+    def points_in_wcs(self) -> tuple[Any, ...]:
+        return self._points
+
+
+class _FakeLWPolylineEntity:
+    def __init__(
+        self,
+        *,
+        handle: str,
+        layer: str,
+        layout_name: str,
+        points: tuple[Any, ...],
+        segment_widths: tuple[tuple[float, float], ...] | None = None,
+        const_width: float = 0.0,
+        closed: bool = False,
+        has_arc: bool = False,
+    ) -> None:
+        self._layout = types.SimpleNamespace(name=layout_name)
+        self._points = points
+        self.is_closed = closed
+        self.has_arc = has_arc
+        widths_by_vertex = segment_widths or tuple((0.0, 0.0) for _ in points)
+        self._vertices = tuple(
+            (point.x, point.y, start_width, end_width, 0.0)
+            for point, (start_width, end_width) in zip(points, widths_by_vertex, strict=True)
+        )
+        self.has_width = const_width != 0.0 or any(
+            start_width != 0.0 or end_width != 0.0
+            for start_width, end_width in widths_by_vertex
+        )
+        self.dxf = types.SimpleNamespace(
+            handle=handle,
+            layer=layer,
+            linetype="Continuous",
+            flags=1 if closed else 0,
+            const_width=const_width,
+        )
+
+    def dxftype(self) -> str:
+        return "LWPOLYLINE"
+
+    def get_layout(self) -> Any:
+        return self._layout
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._vertices)
+
+    def vertices_in_wcs(self) -> tuple[Any, ...]:
+        return self._points
+
+
 class _FakeBlock:
     def __init__(
         self,
@@ -359,6 +482,147 @@ async def test_ezdxf_adapter_normalizes_non_meter_line_geometry_to_meters(
     }
 
 
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_emits_closed_lwpolyline_perimeter_geometry(
+    tmp_path: Path,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    source_path = tmp_path / "closed-lwpolyline.dxf"
+    document = cast(Any, ezdxf).new(units=6)
+    document.modelspace().add_lwpolyline(
+        [(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0)],
+        close=True,
+    )
+    document.saveas(source_path)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=source_path, original_name=source_path.name),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is False
+    assert result.warnings == ()
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    _assert_common_entity_contract(
+        entity,
+        entity_type="polyline",
+        layout_ref="Model",
+        layer_ref="0",
+    )
+    assert entity["kind"] == "polyline"
+    assert entity["closed"] is True
+    assert "length" not in entity
+    assert entity["perimeter"] == pytest.approx(6.0)
+
+    points = _mapping_tuple(entity["points"])
+    assert points == (
+        {"x": 0.0, "y": 0.0, "z": 0.0},
+        {"x": 2.0, "y": 0.0, "z": 0.0},
+        {"x": 2.0, "y": 1.0, "z": 0.0},
+        {"x": 0.0, "y": 1.0, "z": 0.0},
+    )
+    assert entity["vertices"] == entity["points"]
+
+    geometry = _mapping(entity["geometry"])
+    assert geometry["points"] == entity["points"]
+    assert geometry["vertices"] == entity["vertices"]
+    assert geometry["closed"] is True
+    assert geometry["bbox"] == {
+        "min": {"x": 0.0, "y": 0.0, "z": 0.0},
+        "max": {"x": 2.0, "y": 1.0, "z": 0.0},
+    }
+    assert geometry["geometry_summary"] == {
+        "kind": "polyline",
+        "vertex_count": 4,
+        "closed": True,
+        "dimensionality": 2,
+        "perimeter": 6.0,
+    }
+
+    properties = _mapping(entity["properties"])
+    assert properties["source_type"] == "LWPOLYLINE"
+    assert properties["source_handle"] == entity["handle"]
+    assert properties["quantity_hints"] == {"perimeter": 6.0, "count": 1.0}
+
+    native = _mapping(_mapping(_mapping(entity["properties"])["adapter_native"])["ezdxf"])
+    assert native == {
+        "layer": "0",
+        "linetype": "BYLAYER",
+        "flags": 1,
+        "closed": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_emits_open_legacy_polyline_length_geometry(
+    tmp_path: Path,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    source_path = tmp_path / "open-legacy-polyline.dxf"
+    document = cast(Any, ezdxf).new(units=6)
+    document.modelspace().add_polyline3d(
+        [(0.0, 0.0, 0.0), (3.0, 0.0, 4.0), (3.0, 4.0, 4.0)]
+    )
+    document.saveas(source_path)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=source_path, original_name=source_path.name),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is False
+    assert result.warnings == ()
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    _assert_common_entity_contract(
+        entity,
+        entity_type="polyline",
+        layout_ref="Model",
+        layer_ref="0",
+    )
+    assert entity["kind"] == "polyline"
+    assert entity["closed"] is False
+    assert entity["length"] == pytest.approx(9.0)
+    assert "perimeter" not in entity
+
+    points = _mapping_tuple(entity["points"])
+    assert points == (
+        {"x": 0.0, "y": 0.0, "z": 0.0},
+        {"x": 3.0, "y": 0.0, "z": 4.0},
+        {"x": 3.0, "y": 4.0, "z": 4.0},
+    )
+
+    geometry = _mapping(entity["geometry"])
+    assert geometry["bbox"] == {
+        "min": {"x": 0.0, "y": 0.0, "z": 0.0},
+        "max": {"x": 3.0, "y": 4.0, "z": 4.0},
+    }
+    assert geometry["geometry_summary"] == {
+        "kind": "polyline",
+        "vertex_count": 3,
+        "closed": False,
+        "dimensionality": 3,
+        "length": 9.0,
+    }
+
+    properties = _mapping(entity["properties"])
+    assert properties["source_type"] == "POLYLINE"
+    assert properties["source_handle"] == entity["handle"]
+    assert properties["quantity_hints"] == {"length": 9.0, "count": 1.0}
+
+    native = _mapping(_mapping(_mapping(entity["properties"])["adapter_native"])["ezdxf"])
+    assert native == {
+        "layer": "0",
+        "linetype": "BYLAYER",
+        "flags": 8,
+        "closed": False,
+        "mode": "3d",
+    }
+
+
 def test_ezdxf_adapter_sanitizes_structure_errors() -> None:
     class _FakeDXFStructureError(Exception):
         pass
@@ -414,6 +678,250 @@ async def test_ezdxf_adapter_review_gates_malformed_numeric_coordinates(
     assert "start" not in entity
     assert _mapping(result.warnings[0].details)["reason"] == "Point component 'x' must be finite."
     _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_review_gates_malformed_polyline_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    malformed_document = _FakeDocument(
+        entities=(
+            _FakePolylineEntity(
+                handle="13",
+                layer="0",
+                layout_name="Model",
+                points=(
+                    _fake_point(float("nan"), 0.0, 0.0),
+                    _fake_point(2.0, 0.0, 0.0),
+                ),
+                is_2d_polyline=False,
+                is_3d_polyline=True,
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: malformed_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="malformed-polyline.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["malformed_coordinates"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert entity["handle"] == "13"
+    assert _mapping(entity["properties"])["source_type"] == "POLYLINE"
+    assert _mapping(entity["geometry"])["bbox"] is None
+    assert "points" not in entity
+    assert _mapping(result.warnings[0].details)["reason"] == "Point component 'x' must be finite."
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_retains_unsupported_polyline_as_unknown_with_warning(
+    tmp_path: Path,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    source_path = tmp_path / "unsupported-bulged-polyline.dxf"
+    document = cast(Any, ezdxf).new(units=6)
+    document.modelspace().add_lwpolyline(
+        [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)],
+        format="xyb",
+    )
+    document.saveas(source_path)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=source_path, original_name=source_path.name),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert result.confidence.score == 0.95
+    assert [warning.code for warning in result.warnings] == ["unsupported_entity"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    _assert_common_entity_contract(
+        entity,
+        entity_type="unknown",
+        layout_ref="Model",
+        layer_ref="0",
+    )
+    assert entity["kind"] == "unknown"
+    assert _mapping(entity["properties"])["source_type"] == "LWPOLYLINE"
+    assert (
+        _mapping(result.warnings[0].details)["reason"]
+        == "Polyline bulge arcs are not supported."
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("const_width", "segment_widths"),
+    [
+        (0.5, None),
+        (0.0, ((0.5, 0.0), (0.0, 0.0))),
+    ],
+)
+async def test_ezdxf_adapter_retains_width_bearing_lwpolyline_as_unknown_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    const_width: float,
+    segment_widths: tuple[tuple[float, float], ...] | None,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    unsupported_document = _FakeDocument(
+        entities=(
+            _FakeLWPolylineEntity(
+                handle="14",
+                layer="0",
+                layout_name="Model",
+                points=(
+                    _fake_point(0.0, 0.0, 0.0),
+                    _fake_point(2.0, 0.0, 0.0),
+                ),
+                const_width=const_width,
+                segment_widths=segment_widths,
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: unsupported_document)
+
+    result = await adapter.ingest(
+        build_contract_source(
+            file_path=_FIXTURE_PATH,
+            original_name="width-bearing-lwpolyline.dxf",
+        ),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["unsupported_entity"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert _mapping(entity["properties"])["source_type"] == "LWPOLYLINE"
+    assert _mapping(result.warnings[0].details)["reason"] == "Polyline widths are not supported."
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_retains_width_bearing_legacy_polyline_as_unknown_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    unsupported_document = _FakeDocument(
+        entities=(
+            _FakePolylineEntity(
+                handle="15",
+                layer="0",
+                layout_name="Model",
+                points=(
+                    _fake_point(0.0, 0.0, 0.0),
+                    _fake_point(3.0, 0.0, 0.0),
+                ),
+                vertex_widths=((0.0, 0.0), (0.5, 0.25)),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: unsupported_document)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="width-bearing-polyline.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["unsupported_entity"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert _mapping(entity["properties"])["source_type"] == "POLYLINE"
+    assert _mapping(result.warnings[0].details)["reason"] == "Polyline widths are not supported."
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_retains_vertex_capped_polyline_as_unknown_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    oversized_document = _FakeDocument(
+        entities=(
+            _FakeLWPolylineEntity(
+                handle="16",
+                layer="0",
+                layout_name="Model",
+                points=(
+                    _fake_point(0.0, 0.0, 0.0),
+                    _fake_point(1.0, 0.0, 0.0),
+                    _fake_point(2.0, 0.0, 0.0),
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: oversized_document)
+    monkeypatch.setattr("app.ingestion.adapters.ezdxf._MAX_POLYLINE_VERTICES", 2)
+
+    result = await adapter.ingest(
+        build_contract_source(file_path=_FIXTURE_PATH, original_name="oversized-polyline.dxf"),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+    )
+
+    assert result.confidence is not None
+    assert result.confidence.review_required is True
+    assert [warning.code for warning in result.warnings] == ["polyline_vertex_limit_exceeded"]
+
+    entity = _mapping(_mapping_tuple(result.canonical["entities"])[0])
+    assert entity["entity_type"] == "unknown"
+    assert entity["kind"] == "unknown"
+    assert _mapping(entity["properties"])["source_type"] == "LWPOLYLINE"
+    assert _mapping(result.warnings[0].details)["reason"] == (
+        "Polyline vertex count exceeds supported limit of 2."
+    )
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_ezdxf_adapter_honors_cancellation_during_polyline_vertex_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _load_ezdxf_adapter()
+    large_document = _FakeDocument(
+        entities=(
+            _FakePolylineEntity(
+                handle="17",
+                layer="0",
+                layout_name="Model",
+                points=(
+                    _fake_point(0.0, 0.0, 0.0),
+                    _fake_point(1.0, 0.0, 0.0),
+                    _fake_point(2.0, 0.0, 0.0),
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(adapter, "_read_document", lambda _path: large_document)
+    cancellation = _CancellationAfterChecks(cancel_after=4)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.ingest(
+            build_contract_source(file_path=_FIXTURE_PATH, original_name="cancel-polyline.dxf"),
+            AdapterExecutionOptions(
+                timeout=AdapterTimeout(seconds=1),
+                cancellation=cancellation,
+            ),
+        )
+
+    assert cancellation.calls >= 4
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -128,6 +128,19 @@ class _FakeDocument:
         self.closed = True
 
 
+def _assert_no_nonfinite_numbers(value: object) -> None:
+    if isinstance(value, dict):
+        for nested in value.values():
+            _assert_no_nonfinite_numbers(nested)
+        return
+    if isinstance(value, (tuple, list)):
+        for nested in value:
+            _assert_no_nonfinite_numbers(nested)
+        return
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        assert math.isfinite(float(value))
+
+
 async def _ingest_fake_document(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1537,6 +1550,211 @@ async def test_pymupdf_ingest_skips_non_finite_entities_and_text_blocks_with_san
         "pymupdf_entity_non_finite",
         "pymupdf_text_block_non_finite",
     }
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    unsupported_item = (
+        "c",
+        _FakePoint(10.0, 0.0),
+        _FakePoint(12.0, 4.0),
+        _FakePoint(14.0, 4.0),
+        _FakePoint(16.0, 0.0),
+    )
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[
+                    {
+                        "items": (
+                            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
+                            unsupported_item,
+                            ("l", _FakePoint(20.0, 0.0), _FakePoint(30.0, 0.0)),
+                            ("l", _FakePoint(30.0, 0.0), _FakePoint(40.0, 10.0)),
+                        ),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    }
+                ]
+            )
+        ]
+    )
+
+    result = await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    entities = cast(tuple[dict[str, Any], ...], result.canonical["entities"])
+    assert [entity["entity_id"] for entity in entities] == [
+        "page-1:drawing-0:entity-0",
+        "page-1:drawing-0:entity-1",
+        "page-1:drawing-0:entity-2",
+    ]
+
+    first_entity, unknown_entity, final_entity = entities
+    assert first_entity["entity_type"] == "line"
+    assert first_entity["provenance"] == {
+        "page_number": 1,
+        "drawing_index": 0,
+        "item_indices": (0,),
+        "source": "pymupdf.get_drawings",
+    }
+
+    assert unknown_entity["kind"] == "unknown"
+    assert unknown_entity["entity_type"] == "unknown"
+    assert unknown_entity["bbox"] == {
+        "x_min": 10.0,
+        "y_min": 0.0,
+        "x_max": 16.0,
+        "y_max": 4.0,
+    }
+    assert unknown_entity["geometry"] == {
+        "kind": "unknown",
+        "coordinate_space": "pdf_page_space_unrotated",
+        "units": "unknown",
+        "bbox": {
+            "x_min": 10.0,
+            "y_min": 0.0,
+            "x_max": 16.0,
+            "y_max": 4.0,
+        },
+        "status": "unsupported",
+        "reason": "unsupported_path_operator",
+    }
+    assert unknown_entity["confidence"] == {
+        "score": 0.75,
+        "review_required": True,
+        "basis": "vector_pdf_unconfirmed_scale",
+    }
+    assert unknown_entity["provenance"] == {
+        "page_number": 1,
+        "drawing_index": 0,
+        "item_index": 1,
+        "operator": "c",
+        "source": "pymupdf.get_drawings",
+        "normalized_source_hash": pymupdf_adapter._normalized_source_hash(unsupported_item),
+    }
+
+    assert final_entity["entity_type"] == "polyline"
+    assert final_entity["points"] == (
+        {"x": 20.0, "y": 0.0},
+        {"x": 30.0, "y": 0.0},
+        {"x": 40.0, "y": 10.0},
+    )
+    assert final_entity["provenance"] == {
+        "page_number": 1,
+        "drawing_index": 0,
+        "item_indices": (2, 3),
+        "source": "pymupdf.get_drawings",
+    }
+
+    assert result.warnings == (
+        AdapterWarning(
+            code="pymupdf_path_operator_unsupported",
+            message="Retained unsupported PyMuPDF path operator as unknown entity.",
+            details={
+                "page_number": 1,
+                "drawing_index": 0,
+                "item_index": 1,
+                "operator": "c",
+            },
+        ),
+    )
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_skips_non_finite_unsupported_path_operator_with_sanitized_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[
+                    {
+                        "items": (
+                            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
+                            (
+                                "c",
+                                _FakePoint(math.inf, 0.0),
+                                _FakePoint(12.0, 4.0),
+                                _FakePoint(14.0, 4.0),
+                                _FakePoint(16.0, 0.0),
+                            ),
+                            ("l", _FakePoint(20.0, 0.0), _FakePoint(30.0, 0.0)),
+                        ),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    }
+                ]
+            )
+        ]
+    )
+
+    result = await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    entities = cast(tuple[dict[str, Any], ...], result.canonical["entities"])
+    assert [entity["entity_type"] for entity in entities] == ["line", "line"]
+    assert result.warnings == (
+        AdapterWarning(
+            code="pymupdf_entity_non_finite",
+            message="Skipping PyMuPDF entity with non-finite numeric values.",
+            details={
+                "page_number": 1,
+                "drawing_index": 0,
+                "item_index": 1,
+                "operator": "c",
+            },
+        ),
+        AdapterWarning(
+            code="pymupdf_path_operator_unsupported",
+            message="Skipping unsupported PyMuPDF path operator.",
+            details={
+                "page_number": 1,
+                "drawing_index": 0,
+                "item_index": 1,
+                "operator": "c",
+            },
+        ),
+    )
+    _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_unsupported_path_unknown_entity_counts_toward_entity_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[
+                    {
+                        "items": (
+                            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
+                            (
+                                "c",
+                                _FakePoint(10.0, 0.0),
+                                _FakePoint(12.0, 4.0),
+                                _FakePoint(14.0, 4.0),
+                                _FakePoint(16.0, 0.0),
+                            ),
+                        ),
+                        "width": 1.0,
+                        "color": (0.1, 0.2, 0.3),
+                    }
+                ]
+            )
+        ]
+    )
+    monkeypatch.setattr(pymupdf_adapter, "_MAX_ENTITIES", 1)
+
+    with pytest.raises(pymupdf_adapter.PyMuPDFExtractionLimitError) as exc_info:
+        await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    assert str(exc_info.value) == "PyMuPDF extraction exceeded entity limit."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #141

## Summary
- add canonical DXF support for simple `LWPOLYLINE` and legacy `POLYLINE` entities, with strict fallback to `unknown` for widths, unsupported semantics, malformed geometry, and oversized vertex counts
- retain safe unsupported vector PDF path operators as canonical `unknown` entities with deterministic provenance hashing and entity-cap accounting while preserving existing supported line/polyline extraction
- expand adapter tests for supported geometry, malformed/unsupported degradation, cancellation, non-finite PDF input handling, and extraction-cap behavior

## Test plan
- [x] `uv run ruff check app/ingestion/adapters/ezdxf.py app/ingestion/adapters/pymupdf.py tests/test_ezdxf_adapter.py tests/test_ingestion_contracts.py`
- [x] `uv run mypy app/ingestion/adapters/ezdxf.py app/ingestion/adapters/pymupdf.py tests/test_ezdxf_adapter.py tests/test_ingestion_contracts.py`
- [x] `uv run pytest tests/test_ezdxf_adapter.py tests/test_ingestion_contracts.py`

## Notes
- no schema version bump, quantity-engine changes, or dependency changes in this slice
- deep review round 2 approved after tightening DXF width handling, vertex limits, and PDF unsupported-op warning behavior