### PR TITLE
fix(retention): align delete and worker lock order

### DIFF
--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -62,42 +62,115 @@ async def _get_job_or_404(db: AsyncSession, job_id: UUID) -> Job:
     return job
 
 
-async def _get_job_for_update_or_404(db: AsyncSession, job_id: UUID) -> Job:
+async def _get_job_lock_metadata_or_404(
+    db: AsyncSession,
+    job_id: UUID,
+) -> tuple[UUID, UUID]:
+    """Return project/file identifiers needed for ordered job locking."""
+    result = await db.execute(
+        select(Job.project_id, Job.file_id).where(Job.id == job_id)
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise_not_found("Job", str(job_id))
+
+    assert row is not None
+    project_id, file_id = row
+    return project_id, file_id
+
+
+async def _get_project_for_job_update_or_404(
+    db: AsyncSession,
+    *,
+    job_id: UUID,
+    project_id: UUID,
+) -> Project:
+    """Lock a job's project row before any job/file row locks."""
+    result = await db.execute(
+        select(Project)
+        .where(Project.id == project_id)
+        .with_for_update(of=Project)
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise_not_found("Job", str(job_id))
+    assert project is not None
+
+    return project
+
+
+async def _get_job_for_update_or_404(
+    db: AsyncSession,
+    job_id: UUID,
+    *,
+    expected_project_id: UUID | None = None,
+    expected_file_id: UUID | None = None,
+) -> Job:
     """Return a persisted job with a row lock or raise not found."""
-    result = await db.execute(select(Job).where(Job.id == job_id).with_for_update())
+    result = await db.execute(
+        select(Job)
+        .where(Job.id == job_id)
+        .with_for_update(of=Job)
+    )
     job = result.scalar_one_or_none()
     if job is None:
         raise_not_found("Job", str(job_id))
     assert job is not None
+    if expected_project_id is not None and job.project_id != expected_project_id:
+        raise_not_found("Job", str(job_id))
+    if expected_file_id is not None and job.file_id != expected_file_id:
+        raise_not_found("Job", str(job_id))
 
     return job
 
 
-async def _get_active_job_for_retry_or_404(
+async def _get_file_for_job_update_or_404(
+    db: AsyncSession,
+    *,
+    job_id: UUID,
+    project_id: UUID,
+    file_id: UUID,
+) -> File:
+    """Lock a job's source file row after project and job locks."""
+    result = await db.execute(
+        select(File)
+        .where((File.project_id == project_id) & (File.id == file_id))
+        .with_for_update(of=File)
+    )
+    source_file = result.scalar_one_or_none()
+    if source_file is None:
+        raise_not_found("Job", str(job_id))
+    assert source_file is not None
+
+    return source_file
+
+
+async def _lock_retry_source_or_404(
     db: AsyncSession,
     job_id: UUID,
     *,
-    for_update: bool = False,
+    project_id: UUID,
+    file_id: UUID,
 ) -> Job:
-    """Return a job row with active project/file visibility for retries."""
-    statement = (
-        select(Job)
-        .join(
-            File,
-            (File.id == Job.file_id) & (File.project_id == Job.project_id),
-        )
-        .join(Project, Project.id == Job.project_id)
-        .where(
-            (Job.id == job_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
+    """Lock retry source rows in Project -> Job -> File order."""
+    project = await _get_project_for_job_update_or_404(
+        db,
+        job_id=job_id,
+        project_id=project_id,
     )
-    if for_update:
-        statement = statement.with_for_update()
-    result = await db.execute(statement)
-    job = result.scalar_one_or_none()
-    if job is None:
+    job = await _get_job_for_update_or_404(
+        db,
+        job_id,
+        expected_project_id=project_id,
+        expected_file_id=file_id,
+    )
+    source_file = await _get_file_for_job_update_or_404(
+        db,
+        job_id=job_id,
+        project_id=project_id,
+        file_id=file_id,
+    )
+    if project.deleted_at is not None or source_file.deleted_at is not None:
         raise_not_found("Job", str(job_id))
     assert job is not None
 
@@ -235,7 +308,7 @@ async def cancel_job(
         if replay is not None:
             return replay.response
 
-    await _get_job_or_404(db, job_id)
+    project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
 
     if idempotency_key is not None:
         assert fingerprint is not None
@@ -250,7 +323,17 @@ async def cancel_job(
             return claim.response
         reservation = claim
 
-    job = await _get_job_for_update_or_404(db, job_id)
+    await _get_project_for_job_update_or_404(
+        db,
+        job_id=job_id,
+        project_id=project_id,
+    )
+    job = await _get_job_for_update_or_404(
+        db,
+        job_id,
+        expected_project_id=project_id,
+        expected_file_id=file_id,
+    )
     if job.status in _TERMINAL_JOB_STATUSES:
         if reservation is not None:
             body = JobRead.model_validate(job).model_dump(mode="json")
@@ -309,7 +392,7 @@ async def retry_job(
         if replay is not None:
             return replay.response
 
-    await _get_active_job_for_retry_or_404(db, job_id)
+    project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
 
     if idempotency_key is not None:
         assert fingerprint is not None
@@ -324,7 +407,12 @@ async def retry_job(
             return claim.response
         reservation = claim
 
-    job = await _get_active_job_for_retry_or_404(db, job_id, for_update=True)
+    job = await _lock_retry_source_or_404(
+        db,
+        job_id,
+        project_id=project_id,
+        file_id=file_id,
+    )
     if job.status != "failed" or job.attempts >= job.max_attempts:
         if reservation is not None:
             body = JobRead.model_validate(job).model_dump(mode="json")

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -302,22 +302,27 @@ async def delete_project(
         reservation = claim
 
     project = await _get_active_project_or_404(db, project_id, for_update=True)
+    locked_jobs = (
+        await db.execute(
+            select(Job)
+            .where(
+                (Job.project_id == project_id)
+                & (Job.status.in_(("pending", "running")))
+            )
+            .order_by(Job.created_at.asc(), Job.id.asc())
+            .with_for_update(of=Job)
+        )
+    ).scalars().all()
     deleted_at = datetime.now(UTC)
     project.deleted_at = deleted_at
-    await db.execute(
-        update(Job)
-        .where(
-            (Job.project_id == project_id)
-            & (Job.status.in_(("pending", "running")))
-        )
-        .values(
-            status="cancelled",
-            cancel_requested=True,
-            error_code=ErrorCode.JOB_CANCELLED.value,
-            error_message=None,
-            finished_at=deleted_at,
-        )
-    )
+    for job in locked_jobs:
+        job.status = "cancelled"
+        job.cancel_requested = True
+        job.error_code = ErrorCode.JOB_CANCELLED.value
+        job.error_message = None
+        job.finished_at = deleted_at
+        job.attempt_token = None
+        job.attempt_lease_expires_at = None
     await db.execute(
         update(File)
         .where((File.project_id == project_id) & (File.deleted_at.is_(None)))

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -109,6 +109,23 @@ class _EnqueueIntentLease:
     lease_expires_at: datetime
 
 
+@dataclass(frozen=True, slots=True)
+class _JobLockBootstrap:
+    """Non-locking job metadata needed to acquire ordered row locks."""
+
+    project_id: UUID
+    file_id: UUID
+
+
+@dataclass(frozen=True, slots=True)
+class _LockedJobSource:
+    """Project/job/file rows locked in the approved terminal-mutation order."""
+
+    project: Project
+    job: Job
+    source_file: File | None
+
+
 class _PersistedJobCancellationHandle:
     """Cancellation handle backed by worker polling."""
 
@@ -299,8 +316,62 @@ def _claim_enqueue_intent_lease(job: Job, *, now: datetime) -> _EnqueueIntentLea
 
 async def _get_job_for_update(session: AsyncSession, job_id: UUID) -> Job | None:
     """Load and lock a persisted job row."""
-    result = await session.execute(select(Job).where(Job.id == job_id).with_for_update())
+    return await _get_job_for_update_with_metadata(session, job_id)
+
+
+async def _get_job_lock_bootstrap(
+    session: AsyncSession,
+    job_id: UUID,
+) -> _JobLockBootstrap | None:
+    """Load job metadata without taking locks."""
+    result = await session.execute(
+        select(Job.project_id, Job.file_id).where(Job.id == job_id)
+    )
+    row = result.one_or_none()
+    if row is None:
+        return None
+
+    project_id, file_id = row
+    return _JobLockBootstrap(project_id=project_id, file_id=file_id)
+
+
+async def _get_project(
+    session: AsyncSession,
+    project_id: UUID,
+    *,
+    for_update: bool = False,
+) -> Project | None:
+    """Load a persisted project row, optionally under a row lock."""
+    statement = select(Project).where(Project.id == project_id)
+    if for_update:
+        statement = statement.with_for_update(of=Project)
+
+    result = await session.execute(statement)
     return result.scalar_one_or_none()
+
+
+async def _get_job_for_update_with_metadata(
+    session: AsyncSession,
+    job_id: UUID,
+    *,
+    expected_project_id: UUID | None = None,
+    expected_file_id: UUID | None = None,
+) -> Job | None:
+    """Load and lock a persisted job row, revalidating stable metadata."""
+    result = await session.execute(
+        select(Job)
+        .where(Job.id == job_id)
+        .with_for_update(of=Job)
+    )
+    job = result.scalar_one_or_none()
+    if job is None:
+        return None
+    if expected_project_id is not None and job.project_id != expected_project_id:
+        return None
+    if expected_file_id is not None and job.file_id != expected_file_id:
+        return None
+
+    return job
 
 
 async def _get_source_file(
@@ -311,21 +382,48 @@ async def _get_source_file(
     for_update: bool = False,
 ) -> File | None:
     """Load a source file row, optionally under a row lock."""
-    statement = (
-        select(File)
-        .join(Project, Project.id == File.project_id)
-        .where(
-            (File.project_id == project_id)
-            & (File.id == file_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
+    statement = select(File).where(
+        (File.project_id == project_id)
+        & (File.id == file_id)
     )
     if for_update:
-        statement = statement.with_for_update()
+        statement = statement.with_for_update(of=File)
 
     result = await session.execute(statement)
     return result.scalar_one_or_none()
+
+
+async def _lock_job_source_for_terminal_mutation(
+    session: AsyncSession,
+    job_id: UUID,
+) -> _LockedJobSource:
+    """Lock project/job/file rows in the approved order for terminal writes."""
+    bootstrap = await _get_job_lock_bootstrap(session, job_id)
+    if bootstrap is None:
+        raise LookupError(f"Job with identifier '{job_id}' not found")
+
+    project = await _get_project(session, bootstrap.project_id, for_update=True)
+    if project is None:
+        raise LookupError(
+            f"Project with identifier '{bootstrap.project_id}' for job '{job_id}' not found"
+        )
+
+    job = await _get_job_for_update_with_metadata(
+        session,
+        job_id,
+        expected_project_id=bootstrap.project_id,
+        expected_file_id=bootstrap.file_id,
+    )
+    if job is None:
+        raise LookupError(f"Job with identifier '{job_id}' not found")
+
+    source_file = await _get_source_file(
+        session,
+        project_id=bootstrap.project_id,
+        file_id=bootstrap.file_id,
+        for_update=True,
+    )
+    return _LockedJobSource(project=project, job=job, source_file=source_file)
 
 
 async def _get_existing_adapter_run_output(
@@ -672,12 +770,40 @@ async def _build_ingestion_run_request(job_id: UUID, *, attempt_token: UUID) -> 
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as session:
-        job = await _get_job_for_update(session, job_id)
+        bootstrap = await _get_job_lock_bootstrap(session, job_id)
+        if bootstrap is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        project = await _get_project(session, bootstrap.project_id, for_update=True)
+        if project is None:
+            raise LookupError(
+                f"Project with identifier '{bootstrap.project_id}' for job '{job_id}' not found"
+            )
+
+        job = await _get_job_for_update_with_metadata(
+            session,
+            job_id,
+            expected_project_id=bootstrap.project_id,
+            expected_file_id=bootstrap.file_id,
+        )
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
         if not _job_attempt_is_current(job, attempt_token=attempt_token):
             raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
         _assert_job_base_revision_invariants(job)
+
+        if project.deleted_at is not None:
+            cancelled = await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            if not cancelled:
+                raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
+            raise _InactiveSourceError(
+                f"Project with identifier '{job.project_id}' for job '{job_id}' is no longer active"
+            )
 
         source_file = await _get_source_file(
             session,
@@ -685,7 +811,7 @@ async def _build_ingestion_run_request(job_id: UUID, *, attempt_token: UUID) -> 
             file_id=job.file_id,
             for_update=True,
         )
-        if source_file is None:
+        if source_file is None or source_file.deleted_at is not None:
             cancelled = await _cancel_job_for_inactive_source(
                 session,
                 job,
@@ -722,7 +848,22 @@ async def _finalize_ingest_job(
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as session:
-        job = await _get_job_for_update(session, job_id)
+        bootstrap = await _get_job_lock_bootstrap(session, job_id)
+        if bootstrap is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        project = await _get_project(session, bootstrap.project_id, for_update=True)
+        if project is None:
+            raise LookupError(
+                f"Project with identifier '{bootstrap.project_id}' for job '{job_id}' not found"
+            )
+
+        job = await _get_job_for_update_with_metadata(
+            session,
+            job_id,
+            expected_project_id=bootstrap.project_id,
+            expected_file_id=bootstrap.file_id,
+        )
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
@@ -775,13 +916,23 @@ async def _finalize_ingest_job(
         if job.extraction_profile_id is None:
             raise ValueError("Ingest job missing extraction profile during finalization")
 
+        if project.deleted_at is not None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
+            return False
+
         source_file = await _get_source_file(
             session,
             project_id=job.project_id,
             file_id=job.file_id,
             for_update=True,
         )
-        if source_file is None:
+        if source_file is None or source_file.deleted_at is not None:
             await _cancel_job_for_inactive_source(
                 session,
                 job,
@@ -1109,12 +1260,17 @@ async def _poll_job_cancellation(
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
-        if not _job_attempt_is_current(job, attempt_token=attempt_token):
-            return
-
         if job.cancel_requested:
             cancellation.mark_cancelled()
             run_task.cancel()
+            return
+
+        if job.status == "cancelled":
+            cancellation.mark_cancelled()
+            run_task.cancel()
+            return
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
             return
 
         try:
@@ -1182,9 +1338,8 @@ async def _mark_job_failed(
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as session:
-        job = await _get_job_for_update(session, job_id)
-        if job is None:
-            raise LookupError(f"Job with identifier '{job_id}' not found")
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
 
         if job.status in _TERMINAL_JOB_STATUSES:
             logger.info(
@@ -1199,6 +1354,24 @@ async def _mark_job_failed(
         ):
             logger.info(
                 "ingest_job_failure_mark_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if (
+            locked_source.project.deleted_at is not None
+            or locked_source.source_file is None
+            or locked_source.source_file.deleted_at is not None
+        ):
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            logger.info(
+                "ingest_job_failure_mark_skipped_inactive_source",
                 job_id=str(job_id),
                 status=job.status,
             )
@@ -1272,9 +1445,25 @@ async def _mark_job_failed_if_recovery_safe(
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
 
     async with session_maker() as session:
-        job = await _get_job_for_update(session, job_id)
-        if job is None:
-            raise LookupError(f"Job with identifier '{job_id}' not found")
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
+
+        if (
+            locked_source.project.deleted_at is not None
+            or locked_source.source_file is None
+            or locked_source.source_file.deleted_at is not None
+        ):
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info(
+                "ingest_job_recovery_enqueue_failure_mark_skipped_inactive_source",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
 
         if not _job_is_safe_recovery_failure_target(job):
             logger.info(
@@ -1485,7 +1674,22 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
     now = _utcnow()
 
     async with session_maker() as session:
-        job = await _get_job_for_update(session, job_id)
+        bootstrap = await _get_job_lock_bootstrap(session, job_id)
+        if bootstrap is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        project = await _get_project(session, bootstrap.project_id, for_update=True)
+        if project is None:
+            raise LookupError(
+                f"Project with identifier '{bootstrap.project_id}' for job '{job_id}' not found"
+            )
+
+        job = await _get_job_for_update_with_metadata(
+            session,
+            job_id,
+            expected_project_id=bootstrap.project_id,
+            expected_file_id=bootstrap.file_id,
+        )
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
@@ -1497,13 +1701,22 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
             )
             return None
 
+        if project.deleted_at is not None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
+            return None
+
         source_file = await _get_source_file(
             session,
             project_id=job.project_id,
             file_id=job.file_id,
             for_update=True,
         )
-        if source_file is None:
+        if source_file is None or source_file.deleted_at is not None:
             await _cancel_job_for_inactive_source(
                 session,
                 job,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -32,6 +32,7 @@ from app.ingestion.runner import (
     run_ingestion as real_run_ingestion,
 )
 from app.models.file import File
+from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job
 from app.models.job_event import JobEvent
 from app.models.project import Project
@@ -369,6 +370,23 @@ async def _create_job_event(
         await session.refresh(event)
 
     return event
+
+
+async def _get_generated_artifacts_for_job(job_id: uuid.UUID) -> list[GeneratedArtifact]:
+    """Load generated artifacts for a job id."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        artifacts = (
+            await session.execute(
+                select(GeneratedArtifact)
+                .where(GeneratedArtifact.job_id == job_id)
+                .order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc())
+            )
+        ).scalars().all()
+
+    return list(artifacts)
 
 
 @pytest.fixture(autouse=True)
@@ -1359,6 +1377,58 @@ class TestJobs:
             "running",
             "cancelled",
         ]
+
+    async def test_process_ingest_job_cancels_mid_run_when_project_is_deleted(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Project deletion during execution should cancel the active runner."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        runner_started = asyncio.Event()
+
+        async def _wait_for_project_delete_cancel(
+            _: IngestionRunRequest,
+            *,
+            cancellation: CancellationHandle | None = None,
+            **__: Any,
+        ) -> IngestFinalizationPayload:
+            assert cancellation is not None
+            runner_started.set()
+            cancellation_deadline = asyncio.get_running_loop().time() + 1
+            while not cancellation.is_cancelled():
+                if asyncio.get_running_loop().time() >= cancellation_deadline:
+                    raise AssertionError("Expected project delete to cancel runner within 1 second")
+                await asyncio.sleep(0.01)
+
+            await asyncio.sleep(1)
+            raise AssertionError("Worker cancellation should interrupt the runner task")
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _wait_for_project_delete_cancel)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        process_task = asyncio.create_task(worker_module.process_ingest_job(job.id))
+        await asyncio.wait_for(runner_started.wait(), timeout=2)
+
+        delete_response = await async_client.delete(f"/v1/projects/{project['id']}")
+
+        assert delete_response.status_code == 204
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(process_task, timeout=2)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.cancel_requested is True
+        assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated_job.finished_at is not None
 
     async def test_process_ingest_job_skips_fresh_redelivered_running_job(
         self,
@@ -2741,6 +2811,86 @@ class TestJobs:
         unchanged = await _get_job(job.id)
         assert unchanged.status == "failed"
 
+    async def test_retry_job_delete_race_delete_wins_returns_404_without_requeue(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Delete vs retry lock contention should settle without deadlock when delete wins."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
+            retried_job_ids.append(str(job_id))
+            return True
+
+        monkeypatch.setattr(
+            jobs_api,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            error_message="previous failure",
+        )
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            await session.execute(
+                select(Project)
+                .where(Project.id == uuid.UUID(project["id"]))
+                .with_for_update(of=Project)
+            )
+
+            delete_task = asyncio.create_task(
+                async_client.delete(f"/v1/projects/{project['id']}")
+            )
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
+
+            retry_task = asyncio.create_task(async_client.post(f"/v1/jobs/{job.id}/retry"))
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(retry_task), timeout=0.2)
+
+        delete_response = await asyncio.wait_for(delete_task, timeout=2)
+        retry_response = await asyncio.wait_for(retry_task, timeout=2)
+
+        assert delete_response.status_code == 204
+        assert retry_response.status_code == 404
+        assert retry_response.json() == {
+            "error": {
+                "code": "NOT_FOUND",
+                "message": f"Job with identifier '{job.id}' not found",
+                "details": None,
+            }
+        }
+        assert retried_job_ids == []
+
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "failed"
+
     async def test_process_ingest_job_finalizes_cancel_requested_job_as_cancelled(
         self,
         async_client: httpx.AsyncClient,
@@ -2848,6 +2998,200 @@ class TestJobs:
         assert updated.cancel_requested is True
         assert updated.error_code == ErrorCode.JOB_CANCELLED.value
         assert updated.finished_at is not None
+
+    async def test_process_ingest_job_begin_race_delete_wins_cancels_before_runner(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Delete vs worker begin lock contention should cancel without deadlock."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        runner_calls: list[IngestionRunRequest] = []
+
+        async def _unexpected_run_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            runner_calls.append(request)
+            return _build_fake_ingest_payload(request)
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _unexpected_run_ingestion)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            await session.execute(
+                select(Project)
+                .where(Project.id == uuid.UUID(project["id"]))
+                .with_for_update(of=Project)
+            )
+
+            delete_task = asyncio.create_task(
+                async_client.delete(f"/v1/projects/{project['id']}")
+            )
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
+
+            process_task = asyncio.create_task(worker_module.process_ingest_job(job.id))
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(process_task), timeout=0.2)
+
+        delete_response = await asyncio.wait_for(delete_task, timeout=2)
+        await asyncio.wait_for(process_task, timeout=2)
+
+        assert delete_response.status_code == 204
+        updated = await _get_job(job.id)
+        assert runner_calls == []
+        assert updated.status == "cancelled"
+        assert updated.cancel_requested is True
+        assert updated.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated.finished_at is not None
+
+        artifacts = await _get_generated_artifacts_for_job(job.id)
+        assert artifacts == []
+
+    async def test_mark_job_failed_delete_race_delete_wins_without_failed_overwrite(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Delete should win over a concurrent worker failure terminal write."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        lease = await worker_module._begin_or_resume_ingest_job(job.id)
+
+        assert lease is not None
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+
+        async with session_maker() as session:
+            await session.execute(
+                select(Project)
+                .where(Project.id == uuid.UUID(project["id"]))
+                .with_for_update(of=Project)
+            )
+
+            delete_task = asyncio.create_task(
+                async_client.delete(f"/v1/projects/{project['id']}")
+            )
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
+
+            fail_task = asyncio.create_task(
+                worker_module._mark_job_failed(
+                    job.id,
+                    error_message="Ingest job failed unexpectedly.",
+                    attempt_token=lease.token,
+                )
+            )
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(asyncio.shield(fail_task), timeout=0.2)
+
+        delete_response = await asyncio.wait_for(delete_task, timeout=2)
+        failed = await asyncio.wait_for(fail_task, timeout=2)
+
+        assert delete_response.status_code == 204
+        assert failed is False
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.cancel_requested is True
+        assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated_job.error_message is None
+        assert updated_job.finished_at is not None
+
+    async def test_finalize_ingest_job_delete_race_finalize_wins_soft_deletes_artifact(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Finalize before delete should keep job terminal while delete soft-deletes outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        storage_put_started = asyncio.Event()
+        allow_storage_put = asyncio.Event()
+
+        class _BlockingStorage:
+            async def put(self, key: str, payload: bytes, *, immutable: bool = True) -> Any:
+                _ = immutable
+                storage_put_started.set()
+                await allow_storage_put.wait()
+                return types.SimpleNamespace(
+                    key=key,
+                    storage_uri=f"file://tests/{key}",
+                    size_bytes=len(payload),
+                    checksum_sha256=hashlib.sha256(payload).hexdigest(),
+                )
+
+        monkeypatch.setattr(worker_module, "get_storage", lambda: _BlockingStorage())
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        lease = await worker_module._begin_or_resume_ingest_job(job.id)
+        assert lease is not None
+
+        finalize_request = IngestionRunRequest(
+            job_id=job.id,
+            file_id=job.file_id,
+            checksum_sha256=hashlib.sha256(_TEST_UPLOAD_BODY).hexdigest(),
+            detected_format="pdf",
+            media_type="application/pdf",
+            original_name="plan.pdf",
+            extraction_profile_id=job.extraction_profile_id,
+            initial_job_id=job.id,
+        )
+        payload = _build_fake_ingest_payload(finalize_request)
+
+        finalize_task = asyncio.create_task(
+            worker_module._finalize_ingest_job(
+                job.id,
+                attempt_token=lease.token,
+                payload=payload,
+            )
+        )
+
+        await asyncio.wait_for(storage_put_started.wait(), timeout=2)
+
+        delete_task = asyncio.create_task(async_client.delete(f"/v1/projects/{project['id']}"))
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
+
+        allow_storage_put.set()
+
+        finalized = await asyncio.wait_for(finalize_task, timeout=3)
+        delete_response = await asyncio.wait_for(delete_task, timeout=3)
+
+        assert finalized is True
+        assert delete_response.status_code == 204
+
+        updated = await _get_job(job.id)
+        assert updated.status == "succeeded"
+        assert updated.cancel_requested is False
+        assert updated.finished_at is not None
+
+        artifacts = await _get_generated_artifacts_for_job(job.id)
+        assert len(artifacts) == 1
+        assert artifacts[0].deleted_at is not None
 
     async def test_process_ingest_job_finalizes_cancelled_when_requested_during_completion_race(
         self,


### PR DESCRIPTION
Closes #155

## Summary
- standardize Project → Job → File locking across project delete, retry, worker begin/finalize, and worker terminal failure paths
- preserve soft-delete and cancellation semantics for delete-vs-retry and delete-vs-worker races under concurrency
- add bounded regression tests for delete-vs-retry, begin, finalize, mid-run delete, and worker-failure races

## Test plan
- [x] `uv run ruff check app/api/v1/projects.py app/api/v1/jobs.py app/jobs/worker.py tests/test_jobs.py`
- [x] `uv run mypy app/api/v1/projects.py app/api/v1/jobs.py app/jobs/worker.py tests/test_jobs.py`
- [x] `uv run pytest --collect-only -q` for the 5 new targeted race tests
- [ ] Execute the 5 DB-backed targeted race tests after applying latest migrations to the local Postgres test DB (`projects.deleted_at` is currently missing locally)

## Notes
- Deep review round 2 passed after fixing terminal worker mutation ordering and mid-run project-delete cancellation.