### PR TITLE
fix(db): enforce append-only lineage tables

### DIFF
--- a/alembic/versions/2026_05_12_0014_enforce_append_only_lineage_tables.py
+++ b/alembic/versions/2026_05_12_0014_enforce_append_only_lineage_tables.py
@@ -1,0 +1,238 @@
+"""enforce append-only lineage tables
+
+Revision ID: 2026_05_12_0014
+Revises: 2026_05_11_0013
+Create Date: 2026-05-12 20:30:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import NamedTuple
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_12_0014"
+down_revision: str | None = "2026_05_11_0013"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+APPEND_ONLY_SQLSTATE = "55000"
+_ROW_GUARD_FUNCTION_NAME = "enforce_append_only_lineage_row"
+_TRUNCATE_GUARD_FUNCTION_NAME = "enforce_append_only_lineage_truncate"
+_ROW_TRIGGER_NAME = "trg_append_only_row_guard"
+_TRUNCATE_TRIGGER_NAME = "trg_append_only_truncate_guard"
+
+
+class _AppendOnlyTableSpec(NamedTuple):
+    table_name: str
+    allowlisted_update_columns: tuple[str, ...]
+
+
+_PROTECTED_TABLE_SPECS: tuple[_AppendOnlyTableSpec, ...] = (
+    _AppendOnlyTableSpec("files", ("deleted_at",)),
+    _AppendOnlyTableSpec("extraction_profiles", ()),
+    _AppendOnlyTableSpec("adapter_run_outputs", ()),
+    _AppendOnlyTableSpec("drawing_revisions", ()),
+    _AppendOnlyTableSpec("validation_reports", ()),
+    _AppendOnlyTableSpec("generated_artifacts", ("deleted_at",)),
+    _AppendOnlyTableSpec("job_events", ()),
+)
+
+
+def _create_guard_functions() -> None:
+    """Create shared trigger functions for append-only enforcement."""
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE FUNCTION {_ROW_GUARD_FUNCTION_NAME}()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                allowlisted_columns text[] := COALESCE(TG_ARGV, ARRAY[]::text[]);
+                json_column record;
+                sanitized_old jsonb;
+                sanitized_new jsonb;
+                old_deleted_at jsonb;
+                new_deleted_at jsonb;
+                old_json_text text;
+                new_json_text text;
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION USING
+                        ERRCODE = '{APPEND_ONLY_SQLSTATE}',
+                        MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
+                        DETAIL = 'Protected lineage/history tables are append-only.';
+                END IF;
+
+                FOR json_column IN
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = TG_TABLE_SCHEMA
+                      AND table_name = TG_TABLE_NAME
+                      AND data_type = 'json'
+                      AND NOT (column_name = ANY(allowlisted_columns))
+                LOOP
+                    EXECUTE format(
+                        'SELECT ($1).%1$I::text, ($2).%1$I::text',
+                        json_column.column_name
+                    )
+                    INTO old_json_text, new_json_text
+                    USING OLD, NEW;
+
+                    IF old_json_text IS DISTINCT FROM new_json_text THEN
+                        RAISE EXCEPTION USING
+                            ERRCODE = '{APPEND_ONLY_SQLSTATE}',
+                            MESSAGE = format(
+                                'append-only trigger blocked %s on %I',
+                                TG_OP,
+                                TG_TABLE_NAME
+                            ),
+                            DETAIL = (
+                                'Protected JSON payload columns are append-only and cannot be '
+                                'rewritten after insert.'
+                            );
+                    END IF;
+                END LOOP;
+
+                sanitized_old := to_jsonb(OLD) - allowlisted_columns;
+                sanitized_new := to_jsonb(NEW) - allowlisted_columns;
+
+                IF sanitized_old IS DISTINCT FROM sanitized_new THEN
+                    RAISE EXCEPTION USING
+                        ERRCODE = '{APPEND_ONLY_SQLSTATE}',
+                        MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
+                        DETAIL = 'Only allowlisted soft-delete markers may change on protected lineage/history tables.';
+                END IF;
+
+                IF 'deleted_at' = ANY(allowlisted_columns) THEN
+                    old_deleted_at := to_jsonb(OLD) -> 'deleted_at';
+                    new_deleted_at := to_jsonb(NEW) -> 'deleted_at';
+
+                    IF old_deleted_at = new_deleted_at THEN
+                        RETURN NEW;
+                    END IF;
+
+                    IF old_deleted_at = 'null'::jsonb AND new_deleted_at <> 'null'::jsonb THEN
+                        RETURN NEW;
+                    END IF;
+
+                    RAISE EXCEPTION USING
+                        ERRCODE = '{APPEND_ONLY_SQLSTATE}',
+                        MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
+                        DETAIL = 'deleted_at is write-once and may only change from NULL to non-NULL.';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            CREATE FUNCTION {_TRUNCATE_GUARD_FUNCTION_NAME}()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                RAISE EXCEPTION USING
+                    ERRCODE = '{APPEND_ONLY_SQLSTATE}',
+                    MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
+                    DETAIL = 'Protected lineage/history tables are append-only and cannot be truncated.';
+            END;
+            $$
+            """
+        )
+    )
+
+
+def _create_table_triggers() -> None:
+    """Attach row and truncate append-only guards to protected tables."""
+
+    for spec in _PROTECTED_TABLE_SPECS:
+        allowlisted_columns = ", ".join(
+            f"'{column_name}'" for column_name in spec.allowlisted_update_columns
+        )
+        function_arguments = f"({allowlisted_columns})" if allowlisted_columns else "()"
+
+        op.execute(
+            sa.text(
+                f"""
+                CREATE TRIGGER {_ROW_TRIGGER_NAME}
+                BEFORE UPDATE OR DELETE ON "{spec.table_name}"
+                FOR EACH ROW
+                EXECUTE FUNCTION {_ROW_GUARD_FUNCTION_NAME}{function_arguments}
+                """
+            )
+        )
+        op.execute(
+            sa.text(
+                f"""
+                CREATE TRIGGER {_TRUNCATE_TRIGGER_NAME}
+                BEFORE TRUNCATE ON "{spec.table_name}"
+                FOR EACH STATEMENT
+                EXECUTE FUNCTION {_TRUNCATE_GUARD_FUNCTION_NAME}()
+                """
+            )
+        )
+
+
+def _drop_table_triggers() -> None:
+    """Remove append-only triggers from protected tables."""
+
+    for spec in _PROTECTED_TABLE_SPECS:
+        op.execute(sa.text(f'DROP TRIGGER IF EXISTS {_TRUNCATE_TRIGGER_NAME} ON "{spec.table_name}"'))
+        op.execute(sa.text(f'DROP TRIGGER IF EXISTS {_ROW_TRIGGER_NAME} ON "{spec.table_name}"'))
+
+
+def _drop_guard_functions() -> None:
+    """Drop shared append-only enforcement functions."""
+
+    op.execute(sa.text(f"DROP FUNCTION IF EXISTS {_TRUNCATE_GUARD_FUNCTION_NAME}()"))
+    op.execute(sa.text(f"DROP FUNCTION IF EXISTS {_ROW_GUARD_FUNCTION_NAME}()"))
+
+
+def _assert_protected_tables_empty_for_downgrade() -> None:
+    """Refuse to remove append-only protections while protected rows exist."""
+
+    bind = op.get_bind()
+    non_empty_tables: list[str] = []
+
+    for spec in _PROTECTED_TABLE_SPECS:
+        has_rows = bind.execute(
+            sa.select(sa.literal(1)).select_from(sa.table(spec.table_name)).limit(1)
+        ).first()
+        if has_rows is not None:
+            non_empty_tables.append(spec.table_name)
+
+    if non_empty_tables:
+        joined_tables = ", ".join(non_empty_tables)
+        raise RuntimeError(
+            "Refusing to downgrade migration 2026_05_12_0014: removing append-only "
+            "protections while protected tables contain rows can permit destructive "
+            "lineage/history edits. Empty the following tables before retrying: "
+            f"{joined_tables}."
+        )
+
+
+def upgrade() -> None:
+    """Protect lineage/history tables from destructive mutations."""
+
+    _create_guard_functions()
+    _create_table_triggers()
+
+
+def downgrade() -> None:
+    """Remove append-only lineage/history protection from empty databases only."""
+
+    _assert_protected_tables_empty_for_downgrade()
+    _drop_table_triggers()
+    _drop_guard_functions()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,6 +66,36 @@ Write ownership is split by responsibility:
 - Append-only records keep their payload and lineage immutable after commit;
   mutable records are limited to workflow/state transitions.
 
+Database-level append-only enforcement protects the core lineage/history tables:
+
+- `files`
+- `extraction_profiles`
+- `adapter_run_outputs`
+- `drawing_revisions`
+- `validation_reports`
+- `generated_artifacts`
+- `job_events`
+
+The implementation uses shared PostgreSQL PL/pgSQL trigger functions with
+per-table row and truncate triggers. Row-update checks compare `to_jsonb(OLD)`
+and `to_jsonb(NEW)` after removing any explicitly allowlisted mutable keys, so
+the comparison is JSON-safe across nullable and structured columns.
+
+The mutable allowlist is intentionally minimal:
+
+- `files.deleted_at`
+- `generated_artifacts.deleted_at`
+
+Those fields are write-once and may transition only from `NULL` to non-`NULL`.
+Protected tables reject `DELETE` and `TRUNCATE`, including cascaded truncate
+attempts. Review-state or report-state changes on protected historical rows are
+not allowed by this enforcement; any future workflow that needs them must ship
+an explicit migration and allowlist update.
+
+This trigger-based protection is an MVP integrity guardrail, not a full
+privilege boundary. Postgres table owners and superusers can still disable
+triggers, so stronger production role separation is a later hardening concern.
+
 ### Ingestion Adapters
 
 Format-specific adapters turn source files into canonical drawing data.
@@ -424,9 +454,10 @@ Append-only versus mutable record rules:
 - Append-only records include original file records, drawing revisions, approved
   quantity takeoffs, finalized estimate versions, generated artifacts, and
   `job_events`.
-- Mutable workflow/state fields include job status, progress, retry/cancel
-  control flags, `deleted_at`, and allowed review/supersession markers on
-  records that support those transitions.
+- Mutable workflow/state fields include job status, progress, and retry/cancel
+  control flags. Within protected append-only tables, only `files.deleted_at`
+  and `generated_artifacts.deleted_at` are mutable, and only as write-once
+  `NULL -> non-NULL` soft-delete markers.
 - Mutable workflow changes must never replace the stored payload, checksum,
   provenance, or lineage of an already committed append-only record.
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -621,11 +621,31 @@ Database ownership and append-only policy:
   read them, but never replace the original object or rewrite the row as a new
   source. Upload responses and file-read responses must expose the durable
   initial lineage fields `initial_job_id` and `initial_extraction_profile_id`.
-- Drawing revisions, approved quantity takeoffs, finalized estimate versions,
-  export artifacts, and `job_events` are append-only historical records.
-- Mutable workflow/state records include job status, attempt counters, progress,
-  `cancel_requested`, `deleted_at`, and allowed review/supersession state
-  transitions.
+- Database-level append-only enforcement protects lineage/history tables:
+  `files`, `extraction_profiles`, `adapter_run_outputs`,
+  `drawing_revisions`, `validation_reports`, `generated_artifacts`, and
+  `job_events`.
+- Enforcement is implemented with shared PostgreSQL trigger functions plus
+  per-table row and truncate triggers. Row comparison is JSON-safe: trigger
+  checks compare `to_jsonb(OLD)` and `to_jsonb(NEW)` after removing any
+  explicitly allowlisted mutable keys.
+- The explicit mutable allowlist is narrow and write-once: only
+  `files.deleted_at` and `generated_artifacts.deleted_at` may change, and only
+  from `NULL` to non-`NULL`.
+- Review-state or report-state mutation on protected historical rows is not part
+  of this allowlist. If a future workflow needs those fields to change after
+  insert, that requires an explicit migration and allowlist update rather than a
+  silent policy exception.
+- Protected tables reject `DELETE` and `TRUNCATE`, including cascaded truncate
+  attempts, so lineage/history records cannot be cleared through direct or
+  indirect destructive SQL paths.
+- Downgrade policy is conservative: migrations must refuse to remove these
+  protections from populated protected tables.
+- This is an MVP integrity control, not a full privilege boundary: Postgres
+  table owners and superusers can still disable triggers. Stronger production
+  role separation and trigger-hardening remain later operational concerns.
+- Mutable workflow/state records outside the protected append-only contract
+  include job status, attempt counters, progress, and `cancel_requested`.
 - Mutable state must not be used to rewrite the payload, lineage, checksum, or
   source references of an already committed append-only record.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,22 @@ from app.db.session import get_db
 from app.main import app as fastapi_app
 from app.storage.dependencies import _get_default_storage
 
+APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
+    "files",
+    "extraction_profiles",
+    "adapter_run_outputs",
+    "drawing_revisions",
+    "validation_reports",
+    "generated_artifacts",
+    "job_events",
+)
+APPEND_ONLY_ROW_TRIGGER_NAME = "trg_append_only_row_guard"
+APPEND_ONLY_TRUNCATE_TRIGGER_NAME = "trg_append_only_truncate_guard"
+_APPEND_ONLY_TRIGGER_NAMES: tuple[str, ...] = (
+    APPEND_ONLY_ROW_TRIGGER_NAME,
+    APPEND_ONLY_TRUNCATE_TRIGGER_NAME,
+)
+
 # Marker for tests that require a running database
 requires_database = pytest.mark.skipif(
     not os.environ.get("DATABASE_URL"),
@@ -82,6 +98,125 @@ async def _override_get_db() -> AsyncGenerator[AsyncSession, None]:
         await session.close()
 
 
+async def _append_only_trigger_exists(
+    session: AsyncSession,
+    *,
+    table_name: str,
+    trigger_name: str,
+) -> bool:
+    """Return whether a named append-only trigger exists on a table."""
+
+    result = await session.execute(
+        text(
+            """
+            SELECT 1
+            FROM pg_trigger
+            WHERE tgrelid = to_regclass(:table_name)
+              AND tgname = :trigger_name
+            """
+        ),
+        {"table_name": table_name, "trigger_name": trigger_name},
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _load_existing_append_only_triggers(
+    session: AsyncSession,
+) -> list[tuple[str, str]]:
+    """Return append-only triggers currently installed in the test database."""
+
+    existing_triggers: list[tuple[str, str]] = []
+    for table_name in APPEND_ONLY_PROTECTED_TABLES:
+        for trigger_name in _APPEND_ONLY_TRIGGER_NAMES:
+            if await _append_only_trigger_exists(
+                session,
+                table_name=table_name,
+                trigger_name=trigger_name,
+            ):
+                existing_triggers.append((table_name, trigger_name))
+
+    return existing_triggers
+
+
+async def _set_append_only_triggers_enabled(
+    session: AsyncSession,
+    *,
+    triggers: list[tuple[str, str]],
+    enabled: bool,
+) -> None:
+    """Enable or disable named append-only triggers for test-only cleanup."""
+
+    action = "ENABLE" if enabled else "DISABLE"
+    for table_name, trigger_name in triggers:
+        await session.execute(
+            text(f'ALTER TABLE "{table_name}" {action} TRIGGER {trigger_name}')
+        )
+
+
+async def _assert_append_only_triggers_enabled(
+    session: AsyncSession,
+    *,
+    triggers: list[tuple[str, str]],
+) -> None:
+    """Assert named append-only triggers are fully re-enabled."""
+
+    for table_name, trigger_name in triggers:
+        state = await session.execute(
+            text(
+                """
+                SELECT tgenabled
+                FROM pg_trigger
+                WHERE tgrelid = to_regclass(:table_name)
+                  AND tgname = :trigger_name
+                """
+            ),
+            {"table_name": table_name, "trigger_name": trigger_name},
+        )
+        raw_state = state.scalar_one()
+        normalized_state = raw_state.decode() if isinstance(raw_state, bytes) else raw_state
+        assert normalized_state == "O"
+
+
+async def truncate_projects_cascade_for_cleanup() -> None:
+    """Hard-clean projects by temporarily disabling only append-only triggers."""
+
+    if not os.environ.get("DATABASE_URL"):
+        return
+
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        existing_triggers: list[tuple[str, str]] = []
+        triggers_disabled = False
+        try:
+            try:
+                existing_triggers = await _load_existing_append_only_triggers(session)
+                if existing_triggers:
+                    await _set_append_only_triggers_enabled(
+                        session,
+                        triggers=existing_triggers,
+                        enabled=False,
+                    )
+                    triggers_disabled = True
+                await session.execute(text("TRUNCATE TABLE projects CASCADE"))
+            finally:
+                if triggers_disabled:
+                    await _set_append_only_triggers_enabled(
+                        session,
+                        triggers=existing_triggers,
+                        enabled=True,
+                    )
+                    await _assert_append_only_triggers_enabled(session, triggers=existing_triggers)
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
 @pytest_asyncio.fixture
 async def async_client(app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
     """Provide an async HTTP client for testing with DB dependency override."""
@@ -103,17 +238,9 @@ async def cleanup_projects() -> AsyncGenerator[None, None]:
         yield
         return
 
-    import app.db.session as session_module
-
-    session_maker = session_module.AsyncSessionLocal
-    if session_maker is None:
-        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
-
     yield
 
-    async with session_maker() as session:
-        await session.execute(text("TRUNCATE TABLE projects CASCADE"))
-        await session.commit()
+    await truncate_projects_cascade_for_cleanup()
 
 
 @pytest.fixture

--- a/tests/test_append_only_lineage_tables.py
+++ b/tests/test_append_only_lineage_tables.py
@@ -1,0 +1,630 @@
+"""Integration tests for append-only lineage/history table enforcement."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from json import dumps
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import app.db.session as session_module
+import app.jobs.worker as worker_module
+from app.ingestion.finalization import IngestFinalizationPayload
+from app.ingestion.runner import IngestionRunRequest
+from app.jobs.worker import process_ingest_job
+from tests.conftest import (
+    APPEND_ONLY_PROTECTED_TABLES,
+    APPEND_ONLY_ROW_TRIGGER_NAME,
+    APPEND_ONLY_TRUNCATE_TRIGGER_NAME,
+    requires_database,
+    truncate_projects_cascade_for_cleanup,
+)
+from tests.test_ingest_output_persistence import (
+    _as_uuid,
+    _load_job_events,
+    _load_project_outputs,
+)
+from tests.test_jobs import (
+    _build_fake_ingest_payload,
+    _create_project,
+    _get_job_for_file,
+    _upload_file,
+)
+
+_APPEND_ONLY_SQLSTATE = "55000"
+_DOWNGRADE_TARGET_REVISION = "2026_05_11_0013"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class _ProtectedRowIds:
+    project_id: uuid.UUID
+    file_id: uuid.UUID
+    extraction_profile_id: uuid.UUID
+    job_id: uuid.UUID
+    adapter_run_output_id: uuid.UUID
+    drawing_revision_id: uuid.UUID
+    validation_report_id: uuid.UUID
+    generated_artifact_id: uuid.UUID
+    job_event_id: uuid.UUID
+
+
+@pytest.fixture(autouse=True)
+def fake_ingestion_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[IngestionRunRequest]:
+    """Patch worker ingestion with deterministic persisted outputs."""
+
+    recorded_requests: list[IngestionRunRequest] = []
+
+    async def _fake_run_ingestion(request: IngestionRunRequest) -> IngestFinalizationPayload:
+        recorded_requests.append(request)
+        return _build_fake_ingest_payload(request)
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _fake_run_ingestion)
+    return recorded_requests
+
+
+def _database_url() -> URL:
+    """Return the configured database URL for local Alembic validation."""
+
+    raw_database_url = os.environ.get("DATABASE_URL")
+    if raw_database_url is None:
+        raise RuntimeError("DATABASE_URL not set")
+
+    return make_url(raw_database_url)
+
+
+def _url_string(url: URL) -> str:
+    """Render a SQLAlchemy URL with the password preserved."""
+
+    return url.render_as_string(hide_password=False)
+
+
+def _extract_sqlstate(error: BaseException) -> str | None:
+    """Best-effort extraction of a PostgreSQL SQLSTATE from wrapped DB errors."""
+
+    candidates = [
+        error,
+        getattr(error, "orig", None),
+        getattr(getattr(error, "orig", None), "__cause__", None),
+        getattr(error, "__cause__", None),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+
+        for attribute_name in ("sqlstate", "pgcode"):
+            value = getattr(candidate, attribute_name, None)
+            if isinstance(value, str):
+                return value
+
+    return None
+
+
+def _assert_append_only_error(
+    error: DBAPIError,
+    *,
+    operation: str,
+    table_name: str | None,
+) -> None:
+    """Assert a database error came from the append-only trigger guard."""
+
+    assert _extract_sqlstate(error) == _APPEND_ONLY_SQLSTATE
+    assert f"append-only trigger blocked {operation}" in str(error)
+    if table_name is not None:
+        assert f"on {table_name}" in str(error)
+
+
+def _row_id_for_table(row_ids: _ProtectedRowIds, table_name: str) -> uuid.UUID:
+    """Map protected table names to seeded row identifiers."""
+
+    ids_by_table = {
+        "files": row_ids.file_id,
+        "extraction_profiles": row_ids.extraction_profile_id,
+        "adapter_run_outputs": row_ids.adapter_run_output_id,
+        "drawing_revisions": row_ids.drawing_revision_id,
+        "validation_reports": row_ids.validation_report_id,
+        "generated_artifacts": row_ids.generated_artifact_id,
+        "job_events": row_ids.job_event_id,
+    }
+    return ids_by_table[table_name]
+
+
+async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRowIds:
+    """Create one persisted row in each protected lineage/history table."""
+
+    project = await _create_project(async_client)
+    uploaded = await _upload_file(async_client, project["id"])
+    job = await _get_job_for_file(str(uploaded["id"]))
+
+    await process_ingest_job(job.id)
+
+    adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
+        await _load_project_outputs(project["id"])
+    )
+    job_events = await _load_job_events(job.id)
+
+    assert len(adapter_outputs) == 1
+    assert len(drawing_revisions) == 1
+    assert len(validation_reports) == 1
+    assert len(generated_artifacts) == 1
+    assert job.extraction_profile_id is not None
+    assert job_events
+
+    return _ProtectedRowIds(
+        project_id=_as_uuid(project["id"]),
+        file_id=_as_uuid(uploaded["id"]),
+        extraction_profile_id=job.extraction_profile_id,
+        job_id=job.id,
+        adapter_run_output_id=adapter_outputs[0].id,
+        drawing_revision_id=drawing_revisions[0].id,
+        validation_report_id=validation_reports[0].id,
+        generated_artifact_id=generated_artifacts[0].id,
+        job_event_id=job_events[0].id,
+    )
+
+
+async def _run_sql_and_expect_append_only_failure(
+    statement: str,
+    parameters: Mapping[str, Any] | None,
+    *,
+    operation: str,
+    table_name: str | None,
+) -> None:
+    """Execute a SQL mutation and assert the append-only trigger rejects it."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        with pytest.raises(DBAPIError) as exc_info:
+            execution_parameters = {} if parameters is None else dict(parameters)
+            await session.execute(sa.text(statement), execution_parameters)
+            await session.commit()
+
+        await session.rollback()
+
+    _assert_append_only_error(exc_info.value, operation=operation, table_name=table_name)
+
+
+async def _load_append_only_trigger_states() -> dict[tuple[str, str], str | None]:
+    """Load installed append-only trigger enabled states from PostgreSQL."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    trigger_states: dict[tuple[str, str], str | None] = {}
+    async with session_maker() as session:
+        for table_name in APPEND_ONLY_PROTECTED_TABLES:
+            for trigger_name in (APPEND_ONLY_ROW_TRIGGER_NAME, APPEND_ONLY_TRUNCATE_TRIGGER_NAME):
+                result = await session.execute(
+                    sa.text(
+                        """
+                        SELECT tgenabled
+                        FROM pg_trigger
+                        WHERE tgrelid = to_regclass(:table_name)
+                          AND tgname = :trigger_name
+                        """
+                    ),
+                    {"table_name": table_name, "trigger_name": trigger_name},
+                )
+                raw_state = result.scalar_one_or_none()
+                if isinstance(raw_state, bytes):
+                    trigger_states[(table_name, trigger_name)] = raw_state.decode()
+                else:
+                    trigger_states[(table_name, trigger_name)] = raw_state
+
+    return trigger_states
+
+
+def _run_alembic_command(*args: str, database_url: str) -> subprocess.CompletedProcess[str]:
+    """Run Alembic against an explicitly selected database URL."""
+
+    env = os.environ.copy()
+    env["DATABASE_URL"] = database_url
+    return subprocess.run(
+        ["uv", "run", "alembic", *args],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+async def _create_temp_database() -> tuple[str, str]:
+    """Create an isolated PostgreSQL database for downgrade validation."""
+
+    base_url = _database_url()
+    admin_url = base_url.set(drivername="postgresql", database="postgres")
+    database_name = f"draupnir_append_only_{uuid.uuid4().hex}"
+
+    import asyncpg  # type: ignore[import-untyped]
+
+    connection = await asyncpg.connect(_url_string(admin_url))
+    try:
+        await connection.execute(f'CREATE DATABASE "{database_name}"')
+    finally:
+        await connection.close()
+
+    return database_name, _url_string(base_url.set(database=database_name))
+
+
+async def _drop_temp_database(database_name: str) -> None:
+    """Drop an isolated PostgreSQL database created for a downgrade test."""
+
+    admin_url = _database_url().set(drivername="postgresql", database="postgres")
+
+    import asyncpg
+
+    connection = await asyncpg.connect(_url_string(admin_url))
+    try:
+        await connection.execute(
+            (
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = $1 AND pid <> pg_backend_pid()"
+            ),
+            database_name,
+        )
+        await connection.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+    finally:
+        await connection.close()
+
+
+async def _insert_protected_file_row(database_url: str) -> None:
+    """Insert one protected file row for downgrade guard validation."""
+
+    engine = create_async_engine(database_url)
+    project_id = uuid.uuid4()
+    file_id = uuid.uuid4()
+
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO projects (
+                        id,
+                        name,
+                        description,
+                        default_unit_system,
+                        default_currency
+                    )
+                    VALUES (:id, :name, :description, :default_unit_system, :default_currency)
+                    """
+                ),
+                {
+                    "id": project_id,
+                    "name": "append-only downgrade guard",
+                    "description": None,
+                    "default_unit_system": None,
+                    "default_currency": None,
+                },
+            )
+            await connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO files (
+                        id,
+                        project_id,
+                        original_filename,
+                        media_type,
+                        detected_format,
+                        storage_uri,
+                        size_bytes,
+                        checksum_sha256
+                    ) VALUES (
+                        :id,
+                        :project_id,
+                        :original_filename,
+                        :media_type,
+                        :detected_format,
+                        :storage_uri,
+                        :size_bytes,
+                        :checksum_sha256
+                    )
+                    """
+                ),
+                {
+                    "id": file_id,
+                    "project_id": project_id,
+                    "original_filename": "plan.pdf",
+                    "media_type": "application/pdf",
+                    "detected_format": "pdf",
+                    "storage_uri": "file:///tmp/plan.pdf",
+                    "size_bytes": 1,
+                    "checksum_sha256": "a" * 64,
+                },
+            )
+    finally:
+        await engine.dispose()
+
+
+@requires_database
+class TestAppendOnlyLineageTables:
+    """Tests for DB-enforced append-only lineage/history protections."""
+
+    async def test_append_only_triggers_are_installed_and_enabled(self) -> None:
+        """Every protected table should have both append-only triggers enabled."""
+
+        _ = self
+        trigger_states = await _load_append_only_trigger_states()
+
+        for table_name in APPEND_ONLY_PROTECTED_TABLES:
+            assert trigger_states[(table_name, APPEND_ONLY_ROW_TRIGGER_NAME)] == "O"
+            assert trigger_states[(table_name, APPEND_ONLY_TRUNCATE_TRIGGER_NAME)] == "O"
+
+    async def test_cleanup_helper_reenables_append_only_triggers(
+        self,
+        async_client: httpx.AsyncClient,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Cleanup helper should restore trigger state after truncating seeded lineage rows."""
+
+        _ = self
+        _ = enqueued_job_ids
+
+        _ = await _seed_protected_rows(async_client)
+        await truncate_projects_cascade_for_cleanup()
+
+        trigger_states = await _load_append_only_trigger_states()
+        for table_name in APPEND_ONLY_PROTECTED_TABLES:
+            assert trigger_states[(table_name, APPEND_ONLY_ROW_TRIGGER_NAME)] == "O"
+            assert trigger_states[(table_name, APPEND_ONLY_TRUNCATE_TRIGGER_NAME)] == "O"
+
+    async def test_non_allowlisted_updates_are_rejected(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Protected lineage/history rows should reject non-allowlisted updates."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        row_ids = await _seed_protected_rows(async_client)
+        update_cases: tuple[tuple[str, str, str], ...] = (
+            ("files", "original_filename", "mutated-plan.pdf"),
+            ("extraction_profiles", "layout_mode", "manual"),
+            ("adapter_run_outputs", "adapter_version", "mutated"),
+            ("drawing_revisions", "review_state", "superseded"),
+            ("validation_reports", "validator_version", "mutated"),
+            ("generated_artifacts", "name", "mutated-debug-overlay.svg"),
+            ("job_events", "message", "mutated job event"),
+        )
+
+        for table_name, column_name, replacement_value in update_cases:
+            await _run_sql_and_expect_append_only_failure(
+                (
+                    f'UPDATE "{table_name}" SET "{column_name}" = :replacement_value '
+                    "WHERE id = :row_id"
+                ),
+                {
+                    "replacement_value": replacement_value,
+                    "row_id": _row_id_for_table(row_ids, table_name),
+                },
+                operation="UPDATE",
+                table_name=table_name,
+            )
+
+    async def test_semantically_equivalent_json_rewrites_are_rejected(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Protected JSON payload columns should reject text-only equivalent rewrites."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        row_ids = await _seed_protected_rows(async_client)
+        equivalent_canonical_json = dumps(
+            {
+                "schema_version": "0.1",
+                "canonical_entity_schema_version": "0.1",
+                "layers": [{"name": "A-WALL"}],
+                "layouts": [{"name": "Model"}],
+                "blocks": [],
+                "entities": [{"layer": "A-WALL", "kind": "line"}],
+                "entity_counts": {
+                    "entities": 1,
+                    "blocks": 0,
+                    "layers": 1,
+                    "layouts": 1,
+                },
+            },
+            separators=(",", ":"),
+        )
+
+        await _run_sql_and_expect_append_only_failure(
+            (
+                'UPDATE "adapter_run_outputs" '
+                'SET canonical_json = CAST(:replacement_value AS json) '
+                'WHERE id = :row_id'
+            ),
+            {
+                "replacement_value": equivalent_canonical_json,
+                "row_id": row_ids.adapter_run_output_id,
+            },
+            operation="UPDATE",
+            table_name="adapter_run_outputs",
+        )
+
+    async def test_soft_delete_markers_are_write_once(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """File and artifact soft-delete markers may only transition from NULL once."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        row_ids = await _seed_protected_rows(async_client)
+
+        delete_response = await async_client.delete(f"/v1/projects/{row_ids.project_id}")
+        assert delete_response.status_code == 204
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            deleted_file_at = await session.scalar(
+                sa.text('SELECT deleted_at FROM "files" WHERE id = :row_id'),
+                {"row_id": row_ids.file_id},
+            )
+            deleted_artifact_at = await session.scalar(
+                sa.text('SELECT deleted_at FROM "generated_artifacts" WHERE id = :row_id'),
+                {"row_id": row_ids.generated_artifact_id},
+            )
+
+        assert deleted_file_at is not None
+        assert deleted_artifact_at is not None
+
+        for table_name, row_id in (
+            ("files", row_ids.file_id),
+            ("generated_artifacts", row_ids.generated_artifact_id),
+        ):
+            await _run_sql_and_expect_append_only_failure(
+                f'UPDATE "{table_name}" SET deleted_at = NULL WHERE id = :row_id',
+                {"row_id": row_id},
+                operation="UPDATE",
+                table_name=table_name,
+            )
+            await _run_sql_and_expect_append_only_failure(
+                (
+                    f'UPDATE "{table_name}" '
+                    "SET deleted_at = now() + interval '1 second' WHERE id = :row_id"
+                ),
+                {"row_id": row_id},
+                operation="UPDATE",
+                table_name=table_name,
+            )
+
+    async def test_protected_rows_reject_delete(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """DELETE should fail with append-only trigger errors, not FK false positives."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        row_ids = await _seed_protected_rows(async_client)
+
+        for table_name in APPEND_ONLY_PROTECTED_TABLES:
+            await _run_sql_and_expect_append_only_failure(
+                f'DELETE FROM "{table_name}" WHERE id = :row_id',
+                {"row_id": _row_id_for_table(row_ids, table_name)},
+                operation="DELETE",
+                table_name=table_name,
+            )
+
+    async def test_protected_tables_reject_truncate(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Every protected table should reject direct TRUNCATE attempts."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        _ = await _seed_protected_rows(async_client)
+
+        for table_name in APPEND_ONLY_PROTECTED_TABLES:
+            await _run_sql_and_expect_append_only_failure(
+                f'TRUNCATE TABLE "{table_name}" CASCADE',
+                None,
+                operation="TRUNCATE",
+                table_name=table_name,
+            )
+
+    async def test_cascaded_project_truncate_is_blocked(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """TRUNCATE projects CASCADE should still be blocked by protected child tables."""
+
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        _ = await _seed_protected_rows(async_client)
+
+        await _run_sql_and_expect_append_only_failure(
+            'TRUNCATE TABLE "projects" CASCADE',
+            None,
+            operation="TRUNCATE",
+            table_name=None,
+        )
+
+    async def test_downgrade_fails_closed_on_populated_protected_tables(self) -> None:
+        """Downgrade should refuse to remove append-only guards while protected rows exist."""
+
+        _ = self
+        database_name, database_url = await _create_temp_database()
+
+        try:
+            upgrade_result = _run_alembic_command("upgrade", "head", database_url=database_url)
+            assert upgrade_result.returncode == 0, upgrade_result.stdout + upgrade_result.stderr
+
+            await _insert_protected_file_row(database_url)
+
+            downgrade_result = _run_alembic_command(
+                "downgrade",
+                _DOWNGRADE_TARGET_REVISION,
+                database_url=database_url,
+            )
+            assert downgrade_result.returncode != 0
+
+            combined_output = downgrade_result.stdout + downgrade_result.stderr
+            assert "Refusing to downgrade migration 2026_05_12_0014" in combined_output
+            assert "files" in combined_output
+        finally:
+            await _drop_temp_database(database_name)
+
+    async def test_downgrade_succeeds_on_empty_database(self) -> None:
+        """Downgrade should succeed when every protected table is empty."""
+
+        _ = self
+        database_name, database_url = await _create_temp_database()
+
+        try:
+            upgrade_result = _run_alembic_command("upgrade", "head", database_url=database_url)
+            assert upgrade_result.returncode == 0, upgrade_result.stdout + upgrade_result.stderr
+
+            downgrade_result = _run_alembic_command(
+                "downgrade",
+                _DOWNGRADE_TARGET_REVISION,
+                database_url=database_url,
+            )
+            assert (
+                downgrade_result.returncode == 0
+            ), downgrade_result.stdout + downgrade_result.stderr
+        finally:
+            await _drop_temp_database(database_name)

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -3,7 +3,7 @@
 import asyncio
 import uuid
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast
 
 import httpx
@@ -588,6 +588,7 @@ class TestIngestOutputPersistence:
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Persisted validation reports should accept TRD v0.1 status and gate values."""
         _ = self
@@ -598,6 +599,28 @@ class TestIngestOutputPersistence:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
+        async def _run_ingestion_with_trd_values(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            validation_status = "valid_with_warnings"
+            quantity_gate = "allowed_provisional"
+            return replace(
+                payload,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+                report_json={
+                    **payload.report_json,
+                    "summary": {
+                        **payload.report_json["summary"],
+                        "validation_status": validation_status,
+                        "quantity_gate": quantity_gate,
+                    },
+                },
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_ingestion_with_trd_values)
+
         await process_ingest_job(job.id)
 
         (
@@ -606,28 +629,10 @@ class TestIngestOutputPersistence:
             validation_reports,
             _generated_artifacts,
         ) = await _load_project_outputs(project["id"])
+
         validation_report = validation_reports[0]
-
-        session_maker = session_module.AsyncSessionLocal
-        assert session_maker is not None
-
-        async with session_maker() as session:
-            persisted_validation_report = await session.get(ValidationReport, validation_report.id)
-            assert persisted_validation_report is not None
-            persisted_validation_report.validation_status = "valid_with_warnings"
-            persisted_validation_report.quantity_gate = "allowed_provisional"
-            await session.commit()
-
-        (
-            _adapter_outputs,
-            _drawing_revisions,
-            updated_validation_reports,
-            _generated_artifacts,
-        ) = await _load_project_outputs(project["id"])
-        updated_validation_report = updated_validation_reports[0]
-
-        assert updated_validation_report.validation_status == "valid_with_warnings"
-        assert updated_validation_report.quantity_gate == "allowed_provisional"
+        assert validation_report.validation_status == "valid_with_warnings"
+        assert validation_report.quantity_gate == "allowed_provisional"
 
     async def test_concurrent_reprocess_creates_linear_three_revision_chain(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any, cast
 
 import httpx
@@ -297,28 +298,22 @@ async def _update_job(
     return await _get_job(job_id)
 
 
-async def _update_source_file(
-    file_id: uuid.UUID,
-    *,
-    checksum_sha256: str | None = None,
-    original_filename: str | None = None,
-) -> File:
-    """Update and return a persisted source file for test setup."""
+async def _remove_source_file_bytes(file_id: uuid.UUID) -> str:
+    """Delete stored source bytes without mutating append-only file metadata."""
+
     session_maker = session_module.AsyncSessionLocal
     assert session_maker is not None
 
     async with session_maker() as session:
         source_file = await session.get(File, file_id)
         assert source_file is not None
+        storage_uri = source_file.storage_uri
 
-        if checksum_sha256 is not None:
-            source_file.checksum_sha256 = checksum_sha256
-        if original_filename is not None:
-            source_file.original_filename = original_filename
-
-        await session.commit()
-
-    return source_file
+    assert storage_uri.startswith("file://")
+    storage_path = Path(storage_uri.removeprefix("file://"))
+    assert storage_path.exists()
+    storage_path.unlink()
+    return storage_uri
 
 
 async def _mark_source_deleted(
@@ -688,7 +683,6 @@ class TestJobs:
         _ = cleanup_projects
         _ = enqueued_job_ids
 
-        secret_checksum = "f" * 64
         logger_error_calls: list[tuple[str, dict[str, Any]]] = []
 
         def _capture_logger_error(event: str, **kwargs: Any) -> None:
@@ -708,7 +702,7 @@ class TestJobs:
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
-        await _update_source_file(uuid.UUID(uploaded["id"]), checksum_sha256=secret_checksum)
+        secret_storage_uri = await _remove_source_file_bytes(uuid.UUID(uploaded["id"]))
 
         with pytest.raises(
             IngestionRunnerError,
@@ -720,7 +714,7 @@ class TestJobs:
         assert updated_job.status == "failed"
         assert updated_job.error_code == ErrorCode.STORAGE_FAILED.value
         assert updated_job.error_message == "Failed to read original source from storage."
-        assert secret_checksum not in updated_job.error_message
+        assert secret_storage_uri not in updated_job.error_message
 
         response = await async_client.get(f"/v1/jobs/{job.id}/events")
         assert response.status_code == 200
@@ -730,8 +724,8 @@ class TestJobs:
             "error_code": ErrorCode.STORAGE_FAILED.value,
             "error_message": "Failed to read original source from storage.",
         }
-        assert secret_checksum not in str(data["items"][-1]["data_json"])
-        assert secret_checksum not in str(logger_error_calls)
+        assert secret_storage_uri not in str(data["items"][-1]["data_json"])
+        assert secret_storage_uri not in str(logger_error_calls)
         assert logger_error_calls == [
             (
                 "ingest_job_failed",
@@ -782,7 +776,6 @@ class TestJobs:
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
-        await _update_source_file(uuid.UUID(uploaded["id"]), original_filename="..")
         monkeypatch.setattr("app.storage.memory.MemoryStorage.copy_to_path", _fail_copy_to_path)
         monkeypatch.setattr(
             "app.storage.local.LocalFilesystemStorage.copy_to_path",

--- a/tests/test_lineage_delete_restrictions.py
+++ b/tests/test_lineage_delete_restrictions.py
@@ -10,7 +10,7 @@ from typing import Any
 import httpx
 import pytest
 import sqlalchemy as sa
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 
 import app.db.session as session_module
 import app.jobs.worker as worker_module
@@ -318,8 +318,15 @@ async def _assert_hard_delete_fails(model: type[Any], object_id: uuid.UUID) -> N
 
         await session.delete(row)
 
-        with pytest.raises(IntegrityError):
+        with pytest.raises((DBAPIError, IntegrityError)) as exc_info:
             await session.commit()
+
+        if isinstance(exc_info.value, DBAPIError):
+            sqlstate = getattr(exc_info.value.orig, "sqlstate", None)
+            if sqlstate == "55000":
+                assert "append-only trigger blocked DELETE on" in str(exc_info.value)
+            else:
+                assert sqlstate == "23503"
 
         await session.rollback()
 

--- a/tests/test_lineage_delete_restrictions.py
+++ b/tests/test_lineage_delete_restrictions.py
@@ -326,7 +326,7 @@ async def _assert_hard_delete_fails(model: type[Any], object_id: uuid.UUID) -> N
             if sqlstate == "55000":
                 assert "append-only trigger blocked DELETE on" in str(exc_info.value)
             else:
-                assert sqlstate == "23503"
+                assert sqlstate in {"23503", "23001"}
 
         await session.rollback()
 

--- a/tests/test_validation_report_api.py
+++ b/tests/test_validation_report_api.py
@@ -1,6 +1,7 @@
 """Integration tests for validation report API responses."""
 
 import uuid
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -14,7 +15,6 @@ from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
 from app.jobs.worker import process_ingest_job
 from app.models.generated_artifact import GeneratedArtifact
-from app.models.validation_report import ValidationReport
 from tests.conftest import requires_database
 from tests.test_ingest_output_persistence import (
     _assert_validation_report_json_matches_columns,
@@ -143,6 +143,7 @@ class TestValidationReportApi:
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """API output should prefer persisted columns over stale nested confidence JSON."""
         _ = self
@@ -153,42 +154,49 @@ class TestValidationReportApi:
         uploaded = await _upload_file(async_client, project["id"])
         job = await _get_job_for_file(str(uploaded["id"]))
 
-        await process_ingest_job(job.id)
-
-        _adapter_outputs, drawing_revisions, validation_reports, _generated_artifacts = (
-            await _load_project_outputs(project["id"])
-        )
-        drawing_revision = drawing_revisions[0]
-        validation_report = validation_reports[0]
-
-        session_maker = session_module.AsyncSessionLocal
-        assert session_maker is not None
-
-        async with session_maker() as session:
-            persisted_report = await session.get(ValidationReport, validation_report.id)
-            assert persisted_report is not None
-            persisted_report.validation_status = "needs_review"
-            persisted_report.review_state = "review_required"
-            persisted_report.quantity_gate = "review_gated"
-            persisted_report.effective_confidence = 0.59
-            persisted_report.report_json = {
-                **persisted_report.report_json,
-                "confidence": {
+        async def _run_ingestion_with_stale_confidence(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            return replace(
+                payload,
+                validation_status="needs_review",
+                review_state="review_required",
+                quantity_gate="review_gated",
+                effective_confidence=0.59,
+                confidence_json={
                     "score": 0.95,
                     "effective_confidence": 0.95,
                     "review_state": "approved",
-                    "review_required": False,
                     "basis": "stale",
                 },
-                "summary": {
-                    **persisted_report.report_json["summary"],
-                    "validation_status": "valid",
-                    "review_state": "approved",
-                    "quantity_gate": "allowed",
-                    "effective_confidence": 0.95,
+                report_json={
+                    **payload.report_json,
+                    "confidence": {
+                        "score": 0.95,
+                        "effective_confidence": 0.95,
+                        "review_state": "approved",
+                        "review_required": False,
+                        "basis": "stale",
+                    },
+                    "summary": {
+                        **payload.report_json["summary"],
+                        "validation_status": "valid",
+                        "review_state": "approved",
+                        "quantity_gate": "allowed",
+                        "effective_confidence": 0.95,
+                    },
                 },
-            }
-            await session.commit()
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_ingestion_with_stale_confidence)
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
 
         response = await async_client.get(
             f"/v1/revisions/{drawing_revision.id}/validation-report"
@@ -271,23 +279,55 @@ class TestValidationReportApi:
 
         await process_ingest_job(job.id)
 
-        _adapter_outputs, drawing_revisions, validation_reports, _generated_artifacts = (
+        adapter_outputs, drawing_revisions, validation_reports, _generated_artifacts = (
             await _load_project_outputs(project["id"])
         )
         drawing_revision = drawing_revisions[0]
+        adapter_output = adapter_outputs[0]
         validation_report = validation_reports[0]
 
         session_maker = session_module.AsyncSessionLocal
         assert session_maker is not None
 
+        next_created_at = drawing_revision.created_at + timedelta(seconds=1)
+        next_job = _clone_model(
+            job,
+            id=uuid.uuid4(),
+            base_revision_id=drawing_revision.id,
+            job_type="reprocess",
+            status="succeeded",
+            started_at=next_created_at,
+            finished_at=next_created_at,
+            created_at=next_created_at,
+        )
+        next_adapter_output = _clone_model(
+            adapter_output,
+            id=uuid.uuid4(),
+            source_job_id=next_job.id,
+            result_checksum_sha256=uuid.uuid4().hex * 2,
+            created_at=next_created_at,
+        )
+        next_revision = _clone_model(
+            drawing_revision,
+            id=uuid.uuid4(),
+            source_job_id=next_job.id,
+            adapter_run_output_id=next_adapter_output.id,
+            predecessor_revision_id=drawing_revision.id,
+            revision_sequence=drawing_revision.revision_sequence + 1,
+            created_at=next_created_at,
+        )
+
         async with session_maker() as session:
-            persisted_report = await session.get(ValidationReport, validation_report.id)
-            assert persisted_report is not None
-            await session.delete(persisted_report)
+            session.add(next_job)
+            await session.commit()
+
+        async with session_maker() as session:
+            session.add(next_adapter_output)
+            session.add(next_revision)
             await session.commit()
 
         response = await async_client.get(
-            f"/v1/revisions/{drawing_revision.id}/validation-report"
+            f"/v1/revisions/{next_revision.id}/validation-report"
         )
 
         assert response.status_code == 404
@@ -295,7 +335,7 @@ class TestValidationReportApi:
             "error": {
                 "code": ErrorCode.NOT_FOUND.value,
                 "message": (
-                    f"Validation report with identifier '{drawing_revision.id}' not found"
+                    f"Validation report with identifier '{next_revision.id}' not found"
                 ),
                 "details": None,
             }
@@ -307,7 +347,7 @@ class TestValidationReportApi:
             validation_reports_after,
             _generated_artifacts,
         ) = await _load_project_outputs(project["id"])
-        assert validation_reports_after == []
+        assert [report.id for report in validation_reports_after] == [validation_report.id]
 
     async def test_get_validation_report_returns_404_for_soft_deleted_project_data(
         self,


### PR DESCRIPTION
Closes #128

## Summary
- add PostgreSQL append-only trigger enforcement for lineage/history tables with explicit write-once soft-delete allowlists
- cover update, delete, truncate, and JSON rewrite protection with DB-backed regression tests and safe test cleanup
- document the append-only trigger policy, downgrade guardrails, and privilege-boundary limitations

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] fresh throwaway DB: uv run alembic upgrade head
- [x] fresh throwaway DB: uv run pytest tests/test_append_only_lineage_tables.py
- [x] fresh throwaway DB: uv run pytest