### PR TITLE
fix(ingestion): align DWG capability confidence range

### DIFF
--- a/app/ingestion/registry.py
+++ b/app/ingestion/registry.py
@@ -48,7 +48,7 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
         license_name="GPL-3.0-or-later",
         capabilities=AdapterCapabilities(
         ),
-        confidence_range=(0.95, 1.0),
+        confidence_range=(0.2, 0.72),
         probes=(
             ProbeRequirement(
                 kind=ProbeKind.BINARY,

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -251,6 +251,7 @@ def test_registry_is_static_and_covers_every_family() -> None:
     assert registry[InputFamily.DWG].capabilities.supports_quantity_hints is False
     assert registry[InputFamily.DWG].capabilities.supports_layout_selection is False
     assert registry[InputFamily.DWG].capabilities.supports_xref_resolution is False
+    assert registry[InputFamily.DWG].confidence_range == (0.2, 0.72)
     assert registry[InputFamily.DWG].notes == (
         "Primary DWG adapter is isolated behind the ingestion contract.",
         "Current Phase 2 output is placeholder-only and does not expose "
@@ -295,6 +296,17 @@ def test_ifc_registry_metadata_stays_semantic_only() -> None:
     assert descriptor.notes == (
         "Semantic-only IFC extraction; tessellation and shape creation are disabled.",
     )
+
+
+def test_libredwg_registry_confidence_range_matches_current_placeholder_envelope() -> None:
+    descriptor = get_registry()[InputFamily.DWG]
+    confidence_range = descriptor.confidence_range
+
+    assert descriptor.confidence_range == (0.2, 0.72)
+    assert confidence_range is not None
+    minimum_confidence, maximum_confidence = confidence_range
+    for emitted_score in (0.2, 0.4, 0.5, 0.72):
+        assert minimum_confidence <= emitted_score <= maximum_confidence
 
 
 def test_registry_rejects_mutation_and_preserves_cached_metadata() -> None:

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -22,6 +22,7 @@ from app.ingestion.contracts import (
     InputFamily,
     UploadFormat,
 )
+from app.ingestion.registry import get_registry
 from app.ingestion.validation import build_validation_outcome
 from tests.ingestion_contract_harness import (
     ContractFinalizationExpectation,
@@ -102,6 +103,16 @@ def _build_source() -> AdapterSource:
         media_type="image/vnd.dwg",
         original_name="fixtures/libredwg-wrapper-smoke.dwg",
     )
+
+
+def _assert_score_within_libredwg_descriptor_range(score: float | None) -> None:
+    confidence_range = get_registry()[InputFamily.DWG].confidence_range
+
+    assert confidence_range is not None
+    assert score is not None
+    minimum_confidence, maximum_confidence = confidence_range
+
+    assert minimum_confidence <= score <= maximum_confidence
 
 
 def _install_fake_subprocess(
@@ -327,6 +338,7 @@ async def test_libredwg_adapter_maps_line_entities_into_canonical_payload(
         "review_required": True,
         "basis": "libredwg_line_mapping_units_unconfirmed",
     }
+    _assert_score_within_libredwg_descriptor_range(entity["confidence"]["score"])
 
     result = await adapter.ingest(
         source,
@@ -341,6 +353,8 @@ async def test_libredwg_adapter_maps_line_entities_into_canonical_payload(
     assert str(second_output_path.parent) not in stderr_excerpt
     assert "<source>" in stdout_excerpt
     assert "<tempdir>" in stderr_excerpt
+    assert result.confidence is not None
+    _assert_score_within_libredwg_descriptor_range(result.confidence.score)
 
     validation = build_validation_outcome(
         input_family=InputFamily.DWG,
@@ -521,6 +535,7 @@ async def test_libredwg_adapter_ignores_non_entities_and_degrades_unsupported_dr
         "review_required": True,
         "basis": "unsupported_drawable_record",
     }
+    _assert_score_within_libredwg_descriptor_range(entities[0]["confidence"]["score"])
     assert entities[0]["unknown_reason"] == "unsupported_drawable_record"
     assert entities[0]["provenance"]["record_hash"].startswith("sha256:")
     assert [warning.code for warning in result.warnings] == [
@@ -689,6 +704,7 @@ async def test_libredwg_adapter_lowers_confidence_for_mixed_entity_outcomes(
     assert result.confidence.score == adapter_module._MIXED_ENTITY_CONFIDENCE_SCORE
     assert result.confidence.review_required is True
     assert result.confidence.basis == "libredwg_dwgread_json_mixed_entity_mapping"
+    _assert_score_within_libredwg_descriptor_range(result.confidence.score)
 
 
 @pytest.mark.asyncio
@@ -725,6 +741,8 @@ async def test_libredwg_adapter_sets_non_placeholder_empty_reason_without_candid
         "malformed_drawables": 0,
     }
     assert [warning.code for warning in result.warnings] == ["libredwg.units_unconfirmed"]
+    assert result.confidence is not None
+    _assert_score_within_libredwg_descriptor_range(result.confidence.score)
 
 
 @pytest.mark.asyncio

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -153,6 +153,9 @@ async def test_system_capabilities_reflect_registry_availability_consistently(
     assert adapters_by_key["vtracer_tesseract"]["status"] == "degraded"
     assert adapters_by_key["vtracer_tesseract"]["availability_reason"] == "missing_binary"
 
+    libredwg_confidence_range = adapters_by_key["libredwg"]["confidence_range"]
+    assert libredwg_confidence_range == {"min": 0.2, "max": 0.72}
+
 
 @pytest.mark.asyncio
 async def test_system_health_returns_ok_and_200_when_all_checks_are_healthy(


### PR DESCRIPTION
Closes #166

## Summary
- align the LibreDWG DWG capability confidence range with the current placeholder and sparse output envelope
- add registry, system capability, and adapter tests to prevent public confidence contract drift

## Test plan
- [x] uv run ruff check app/ingestion/registry.py tests/test_ingestion_contracts.py tests/test_system_endpoints.py tests/test_libredwg_adapter.py
- [x] uv run mypy app tests
- [x] uv build
- [x] uv run pytest tests/test_ingestion_contracts.py tests/test_system_endpoints.py tests/test_libredwg_adapter.py