### PR TITLE
feat(api): support revision entity lookup by entity_id

### DIFF
--- a/alembic/versions/2026_05_12_0014_enforce_append_only_lineage_tables.py
+++ b/alembic/versions/2026_05_12_0014_enforce_append_only_lineage_tables.py
@@ -66,7 +66,11 @@ def _create_guard_functions() -> None:
                 IF TG_OP = 'DELETE' THEN
                     RAISE EXCEPTION USING
                         ERRCODE = '{APPEND_ONLY_SQLSTATE}',
-                        MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
+                        MESSAGE = format(
+                            'append-only trigger blocked %s on %I',
+                            TG_OP,
+                            TG_TABLE_NAME
+                        ),
                         DETAIL = 'Protected lineage/history tables are append-only.';
                 END IF;
 
@@ -106,8 +110,15 @@ def _create_guard_functions() -> None:
                 IF sanitized_old IS DISTINCT FROM sanitized_new THEN
                     RAISE EXCEPTION USING
                         ERRCODE = '{APPEND_ONLY_SQLSTATE}',
-                        MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
-                        DETAIL = 'Only allowlisted soft-delete markers may change on protected lineage/history tables.';
+                        MESSAGE = format(
+                            'append-only trigger blocked %s on %I',
+                            TG_OP,
+                            TG_TABLE_NAME
+                        ),
+                        DETAIL = (
+                            'Only allowlisted soft-delete markers may change on '
+                            'protected lineage/history tables.'
+                        );
                 END IF;
 
                 IF 'deleted_at' = ANY(allowlisted_columns) THEN
@@ -124,8 +135,15 @@ def _create_guard_functions() -> None:
 
                     RAISE EXCEPTION USING
                         ERRCODE = '{APPEND_ONLY_SQLSTATE}',
-                        MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
-                        DETAIL = 'deleted_at is write-once and may only change from NULL to non-NULL.';
+                        MESSAGE = format(
+                            'append-only trigger blocked %s on %I',
+                            TG_OP,
+                            TG_TABLE_NAME
+                        ),
+                        DETAIL = (
+                            'deleted_at is write-once and may only change from NULL '
+                            'to non-NULL.'
+                        );
                 END IF;
 
                 RETURN NEW;
@@ -145,8 +163,15 @@ def _create_guard_functions() -> None:
             BEGIN
                 RAISE EXCEPTION USING
                     ERRCODE = '{APPEND_ONLY_SQLSTATE}',
-                    MESSAGE = format('append-only trigger blocked %s on %I', TG_OP, TG_TABLE_NAME),
-                    DETAIL = 'Protected lineage/history tables are append-only and cannot be truncated.';
+                    MESSAGE = format(
+                        'append-only trigger blocked %s on %I',
+                        TG_OP,
+                        TG_TABLE_NAME
+                    ),
+                    DETAIL = (
+                        'Protected lineage/history tables are append-only and '
+                        'cannot be truncated.'
+                    );
             END;
             $$
             """
@@ -189,8 +214,14 @@ def _drop_table_triggers() -> None:
     """Remove append-only triggers from protected tables."""
 
     for spec in _PROTECTED_TABLE_SPECS:
-        op.execute(sa.text(f'DROP TRIGGER IF EXISTS {_TRUNCATE_TRIGGER_NAME} ON "{spec.table_name}"'))
-        op.execute(sa.text(f'DROP TRIGGER IF EXISTS {_ROW_TRIGGER_NAME} ON "{spec.table_name}"'))
+        op.execute(
+            sa.text(
+                f'DROP TRIGGER IF EXISTS {_TRUNCATE_TRIGGER_NAME} ON "{spec.table_name}"'
+            )
+        )
+        op.execute(
+            sa.text(f'DROP TRIGGER IF EXISTS {_ROW_TRIGGER_NAME} ON "{spec.table_name}"')
+        )
 
 
 def _drop_guard_functions() -> None:

--- a/alembic/versions/2026_05_13_0015_add_revision_scoped_entity_materialization.py
+++ b/alembic/versions/2026_05_13_0015_add_revision_scoped_entity_materialization.py
@@ -140,7 +140,10 @@ def upgrade() -> None:
             "counts_json",
             sa.JSON(),
             nullable=False,
-            comment="Materialized normalized row counts keyed by layouts, layers, blocks, and entities",
+            comment=(
+                "Materialized normalized row counts keyed by layouts, layers, "
+                "blocks, and entities"
+            ),
         ),
         sa.Column(
             "created_at",
@@ -301,7 +304,10 @@ def upgrade() -> None:
                 ref_column,
                 sa.String(length=255),
                 nullable=False,
-                comment=f"Stable non-null {table_label} reference extracted from the canonical {table_label} payload",
+                comment=(
+                    f"Stable non-null {table_label} reference extracted from "
+                    f"the canonical {table_label} payload"
+                ),
             ),
             sa.Column(
                 "created_at",
@@ -363,9 +369,24 @@ def upgrade() -> None:
                 name=f"ck_{table_name}_sequence_index_ge_0",
             ),
         )
-        op.create_index(op.f(f"ix_{table_name}_adapter_run_output_id"), table_name, ["adapter_run_output_id"], unique=False)
-        op.create_index(op.f(f"ix_{table_name}_extraction_profile_id"), table_name, ["extraction_profile_id"], unique=False)
-        op.create_index(op.f(f"ix_{table_name}_project_id"), table_name, ["project_id"], unique=False)
+        op.create_index(
+            op.f(f"ix_{table_name}_adapter_run_output_id"),
+            table_name,
+            ["adapter_run_output_id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f(f"ix_{table_name}_extraction_profile_id"),
+            table_name,
+            ["extraction_profile_id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f(f"ix_{table_name}_project_id"),
+            table_name,
+            ["project_id"],
+            unique=False,
+        )
         op.create_index(
             op.f(f"ix_{table_name}_{ref_column}"),
             table_name,
@@ -446,7 +467,10 @@ def upgrade() -> None:
             "entity_id",
             sa.String(length=255),
             nullable=False,
-            comment="Stable non-null entity identifier extracted or derived from the canonical entity payload",
+            comment=(
+                "Stable non-null entity identifier extracted or derived from the "
+                "canonical entity payload"
+            ),
         ),
         sa.Column(
             "entity_type",
@@ -464,7 +488,10 @@ def upgrade() -> None:
             "parent_entity_ref",
             sa.String(length=255),
             nullable=True,
-            comment="Optional raw parent entity reference extracted from the canonical entity payload",
+            comment=(
+                "Optional raw parent entity reference extracted from the canonical "
+                "entity payload"
+            ),
         ),
         sa.Column(
             "confidence_score",
@@ -500,7 +527,10 @@ def upgrade() -> None:
             "canonical_entity_json",
             sa.JSON(),
             nullable=True,
-            comment="Optional full canonical entity payload retained alongside split contract fields",
+            comment=(
+                "Optional full canonical entity payload retained alongside split "
+                "contract fields"
+            ),
         ),
         sa.Column(
             "layout_ref",
@@ -524,7 +554,10 @@ def upgrade() -> None:
             "source_identity",
             sa.String(length=255),
             nullable=True,
-            comment="Stable source identity derived from canonical entity top-level or provenance refs",
+            comment=(
+                "Stable source identity derived from canonical entity top-level or "
+                "provenance refs"
+            ),
         ),
         sa.Column(
             "source_hash",
@@ -536,25 +569,37 @@ def upgrade() -> None:
             "layout_id",
             sa.Uuid(),
             nullable=True,
-            comment="Best-effort resolved materialized layout row for layout_ref within the same drawing revision",
+            comment=(
+                "Best-effort resolved materialized layout row for layout_ref within "
+                "the same drawing revision"
+            ),
         ),
         sa.Column(
             "layer_id",
             sa.Uuid(),
             nullable=True,
-            comment="Best-effort resolved materialized layer row for layer_ref within the same drawing revision",
+            comment=(
+                "Best-effort resolved materialized layer row for layer_ref within "
+                "the same drawing revision"
+            ),
         ),
         sa.Column(
             "block_id",
             sa.Uuid(),
             nullable=True,
-            comment="Best-effort resolved materialized block row for block_ref within the same drawing revision",
+            comment=(
+                "Best-effort resolved materialized block row for block_ref within "
+                "the same drawing revision"
+            ),
         ),
         sa.Column(
             "parent_entity_row_id",
             sa.Uuid(),
             nullable=True,
-            comment="Best-effort resolved materialized parent entity row for parent_entity_ref within the same drawing revision",
+            comment=(
+                "Best-effort resolved materialized parent entity row for "
+                "parent_entity_ref within the same drawing revision"
+            ),
         ),
         sa.Column(
             "created_at",
@@ -635,9 +680,15 @@ def upgrade() -> None:
             "sequence_index",
             name="uq_revision_entities_revision_sequence_index",
         ),
-        sa.CheckConstraint("sequence_index >= 0", name="ck_revision_entities_sequence_index_ge_0"),
         sa.CheckConstraint(
-            "source_hash IS NULL OR (length(source_hash) = 64 AND source_hash = lower(source_hash))",
+            "sequence_index >= 0",
+            name="ck_revision_entities_sequence_index_ge_0",
+        ),
+        sa.CheckConstraint(
+            (
+                "source_hash IS NULL OR (length(source_hash) = 64 AND "
+                "source_hash = lower(source_hash))"
+            ),
             name="ck_revision_entities_source_hash",
         ),
     )

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -635,6 +635,7 @@ async def list_revision_entities(
     db: Annotated[AsyncSession, Depends(get_db)],
     limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
     cursor: str | None = Query(default=None),
+    entity_id: str | None = Query(default=None),
     entity_type: str | None = Query(default=None),
     layout_ref: str | None = Query(default=None),
     layer_ref: str | None = Query(default=None),
@@ -649,6 +650,8 @@ async def list_revision_entities(
     pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
 
     query = select(RevisionEntity).where(RevisionEntity.drawing_revision_id == revision_id)
+    if entity_id is not None:
+        query = query.where(RevisionEntity.entity_id == entity_id)
     if entity_type is not None:
         query = query.where(RevisionEntity.entity_type == entity_type)
     if layout_ref is not None:
@@ -691,6 +694,32 @@ async def list_revision_entities(
         items=[RevisionEntityRead.model_validate(row) for row in page],
         next_cursor=next_cursor,
     )
+
+
+@revisions_router.get(
+    "/revisions/{revision_id}/entities/{entity_id:path}",
+    response_model=RevisionEntityRead,
+)
+async def get_revision_entity(
+    revision_id: UUID,
+    entity_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> RevisionEntityRead:
+    """Return a materialized entity row for a drawing revision by entity identifier."""
+
+    await _get_active_revision_manifest_or_409(revision_id, db)
+
+    result = await db.execute(
+        select(RevisionEntity).where(
+            (RevisionEntity.drawing_revision_id == revision_id)
+            & (RevisionEntity.entity_id == entity_id)
+        )
+    )
+    entity = result.scalar_one_or_none()
+    if entity is None:
+        raise_not_found("Revision entity", entity_id)
+
+    return RevisionEntityRead.model_validate(entity)
 
 
 @revisions_router.get(

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -483,12 +483,13 @@ HTTP/status semantics:
 - `200` - report exists for the revision
 - `404` with `NOT_FOUND` - revision or report does not exist in scope
 
-#### Revision Materialization List Endpoints
+#### Revision Materialization Endpoints
 
 - `GET /v1/revisions/{revision_id}/layouts`
 - `GET /v1/revisions/{revision_id}/layers`
 - `GET /v1/revisions/{revision_id}/blocks`
 - `GET /v1/revisions/{revision_id}/entities`
+- `GET /v1/revisions/{revision_id}/entities/{entity_id}`
 
 These endpoints expose immutable revision-scoped normalized rows materialized by
 workers from adapter output for query and pagination. They do not rewrite the
@@ -502,6 +503,15 @@ List behavior:
   `layouts`, `layers`, `blocks`, and `entities`.
 - `GET /v1/revisions/{revision_id}/entities` returns entity items plus the same
   manifest/count metadata envelope.
+- `GET /v1/revisions/{revision_id}/entities?entity_id=...` is an exact-match
+  composable filter on the list endpoint. It uses the same response envelope and
+  can be combined with the normal list query shape when clients want the fully
+  general exact-match lookup form.
+- `GET /v1/revisions/{revision_id}/entities/{entity_id}` returns the singular
+  materialized entity row for an exact entity identifier match.
+- For path lookup, clients must percent-encode URL-reserved characters in
+  `{entity_id}`. The query filter form is the fully general exact-match option
+  when client-side encoding or intermediary path handling would be ambiguous.
 
 HTTP/status semantics:
 
@@ -510,6 +520,15 @@ HTTP/status semantics:
 - `409` with `NORMALIZED_ENTITIES_NOT_MATERIALIZED` - revision exists but its
   normalized materialization rows are unavailable, such as pre-existing
   revisions created before this materialization contract
+
+Entity lookup semantics:
+
+- `GET /v1/revisions/{revision_id}/entities/{entity_id}` returns `404` with
+  `NOT_FOUND` when the revision exists but the exact entity identifier is absent
+  from that revision.
+- `GET /v1/revisions/{revision_id}/entities?entity_id=...` remains a normal
+  list request, so `200` may return an empty `items` array when no exact-match
+  entity row exists.
 
 #### Quantity Behavior From Validation And Review State
 

--- a/tests/test_revision_materialization_api.py
+++ b/tests/test_revision_materialization_api.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -116,7 +117,7 @@ class TestRevisionMaterializationApi:
                         source_hash="a" * 64,
                     ),
                     _build_contract_entity(
-                        entity_id="entity-paper",
+                        entity_id="entity/paper",
                         entity_type="circle",
                         layout_ref="Paper",
                         layer_ref="A-WALL",
@@ -290,7 +291,7 @@ class TestRevisionMaterializationApi:
                         source_hash="a" * 64,
                     ),
                     _build_contract_entity(
-                        entity_id="entity-paper",
+                        entity_id="entity/paper",
                         entity_type="circle",
                         layout_ref="Paper",
                         layer_ref="A-WALL",
@@ -309,12 +310,13 @@ class TestRevisionMaterializationApi:
         drawing_revision = drawing_revisions[0]
 
         filter_cases = [
+            ({"entity_id": "entity-parent"}, ["entity-parent"]),
             ({"entity_type": "insert"}, ["entity-parent"]),
-            ({"layout_ref": "Paper"}, ["entity-paper"]),
+            ({"layout_ref": "Paper"}, ["entity/paper"]),
             ({"layer_ref": "A-DOOR"}, ["entity-parent"]),
             ({"block_ref": "DOOR-1"}, ["entity-parent"]),
             ({"parent_entity_ref": "entity-parent"}, ["entity-child"]),
-            ({"source_identity": "entity-source-paper"}, ["entity-paper"]),
+            ({"source_identity": "entity-source-paper"}, ["entity/paper"]),
             ({"source_hash": "a" * 64}, ["entity-child"]),
         ]
 
@@ -325,6 +327,19 @@ class TestRevisionMaterializationApi:
             )
             assert response.status_code == 200
             assert [item["entity_id"] for item in response.json()["items"]] == expected_entity_ids
+
+        combined_filter_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/entities",
+            params={
+                "entity_id": "entity/paper",
+                "layout_ref": "Paper",
+                "source_identity": "entity-source-paper",
+            },
+        )
+        assert combined_filter_response.status_code == 200
+        assert [item["entity_id"] for item in combined_filter_response.json()["items"]] == [
+            "entity/paper"
+        ]
 
         first_page_response = await async_client.get(
             f"/v1/revisions/{drawing_revision.id}/entities",
@@ -344,7 +359,7 @@ class TestRevisionMaterializationApi:
         )
         assert second_page_response.status_code == 200
         second_page = second_page_response.json()
-        assert [item["entity_id"] for item in second_page["items"]] == ["entity-paper"]
+        assert [item["entity_id"] for item in second_page["items"]] == ["entity/paper"]
         assert second_page["next_cursor"] is None
 
         invalid_cursor_response = await async_client.get(
@@ -356,6 +371,83 @@ class TestRevisionMaterializationApi:
             "error": {
                 "code": ErrorCode.INVALID_CURSOR.value,
                 "message": "Invalid cursor format",
+                "details": None,
+            }
+        }
+
+    async def test_revision_entity_lookup_supports_singular_reads_and_encoded_paths(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Singular entity reads should resolve exact entity identifiers.
+
+        Encoded slashes must round-trip through the path converter.
+        """
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _run_materialized_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            return _replace_fake_canonical_payload(
+                payload,
+                entities=[
+                    _build_contract_entity(
+                        entity_id="entity-parent",
+                        entity_type="insert",
+                        layer_ref="A-DOOR",
+                        source_id="entity-source-parent",
+                    ),
+                    _build_contract_entity(
+                        entity_id="entity/paper",
+                        entity_type="circle",
+                        layout_ref="Paper",
+                        layer_ref="A-WALL",
+                        source_id="entity-source-paper",
+                    ),
+                ],
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_materialized_ingestion)
+
+        await process_ingest_job(job.id)
+
+        _adapter_outputs, drawing_revisions, _validation_reports, _generated_artifacts = (
+            await _load_project_outputs(project["id"])
+        )
+        drawing_revision = drawing_revisions[0]
+
+        entity_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/entities/entity-parent"
+        )
+        assert entity_response.status_code == 200
+        assert entity_response.json()["entity_id"] == "entity-parent"
+        assert entity_response.json()["entity_type"] == "insert"
+
+        encoded_entity_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/entities/{quote('entity/paper', safe='')}"
+        )
+        assert encoded_entity_response.status_code == 200
+        assert encoded_entity_response.json()["entity_id"] == "entity/paper"
+        assert encoded_entity_response.json()["layout_ref"] == "Paper"
+
+        missing_entity_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/entities/missing-entity"
+        )
+        assert missing_entity_response.status_code == 404
+        assert missing_entity_response.json() == {
+            "error": {
+                "code": ErrorCode.NOT_FOUND.value,
+                "message": "Revision entity with identifier 'missing-entity' not found",
                 "details": None,
             }
         }
@@ -384,6 +476,9 @@ class TestRevisionMaterializationApi:
 
         missing_revision_id = uuid.uuid4()
         missing_response = await async_client.get(f"/v1/revisions/{missing_revision_id}/layouts")
+        missing_entity_response = await async_client.get(
+            f"/v1/revisions/{missing_revision_id}/entities/entity-parent"
+        )
 
         assert missing_response.status_code == 404
         assert missing_response.json() == {
@@ -393,11 +488,16 @@ class TestRevisionMaterializationApi:
                 "details": None,
             }
         }
+        assert missing_entity_response.status_code == 404
+        assert missing_entity_response.json() == missing_response.json()
 
         delete_response = await async_client.delete(f"/v1/projects/{project['id']}")
         assert delete_response.status_code == 204
 
         inactive_response = await async_client.get(f"/v1/revisions/{drawing_revision.id}/layouts")
+        inactive_entity_response = await async_client.get(
+            f"/v1/revisions/{drawing_revision.id}/entities/entity-parent"
+        )
 
         assert inactive_response.status_code == 404
         assert inactive_response.json() == {
@@ -407,6 +507,8 @@ class TestRevisionMaterializationApi:
                 "details": None,
             }
         }
+        assert inactive_entity_response.status_code == 404
+        assert inactive_entity_response.json() == inactive_response.json()
 
     async def test_materialization_endpoints_return_409_when_manifest_missing(
         self,
@@ -497,6 +599,9 @@ class TestRevisionMaterializationApi:
             await session.commit()
 
         response = await async_client.get(f"/v1/revisions/{revision_id}/entities")
+        singular_response = await async_client.get(
+            f"/v1/revisions/{revision_id}/entities/missing-entity"
+        )
 
         assert response.status_code == 409
         assert response.json() == {
@@ -509,6 +614,8 @@ class TestRevisionMaterializationApi:
                 "details": None,
             }
         }
+        assert singular_response.status_code == 409
+        assert singular_response.json() == response.json()
 
     async def test_materialization_endpoints_return_empty_lists_for_empty_manifest(
         self,


### PR DESCRIPTION
Closes #176

## Summary
- add exact `entity_id` filtering to the revision entity materialization list endpoint
- add singular revision entity lookup with encoded path handling for URL-reserved characters
- document the API semantics and cover combined-filter plus 404/409 behavior in tests

## Test plan
- [x] `uv run mypy .`
- [x] `uv run pytest tests/test_revision_materialization_api.py` *(6 skipped due DB gating in this environment)*
- [x] `uv run ruff check .` *(currently fails on unrelated pre-existing E501 errors in Alembic revisions `2026_05_12_0014_enforce_append_only_lineage_tables.py` and `2026_05_13_0015_add_revision_scoped_entity_materialization.py`)*

## Notes
- Deep review passed with no Must-fix or Should-fix findings.