### PR TITLE
fix(jobs): canonicalize materialized entity provenance

### DIFF
--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -64,6 +64,16 @@ _DEBUG_OVERLAY_ARTIFACT_FORMAT = "svg"
 _DEBUG_OVERLAY_GENERATOR_NAME = "app.ingestion.debug_overlay"
 _DEBUG_OVERLAY_GENERATOR_VERSION = "1"
 _NORMALIZED_ENTITY_INSERT_CHUNK_SIZE = 500
+_CANONICAL_ENTITY_PROVENANCE_ORIGINS = frozenset(
+    {
+        "source_direct",
+        "adapter_normalized",
+        "inferred",
+        "user_created",
+        "agent_proposed",
+        "generated_export",
+    }
+)
 _SAFE_RUNNER_ERROR_DETAIL_KEYS = (
     "adapter_key",
     "input_family",
@@ -738,12 +748,42 @@ def _hash_ref(value: Any) -> str | None:
     return lowered if len(lowered) == 64 else None
 
 
+def _first_string_ref(*values: Any) -> str | None:
+    """Return the first non-empty normalized string from candidate values."""
+    for value in values:
+        normalized = _string_ref(value)
+        if normalized is not None:
+            return normalized
+
+    return None
+
+
+def _first_hash_ref(*values: Any) -> str | None:
+    """Return the first valid normalized hash from candidate values."""
+    for value in values:
+        normalized = _hash_ref(value)
+        if normalized is not None:
+            return normalized
+
+    return None
+
+
 def _json_object(value: Any) -> dict[str, Any]:
     """Return a deep-copied JSON object or an empty object."""
     if isinstance(value, dict):
         return deepcopy(value)
 
     return {}
+
+
+def _json_array(value: Any) -> list[Any]:
+    """Return a deep-copied JSON array-like value or an empty list."""
+    if isinstance(value, list):
+        return deepcopy(value)
+    if isinstance(value, tuple):
+        return deepcopy(list(value))
+
+    return []
 
 
 def _float_value(value: Any) -> float | None:
@@ -805,44 +845,79 @@ def _resolve_collection_ref(
 def _entity_provenance_json(entity_payload_json: dict[str, Any]) -> dict[str, Any]:
     """Return canonical entity provenance JSON from contract or legacy payloads."""
     provenance_json = entity_payload_json.get("provenance_json")
-    if isinstance(provenance_json, dict):
-        return deepcopy(provenance_json)
+    provenance = provenance_json if isinstance(provenance_json, dict) else None
+    if provenance is None:
+        legacy_provenance = entity_payload_json.get("provenance")
+        provenance = legacy_provenance if isinstance(legacy_provenance, dict) else {}
 
-    provenance = entity_payload_json.get("provenance")
-    if isinstance(provenance, dict):
-        return deepcopy(provenance)
+    origin = _first_string_ref(provenance.get("origin"), entity_payload_json.get("origin"))
+    if origin is not None and origin not in _CANONICAL_ENTITY_PROVENANCE_ORIGINS:
+        raise ValueError(f"Invalid entity provenance origin '{origin}'")
 
-    return {}
+    extraction_path_value = (
+        provenance.get("extraction_path")
+        if "extraction_path" in provenance
+        else entity_payload_json.get("extraction_path")
+    )
+    notes_value = (
+        provenance.get("notes")
+        if "notes" in provenance
+        else entity_payload_json.get("notes")
+    )
+    adapter_json = provenance.get("adapter")
+    if isinstance(adapter_json, dict):
+        adapter = deepcopy(adapter_json)
+    elif adapter_json is None:
+        adapter = {}
+    else:
+        adapter = {"value": deepcopy(adapter_json)}
+
+    return {
+        "origin": origin or "adapter_normalized",
+        "adapter": adapter,
+        "source_ref": _first_string_ref(
+            provenance.get("source_ref"),
+            entity_payload_json.get("source_ref"),
+            provenance.get("source_entity_ref"),
+            entity_payload_json.get("source_entity_ref"),
+        ),
+        "source_identity": _first_string_ref(
+            provenance.get("source_identity"),
+            entity_payload_json.get("source_identity"),
+            provenance.get("source_handle"),
+            entity_payload_json.get("source_handle"),
+            provenance.get("dxf_handle"),
+            entity_payload_json.get("dxf_handle"),
+            provenance.get("source_entity_handle"),
+            entity_payload_json.get("source_entity_handle"),
+            provenance.get("native_handle"),
+            entity_payload_json.get("native_handle"),
+            provenance.get("source_id"),
+            entity_payload_json.get("source_id"),
+        ),
+        "source_hash": _first_hash_ref(
+            provenance.get("source_hash"),
+            entity_payload_json.get("source_hash"),
+            provenance.get("normalized_source_hash"),
+            entity_payload_json.get("normalized_source_hash"),
+            provenance.get("record_hash"),
+            entity_payload_json.get("record_hash"),
+        ),
+        "extraction_path": _json_array(extraction_path_value),
+        "notes": _json_array(notes_value),
+    }
 
 
 def _resolve_entity_source_identity(entity_payload_json: dict[str, Any]) -> str | None:
     """Resolve the best-effort stable source identity for a materialized entity row."""
-    source_identity = _string_ref(entity_payload_json.get("source_identity"))
-    if source_identity is not None:
-        return source_identity
-
     provenance = _entity_provenance_json(entity_payload_json)
-    if not provenance:
-        return None
-
-    source_handle = _string_ref(provenance.get("source_handle"))
-    if source_handle is not None:
-        return source_handle
-
-    return _string_ref(provenance.get("source_id"))
+    return _string_ref(provenance.get("source_identity"))
 
 
 def _resolve_entity_source_hash(entity_payload_json: dict[str, Any]) -> str | None:
     """Resolve the best-effort stable source hash for a materialized entity row."""
-    source_hash = _hash_ref(entity_payload_json.get("source_hash"))
-    if source_hash is not None:
-        return source_hash
-
     provenance = _entity_provenance_json(entity_payload_json)
-    if not provenance:
-        return None
-
-    return _hash_ref(provenance.get("normalized_source_hash"))
+    return _hash_ref(provenance.get("source_hash"))
 
 
 def _resolve_entity_ref(
@@ -893,13 +968,14 @@ def _resolve_entity_id(
     used_values: set[str],
 ) -> str:
     """Resolve a stable non-null unique entity id for a materialized row."""
+    provenance = _entity_provenance_json(entity_payload_json)
     return _allocate_unique_ref(
         candidates=[
             entity_payload_json.get("entity_id"),
             entity_payload_json.get("id"),
             entity_payload_json.get("source_identity"),
-            _entity_provenance_json(entity_payload_json).get("source_handle"),
-            _entity_provenance_json(entity_payload_json).get("source_id"),
+            provenance.get("source_identity"),
+            provenance.get("source_ref"),
         ],
         prefix="entity",
         sequence_index=sequence_index,

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -88,9 +88,15 @@ def _build_contract_entity(
     confidence_score: float = _FAKE_RUNNER_CONFIDENCE_SCORE,
 ) -> dict[str, Any]:
     """Build a canonical contract-shaped entity payload for materialization tests."""
-    provenance_json: dict[str, Any] = {"source_id": source_id}
-    if source_hash is not None:
-        provenance_json["normalized_source_hash"] = source_hash
+    provenance_json: dict[str, Any] = {
+        "origin": "adapter_normalized",
+        "adapter": {},
+        "source_ref": None,
+        "source_identity": source_id,
+        "source_hash": source_hash,
+        "extraction_path": [],
+        "notes": [],
+    }
 
     entity: dict[str, Any] = {
         "entity_id": entity_id,
@@ -501,7 +507,15 @@ class TestIngestOutputPersistence:
                         "coordinates": [[0.0, 0.0], [1.0, 1.0]],
                     },
                     "properties_json": {"layer": "A-WALL"},
-                    "provenance_json": {"source_id": "entity-source-001"},
+                    "provenance_json": {
+                        "origin": "adapter_normalized",
+                        "adapter": {},
+                        "source_ref": None,
+                        "source_identity": "entity-source-001",
+                        "source_hash": None,
+                        "extraction_path": [],
+                        "notes": [],
+                    },
                 }
             ],
             "entity_counts": {
@@ -635,7 +649,15 @@ class TestIngestOutputPersistence:
             "coordinates": [[0.0, 0.0], [1.0, 1.0]],
         }
         assert entity.properties_json == {"layer": "A-WALL"}
-        assert entity.provenance_json == {"source_id": "entity-source-001"}
+        assert entity.provenance_json == {
+            "origin": "adapter_normalized",
+            "adapter": {},
+            "source_ref": None,
+            "source_identity": "entity-source-001",
+            "source_hash": None,
+            "extraction_path": [],
+            "notes": [],
+        }
         assert entity.layout_ref == "Model"
         assert entity.layer_ref == "A-WALL"
         assert entity.block_ref is None
@@ -661,7 +683,285 @@ class TestIngestOutputPersistence:
                 "coordinates": [[0.0, 0.0], [1.0, 1.0]],
             },
             "properties_json": {"layer": "A-WALL"},
-            "provenance_json": {"source_id": "entity-source-001"},
+            "provenance_json": {
+                "origin": "adapter_normalized",
+                "adapter": {},
+                "source_ref": None,
+                "source_identity": "entity-source-001",
+                "source_hash": None,
+                "extraction_path": [],
+                "notes": [],
+            },
+        }
+
+    async def test_revision_materialization_canonicalizes_legacy_entity_provenance(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Legacy entity provenance payloads should persist in canonical contract shape."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _run_legacy_provenance_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            return _replace_fake_canonical_payload(
+                payload,
+                entities=[
+                    {
+                        "entity_id": "entity-dxf-legacy",
+                        "entity_type": "line",
+                        "entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+                        "layout_ref": "Model",
+                        "layer_ref": "A-WALL",
+                        "confidence_score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                        "confidence_json": {
+                            "score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                            "basis": "adapter",
+                        },
+                        "geometry_json": {
+                            "type": "line",
+                            "coordinates": [[0.0, 0.0], [1.0, 1.0]],
+                        },
+                        "properties_json": {"layer": "A-WALL"},
+                        "provenance_json": {
+                            "source_handle": "A1",
+                            "source_entity_ref": "doc:entities/A1",
+                            "normalized_source_hash": "b" * 64,
+                            "adapter": {"family": "dxf"},
+                        },
+                    },
+                    {
+                        "entity_id": "entity-ifc-legacy",
+                        "entity_type": "polyline",
+                        "entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+                        "layout_ref": "Model",
+                        "layer_ref": "A-WALL",
+                        "confidence_score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                        "confidence_json": {
+                            "score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                            "basis": "adapter",
+                        },
+                        "geometry_json": {
+                            "type": "polyline",
+                            "coordinates": [[0.0, 0.0], [1.0, 1.0]],
+                        },
+                        "properties_json": {"layer": "A-WALL"},
+                        "provenance": {
+                            "origin": "source_direct",
+                            "source_identity": "ifc-guid-001",
+                            "normalized_source_hash": "c" * 64,
+                            "extraction_path": ("IfcProject", "IfcWall", "Body"),
+                            "notes": ("ifc", "semantic"),
+                        },
+                    },
+                ],
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_legacy_provenance_ingestion)
+
+        await process_ingest_job(job.id)
+
+        _, _, _, _, entities = await _load_project_materialization(project["id"])
+
+        legacy_dxf_entity, legacy_ifc_entity = entities
+        assert legacy_dxf_entity.provenance_json == {
+            "origin": "adapter_normalized",
+            "adapter": {"family": "dxf"},
+            "source_ref": "doc:entities/A1",
+            "source_identity": "A1",
+            "source_hash": "b" * 64,
+            "extraction_path": [],
+            "notes": [],
+        }
+        assert legacy_dxf_entity.source_identity == "A1"
+        assert legacy_dxf_entity.source_hash == "b" * 64
+        assert legacy_dxf_entity.canonical_entity_json is not None
+        assert legacy_dxf_entity.canonical_entity_json["provenance_json"] == {
+            "source_handle": "A1",
+            "source_entity_ref": "doc:entities/A1",
+            "normalized_source_hash": "b" * 64,
+            "adapter": {"family": "dxf"},
+        }
+
+        assert legacy_ifc_entity.provenance_json == {
+            "origin": "source_direct",
+            "adapter": {},
+            "source_ref": None,
+            "source_identity": "ifc-guid-001",
+            "source_hash": "c" * 64,
+            "extraction_path": ["IfcProject", "IfcWall", "Body"],
+            "notes": ["ifc", "semantic"],
+        }
+        assert legacy_ifc_entity.source_identity == "ifc-guid-001"
+        assert legacy_ifc_entity.source_hash == "c" * 64
+        assert legacy_ifc_entity.canonical_entity_json is not None
+        assert legacy_ifc_entity.canonical_entity_json["provenance"] == {
+            "origin": "source_direct",
+            "source_identity": "ifc-guid-001",
+            "normalized_source_hash": "c" * 64,
+            "extraction_path": ["IfcProject", "IfcWall", "Body"],
+            "notes": ["ifc", "semantic"],
+        }
+
+    async def test_revision_materialization_rejects_invalid_nonempty_entity_origin(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Invalid non-empty provenance origins should fail before persisting outputs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _run_invalid_origin_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            return _replace_fake_canonical_payload(
+                payload,
+                entities=[
+                    {
+                        "entity_id": "entity-invalid-origin",
+                        "entity_type": "line",
+                        "entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+                        "layout_ref": "Model",
+                        "layer_ref": "A-WALL",
+                        "confidence_score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                        "confidence_json": {
+                            "score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                            "basis": "adapter",
+                        },
+                        "geometry_json": {
+                            "type": "line",
+                            "coordinates": [[0.0, 0.0], [1.0, 1.0]],
+                        },
+                        "properties_json": {"layer": "A-WALL"},
+                        "provenance_json": {
+                            "origin": "legacy_adapter",
+                            "source_id": "entity-source-001",
+                        },
+                    }
+                ],
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_invalid_origin_ingestion)
+
+        with pytest.raises(ValueError, match="Invalid entity provenance origin 'legacy_adapter'"):
+            await process_ingest_job(job.id)
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert updated_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
+
+        (
+            adapter_outputs,
+            drawing_revisions,
+            validation_reports,
+            generated_artifacts,
+        ) = await _load_project_outputs(project["id"])
+        assert adapter_outputs == []
+        assert drawing_revisions == []
+        assert validation_reports == []
+        assert generated_artifacts == []
+
+        manifests, layouts, layers, blocks, entities = await _load_project_materialization(
+            project["id"]
+        )
+        assert manifests == []
+        assert layouts == []
+        assert layers == []
+        assert blocks == []
+        assert entities == []
+
+    async def test_revision_materialization_wraps_scalar_adapter_provenance(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Scalar legacy adapter provenance should be preserved in object form."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+
+        async def _run_scalar_adapter_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            payload = _build_fake_ingest_payload(request)
+            return _replace_fake_canonical_payload(
+                payload,
+                entities=[
+                    {
+                        "entity_id": "entity-dwg-scalar-adapter",
+                        "entity_type": "line",
+                        "entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+                        "layout_ref": "Model",
+                        "layer_ref": "A-WALL",
+                        "confidence_score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                        "confidence_json": {
+                            "score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+                            "basis": "adapter",
+                        },
+                        "geometry_json": {
+                            "type": "line",
+                            "coordinates": [[0.0, 0.0], [1.0, 1.0]],
+                        },
+                        "properties_json": {"layer": "A-WALL"},
+                        "provenance_json": {
+                            "source_handle": "A1",
+                            "source_entity_ref": "doc:entities/A1",
+                            "normalized_source_hash": "b" * 64,
+                            "adapter": "libredwg",
+                        },
+                    }
+                ],
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_scalar_adapter_ingestion)
+
+        await process_ingest_job(job.id)
+
+        _, _, _, _, entities = await _load_project_materialization(project["id"])
+
+        assert len(entities) == 1
+        entity = entities[0]
+        assert entity.provenance_json == {
+            "origin": "adapter_normalized",
+            "adapter": {"value": "libredwg"},
+            "source_ref": "doc:entities/A1",
+            "source_identity": "A1",
+            "source_hash": "b" * 64,
+            "extraction_path": [],
+            "notes": [],
+        }
+        assert entity.canonical_entity_json is not None
+        assert entity.canonical_entity_json["provenance_json"] == {
+            "source_handle": "A1",
+            "source_entity_ref": "doc:entities/A1",
+            "normalized_source_hash": "b" * 64,
+            "adapter": "libredwg",
         }
 
     async def test_revision_materialization_resolves_entity_relationship_columns(


### PR DESCRIPTION
Closes #177

## Summary
- canonicalize newly materialized entity provenance to the TRD-required shape during worker finalization
- map legacy provenance fields into canonical source refs, identities, and hashes while preserving original canonical entity payloads
- add regression coverage for legacy provenance, invalid origins, and scalar adapter preservation

## Test plan
- [x] uv run ruff check app/jobs/worker.py tests/test_ingest_output_persistence.py tests/test_revision_materialization_api.py
- [x] uv run mypy app/jobs/worker.py tests/test_ingest_output_persistence.py tests/test_revision_materialization_api.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_issue177_validation_20260514_064316 uv run pytest tests/test_ingest_output_persistence.py tests/test_revision_materialization_api.py