### PR TITLE
fix(ingestion): emit canonical entity provenance

### DIFF
--- a/app/ingestion/adapters/ezdxf.py
+++ b/app/ingestion/adapters/ezdxf.py
@@ -1045,19 +1045,33 @@ def _entity_provenance(
     entity_id: str,
     geometry: dict[str, JSONValue] | None,
 ) -> dict[str, JSONValue]:
+    source_entity_ref = f"entities.{native_type}:{handle or entity_id}"
+    source_hash = _entity_fingerprint(
+        native_type=native_type,
+        handle=handle,
+        layout_name=layout_name,
+        layer_name=layer_name,
+        geometry=geometry,
+    )
+    notes: tuple[str, ...] = ()
+    if geometry is None:
+        notes = ("unsupported_or_invalid_geometry",)
     return {
-        "source_entity_ref": f"entities.{native_type}:{handle or entity_id}",
+        "origin": "adapter_normalized",
+        "adapter": {"key": _DESCRIPTOR.key},
+        "adapter_key": _DESCRIPTOR.key,
+        "source": source_entity_ref,
+        "source_ref": source_entity_ref,
+        "source_entity_ref": source_entity_ref,
+        "source_identity": handle or entity_id,
+        "source_hash": source_hash,
         "dxf_handle": handle or None,
         "native_entity_type": native_type,
         "layout_name": layout_name,
         "layer_name": layer_name,
-        "normalized_source_hash": _entity_fingerprint(
-            native_type=native_type,
-            handle=handle,
-            layout_name=layout_name,
-            layer_name=layer_name,
-            geometry=geometry,
-        ),
+        "normalized_source_hash": source_hash,
+        "extraction_path": ("modelspace", native_type),
+        "notes": notes,
     }
 
 

--- a/app/ingestion/adapters/ifcopenshell.py
+++ b/app/ingestion/adapters/ifcopenshell.py
@@ -820,18 +820,22 @@ def _entity_provenance(
         step_id_token=step_id_token,
         fallback_identity=fallback_identity,
     )
+    source_hash = _normalized_source_hash(
+        ifc_type=ifc_type,
+        global_id=global_id,
+        step_id_token=step_id_token,
+        fallback_identity=fallback_identity,
+    )
     return {
         "origin": "adapter_normalized",
-        "adapter": _ADAPTER_KEY,
+        "adapter": {"key": _ADAPTER_KEY},
+        "adapter_key": _ADAPTER_KEY,
         "source": source_entity_ref,
+        "source_ref": source_entity_ref,
         "source_entity_ref": source_entity_ref,
         "source_identity": global_id or step_id_token or fallback_identity,
-        "normalized_source_hash": _normalized_source_hash(
-            ifc_type=ifc_type,
-            global_id=global_id,
-            step_id_token=step_id_token,
-            fallback_identity=fallback_identity,
-        ),
+        "source_hash": source_hash,
+        "normalized_source_hash": source_hash,
         "native_entity_type": ifc_type,
         "ifc_global_id": global_id,
         "ifc_step_id": step_id_token,

--- a/app/ingestion/adapters/libredwg.py
+++ b/app/ingestion/adapters/libredwg.py
@@ -781,17 +781,13 @@ def _build_line_entity(record: Mapping[str, Any]) -> _JSONDict | None:
                 }
             },
         },
-        "provenance": {
-            "adapter": "libredwg",
-            "source_section": "OBJECTS",
-            "source_entity_ref": _source_locator(record, record_type="LINE"),
-            "source_locator": _source_locator(record, record_type="LINE"),
-            "source_ref": _source_locator(record, record_type="LINE"),
-            "entity_ref": _source_locator(record, record_type="LINE"),
-            "native_handle": source_handle,
-            "source_entity_handle": source_handle,
-            "record_hash": _hash_json_value(safe_projection),
-        },
+        "provenance": _entity_provenance(
+            record,
+            record_type="LINE",
+            source_handle=source_handle,
+            safe_projection=safe_projection,
+            notes=("units_unconfirmed",),
+        ),
         "confidence": {
             "score": _LINE_ENTITY_CONFIDENCE_SCORE,
             "review_required": True,
@@ -845,17 +841,13 @@ def _build_unknown_entity(record: Mapping[str, Any], *, reason: str) -> _JSONDic
             "record_type": record_type,
             "handle": source_handle,
         },
-        "provenance": {
-            "adapter": "libredwg",
-            "source_section": "OBJECTS",
-            "source_entity_ref": _source_locator(record, record_type=record_type),
-            "source_locator": _source_locator(record, record_type=record_type),
-            "source_ref": _source_locator(record, record_type=record_type),
-            "entity_ref": _source_locator(record, record_type=record_type),
-            "native_handle": source_handle,
-            "source_entity_handle": source_handle,
-            "record_hash": _hash_json_value(safe_projection),
-        },
+        "provenance": _entity_provenance(
+            record,
+            record_type=record_type,
+            source_handle=source_handle,
+            safe_projection=safe_projection,
+            notes=("units_unconfirmed", reason),
+        ),
         "confidence": {
             "score": _UNKNOWN_ENTITY_CONFIDENCE_SCORE,
             "review_required": True,
@@ -997,6 +989,37 @@ def _entity_id(record: Mapping[str, Any], *, record_type: str) -> str:
     return f"libredwg-{record_type}-{record_hash[:18]}"
 
 
+def _entity_provenance(
+    record: Mapping[str, Any],
+    *,
+    record_type: str,
+    source_handle: str | None,
+    safe_projection: _JSONDict,
+    notes: tuple[str, ...],
+) -> _JSONDict:
+    source_locator = _source_locator(record, record_type=record_type)
+    source_hash = _canonical_hash_json_value(safe_projection)
+    return {
+        "origin": "adapter_normalized",
+        "adapter": {"key": _DESCRIPTOR.key},
+        "adapter_key": _DESCRIPTOR.key,
+        "source": source_locator,
+        "source_section": "OBJECTS",
+        "source_ref": source_locator,
+        "source_entity_ref": source_locator,
+        "source_locator": source_locator,
+        "entity_ref": source_locator,
+        "source_identity": source_handle or _entity_id(record, record_type=record_type.lower()),
+        "source_hash": source_hash,
+        "normalized_source_hash": source_hash,
+        "native_handle": source_handle,
+        "source_entity_handle": source_handle,
+        "record_hash": _hash_json_value(safe_projection),
+        "extraction_path": ("OBJECTS", record_type),
+        "notes": notes,
+    }
+
+
 def _source_locator(record: Mapping[str, Any], *, record_type: str) -> str:
     handle = _extract_handle(record)
     if handle is not None:
@@ -1083,12 +1106,18 @@ def _safe_record_projection(
 
 
 def _hash_json_value(value: JSONValue) -> str:
+    return f"sha256:{_canonical_hash_json_value(value)}"
+
+
+def _canonical_hash_json_value(value: JSONValue) -> str:
     payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-    return f"sha256:{_hash_text(payload)}"
+    return _hash_text(payload)
 
 
 def _hash_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
 def _source_ref(source: AdapterSource) -> str:
     candidate = (
         source.original_name.replace("\\", "/").split("/")[-1].strip()

--- a/app/ingestion/adapters/pymupdf.py
+++ b/app/ingestion/adapters/pymupdf.py
@@ -9,7 +9,7 @@ import importlib.metadata
 import json
 import math
 import multiprocessing
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from pathlib import Path, PureWindowsPath
@@ -775,12 +775,13 @@ def _build_lineish_entity(
         "layer": layer_name,
         "bbox": bbox,
         "properties": _entity_properties(drawing, closed=closed, rect_like=rect_like),
-        "provenance": {
-            "page_number": page_number,
-            "drawing_index": drawing_index,
-            "item_indices": item_indices,
-            "source": "pymupdf.get_drawings",
-        },
+        "provenance": _entity_provenance(
+            page_number=page_number,
+            drawing_index=drawing_index,
+            drawing=drawing,
+            item_indices=item_indices,
+            operator="re" if rect_like else "l",
+        ),
         "confidence": {
             "score": _VECTOR_CONFIDENCE_SCORE,
             "basis": "vector_path_segment",
@@ -882,15 +883,14 @@ def _build_unknown_entity(
     )
     bbox = _bbox_from_unsupported_item(item)
     provenance: dict[str, JSONValue] = {
-        "page_number": page_number,
-        "drawing_index": drawing_index,
-        "item_index": item_index,
-        "operator": operator,
-        "source": "pymupdf.get_drawings",
+        **_entity_provenance(
+            page_number=page_number,
+            drawing_index=drawing_index,
+            drawing=drawing,
+            item_index=item_index,
+            operator=operator,
+        ),
     }
-    normalized_source_hash = _normalized_source_hash(item)
-    if normalized_source_hash is not None:
-        provenance["normalized_source_hash"] = normalized_source_hash
 
     return {
         "entity_id": entity_id,
@@ -1004,6 +1004,159 @@ def _entity_properties(
         "rect_like": rect_like,
         "sequence_number": int(drawing.get("seqno", 0)),
     }
+
+
+def _entity_provenance(
+    *,
+    page_number: int,
+    drawing_index: int,
+    drawing: Mapping[str, Any],
+    operator: str,
+    item_indices: tuple[int, ...] | None = None,
+    item_index: int | None = None,
+) -> dict[str, JSONValue]:
+    location_payload = _entity_location_payload(
+        page_number=page_number,
+        drawing_index=drawing_index,
+        operator=operator,
+        item_indices=item_indices,
+        item_index=item_index,
+    )
+    source_ref = _entity_source_ref(location_payload)
+    source_hash = _entity_source_hash(
+        _entity_source_payload(
+            page_number=page_number,
+            operator=operator,
+            drawing=drawing,
+            item_indices=item_indices,
+            item_index=item_index,
+        )
+    )
+    provenance: dict[str, JSONValue] = {
+        "origin": "adapter_normalized",
+        "adapter": {"key": _DESCRIPTOR.key},
+        "adapter_key": _DESCRIPTOR.key,
+        "source": location_payload["source"],
+        "source_ref": source_ref,
+        "source_entity_ref": source_ref,
+        "source_identity": _entity_source_identity(location_payload),
+        "source_hash": source_hash,
+        "page_number": page_number,
+        "drawing_index": drawing_index,
+        "operator": operator,
+        "normalized_source_hash": source_hash,
+        "extraction_path": (
+            "get_drawings",
+            f"page-{page_number}",
+            f"drawing-{drawing_index}",
+            operator,
+        ),
+        "notes": ("vector_pdf_unconfirmed_scale",),
+    }
+    if item_indices is not None:
+        provenance["item_indices"] = item_indices
+    if item_index is not None:
+        provenance["item_index"] = item_index
+    return provenance
+
+
+def _entity_location_payload(
+    *,
+    page_number: int,
+    drawing_index: int,
+    operator: str,
+    item_indices: tuple[int, ...] | None,
+    item_index: int | None,
+) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "page_number": page_number,
+        "drawing_index": drawing_index,
+        "operator": operator,
+        "source": "pymupdf.get_drawings",
+    }
+    if item_indices is not None:
+        payload["item_indices"] = item_indices
+    if item_index is not None:
+        payload["item_index"] = item_index
+    return payload
+
+
+def _entity_source_payload(
+    *,
+    page_number: int,
+    operator: str,
+    drawing: Mapping[str, Any],
+    item_indices: tuple[int, ...] | None,
+    item_index: int | None,
+) -> dict[str, Any]:
+    return {
+        "page_number": page_number,
+        "operator": operator,
+        "source": "pymupdf.get_drawings",
+        "drawing": _entity_source_drawing_payload(drawing),
+        "items": _entity_source_items(
+            drawing,
+            item_indices=item_indices,
+            item_index=item_index,
+        ),
+    }
+
+
+def _entity_source_ref(payload: Mapping[str, JSONValue]) -> str:
+    page_number = int(cast(int, payload["page_number"]))
+    drawing_index = int(cast(int, payload["drawing_index"]))
+    operator = str(payload["operator"])
+    if "item_indices" in payload:
+        indices = ",".join(
+            str(index) for index in cast(tuple[int, ...], payload["item_indices"])
+        )
+        return f"pdf://page-{page_number}/drawing-{drawing_index}/{operator}/items:{indices}"
+    item_index = int(cast(int, payload["item_index"]))
+    return f"pdf://page-{page_number}/drawing-{drawing_index}/{operator}/item:{item_index}"
+
+
+def _entity_source_identity(payload: Mapping[str, JSONValue]) -> str:
+    page_number = int(cast(int, payload["page_number"]))
+    drawing_index = int(cast(int, payload["drawing_index"]))
+    if "item_indices" in payload:
+        indices = ",".join(
+            str(index) for index in cast(tuple[int, ...], payload["item_indices"])
+        )
+        return f"page-{page_number}:drawing-{drawing_index}:items-{indices}"
+    return (
+        f"page-{page_number}:drawing-{drawing_index}:item-"
+        f"{int(cast(int, payload['item_index']))}"
+    )
+
+
+def _entity_source_hash(payload: Mapping[str, Any]) -> str:
+    source_hash = _normalized_source_hash(payload)
+    if source_hash is None:
+        raise TypeError("PyMuPDF source payload is not JSON-normalizable.")
+    return source_hash
+
+
+def _entity_source_drawing_payload(drawing: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in drawing.items() if key != "items"}
+
+
+def _entity_source_items(
+    drawing: Mapping[str, Any],
+    *,
+    item_indices: tuple[int, ...] | None,
+    item_index: int | None,
+) -> tuple[Any, ...]:
+    raw_items = drawing.get("items")
+    if not isinstance(raw_items, (tuple, list)):
+        return ()
+    items = tuple(raw_items)
+    if item_indices is not None:
+        return tuple(
+            items[index] for index in item_indices if 0 <= index < len(items)
+        )
+    if item_index is not None and 0 <= item_index < len(items):
+        return (items[item_index],)
+    return ()
 
 
 def _normalized_source_hash(value: Any) -> str | None:

--- a/tests/ingestion_contract_harness.py
+++ b/tests/ingestion_contract_harness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -37,6 +38,7 @@ from app.ingestion.finalization import (
 _DEFAULT_CONTRACT_TIMEOUT = AdapterTimeout(seconds=0.5)
 _DEFAULT_FAILURE_TIMEOUT = AdapterTimeout(seconds=0.01)
 _CONTRACT_ENTITY_SCHEMA_VERSION = "0.1"
+_CANONICAL_SOURCE_HASH_PATTERN = re.compile(r"[0-9a-f]{64}")
 _NULLABLE_LINKAGE_FIELDS = (
     "drawing_revision_id",
     "source_file_id",
@@ -95,7 +97,11 @@ def build_contract_source(
     )
 
 
-def build_complete_canonical(*, include_pdf_scale: bool = False) -> dict[str, JSONValue]:
+def build_complete_canonical(
+    *,
+    include_pdf_scale: bool = False,
+    adapter_key: str = "contract",
+) -> dict[str, JSONValue]:
     """Return a canonical payload that satisfies baseline validator checks."""
 
     canonical: dict[str, JSONValue] = {
@@ -135,6 +141,13 @@ def build_complete_canonical(*, include_pdf_scale: bool = False) -> dict[str, JS
                     "adapter_native": {"contract": {"layer": "A-WALL"}},
                 },
                 "provenance": {
+                    "origin": "adapter_normalized",
+                    "adapter": {"key": adapter_key},
+                    "source_ref": "entities.contract-entity-1",
+                    "source_identity": "ABC",
+                    "source_hash": "0" * 64,
+                    "extraction_path": ("contract",),
+                    "notes": (),
                     "source_entity_ref": "entities.contract-entity-1",
                     "normalized_source_hash": "0" * 64,
                 },
@@ -212,7 +225,11 @@ def assert_adapter_result_contract(
     if not entities:
         _assert_empty_entity_collection_reason(result.canonical)
     else:
-        _assert_entity_envelopes(entities, expected_schema_version=schema_version)
+        _assert_entity_envelopes(
+            entities,
+            expected_schema_version=schema_version,
+            expected_adapter_key=expected_adapter_key,
+        )
 
     for record in result.provenance:
         if not record.stage or not record.source_ref:
@@ -288,6 +305,7 @@ def _assert_entity_envelopes(
     entities: tuple[JSONValue, ...],
     *,
     expected_schema_version: str,
+    expected_adapter_key: str,
 ) -> None:
     seen_entity_ids: set[str] = set()
     for entity_payload in entities:
@@ -314,33 +332,52 @@ def _assert_entity_envelopes(
         provenance = entity_payload.get("provenance")
         if not isinstance(provenance, dict) or not provenance:
             raise AssertionError("Canonical entities must include provenance metadata.")
-        if not _has_stable_entity_provenance(provenance):
-            raise AssertionError(
-                "Canonical entity provenance must include a stable source locator."
-            )
+        _assert_canonical_entity_provenance(provenance, expected_adapter_key=expected_adapter_key)
 
         _assert_required_nullable_linkage_fields(entity_payload)
         _assert_entity_confidence(entity_payload.get("confidence"))
         _assert_geometry_reason_if_required(entity_payload)
 
 
-def _has_stable_entity_provenance(provenance: dict[str, JSONValue]) -> bool:
-    stable_keys = (
-        "source_entity_ref",
-        "normalized_source_hash",
-        "ifc_step_id",
-        "ifc_global_id",
-        "page_number",
-        "drawing_index",
-        "source",
-    )
-    for key in stable_keys:
-        value = provenance.get(key)
-        if isinstance(value, str) and value.strip():
-            return True
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            return True
-    return False
+def _assert_canonical_entity_provenance(
+    provenance: dict[str, JSONValue],
+    *,
+    expected_adapter_key: str,
+) -> None:
+    if provenance.get("origin") != "adapter_normalized":
+        raise AssertionError("Canonical entity provenance origin must be adapter_normalized.")
+
+    adapter = provenance.get("adapter")
+    if not isinstance(adapter, dict) or adapter.get("key") != expected_adapter_key:
+        raise AssertionError("Canonical entity provenance adapter.key must match the adapter.")
+
+    source_ref = provenance.get("source_ref")
+    if not isinstance(source_ref, str) or not source_ref.strip():
+        raise AssertionError("Canonical entity provenance must include source_ref.")
+
+    source_identity = provenance.get("source_identity")
+    if not isinstance(source_identity, str) or not source_identity.strip():
+        raise AssertionError("Canonical entity provenance must include source_identity.")
+
+    source_hash = provenance.get("source_hash")
+    if not isinstance(source_hash, str) or not _CANONICAL_SOURCE_HASH_PATTERN.fullmatch(
+        source_hash
+    ):
+        raise AssertionError(
+            "Canonical entity provenance source_hash must be lowercase 64-char SHA-256 hex."
+        )
+
+    extraction_path = provenance.get("extraction_path")
+    if not isinstance(extraction_path, (tuple, list)):
+        raise AssertionError("Canonical entity provenance must include extraction_path.")
+    if not all(isinstance(segment, str) and segment.strip() for segment in extraction_path):
+        raise AssertionError("Canonical entity provenance extraction_path must contain strings.")
+
+    notes = provenance.get("notes")
+    if not isinstance(notes, (tuple, list)):
+        raise AssertionError("Canonical entity provenance must include notes.")
+    if not all(isinstance(note, str) and note.strip() for note in notes):
+        raise AssertionError("Canonical entity provenance notes must contain non-empty strings.")
 
 
 def _assert_entity_confidence(confidence: JSONValue) -> None:

--- a/tests/test_adapter_contract_harness.py
+++ b/tests/test_adapter_contract_harness.py
@@ -114,7 +114,7 @@ async def test_contract_harness_applies_review_thresholds(
         result=build_result(
             adapter_key=adapter_key,
             score=score,
-            canonical=build_complete_canonical(),
+            canonical=build_complete_canonical(adapter_key=adapter_key),
         ),
         family=InputFamily.DXF,
         key=adapter_key,
@@ -153,7 +153,7 @@ async def test_contract_harness_asserts_warnings_and_diagnostics_shape(tmp_path:
         result=build_result(
             adapter_key=adapter_key,
             score=0.97,
-            canonical=build_complete_canonical(),
+            canonical=build_complete_canonical(adapter_key=adapter_key),
             warnings=warnings,
             diagnostics=diagnostics,
         ),
@@ -215,7 +215,7 @@ async def test_contract_harness_rejects_missing_entity_envelope_fields(tmp_path:
     source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
     source = build_contract_source(file_path=source_path)
     adapter_key = "fake-dxf"
-    canonical = build_complete_canonical()
+    canonical = build_complete_canonical(adapter_key=adapter_key)
     canonical["entities"] = (
         {
             "kind": "line",
@@ -256,7 +256,7 @@ async def test_contract_harness_rejects_empty_entities_without_explicit_reason(
     source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
     source = build_contract_source(file_path=source_path)
     adapter_key = "fake-dxf"
-    canonical = build_complete_canonical()
+    canonical = build_complete_canonical(adapter_key=adapter_key)
     canonical["entities"] = ()
     adapter = _ResultAdapter(
         result=build_result(
@@ -290,7 +290,7 @@ async def test_contract_harness_rejects_absent_geometry_without_explicit_reason(
     source_path.write_text("0\nSECTION\n2\nENTITIES\n0\nENDSEC\n0\nEOF\n", encoding="utf-8")
     source = build_contract_source(file_path=source_path)
     adapter_key = "fake-dxf"
-    canonical = build_complete_canonical()
+    canonical = build_complete_canonical(adapter_key=adapter_key)
     entity = cast(tuple[dict[str, Any], ...], canonical["entities"])[0]
     canonical["entities"] = (
         {

--- a/tests/test_ezdxf_adapter.py
+++ b/tests/test_ezdxf_adapter.py
@@ -299,6 +299,15 @@ def _assert_common_entity_contract(
     assert "adapter_native" in properties
 
     provenance = _mapping(entity["provenance"])
+    assert provenance["origin"] == "adapter_normalized"
+    assert provenance["adapter"] == {"key": "ezdxf"}
+    assert provenance["adapter_key"] == "ezdxf"
+    assert provenance["source_ref"] == provenance["source_entity_ref"]
+    assert provenance["source"] == provenance["source_ref"]
+    assert provenance["source_identity"] == entity["handle"]
+    assert provenance["source_hash"] == provenance["normalized_source_hash"]
+    assert provenance["extraction_path"] == ("modelspace", str(properties["source_type"]))
+    assert isinstance(provenance["notes"], tuple)
     assert provenance["dxf_handle"] == entity["handle"]
     assert isinstance(provenance["normalized_source_hash"], str)
     assert len(provenance["normalized_source_hash"]) == 64

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -156,6 +156,10 @@ def _canonical_entities(result: object) -> tuple[Mapping[str, object], ...]:
     return cast(tuple[Mapping[str, object], ...], cast(Any, result).canonical["entities"])
 
 
+def _entity_provenance(entity: Mapping[str, object]) -> Mapping[str, object]:
+    return cast(Mapping[str, object], entity["provenance"])
+
+
 def test_probe_reports_unavailable_without_ifcopenshell_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -275,17 +279,23 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
     assert entities[0]["entity_schema_version"] == "0.1"
     assert entities[0]["geometry"]["reason"] == "semantic_metadata_only"
     assert entities[0]["provenance"]["origin"] == "adapter_normalized"
-    assert entities[0]["provenance"]["adapter"] == "ifcopenshell"
+    assert entities[0]["provenance"]["adapter"] == {"key": "ifcopenshell"}
+    assert entities[0]["provenance"]["adapter_key"] == "ifcopenshell"
     assert entities[0]["provenance"]["source"] == "ifc://IfcWall/global-id:DUPLICATE/step-id:10"
+    assert entities[0]["provenance"]["source_ref"] == "ifc://IfcWall/global-id:DUPLICATE/step-id:10"
     assert (
         entities[0]["provenance"]["source_entity_ref"]
         == "ifc://IfcWall/global-id:DUPLICATE/step-id:10"
     )
     assert entities[0]["provenance"]["source_identity"] == "DUPLICATE"
     assert entities[0]["provenance"]["canonical_entity_ref"] == "entities.DUPLICATE"
+    assert entities[0]["provenance"]["source_hash"] == hashlib.sha256(
+        b"ifc://IfcWall/global-id:DUPLICATE"
+    ).hexdigest()
     assert entities[0]["provenance"]["normalized_source_hash"] == hashlib.sha256(
         b"ifc://IfcWall/global-id:DUPLICATE"
     ).hexdigest()
+    assert entities[0]["provenance"]["extraction_path"] == ["semantic_extract"]
     assert entities[0]["provenance"]["notes"] == ["semantic_ifc_metadata_only"]
     assert entities[0]["confidence"] == {
         "score": 0.4,
@@ -300,9 +310,13 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
         == "Body"
     )
     assert entities[2]["provenance"]["source"] == "ifc://IfcDoor/step-id:42"
+    assert entities[2]["provenance"]["source_ref"] == "ifc://IfcDoor/step-id:42"
     assert entities[2]["provenance"]["source_entity_ref"] == "ifc://IfcDoor/step-id:42"
     assert entities[2]["provenance"]["source_identity"] == "#42"
     assert entities[2]["provenance"]["canonical_entity_ref"] == "entities.#42"
+    assert entities[2]["provenance"]["source_hash"] == hashlib.sha256(
+        b"ifc://IfcDoor/step-id:42"
+    ).hexdigest()
     assert entities[2]["provenance"]["normalized_source_hash"] == hashlib.sha256(
         b"ifc://IfcDoor/step-id:42"
     ).hexdigest()
@@ -345,6 +359,13 @@ async def test_ifcopenshell_adapter_orders_duplicate_and_missing_ids_determinist
     assert [entity["id"] for entity in _canonical_entities(result)] == [
         "DUPLICATE",
         "DUPLICATE-2",
+        "#3",
+        "#7",
+    ]
+    entities = _canonical_entities(result)
+    assert [_entity_provenance(entity)["source_identity"] for entity in entities] == [
+        "DUPLICATE",
+        "DUPLICATE",
         "#3",
         "#7",
     ]

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -141,6 +141,11 @@ def _assert_no_nonfinite_numbers(value: object) -> None:
         assert math.isfinite(float(value))
 
 
+def _assert_canonical_source_hash(value: str) -> None:
+    assert len(value) == 64
+    assert all(character in "0123456789abcdef" for character in value)
+
+
 async def _ingest_fake_document(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -998,12 +1003,32 @@ async def test_pymupdf_vector_fixture_extracts_metadata_only_text() -> None:
         "y_max": 90.0,
     }
     assert entity["properties"]["rect_like"] is False
-    assert entity["provenance"] == {
-        "page_number": 1,
-        "drawing_index": 0,
-        "item_indices": (0, 1),
-        "source": "pymupdf.get_drawings",
-    }
+    provenance = cast(dict[str, Any], entity["provenance"])
+    assert provenance["origin"] == "adapter_normalized"
+    assert provenance["adapter"] == {"key": "pymupdf"}
+    assert provenance["adapter_key"] == "pymupdf"
+    assert provenance["page_number"] == 1
+    assert provenance["drawing_index"] == 0
+    assert provenance["operator"] == "l"
+    assert provenance["item_indices"] == (0, 1)
+    assert provenance["source"] == "pymupdf.get_drawings"
+    assert provenance["source_ref"] == "pdf://page-1/drawing-0/l/items:0,1"
+    assert provenance["source_entity_ref"] == "pdf://page-1/drawing-0/l/items:0,1"
+    assert provenance["source_identity"] == "page-1:drawing-0:items-0,1"
+    locator_hash = pymupdf_adapter._entity_source_hash(
+        {
+            "page_number": 1,
+            "drawing_index": 0,
+            "operator": "l",
+            "item_indices": (0, 1),
+            "source": "pymupdf.get_drawings",
+        }
+    )
+    assert provenance["source_hash"] != locator_hash
+    assert provenance["normalized_source_hash"] == provenance["source_hash"]
+    _assert_canonical_source_hash(cast(str, provenance["source_hash"]))
+    assert provenance["extraction_path"] == ("get_drawings", "page-1", "drawing-0", "l")
+    assert provenance["notes"] == ("vector_pdf_unconfirmed_scale",)
 
     geometry = cast(dict[str, Any], entity["geometry"])
     assert geometry["kind"] == entity["entity_type"]
@@ -1576,21 +1601,20 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         _FakePoint(14.0, 4.0),
         _FakePoint(16.0, 0.0),
     )
+    drawing = {
+        "items": (
+            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
+            unsupported_item,
+            ("l", _FakePoint(20.0, 0.0), _FakePoint(30.0, 0.0)),
+            ("l", _FakePoint(30.0, 0.0), _FakePoint(40.0, 10.0)),
+        ),
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
     document = _FakeDocument(
         [
             _FakePage(
-                drawings=[
-                    {
-                        "items": (
-                            ("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),
-                            unsupported_item,
-                            ("l", _FakePoint(20.0, 0.0), _FakePoint(30.0, 0.0)),
-                            ("l", _FakePoint(30.0, 0.0), _FakePoint(40.0, 10.0)),
-                        ),
-                        "width": 1.0,
-                        "color": (0.1, 0.2, 0.3),
-                    }
-                ]
+                drawings=[drawing]
             )
         ]
     )
@@ -1607,11 +1631,39 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
     first_entity, unknown_entity, final_entity = entities
     assert first_entity["entity_type"] == "line"
     assert first_entity["provenance"] == {
+        "origin": "adapter_normalized",
+        "adapter": {"key": "pymupdf"},
+        "adapter_key": "pymupdf",
         "page_number": 1,
         "drawing_index": 0,
+        "operator": "l",
         "item_indices": (0,),
         "source": "pymupdf.get_drawings",
+        "source_ref": "pdf://page-1/drawing-0/l/items:0",
+        "source_entity_ref": "pdf://page-1/drawing-0/l/items:0",
+        "source_identity": "page-1:drawing-0:items-0",
+        "source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="l",
+                drawing=drawing,
+                item_indices=(0,),
+                item_index=None,
+            )
+        ),
+        "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="l",
+                drawing=drawing,
+                item_indices=(0,),
+                item_index=None,
+            )
+        ),
+        "extraction_path": ("get_drawings", "page-1", "drawing-0", "l"),
+        "notes": ("vector_pdf_unconfirmed_scale",),
     }
+    _assert_canonical_source_hash(cast(str, first_entity["provenance"]["source_hash"]))
 
     assert unknown_entity["kind"] == "unknown"
     assert unknown_entity["entity_type"] == "unknown"
@@ -1640,13 +1692,39 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         "basis": "vector_pdf_unconfirmed_scale",
     }
     assert unknown_entity["provenance"] == {
+        "origin": "adapter_normalized",
+        "adapter": {"key": "pymupdf"},
+        "adapter_key": "pymupdf",
         "page_number": 1,
         "drawing_index": 0,
         "item_index": 1,
         "operator": "c",
         "source": "pymupdf.get_drawings",
-        "normalized_source_hash": pymupdf_adapter._normalized_source_hash(unsupported_item),
+        "source_ref": "pdf://page-1/drawing-0/c/item:1",
+        "source_entity_ref": "pdf://page-1/drawing-0/c/item:1",
+        "source_identity": "page-1:drawing-0:item-1",
+        "source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="c",
+                drawing=drawing,
+                item_indices=None,
+                item_index=1,
+            )
+        ),
+        "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="c",
+                drawing=drawing,
+                item_indices=None,
+                item_index=1,
+            )
+        ),
+        "extraction_path": ("get_drawings", "page-1", "drawing-0", "c"),
+        "notes": ("vector_pdf_unconfirmed_scale",),
     }
+    _assert_canonical_source_hash(cast(str, unknown_entity["provenance"]["source_hash"]))
 
     assert final_entity["entity_type"] == "polyline"
     assert final_entity["points"] == (
@@ -1655,11 +1733,39 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         {"x": 40.0, "y": 10.0},
     )
     assert final_entity["provenance"] == {
+        "origin": "adapter_normalized",
+        "adapter": {"key": "pymupdf"},
+        "adapter_key": "pymupdf",
         "page_number": 1,
         "drawing_index": 0,
+        "operator": "l",
         "item_indices": (2, 3),
         "source": "pymupdf.get_drawings",
+        "source_ref": "pdf://page-1/drawing-0/l/items:2,3",
+        "source_entity_ref": "pdf://page-1/drawing-0/l/items:2,3",
+        "source_identity": "page-1:drawing-0:items-2,3",
+        "source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="l",
+                drawing=drawing,
+                item_indices=(2, 3),
+                item_index=None,
+            )
+        ),
+        "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="l",
+                drawing=drawing,
+                item_indices=(2, 3),
+                item_index=None,
+            )
+        ),
+        "extraction_path": ("get_drawings", "page-1", "drawing-0", "l"),
+        "notes": ("vector_pdf_unconfirmed_scale",),
     }
+    _assert_canonical_source_hash(cast(str, final_entity["provenance"]["source_hash"]))
 
     assert result.warnings == (
         AdapterWarning(
@@ -1674,6 +1780,137 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         ),
     )
     _assert_no_nonfinite_numbers(result.canonical)
+
+
+@pytest.mark.asyncio
+async def test_pymupdf_ingest_emits_rect_entity_with_canonical_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    drawing = {
+        "items": (("re", _FakeRect(10.0, 20.0, 30.0, 40.0)),),
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
+    document = _FakeDocument(
+        [
+            _FakePage(
+                drawings=[drawing]
+            )
+        ]
+    )
+
+    result = await _ingest_fake_document(monkeypatch, tmp_path, document)
+
+    entity = cast(tuple[dict[str, Any], ...], result.canonical["entities"])[0]
+    assert entity["entity_type"] == "polyline"
+    assert entity["properties"]["rect_like"] is True
+    assert entity["provenance"] == {
+        "origin": "adapter_normalized",
+        "adapter": {"key": "pymupdf"},
+        "adapter_key": "pymupdf",
+        "page_number": 1,
+        "drawing_index": 0,
+        "operator": "re",
+        "item_indices": (0,),
+        "source": "pymupdf.get_drawings",
+        "source_ref": "pdf://page-1/drawing-0/re/items:0",
+        "source_entity_ref": "pdf://page-1/drawing-0/re/items:0",
+        "source_identity": "page-1:drawing-0:items-0",
+        "source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="re",
+                drawing=drawing,
+                item_indices=(0,),
+                item_index=None,
+            )
+        ),
+        "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+            pymupdf_adapter._entity_source_payload(
+                page_number=1,
+                operator="re",
+                drawing=drawing,
+                item_indices=(0,),
+                item_index=None,
+            )
+        ),
+        "extraction_path": ("get_drawings", "page-1", "drawing-0", "re"),
+        "notes": ("vector_pdf_unconfirmed_scale",),
+    }
+    _assert_canonical_source_hash(cast(str, entity["provenance"]["source_hash"]))
+
+
+def test_pymupdf_source_hash_is_deterministic_for_identical_payloads() -> None:
+    drawing_one = {
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+        "fill": None,
+        "items": (("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),),
+    }
+    drawing_two = {
+        "items": (("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),),
+        "fill": None,
+        "color": (0.1, 0.2, 0.3),
+        "width": 1.0,
+    }
+
+    first_hash = pymupdf_adapter._entity_source_hash(
+        pymupdf_adapter._entity_source_payload(
+            page_number=1,
+            operator="l",
+            drawing=drawing_one,
+            item_indices=(0,),
+            item_index=None,
+        )
+    )
+    second_hash = pymupdf_adapter._entity_source_hash(
+        pymupdf_adapter._entity_source_payload(
+            page_number=1,
+            operator="l",
+            drawing=drawing_two,
+            item_indices=(0,),
+            item_index=None,
+        )
+    )
+
+    assert first_hash == second_hash
+    _assert_canonical_source_hash(first_hash)
+
+
+def test_pymupdf_source_hash_changes_for_different_item_payloads_at_same_location() -> None:
+    base_drawing = {
+        "width": 1.0,
+        "color": (0.1, 0.2, 0.3),
+    }
+    first_hash = pymupdf_adapter._entity_source_hash(
+        pymupdf_adapter._entity_source_payload(
+            page_number=1,
+            operator="l",
+            drawing={
+                **base_drawing,
+                "items": (("l", _FakePoint(0.0, 0.0), _FakePoint(10.0, 0.0)),),
+            },
+            item_indices=(0,),
+            item_index=None,
+        )
+    )
+    second_hash = pymupdf_adapter._entity_source_hash(
+        pymupdf_adapter._entity_source_payload(
+            page_number=1,
+            operator="l",
+            drawing={
+                **base_drawing,
+                "items": (("l", _FakePoint(0.0, 0.0), _FakePoint(15.0, 0.0)),),
+            },
+            item_indices=(0,),
+            item_index=None,
+        )
+    )
+
+    assert first_hash != second_hash
+    _assert_canonical_source_hash(first_hash)
+    _assert_canonical_source_hash(second_hash)
 
 
 @pytest.mark.asyncio

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -331,8 +331,33 @@ async def test_libredwg_adapter_maps_line_entities_into_canonical_payload(
     assert entity["length"] == 5.0
     assert "quantity_hints" not in entity
     assert "adapter_native" not in entity
+    assert entity["provenance"]["origin"] == "adapter_normalized"
+    assert entity["provenance"]["adapter"] == {"key": "libredwg"}
+    assert entity["provenance"]["adapter_key"] == "libredwg"
+    assert entity["provenance"]["source_ref"] == "OBJECTS/LINE/1A"
+    assert entity["provenance"]["source_identity"] == "1A"
+    assert entity["provenance"]["source_hash"] == adapter_module._canonical_hash_json_value(
+        {
+            "record_type": "LINE",
+            "handle": "1A",
+            "layer_name": "Walls",
+            "layout_name": "Model",
+            "block_name": None,
+            "geometry": {
+                "start": {"x": 1.0, "y": 2.0, "z": 0.0},
+                "end": {"x": 4.0, "y": 6.0, "z": 0.0},
+            },
+        }
+    )
+    assert entity["provenance"]["normalized_source_hash"] == entity["provenance"]["source_hash"]
+    assert entity["provenance"]["extraction_path"] == ["OBJECTS", "LINE"]
+    assert entity["provenance"]["notes"] == ["units_unconfirmed"]
     assert entity["provenance"]["source_locator"] == "OBJECTS/LINE/1A"
-    assert entity["provenance"]["record_hash"].startswith("sha256:")
+    assert len(entity["provenance"]["source_hash"]) == 64
+    assert all(
+        character in "0123456789abcdef" for character in entity["provenance"]["source_hash"]
+    )
+    assert entity["provenance"]["record_hash"] == f"sha256:{entity['provenance']['source_hash']}"
     assert entity["confidence"] == {
         "score": adapter_module._LINE_ENTITY_CONFIDENCE_SCORE,
         "review_required": True,
@@ -529,7 +554,36 @@ async def test_libredwg_adapter_ignores_non_entities_and_degrades_unsupported_dr
         "record_type": "CIRCLE",
         "handle": "20",
     }
-    assert entities[0]["provenance"]["record_hash"].startswith("sha256:")
+    assert entities[0]["provenance"]["origin"] == "adapter_normalized"
+    assert entities[0]["provenance"]["adapter"] == {"key": "libredwg"}
+    assert entities[0]["provenance"]["source_ref"] == "OBJECTS/CIRCLE/20"
+    assert entities[0]["provenance"]["source_identity"] == "20"
+    assert entities[0]["provenance"]["source_hash"] == adapter_module._canonical_hash_json_value(
+        {
+            "record_type": "CIRCLE",
+            "handle": "20",
+            "layer_name": "Unsupported",
+            "layout_name": "Model",
+            "block_name": None,
+        }
+    )
+    assert (
+        entities[0]["provenance"]["normalized_source_hash"]
+        == entities[0]["provenance"]["source_hash"]
+    )
+    assert entities[0]["provenance"]["extraction_path"] == ("OBJECTS", "CIRCLE")
+    assert entities[0]["provenance"]["notes"] == (
+        "units_unconfirmed",
+        "unsupported_drawable_record",
+    )
+    assert len(entities[0]["provenance"]["source_hash"]) == 64
+    assert all(
+        character in "0123456789abcdef"
+        for character in entities[0]["provenance"]["source_hash"]
+    )
+    assert entities[0]["provenance"]["record_hash"] == (
+        f"sha256:{entities[0]['provenance']['source_hash']}"
+    )
     assert entities[0]["confidence"] == {
         "score": adapter_module._UNKNOWN_ENTITY_CONFIDENCE_SCORE,
         "review_required": True,
@@ -537,7 +591,6 @@ async def test_libredwg_adapter_ignores_non_entities_and_degrades_unsupported_dr
     }
     _assert_score_within_libredwg_descriptor_range(entities[0]["confidence"]["score"])
     assert entities[0]["unknown_reason"] == "unsupported_drawable_record"
-    assert entities[0]["provenance"]["record_hash"].startswith("sha256:")
     assert [warning.code for warning in result.warnings] == [
         "libredwg.units_unconfirmed",
         "libredwg.unsupported_drawable_record",


### PR DESCRIPTION
Closes #178

## Summary
- emit canonical provenance keys directly from DXF, DWG, vector PDF, and IFC adapters while preserving legacy/debug aliases needed for compatibility
- tighten ingestion contract and adapter tests around canonical provenance shape, approved origins, and lowercase 64-char source hashes
- align DWG and PyMuPDF source hashing with worker/materialization expectations for stable lineage, persistence, and re-ingestion comparisons

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv build
- [x] uv run pytest tests/test_ezdxf_adapter.py tests/test_libredwg_adapter.py tests/test_ifcopenshell_adapter.py tests/test_ingestion_contracts.py
- [x] uv run pytest tests -k "ingestion or adapter"