### PR TITLE
feat(quantity): add deterministic quantity engine

### DIFF
--- a/app/estimating/quantities/__init__.py
+++ b/app/estimating/quantities/__init__.py
@@ -1,0 +1,23 @@
+from app.estimating.quantities.contracts import (
+    BoundingBoxSummary,
+    QuantityAggregate,
+    QuantityConflict,
+    QuantityContributor,
+    QuantityEngineResult,
+    QuantityExclusion,
+    RevisionEntityInput,
+    RevisionGateMetadata,
+)
+from app.estimating.quantities.engine import compute_quantities
+
+__all__ = [
+    "BoundingBoxSummary",
+    "QuantityAggregate",
+    "QuantityConflict",
+    "QuantityContributor",
+    "QuantityEngineResult",
+    "QuantityExclusion",
+    "RevisionEntityInput",
+    "RevisionGateMetadata",
+    "compute_quantities",
+]

--- a/app/estimating/quantities/contracts.py
+++ b/app/estimating/quantities/contracts.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+type JSONScalar = None | bool | int | float | str
+type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
+type GateStatus = Literal[
+    "allowed",
+    "allowed_provisional",
+    "review_gated",
+    "blocked",
+]
+type QuantityType = Literal["length", "perimeter", "area", "count"]
+type ContributorTrust = Literal["preferred", "lower_trust"]
+type ContributorMethod = Literal["geometry", "hint_fallback", "entity_count"]
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionGateMetadata:
+    status: GateStatus
+    validation_status: str | None = None
+    reason: str | None = None
+    details: dict[str, JSONValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionEntityInput:
+    entity_id: str
+    entity_type: str
+    sequence_index: int
+    geometry_json: JSONValue
+    properties_json: JSONValue
+    provenance_json: JSONValue
+    canonical_entity_json: JSONValue
+    source_identity: str | None = None
+    source_hash: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BoundingBoxSummary:
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+    point_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class QuantityContributor:
+    entity_id: str
+    entity_type: str
+    sequence_index: int
+    quantity_type: QuantityType
+    value: float
+    unit: str
+    context: str | None
+    method: ContributorMethod
+    trust: ContributorTrust
+    dedup_key: str
+    geometry_fingerprint: str
+    bbox: BoundingBoxSummary | None
+    source_identity: str | None
+    source_hash: str | None
+    provenance: dict[str, JSONValue]
+    duplicate_entity_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class QuantityAggregate:
+    quantity_type: QuantityType
+    unit: str
+    context: str | None
+    total: float
+    contributor_count: int
+    trusted: bool
+
+
+@dataclass(frozen=True, slots=True)
+class QuantityExclusion:
+    entity_id: str
+    quantity_type: QuantityType | None
+    reason: str
+    details: dict[str, JSONValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class QuantityConflict:
+    dedup_key: str
+    entity_ids: tuple[str, ...]
+    reason: str
+    details: dict[str, JSONValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class QuantityEngineResult:
+    gate: RevisionGateMetadata
+    aggregates: tuple[QuantityAggregate, ...]
+    contributors: tuple[QuantityContributor, ...]
+    exclusions: tuple[QuantityExclusion, ...]
+    conflicts: tuple[QuantityConflict, ...]
+    trusted_totals: bool

--- a/app/estimating/quantities/dedup.py
+++ b/app/estimating/quantities/dedup.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+
+from app.estimating.quantities.contracts import (
+    BoundingBoxSummary,
+    ContributorTrust,
+    JSONValue,
+    QuantityConflict,
+    QuantityContributor,
+    RevisionEntityInput,
+)
+from app.estimating.quantities.geometry import GeometryQuantity
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateContribution:
+    entity: RevisionEntityInput
+    quantity: GeometryQuantity
+    geometry_fingerprint: str
+    bbox: BoundingBoxSummary | None
+    provenance: dict[str, JSONValue]
+
+
+@dataclass(frozen=True, slots=True)
+class DeduplicationResult:
+    contributors: tuple[QuantityContributor, ...]
+    conflicts: tuple[QuantityConflict, ...]
+
+
+def deduplicate_contributors(
+    candidates: list[CandidateContribution],
+) -> DeduplicationResult:
+    groups: dict[str, list[CandidateContribution]] = {}
+    for candidate in candidates:
+        key = dedup_key(candidate)
+        groups.setdefault(key, []).append(candidate)
+
+    contributors: list[QuantityContributor] = []
+    conflicts: list[QuantityConflict] = []
+    for key in sorted(groups):
+        group = groups[key]
+        payloads = {_comparison_payload(candidate) for candidate in group}
+        if len(payloads) > 1:
+            conflicts.append(
+                QuantityConflict(
+                    dedup_key=key,
+                    entity_ids=tuple(sorted(candidate.entity.entity_id for candidate in group)),
+                    reason="dedup_conflict",
+                    details={
+                        "detail": "contributors share a dedup key but differ after normalization",
+                    },
+                )
+            )
+            continue
+
+        primary = min(group, key=lambda candidate: candidate.entity.sequence_index)
+        trust = _candidate_trust(primary)
+        contributors.append(
+            QuantityContributor(
+                entity_id=primary.entity.entity_id,
+                entity_type=primary.entity.entity_type,
+                sequence_index=primary.entity.sequence_index,
+                quantity_type=primary.quantity.quantity_type,
+                value=primary.quantity.value,
+                unit=primary.quantity.unit,
+                context=primary.quantity.context,
+                method=primary.quantity.method,
+                trust=trust,
+                dedup_key=key,
+                geometry_fingerprint=primary.geometry_fingerprint,
+                bbox=primary.bbox,
+                source_identity=primary.entity.source_identity,
+                source_hash=primary.entity.source_hash,
+                provenance=primary.provenance,
+                duplicate_entity_ids=tuple(
+                    sorted(
+                        candidate.entity.entity_id
+                        for candidate in group
+                        if candidate.entity.entity_id != primary.entity.entity_id
+                    )
+                ),
+            )
+        )
+
+    contributors.sort(
+        key=lambda contributor: (contributor.sequence_index, contributor.quantity_type)
+    )
+    return DeduplicationResult(
+        contributors=tuple(contributors),
+        conflicts=tuple(conflicts),
+    )
+
+
+def dedup_key(candidate: CandidateContribution) -> str:
+    quantity = candidate.quantity
+    source_hash = _normalize_hash(candidate.entity.source_hash)
+    if source_hash is not None:
+        payload: dict[str, JSONValue] = {
+            "mode": "source_hash",
+            "quantity_type": quantity.quantity_type,
+            "source_hash": source_hash,
+            "unit": quantity.unit,
+            "context": quantity.context,
+        }
+        return _canonical(payload)
+
+    fallback_source = candidate.entity.source_identity or _provenance_source_ref(
+        candidate.provenance
+    )
+    payload = {
+        "mode": "missing_source_hash",
+        "quantity_type": quantity.quantity_type,
+        "entity_id": candidate.entity.entity_id,
+        "fallback_source": fallback_source,
+        "unit": quantity.unit,
+        "context": quantity.context,
+        "geometry_fingerprint": candidate.geometry_fingerprint,
+    }
+    return _canonical(payload)
+
+
+def _candidate_trust(candidate: CandidateContribution) -> ContributorTrust:
+    if _normalize_hash(candidate.entity.source_hash) is not None:
+        return "preferred"
+    return "lower_trust"
+
+
+def _comparison_payload(candidate: CandidateContribution) -> str:
+    payload: dict[str, JSONValue] = {
+        "entity_type": candidate.entity.entity_type,
+        "quantity_type": candidate.quantity.quantity_type,
+        "value": candidate.quantity.value,
+        "unit": candidate.quantity.unit,
+        "context": candidate.quantity.context,
+        "method": candidate.quantity.method,
+        "geometry_fingerprint": candidate.geometry_fingerprint,
+        "source_identity": candidate.entity.source_identity,
+        "source_hash": _normalize_hash(candidate.entity.source_hash),
+        "canonical_entity_json": _normalize_json_value(candidate.entity.canonical_entity_json),
+        "geometry_json": _normalize_json_value(candidate.entity.geometry_json),
+        "provenance": _normalize_json_value(candidate.provenance),
+    }
+    return _canonical(payload)
+
+
+def _normalize_hash(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if len(normalized) != 64:
+        return None
+    if any(character not in "0123456789abcdef" for character in normalized):
+        return None
+    return normalized
+
+
+def _provenance_source_ref(provenance: dict[str, JSONValue]) -> str | None:
+    source_ref = provenance.get("source_ref")
+    return source_ref if isinstance(source_ref, str) and source_ref.strip() else None
+
+
+def _canonical(payload: dict[str, JSONValue]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _normalize_json_value(value: JSONValue) -> JSONValue:
+    if isinstance(value, dict):
+        return {key: _normalize_json_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_json_value(item) for item in value]
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            if math.isnan(numeric):
+                return "nan"
+            if numeric > 0:
+                return "infinity"
+            return "-infinity"
+        if isinstance(value, int):
+            return value
+        return numeric
+    return value

--- a/app/estimating/quantities/engine.py
+++ b/app/estimating/quantities/engine.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import math
+from typing import TypedDict
+
+from app.estimating.quantities.contracts import (
+    JSONValue,
+    QuantityAggregate,
+    QuantityContributor,
+    QuantityEngineResult,
+    QuantityExclusion,
+    QuantityType,
+    RevisionEntityInput,
+    RevisionGateMetadata,
+)
+from app.estimating.quantities.dedup import (
+    CandidateContribution,
+    deduplicate_contributors,
+)
+from app.estimating.quantities.geometry import GeometryQuantity, extract_geometry_quantities
+
+
+class NormalizedHint(TypedDict):
+    quantity_type: QuantityType
+    value: float
+    unit: str
+    context: str | None
+    strict: bool
+    provenance: dict[str, JSONValue]
+
+
+def compute_quantities(
+    gate: RevisionGateMetadata,
+    entities: list[RevisionEntityInput],
+) -> QuantityEngineResult:
+    exclusions: list[QuantityExclusion] = []
+    candidates: list[CandidateContribution] = []
+
+    for entity in sorted(entities, key=lambda item: item.sequence_index):
+        extraction = extract_geometry_quantities(entity)
+        exclusions.extend(extraction.exclusions)
+
+        geometry_quantities: dict[
+            tuple[QuantityType, str, str | None],
+            GeometryQuantity,
+        ] = {
+            (quantity.quantity_type, quantity.unit, quantity.context): quantity
+            for quantity in extraction.quantities
+        }
+        hints = _normalize_hints(entity)
+
+        for quantity in _count_quantities(entity):
+            candidates.append(
+                CandidateContribution(
+                    entity=entity,
+                    quantity=quantity,
+                    geometry_fingerprint=extraction.fingerprint,
+                    bbox=extraction.bbox,
+                    provenance=_provenance_object(entity),
+                )
+            )
+
+        for quantity in extraction.quantities:
+            if _is_ineligible_geometric_unit(quantity):
+                exclusions.append(
+                    QuantityExclusion(
+                        entity_id=entity.entity_id,
+                        quantity_type=quantity.quantity_type,
+                        reason="ineligible_unit",
+                        details={"unit": quantity.unit},
+                    )
+                )
+                continue
+            candidates.append(
+                CandidateContribution(
+                    entity=entity,
+                    quantity=quantity,
+                    geometry_fingerprint=extraction.fingerprint,
+                    bbox=extraction.bbox,
+                    provenance=_provenance_object(entity),
+                )
+            )
+
+        if not extraction.quantities:
+            for hint in hints:
+                if not _hint_supports_fallback(hint):
+                    continue
+                fallback_quantity = GeometryQuantity(
+                    quantity_type=hint["quantity_type"],
+                    value=hint["value"],
+                    unit=hint["unit"],
+                    context=hint["context"],
+                    method="hint_fallback",
+                )
+                candidates.append(
+                    CandidateContribution(
+                        entity=entity,
+                        quantity=fallback_quantity,
+                        geometry_fingerprint=extraction.fingerprint,
+                        bbox=extraction.bbox,
+                        provenance=_hint_provenance(entity, hint),
+                    )
+                )
+                break
+            continue
+
+        for hint in hints:
+            key = (hint["quantity_type"], hint["unit"], hint["context"])
+            geometry_quantity = geometry_quantities.get(key)
+            if geometry_quantity is None:
+                continue
+            if geometry_quantity.value != hint["value"]:
+                exclusions.append(
+                    QuantityExclusion(
+                        entity_id=entity.entity_id,
+                        quantity_type=hint["quantity_type"],
+                        reason="hint_mismatch",
+                        details={
+                            "hint_value": hint["value"],
+                            "geometry_value": geometry_quantity.value,
+                        },
+                    )
+                )
+
+    deduped = deduplicate_contributors(candidates)
+    trusted_totals = gate.status == "allowed"
+    aggregates = (
+        _aggregate(deduped.contributors, trusted=trusted_totals)
+        if gate.status in {"allowed", "allowed_provisional"}
+        else ()
+    )
+    return QuantityEngineResult(
+        gate=gate,
+        aggregates=aggregates,
+        contributors=deduped.contributors,
+        exclusions=tuple(exclusions),
+        conflicts=deduped.conflicts,
+        trusted_totals=trusted_totals,
+    )
+
+
+def _count_quantities(entity: RevisionEntityInput) -> tuple[GeometryQuantity, GeometryQuantity]:
+    entity_type = _normalize_entity_type(entity.entity_type)
+    return (
+        GeometryQuantity(
+            quantity_type="count",
+            value=1.0,
+            unit="each",
+            context="entity_count",
+            method="entity_count",
+        ),
+        GeometryQuantity(
+            quantity_type="count",
+            value=1.0,
+            unit="each",
+            context=f"{entity_type}_count",
+            method="entity_count",
+        ),
+    )
+
+
+def _aggregate(
+    contributors: tuple[QuantityContributor, ...],
+    trusted: bool,
+) -> tuple[QuantityAggregate, ...]:
+    grouped: dict[tuple[QuantityType, str, str | None], list[float]] = {}
+    for contributor in contributors:
+        key = (contributor.quantity_type, contributor.unit, contributor.context)
+        grouped.setdefault(key, []).append(contributor.value)
+
+    aggregates = [
+        QuantityAggregate(
+            quantity_type=quantity_type,
+            unit=unit,
+            context=context,
+            total=math.fsum(values),
+            contributor_count=len(values),
+            trusted=trusted,
+        )
+        for (quantity_type, unit, context), values in sorted(grouped.items())
+    ]
+    return tuple(aggregates)
+
+
+def _normalize_hints(entity: RevisionEntityInput) -> list[NormalizedHint]:
+    properties = entity.properties_json
+    if not isinstance(properties, dict):
+        return []
+    raw_hints = properties.get("quantity_hints")
+    if isinstance(raw_hints, list):
+        return [hint for hint in (_normalize_hint(item) for item in raw_hints) if hint is not None]
+    if isinstance(raw_hints, dict):
+        hints: list[NormalizedHint] = []
+        for quantity_type, raw_value in raw_hints.items():
+            if isinstance(raw_value, dict):
+                merged_hint = {"quantity_type": quantity_type, **raw_value}
+                hint = _normalize_hint(merged_hint)
+            else:
+                hint = _normalize_hint({"quantity_type": quantity_type, "value": raw_value})
+            if hint is not None:
+                hints.append(hint)
+        return hints
+    return []
+
+
+def _normalize_hint(raw_hint: JSONValue) -> NormalizedHint | None:
+    if not isinstance(raw_hint, dict):
+        return None
+    quantity_type = _parse_quantity_type(raw_hint.get("quantity_type") or raw_hint.get("type"))
+    if quantity_type is None:
+        return None
+    raw_value = raw_hint.get("value")
+    if isinstance(raw_value, bool) or not isinstance(raw_value, int | float):
+        return None
+    value = float(raw_value)
+    if not math.isfinite(value) or value <= 0.0:
+        return None
+    raw_unit = raw_hint.get("unit")
+    if raw_unit is not None and not isinstance(raw_unit, str):
+        return None
+    raw_context = raw_hint.get("context")
+    if raw_context is not None and not isinstance(raw_context, str):
+        return None
+    provenance = raw_hint.get("provenance")
+    if provenance is not None and not isinstance(provenance, dict):
+        return None
+    unit = "unitless"
+    if isinstance(raw_unit, str) and raw_unit.strip():
+        unit = raw_unit.strip().lower()
+    context: str | None = None
+    if isinstance(raw_context, str) and raw_context.strip():
+        context = raw_context.strip().lower()
+    return {
+        "quantity_type": quantity_type,
+        "value": value,
+        "unit": unit,
+        "context": context,
+        "strict": raw_hint.get("strict") is True,
+        "provenance": provenance if isinstance(provenance, dict) else {},
+    }
+
+
+def _parse_quantity_type(raw_value: JSONValue) -> QuantityType | None:
+    if raw_value == "count":
+        return "count"
+    if raw_value == "length":
+        return "length"
+    if raw_value == "perimeter":
+        return "perimeter"
+    if raw_value == "area":
+        return "area"
+    return None
+
+
+def _normalize_entity_type(raw_value: str) -> str:
+    normalized = "_".join(raw_value.strip().lower().split())
+    return normalized or "unknown"
+
+
+def _is_ineligible_geometric_unit(quantity: GeometryQuantity) -> bool:
+    if quantity.method != "geometry":
+        return False
+    if quantity.quantity_type == "count":
+        return False
+    return quantity.unit in {"unknown", "unitless", "point"}
+
+
+def _hint_supports_fallback(hint: NormalizedHint) -> bool:
+    if hint["strict"] is not True:
+        return False
+    if hint["quantity_type"] == "count":
+        return False
+    if hint["unit"] in {"unknown", "unitless", "point"}:
+        return False
+    provenance = hint["provenance"]
+    return bool(provenance)
+
+
+def _provenance_object(entity: RevisionEntityInput) -> dict[str, JSONValue]:
+    if isinstance(entity.provenance_json, dict):
+        return entity.provenance_json
+    return {}
+
+
+def _hint_provenance(
+    entity: RevisionEntityInput,
+    hint: NormalizedHint,
+) -> dict[str, JSONValue]:
+    provenance = _provenance_object(entity).copy()
+    hint_provenance = hint["provenance"]
+    if hint_provenance:
+        provenance["hint_provenance"] = hint_provenance
+    return provenance

--- a/app/estimating/quantities/geometry.py
+++ b/app/estimating/quantities/geometry.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import TypedDict
+
+from app.estimating.quantities.contracts import (
+    BoundingBoxSummary,
+    ContributorMethod,
+    JSONValue,
+    QuantityExclusion,
+    QuantityType,
+    RevisionEntityInput,
+)
+
+type Point = tuple[float, ...]
+
+
+class UnitMap(TypedDict):
+    length: str
+    area: str
+    context: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class GeometryQuantity:
+    quantity_type: QuantityType
+    value: float
+    unit: str
+    context: str | None
+    method: ContributorMethod
+
+
+@dataclass(frozen=True, slots=True)
+class GeometryExtraction:
+    quantities: tuple[GeometryQuantity, ...]
+    exclusions: tuple[QuantityExclusion, ...]
+    bbox: BoundingBoxSummary | None
+    fingerprint: str
+
+
+def extract_geometry_quantities(entity: RevisionEntityInput) -> GeometryExtraction:
+    geometry = entity.geometry_json
+    if not isinstance(geometry, dict):
+        return GeometryExtraction(
+            quantities=(),
+            exclusions=(
+                QuantityExclusion(
+                    entity_id=entity.entity_id,
+                    quantity_type=None,
+                    reason="unsupported_geometry",
+                    details={"detail": "geometry_json must be an object"},
+                ),
+            ),
+            bbox=None,
+            fingerprint=_fingerprint(None),
+        )
+
+    start = _extract_point(geometry.get("start"))
+    end = _extract_point(geometry.get("end"))
+    points = _extract_points(geometry.get("points") or geometry.get("vertices"))
+    kind = _infer_kind(geometry, start, end, points)
+    raw_units = geometry.get("units") if "units" in geometry else entity.properties_json
+    unit_map = _normalize_units(raw_units)
+
+    if kind == "line":
+        if start is None or end is None:
+            return _invalid_geometry(
+                entity.entity_id,
+                kind,
+                "line requires finite start/end points",
+            )
+        length = _segment_length(start, end)
+        bbox = _bbox([start, end])
+        payload_line: JSONValue = {
+            "kind": kind,
+            "start": list(start),
+            "end": list(end),
+            "units": _unit_payload(unit_map),
+        }
+        return GeometryExtraction(
+            quantities=(
+                GeometryQuantity(
+                    quantity_type="length",
+                    value=length,
+                    unit=unit_map["length"],
+                    context=unit_map["context"],
+                    method="geometry",
+                ),
+            ),
+            exclusions=(),
+            bbox=bbox,
+            fingerprint=_fingerprint(payload_line),
+        )
+
+    if kind in {"polyline", "lwpolyline"}:
+        if len(points) < 2:
+            return _invalid_geometry(
+                entity.entity_id,
+                kind,
+                "polyline requires at least two finite points",
+            )
+        is_closed = _is_closed_polyline(geometry, points)
+        segment_total = math.fsum(
+            _segment_length(points[index], points[index + 1])
+            for index in range(len(points) - 1)
+        )
+        exclusions: list[QuantityExclusion] = []
+        quantities: list[GeometryQuantity] = []
+        bbox = _bbox(points)
+        if is_closed:
+            perimeter = segment_total
+            if points[0] != points[-1]:
+                perimeter += _segment_length(points[-1], points[0])
+            quantities.append(
+                GeometryQuantity(
+                    quantity_type="perimeter",
+                    value=perimeter,
+                    unit=unit_map["length"],
+                    context=unit_map["context"],
+                    method="geometry",
+                )
+            )
+            area = _polygon_area(points)
+            if area is None:
+                exclusions.append(
+                    QuantityExclusion(
+                        entity_id=entity.entity_id,
+                        quantity_type="area",
+                        reason="ineligible_area",
+                        details={"detail": "closed polyline area must be finite and non-zero"},
+                    )
+                )
+            else:
+                quantities.append(
+                    GeometryQuantity(
+                        quantity_type="area",
+                        value=area,
+                        unit=unit_map["area"],
+                        context=unit_map["context"],
+                        method="geometry",
+                    )
+                )
+        else:
+            quantities.append(
+                GeometryQuantity(
+                    quantity_type="length",
+                    value=segment_total,
+                    unit=unit_map["length"],
+                    context=unit_map["context"],
+                    method="geometry",
+                )
+            )
+        payload_polyline: JSONValue = {
+            "kind": kind,
+            "closed": is_closed,
+            "points": [list(point) for point in points],
+            "units": _unit_payload(unit_map),
+        }
+        return GeometryExtraction(
+            quantities=tuple(quantities),
+            exclusions=tuple(exclusions),
+            bbox=bbox,
+            fingerprint=_fingerprint(payload_polyline),
+        )
+
+    summary_bbox = _summary_bbox(geometry.get("geometry_summary"))
+    return GeometryExtraction(
+        quantities=(),
+        exclusions=(
+            QuantityExclusion(
+                entity_id=entity.entity_id,
+                quantity_type=None,
+                reason="unsupported_geometry",
+                details={"detail": f"unsupported geometry type: {kind or 'unknown'}"},
+            ),
+        ),
+        bbox=summary_bbox,
+        fingerprint=_fingerprint({"kind": kind, "summary_bbox": _bbox_payload(summary_bbox)}),
+    )
+
+
+def _invalid_geometry(entity_id: str, kind: str | None, detail: str) -> GeometryExtraction:
+    return GeometryExtraction(
+        quantities=(),
+        exclusions=(
+            QuantityExclusion(
+                entity_id=entity_id,
+                quantity_type=None,
+                reason="unsupported_geometry",
+                details={"geometry_type": kind or "unknown", "detail": detail},
+            ),
+        ),
+        bbox=None,
+        fingerprint=_fingerprint({"kind": kind}),
+    )
+
+
+def _normalize_units(raw_units: JSONValue) -> UnitMap:
+    default_unit = "unitless"
+    context: str | None = None
+
+    if isinstance(raw_units, dict):
+        if "units" in raw_units:
+            return _normalize_units(raw_units["units"])
+        length = _normalize_string(raw_units.get("length"))
+        if length is None:
+            length = _normalize_string(raw_units.get("unit"))
+        if length is None:
+            length = _normalize_string(raw_units.get("normalized"))
+        area = _normalize_string(raw_units.get("area")) or length
+        context = _normalize_string(raw_units.get("context"))
+        return {
+            "length": length or default_unit,
+            "area": area or length or default_unit,
+            "context": context,
+        }
+
+    scalar_unit = _normalize_string(raw_units)
+    return {
+        "length": scalar_unit or default_unit,
+        "area": scalar_unit or default_unit,
+        "context": context,
+    }
+
+
+def _normalize_string(value: JSONValue) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _infer_kind(
+    geometry: dict[str, JSONValue],
+    start: Point | None,
+    end: Point | None,
+    points: list[Point],
+) -> str | None:
+    direct_kind = _normalize_string(geometry.get("type") or geometry.get("kind"))
+    if direct_kind is not None:
+        return direct_kind
+
+    if start is not None and end is not None:
+        return "line"
+
+    if len(points) >= 2:
+        return "polyline"
+
+    summary = geometry.get("geometry_summary")
+    if isinstance(summary, dict):
+        summary_kind = _normalize_string(summary.get("kind") or summary.get("type"))
+        if summary_kind is not None:
+            return summary_kind
+
+    return None
+
+
+def _extract_points(raw_points: JSONValue) -> list[Point]:
+    if not isinstance(raw_points, list):
+        return []
+    points: list[Point] = []
+    for raw_point in raw_points:
+        point = _extract_point(raw_point)
+        if point is None:
+            return []
+        points.append(point)
+    return points
+
+
+def _extract_point(raw_point: JSONValue) -> Point | None:
+    if isinstance(raw_point, dict):
+        coords: list[float] = []
+        for axis in ("x", "y", "z"):
+            raw_axis = raw_point.get(axis)
+            if raw_axis is None:
+                continue
+            if not isinstance(raw_axis, int | float) or not math.isfinite(float(raw_axis)):
+                return None
+            coords.append(float(raw_axis))
+        if len(coords) < 2:
+            return None
+        return tuple(coords)
+
+    if isinstance(raw_point, list):
+        coords = []
+        for value in raw_point:
+            if not isinstance(value, int | float) or not math.isfinite(float(value)):
+                return None
+            coords.append(float(value))
+        if len(coords) < 2:
+            return None
+        return tuple(coords)
+
+    return None
+
+
+def _segment_length(start: Point, end: Point) -> float:
+    dimensions = min(len(start), len(end))
+    return math.dist(start[:dimensions], end[:dimensions])
+
+
+def _bbox(points: list[Point]) -> BoundingBoxSummary | None:
+    if not points:
+        return None
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    return BoundingBoxSummary(
+        min_x=min(xs),
+        min_y=min(ys),
+        max_x=max(xs),
+        max_y=max(ys),
+        point_count=len(points),
+    )
+
+
+def _summary_bbox(summary: JSONValue) -> BoundingBoxSummary | None:
+    if not isinstance(summary, dict):
+        return None
+    raw_bbox = summary.get("bbox")
+    if not isinstance(raw_bbox, dict):
+        return None
+    keys = ("min_x", "min_y", "max_x", "max_y")
+    values: dict[str, float] = {}
+    for key in keys:
+        raw_value = raw_bbox.get(key)
+        if not isinstance(raw_value, int | float) or not math.isfinite(float(raw_value)):
+            return None
+        values[key] = float(raw_value)
+    raw_points = raw_bbox.get("point_count", 0)
+    if not isinstance(raw_points, int):
+        return None
+    return BoundingBoxSummary(point_count=raw_points, **values)
+
+
+def _is_closed_polyline(geometry: dict[str, JSONValue], points: list[Point]) -> bool:
+    raw_closed = geometry.get("closed")
+    if isinstance(raw_closed, bool):
+        return raw_closed
+    return points[0] == points[-1]
+
+
+def _polygon_area(points: list[Point]) -> float | None:
+    unique_points = points[:-1] if points[0] == points[-1] else points
+    if len(unique_points) < 3:
+        return None
+
+    total = 0.0
+    loop_points = [*unique_points, unique_points[0]]
+    for start, end in pairwise(loop_points):
+        total += (start[0] * end[1]) - (end[0] * start[1])
+    area = abs(total) / 2.0
+    if not math.isfinite(area) or area <= 0.0:
+        return None
+    return area
+
+
+def _fingerprint(payload: JSONValue | None) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def _unit_payload(unit_map: UnitMap) -> dict[str, JSONValue]:
+    return {
+        "length": unit_map["length"],
+        "area": unit_map["area"],
+        "context": unit_map["context"],
+    }
+
+
+def _bbox_payload(bbox: BoundingBoxSummary | None) -> JSONValue:
+    if bbox is None:
+        return None
+    return {
+        "min_x": bbox.min_x,
+        "min_y": bbox.min_y,
+        "max_x": bbox.max_x,
+        "max_y": bbox.max_y,
+        "point_count": bbox.point_count,
+    }

--- a/tests/test_quantity_engine.py
+++ b/tests/test_quantity_engine.py
@@ -1,0 +1,621 @@
+from __future__ import annotations
+
+from app.estimating.quantities import RevisionEntityInput, RevisionGateMetadata, compute_quantities
+
+
+def test_allowed_line_length_is_trusted_and_summarizes_bbox() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="line-1",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "type": "line",
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": 10, "y": 0},
+                    "units": {"length": "ft", "context": "model"},
+                },
+                properties_json={},
+                provenance_json={"source_ref": "layer/1"},
+                canonical_entity_json={"shape": "line"},
+                source_identity="layer/1",
+                source_hash="a" * 64,
+            )
+        ],
+    )
+
+    assert result.trusted_totals is True
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    }
+    assert totals == {
+        ("count", "entity_count"): 1.0,
+        ("count", "line_count"): 1.0,
+        ("length", "model"): 10.0,
+    }
+    contributor = next(
+        contributor
+        for contributor in result.contributors
+        if contributor.quantity_type == "length"
+    )
+    assert contributor.bbox is not None
+    assert contributor.bbox.min_x == 0.0
+    assert contributor.bbox.max_x == 10.0
+    assert result.exclusions == ()
+    assert result.conflicts == ()
+
+
+def test_closed_polyline_yields_perimeter_and_area() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="poly-1",
+                entity_type="polyline",
+                sequence_index=1,
+                geometry_json={
+                    "type": "polyline",
+                    "closed": True,
+                    "points": [
+                        {"x": 0, "y": 0},
+                        {"x": 2, "y": 0},
+                        {"x": 2, "y": 2},
+                        {"x": 0, "y": 2},
+                    ],
+                    "units": {"length": "ft", "area": "sqft"},
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={"shape": "rectangle"},
+                source_hash="b" * 64,
+            )
+        ],
+    )
+
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    }
+    assert totals == {
+        ("area", None): 4.0,
+        ("count", "entity_count"): 1.0,
+        ("count", "polyline_count"): 1.0,
+        ("perimeter", None): 8.0,
+    }
+
+
+def test_allowed_provisional_totals_are_not_trusted() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed_provisional", reason="needs_review"),
+        [
+            RevisionEntityInput(
+                entity_id="line-1",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "type": "line",
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": 5, "y": 0},
+                    "units": "ft",
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="c" * 64,
+            )
+        ],
+    )
+
+    assert result.trusted_totals is False
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate
+        for aggregate in result.aggregates
+    }
+    assert totals[("length", None)].total == 5.0
+    assert totals[("length", None)].trusted is False
+    assert totals[("count", "entity_count")].trusted is False
+    assert totals[("count", "line_count")].total == 1.0
+
+
+def test_review_gated_suppresses_aggregates() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="review_gated", reason="scale_unknown"),
+        [
+            RevisionEntityInput(
+                entity_id="line-1",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "type": "line",
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": 7, "y": 0},
+                    "units": "ft",
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="d" * 64,
+            )
+        ],
+    )
+
+    assert result.aggregates == ()
+    assert len(result.contributors) == 3
+
+
+def test_source_hash_dedups_identical_contributors_and_conflicts_on_mismatch() -> None:
+    duplicate_hash = "e" * 64
+    duplicate = RevisionEntityInput(
+        entity_id="line-1",
+        entity_type="line",
+        sequence_index=1,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 10, "y": 0},
+            "units": "ft",
+        },
+        properties_json={},
+        provenance_json={},
+        canonical_entity_json={"shape": "line"},
+        source_hash=duplicate_hash,
+    )
+    duplicate_copy = RevisionEntityInput(
+        entity_id="line-2",
+        entity_type="line",
+        sequence_index=2,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 10, "y": 0},
+            "units": "ft",
+        },
+        properties_json={},
+        provenance_json={},
+        canonical_entity_json={"shape": "line"},
+        source_hash=duplicate_hash,
+    )
+    conflict = RevisionEntityInput(
+        entity_id="line-3",
+        entity_type="line",
+        sequence_index=3,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 11, "y": 0},
+            "units": "ft",
+        },
+        properties_json={},
+        provenance_json={},
+        canonical_entity_json={"shape": "line"},
+        source_hash=duplicate_hash,
+    )
+
+    deduped = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [duplicate, duplicate_copy],
+    )
+    assert len(deduped.contributors) == 3
+    length_contributor = next(
+        contributor
+        for contributor in deduped.contributors
+        if contributor.quantity_type == "length"
+    )
+    assert length_contributor.duplicate_entity_ids == ("line-2",)
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in deduped.aggregates
+    }
+    assert totals[("length", None)] == 10.0
+    assert totals[("count", "entity_count")] == 1.0
+
+    conflicted = compute_quantities(RevisionGateMetadata(status="allowed"), [duplicate, conflict])
+    assert conflicted.contributors == ()
+    assert len(conflicted.conflicts) == 3
+
+
+def test_missing_source_hash_uses_fingerprint_scoped_lower_trust_fallback() -> None:
+    entity = RevisionEntityInput(
+        entity_id="line-1",
+        entity_type="line",
+        sequence_index=1,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 3, "y": 4},
+            "units": {"length": "ft", "context": "model"},
+        },
+        properties_json={},
+        provenance_json={"source_ref": "ref-1"},
+        canonical_entity_json={"shape": "line"},
+        source_identity="fallback-1",
+    )
+    same_fingerprint = RevisionEntityInput(
+        entity_id="line-1",
+        entity_type="line",
+        sequence_index=2,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 3, "y": 4},
+            "units": {"length": "ft", "context": "model"},
+        },
+        properties_json={},
+        provenance_json={"source_ref": "ref-1"},
+        canonical_entity_json={"shape": "line"},
+        source_identity="fallback-1",
+    )
+    changed_fingerprint = RevisionEntityInput(
+        entity_id="line-1",
+        entity_type="line",
+        sequence_index=3,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 6, "y": 8},
+            "units": {"length": "ft", "context": "model"},
+        },
+        properties_json={},
+        provenance_json={"source_ref": "ref-1"},
+        canonical_entity_json={"shape": "line"},
+        source_identity="fallback-1",
+    )
+
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [entity, same_fingerprint, changed_fingerprint],
+    )
+
+    length_contributors = [
+        contributor
+        for contributor in result.contributors
+        if contributor.quantity_type == "length"
+    ]
+    assert len(length_contributors) == 2
+    assert {contributor.value for contributor in length_contributors} == {5.0, 10.0}
+    assert {contributor.trust for contributor in result.contributors} == {"lower_trust"}
+
+
+def test_strict_hint_fallback_never_double_counts_geometry() -> None:
+    geometry_entity = RevisionEntityInput(
+        entity_id="line-1",
+        entity_type="line",
+        sequence_index=1,
+        geometry_json={
+            "type": "line",
+            "start": {"x": 0, "y": 0},
+            "end": {"x": 10, "y": 0},
+            "units": "ft",
+        },
+        properties_json={
+            "quantity_hints": [
+                {
+                    "quantity_type": "length",
+                    "value": 10.0,
+                    "unit": "ft",
+                    "strict": True,
+                    "provenance": {"origin": "adapter"},
+                }
+            ]
+        },
+        provenance_json={},
+        canonical_entity_json={},
+        source_hash="f" * 64,
+    )
+    hint_only_entity = RevisionEntityInput(
+        entity_id="text-1",
+        entity_type="text",
+        sequence_index=2,
+        geometry_json={"type": "text"},
+        properties_json={
+            "quantity_hints": [
+                {
+                    "quantity_type": "length",
+                    "value": 9.0,
+                    "unit": "ft",
+                    "strict": True,
+                    "provenance": {"origin": "adapter", "source_ref": "hint-1"},
+                }
+            ]
+        },
+        provenance_json={"source_ref": "hint-parent"},
+        canonical_entity_json={},
+        source_hash="1" * 64,
+    )
+
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [geometry_entity, hint_only_entity],
+    )
+
+    quantity_methods = {contributor.method for contributor in result.contributors}
+    assert quantity_methods == {"entity_count", "geometry", "hint_fallback"}
+    measured_total = sum(
+        contributor.value
+        for contributor in result.contributors
+        if contributor.quantity_type == "length"
+    )
+    assert measured_total == 19.0
+    assert {
+        aggregate.context for aggregate in result.aggregates if aggregate.quantity_type == "count"
+    } == {"entity_count", "line_count", "text_count"}
+
+
+def test_count_output_and_adapter_shape_inference_without_top_level_kind() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="line-1",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": 10, "y": 0},
+                    "units": "ft",
+                    "geometry_summary": {"kind": "line"},
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="2" * 64,
+            ),
+            RevisionEntityInput(
+                entity_id="poly-1",
+                entity_type="polyline",
+                sequence_index=2,
+                geometry_json={
+                    "vertices": [
+                        {"x": 0, "y": 0},
+                        {"x": 4, "y": 0},
+                        {"x": 4, "y": 3},
+                    ],
+                    "units": "ft",
+                    "geometry_summary": {"kind": "polyline"},
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="3" * 64,
+            ),
+        ],
+    )
+
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    }
+    assert totals[("length", None)] == 17.0
+    assert totals[("count", "entity_count")] == 2.0
+    assert totals[("count", "line_count")] == 1.0
+    assert totals[("count", "polyline_count")] == 1.0
+
+
+def test_unknown_unit_geometry_is_excluded_from_aggregates() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="line-1",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "type": "line",
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": 10, "y": 0},
+                    "units": "point",
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="4" * 64,
+            )
+        ],
+    )
+
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    }
+    assert totals == {
+        ("count", "entity_count"): 1.0,
+        ("count", "line_count"): 1.0,
+    }
+    assert [exclusion.reason for exclusion in result.exclusions] == ["ineligible_unit"]
+    assert all(contributor.quantity_type == "count" for contributor in result.contributors)
+
+
+def test_adapter_style_normalized_units_aggregate_length() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="line-1",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "type": "line",
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": 3, "y": 4},
+                    "units": {"normalized": "meter", "source": "$INSUNITS"},
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="5" * 64,
+            )
+        ],
+    )
+
+    totals = {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    }
+    assert totals == {
+        ("count", "entity_count"): 1.0,
+        ("count", "line_count"): 1.0,
+        ("length", None): 5.0,
+    }
+    length_contributor = next(
+        contributor
+        for contributor in result.contributors
+        if contributor.quantity_type == "length"
+    )
+    assert length_contributor.unit == "meter"
+
+
+def test_ineligible_and_count_hint_fallbacks_are_suppressed() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="text-1",
+                entity_type="text",
+                sequence_index=1,
+                geometry_json={"type": "text"},
+                properties_json={
+                    "quantity_hints": [
+                        {
+                            "quantity_type": "count",
+                            "value": 7.0,
+                            "unit": "each",
+                            "strict": True,
+                            "provenance": {"origin": "adapter"},
+                        },
+                        {
+                            "quantity_type": "length",
+                            "value": 12.0,
+                            "unit": "point",
+                            "strict": True,
+                            "provenance": {"origin": "adapter"},
+                        },
+                    ]
+                },
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="6" * 64,
+            )
+        ],
+    )
+
+    assert all(contributor.quantity_type == "count" for contributor in result.contributors)
+    assert {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    } == {
+        ("count", "entity_count"): 1.0,
+        ("count", "text_count"): 1.0,
+    }
+
+
+def test_malformed_hint_strict_and_value_inputs_do_not_create_fallbacks() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="text-1",
+                entity_type="text",
+                sequence_index=1,
+                geometry_json={"type": "text"},
+                properties_json={
+                    "quantity_hints": [
+                        {
+                            "quantity_type": "length",
+                            "value": 8.0,
+                            "unit": "ft",
+                            "strict": "true",
+                            "provenance": {"origin": "adapter"},
+                        }
+                    ]
+                },
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="7" * 64,
+            ),
+            RevisionEntityInput(
+                entity_id="text-2",
+                entity_type="text",
+                sequence_index=2,
+                geometry_json={"type": "text"},
+                properties_json={
+                    "quantity_hints": [
+                        {
+                            "quantity_type": "length",
+                            "value": True,
+                            "unit": "ft",
+                            "strict": True,
+                            "provenance": {"origin": "adapter"},
+                        }
+                    ]
+                },
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="8" * 64,
+            ),
+            RevisionEntityInput(
+                entity_id="text-3",
+                entity_type="text",
+                sequence_index=3,
+                geometry_json={"type": "text"},
+                properties_json={
+                    "quantity_hints": [
+                        {
+                            "quantity_type": "length",
+                            "value": -3.0,
+                            "unit": "ft",
+                            "strict": True,
+                            "provenance": {"origin": "adapter"},
+                        }
+                    ]
+                },
+                provenance_json={},
+                canonical_entity_json={},
+                source_hash="9" * 64,
+            ),
+        ],
+    )
+
+    assert all(contributor.quantity_type == "count" for contributor in result.contributors)
+    assert {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    } == {
+        ("count", "entity_count"): 3.0,
+        ("count", "text_count"): 3.0,
+    }
+
+
+def test_nonfinite_geometry_is_excluded() -> None:
+    result = compute_quantities(
+        RevisionGateMetadata(status="allowed"),
+        [
+            RevisionEntityInput(
+                entity_id="bad-line",
+                entity_type="line",
+                sequence_index=1,
+                geometry_json={
+                    "type": "line",
+                    "start": {"x": 0, "y": 0},
+                    "end": {"x": float("inf"), "y": 0},
+                    "units": "ft",
+                },
+                properties_json={},
+                provenance_json={},
+                canonical_entity_json={},
+            )
+        ],
+    )
+
+    assert all(contributor.quantity_type == "count" for contributor in result.contributors)
+    assert {
+        (aggregate.quantity_type, aggregate.context): aggregate.total
+        for aggregate in result.aggregates
+    } == {
+        ("count", "entity_count"): 1.0,
+        ("count", "line_count"): 1.0,
+    }
+    assert len(result.exclusions) == 1
+    assert result.exclusions[0].reason == "unsupported_geometry"


### PR DESCRIPTION
Closes #184

## Summary
- add a pure quantity engine package for deterministic count, length, perimeter, and area computation from revision materialization inputs
- enforce deterministic dedup, gate-aware trusted/provisional output behavior, and strict hint fallback validation for externally supplied CAD-derived entity data
- add focused quantity engine coverage for geometry extraction, unit eligibility, dedup conflicts, and malformed hint regressions

## Test plan
- [x] uv run pytest tests/test_quantity_engine.py
- [x] uv run pytest
- [x] uv run mypy app tests
- [x] uv run ruff check app tests