### PR TITLE
refactor(jobs): generalize revision-scoped job contract

### DIFF
--- a/alembic/versions/2026_05_14_0016_add_revision_scoped_job_contract.py
+++ b/alembic/versions/2026_05_14_0016_add_revision_scoped_job_contract.py
@@ -1,0 +1,213 @@
+"""add revision scoped job contract
+
+Revision ID: 2026_05_14_0016
+Revises: 2026_05_13_0015
+Create Date: 2026-05-14 12:55:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_14_0016"
+down_revision: str | None = "2026_05_13_0015"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def _require_no_revision_scoped_rows_before_downgrade() -> None:
+    """Refuse downgrade while new revision-scoped job semantics still exist."""
+
+    bind = op.get_bind()
+    quantity_takeoff_jobs_exist = bool(
+        bind.execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM jobs
+                    WHERE job_type = 'quantity_takeoff'
+                )
+                """
+            )
+        ).scalar()
+    )
+    if quantity_takeoff_jobs_exist:
+        raise RuntimeError(
+            "Manual data-preserving rollback is required before downgrading "
+            "migration 2026_05_14_0016; quantity_takeoff jobs still depend on the "
+            "revision-scoped job contract."
+        )
+
+    parented_jobs_exist = bool(
+        bind.execute(
+            sa.text(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM jobs
+                    WHERE parent_job_id IS NOT NULL
+                )
+                """
+            )
+        ).scalar()
+    )
+    if parented_jobs_exist:
+        raise RuntimeError(
+            "Manual data-preserving rollback is required before downgrading "
+            "migration 2026_05_14_0016; parent_job_id lineage rows still depend on "
+            "the revision-scoped job contract."
+        )
+
+
+def upgrade() -> None:
+    """Constrain jobs to revision-scoped base revisions and parent lineage."""
+
+    op.alter_column(
+        "jobs",
+        "base_revision_id",
+        existing_type=sa.Uuid(),
+        comment=(
+            "Pinned latest finalized drawing revision captured when a revision-"
+            "scoped job was created. Null for initial ingest jobs."
+        ),
+    )
+    op.create_unique_constraint(
+        "uq_drawing_revisions_id_project_id_source_file_id",
+        "drawing_revisions",
+        ["id", "project_id", "source_file_id"],
+    )
+    op.create_unique_constraint(
+        "uq_jobs_id_project_id_file_id",
+        "jobs",
+        ["id", "project_id", "file_id"],
+    )
+
+    op.drop_constraint(
+        "fk_jobs_base_revision_id_drawing_revisions",
+        "jobs",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_jobs_base_revision_id_project_id_file_id_drawing_revisions",
+        "jobs",
+        "drawing_revisions",
+        ["base_revision_id", "project_id", "file_id"],
+        ["id", "project_id", "source_file_id"],
+        ondelete="RESTRICT",
+    )
+
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "parent_job_id",
+            sa.Uuid(),
+            nullable=True,
+            comment="Optional parent job identifier for same-project, same-file job lineage.",
+        ),
+    )
+    op.create_index("ix_jobs_parent_job_id", "jobs", ["parent_job_id"], unique=False)
+    op.create_foreign_key(
+        "fk_jobs_parent_job_id_project_id_file_id_jobs",
+        "jobs",
+        "jobs",
+        ["parent_job_id", "project_id", "file_id"],
+        ["id", "project_id", "file_id"],
+        ondelete="RESTRICT",
+    )
+
+    op.drop_constraint("ck_jobs_job_type_valid", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_job_type_valid",
+        "jobs",
+        "job_type IN ('ingest', 'reprocess', 'quantity_takeoff')",
+    )
+
+    op.drop_constraint("ck_jobs_reprocess_base_revision_required", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_reprocess_base_revision_required",
+        "jobs",
+        "job_type NOT IN ('reprocess', 'quantity_takeoff') OR base_revision_id IS NOT NULL",
+    )
+
+    op.create_check_constraint(
+        "ck_jobs_quantity_takeoff_extraction_profile_forbidden",
+        "jobs",
+        "job_type != 'quantity_takeoff' OR extraction_profile_id IS NULL",
+    )
+    op.create_check_constraint(
+        "ck_jobs_parent_job_id_not_self",
+        "jobs",
+        "parent_job_id IS NULL OR parent_job_id != id",
+    )
+
+
+def downgrade() -> None:
+    """Drop revision-scoped job constraints and parent lineage support."""
+
+    _require_no_revision_scoped_rows_before_downgrade()
+
+    op.alter_column(
+        "jobs",
+        "base_revision_id",
+        existing_type=sa.Uuid(),
+        comment=(
+            "Pinned latest finalized drawing revision captured when a reprocess "
+            "job was created. Null for initial ingest jobs."
+        ),
+    )
+
+    op.drop_constraint("ck_jobs_parent_job_id_not_self", "jobs", type_="check")
+    op.drop_constraint(
+        "ck_jobs_quantity_takeoff_extraction_profile_forbidden",
+        "jobs",
+        type_="check",
+    )
+
+    op.drop_constraint("ck_jobs_reprocess_base_revision_required", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_reprocess_base_revision_required",
+        "jobs",
+        "job_type != 'reprocess' OR base_revision_id IS NOT NULL",
+    )
+
+    op.drop_constraint("ck_jobs_job_type_valid", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_job_type_valid",
+        "jobs",
+        "job_type IN ('ingest', 'reprocess')",
+    )
+
+    op.drop_constraint(
+        "fk_jobs_parent_job_id_project_id_file_id_jobs",
+        "jobs",
+        type_="foreignkey",
+    )
+    op.drop_index("ix_jobs_parent_job_id", table_name="jobs")
+    op.drop_column("jobs", "parent_job_id")
+
+    op.drop_constraint(
+        "fk_jobs_base_revision_id_project_id_file_id_drawing_revisions",
+        "jobs",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_jobs_base_revision_id_drawing_revisions",
+        "jobs",
+        "drawing_revisions",
+        ["base_revision_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    op.drop_constraint("uq_jobs_id_project_id_file_id", "jobs", type_="unique")
+    op.drop_constraint(
+        "uq_drawing_revisions_id_project_id_source_file_id",
+        "drawing_revisions",
+        type_="unique",
+    )

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -30,6 +30,7 @@ from app.jobs.worker import (
     enqueue_ingest_job as _enqueue_ingest_job,
 )
 from app.jobs.worker import (
+    is_ingest_worker_job_type,
     prepare_job_enqueue_intent,
     publish_job_enqueue_intent,
 )
@@ -427,6 +428,19 @@ async def retry_job(
         return job
 
     if job.error_code == ErrorCode.REVISION_CONFLICT.value:
+        if reservation is not None:
+            body = JobRead.model_validate(job).model_dump(mode="json")
+            await mark_idempotency_completed(
+                db,
+                reservation,
+                status_code=status.HTTP_202_ACCEPTED,
+                response_body=body,
+            )
+            await db.commit()
+            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+        return job
+
+    if not is_ingest_worker_job_type(job.job_type):
         if reservation is not None:
             body = JobRead.model_validate(job).model_dump(mode="json")
             await mark_idempotency_completed(

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -84,6 +84,12 @@ _SAFE_RUNNER_ERROR_DETAIL_KEYS = (
 )
 
 
+def is_ingest_worker_job_type(job_type: JobType | str) -> bool:
+    """Return whether a job type is published to the ingest worker."""
+    normalized_job_type = job_type.value if isinstance(job_type, JobType) else job_type
+    return normalized_job_type in _RECOVERABLE_INGEST_JOB_TYPES
+
+
 class _InactiveSourceError(Exception):
     """Raised when a job source project or file is no longer active."""
 
@@ -2183,7 +2189,7 @@ async def _claim_job_enqueue_intent(job_id: UUID) -> _EnqueueIntentLease | None:
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
-        if job.job_type not in _RECOVERABLE_INGEST_JOB_TYPES or job.status != "pending":
+        if not is_ingest_worker_job_type(job.job_type) or job.status != "pending":
             return None
 
         if job.enqueue_status == _ENQUEUE_STATUS_PUBLISHED:
@@ -2378,6 +2384,15 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
         )
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if not is_ingest_worker_job_type(job.job_type):
+            logger.info(
+                "ingest_job_unsupported_type_skipped",
+                job_id=str(job_id),
+                job_type=job.job_type,
+                status=job.status,
+            )
+            return None
 
         if job.status in _TERMINAL_JOB_STATUSES:
             logger.info(

--- a/app/models/drawing_revision.py
+++ b/app/models/drawing_revision.py
@@ -50,6 +50,12 @@ class DrawingRevision(Base):
             name="uq_drawing_revisions_id_project_id",
         ),
         UniqueConstraint(
+            "id",
+            "project_id",
+            "source_file_id",
+            name="uq_drawing_revisions_id_project_id_source_file_id",
+        ),
+        UniqueConstraint(
             "adapter_run_output_id",
             name="uq_drawing_revisions_adapter_run_output_id",
         ),

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Integer,
     String,
+    UniqueConstraint,
     func,
 )
 from sqlalchemy.orm import Mapped, mapped_column
@@ -25,6 +26,7 @@ class JobType(StrEnum):
 
     INGEST = "ingest"
     REPROCESS = "reprocess"
+    QUANTITY_TAKEOFF = "quantity_takeoff"
 
 
 class JobStatus(StrEnum):
@@ -42,7 +44,10 @@ _JOB_STATUS_VALUES = tuple(status.value for status in JobStatus)
 _JOB_ERROR_CODE_VALUES = tuple(error_code.value for error_code in ErrorCode)
 _ENQUEUE_STATUS_VALUES = ("pending", "publishing", "published")
 _PROFILE_REQUIRED_JOB_TYPE_VALUES = (JobType.INGEST.value, JobType.REPROCESS.value)
-_BASE_REQUIRED_JOB_TYPE_VALUES = (JobType.REPROCESS.value,)
+_BASE_REQUIRED_JOB_TYPE_VALUES = (
+    JobType.REPROCESS.value,
+    JobType.QUANTITY_TAKEOFF.value,
+)
 
 
 def _sql_in_list(values: tuple[str, ...]) -> str:
@@ -67,6 +72,22 @@ class Job(Base):
             ["extraction_profiles.id", "extraction_profiles.project_id"],
             ondelete="RESTRICT",
             name="fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+        ),
+        ForeignKeyConstraint(
+            ["base_revision_id", "project_id", "file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_jobs_base_revision_id_project_id_file_id_drawing_revisions",
+        ),
+        ForeignKeyConstraint(
+            ["parent_job_id", "project_id", "file_id"],
+            ["jobs.id", "jobs.project_id", "jobs.file_id"],
+            ondelete="RESTRICT",
+            name="fk_jobs_parent_job_id_project_id_file_id_jobs",
         ),
         CheckConstraint(
             f"job_type IN ({_sql_in_list(_JOB_TYPE_VALUES)})",
@@ -98,8 +119,23 @@ class Job(Base):
             name="ck_jobs_reprocess_base_revision_required",
         ),
         CheckConstraint(
+            f"job_type != '{JobType.QUANTITY_TAKEOFF.value}' "
+            "OR extraction_profile_id IS NULL",
+            name="ck_jobs_quantity_takeoff_extraction_profile_forbidden",
+        ),
+        CheckConstraint(
             f"job_type != '{JobType.INGEST.value}' OR base_revision_id IS NULL",
             name="ck_jobs_ingest_base_revision_forbidden",
+        ),
+        CheckConstraint(
+            "parent_job_id IS NULL OR parent_job_id != id",
+            name="ck_jobs_parent_job_id_not_self",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            "file_id",
+            name="uq_jobs_id_project_id_file_id",
         ),
     )
 
@@ -133,22 +169,25 @@ class Job(Base):
         ),
     )
     base_revision_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey(
-            "drawing_revisions.id",
-            name="fk_jobs_base_revision_id_drawing_revisions",
-            ondelete="RESTRICT",
-        ),
         nullable=True,
         index=True,
         comment=(
-            "Pinned latest finalized drawing revision captured when a reprocess "
-            "job was created. Null for initial ingest jobs."
+            "Pinned latest finalized drawing revision captured when a revision-"
+            "scoped job was created. Null for initial ingest jobs."
+        ),
+    )
+    parent_job_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment=(
+            "Optional parent job identifier for same-project, same-file job "
+            "lineage."
         ),
     )
     job_type: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
-        comment="Job type (e.g. ingest)",
+        comment="Job type (e.g. ingest, reprocess, quantity_takeoff)",
     )
     status: Mapped[str] = mapped_column(
         String(32),

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -29,9 +29,13 @@ class JobRead(BaseModel):
     base_revision_id: uuid.UUID | None = Field(
         default=None,
         description=(
-            "Pinned latest finalized drawing revision captured when a reprocess "
-            "job was created. Null for initial ingest jobs."
+            "Pinned latest finalized drawing revision captured when a revision-"
+            "scoped job was created. Null for initial ingest jobs."
         ),
+    )
+    parent_job_id: uuid.UUID | None = Field(
+        default=None,
+        description="Optional parent job identifier for same-project, same-file job lineage.",
     )
     job_type: JobType = Field(..., description="Job type")
     status: JobStatus = Field(..., description="Job status")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -370,7 +370,8 @@ MVP does not perform automatic physical deletion. In particular:
 
 ## Job Pipeline Orchestration
 
-Jobs form a small DAG per uploaded file:
+Jobs form a small DAG per uploaded file, with `jobs.file_id` as the durable
+origin and lock anchor for the chain:
 
 ```text
 ingest(file)
@@ -379,12 +380,24 @@ ingest(file)
             -> [optional] export(...)
 ```
 
+`ingest(file)` produces a `drawing_revision` that becomes the pinned input for
+later revision-scoped work. A future `quantity_takeoff(drawing_revision)` job
+will run against exactly one persisted revision rather than against the mutable
+file head.
+
 For MVP every step is triggered explicitly via API. A later iteration may add an
 auto-chain configuration on the project that fires the next step on success.
+The quantity worker/API remains deferred; this DAG documents the persisted job
+shape and lineage model, not a shipped downstream quantity surface.
 
 Workers must:
 
 - record the parent job id when chaining
+- keep any optional `jobs.parent_job_id` in the same project/file lineage as the
+  child job
+- use `jobs.base_revision_id` to pin the exact input/base revision for
+  revision-scoped work; reprocess keeps its stale-base conflict fence as the
+  special current-revision check
 - never silently start downstream work on failure or partial output
 - surface the chain in `job_events` so clients can render a pipeline view
 - treat each attempt as an isolated execution context with any temporary staged

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -697,6 +697,20 @@ Database ownership and append-only policy:
 - Mutable state must not be used to rewrite the payload, lineage, checksum, or
   source references of an already committed append-only record.
 
+Persisted job lineage rules:
+
+- `jobs.file_id` is the durable origin and lock anchor for the full downstream
+  job chain rooted at an uploaded file.
+- `jobs.base_revision_id` pins the exact drawing revision used as the input/base
+  revision for revision-scoped work. This supports downstream single-revision
+  jobs without introducing a separate `job_targets` table.
+- Reprocess remains a special case: its stale-base `REVISION_CONFLICT` fence is
+  checked against the current finalized file revision at request/finalization
+  time rather than treated as generic downstream chaining.
+- `jobs.parent_job_id` is optional lineage metadata when one job is spawned from
+  another, but any parent/child link must stay within the same project/file
+  lineage.
+
 ## MVP Retention And Deletion Policy
 
 For MVP, retention is conservative:
@@ -813,6 +827,13 @@ New codes require a docs change in this file.
   different completed job path.
 - Retrying a job that failed with `REVISION_CONFLICT` must return the unchanged
   failed job and must not enqueue a new attempt.
+- Persisted jobs are revision-scoped when needed: ingestion runs from `file_id`,
+  produces a `drawing_revision`, and later downstream work such as
+  `quantity_takeoff(drawing_revision)` pins that revision in
+  `jobs.base_revision_id` while still using `jobs.file_id` as the durable
+  origin/lock anchor.
+- The optional `jobs.parent_job_id` link is lineage only; it does not replace
+  the required same-project/same-file constraints on parent/child jobs.
 - Attempt-local staging is mutable until commit, but staged rows/objects are not
   authoritative product records. Only the atomic finalization step may publish
   new append-only records, and cancellation before that step must leave no new
@@ -1042,15 +1063,22 @@ Probe rules:
 
 ## Provenance And Confidence
 
-- Ingestion and downstream jobs must reference both `file_id` and
+- Ingestion and reprocessing jobs must reference both `file_id` and
   `extraction_profile_id`. The file identifies the immutable source upload; the
   extraction profile identifies the normalization/extraction settings used to
-  derive a revision.
+  derive a revision. Revision-scoped downstream jobs instead pin their input via
+  `jobs.base_revision_id` and inherit extraction settings through that revision
+  unless their own contract explicitly requires a profile.
+- For persisted jobs, `jobs.file_id` remains the durable origin and lock anchor,
+  while `jobs.base_revision_id` pins the exact drawing revision used by
+  revision-scoped downstream work.
 - Reprocessing is not an in-place rerun. Reprocessing creates a new drawing
   revision from an existing `file_id`, records the `extraction_profile_id` used
   for the run, and records the adapter name/version that produced the result.
 - Reprocess jobs also record the finalized base revision they were created
   against in `jobs.base_revision_id`.
+- Optional `jobs.parent_job_id` lineage must remain within the same project/file
+  as the child job.
 - The prior revision remains available for lineage, comparison, and audit even
   when the newer reprocessed revision supersedes it.
 - Reprocess API contract: `POST /v1/projects/{project_id}/files/{file_id}/reprocess`

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -32,9 +32,10 @@ from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest
 from app.ingestion.runner import (
     run_ingestion as real_run_ingestion,
 )
+from app.models.drawing_revision import DrawingRevision
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
-from app.models.job import Job
+from app.models.job import Job, JobType
 from app.models.job_event import JobEvent
 from app.models.project import Project
 from tests.conftest import requires_database
@@ -241,6 +242,60 @@ async def _get_job(job_id: uuid.UUID) -> Job:
 
     assert job is not None
     return job
+
+
+async def _get_latest_revision_for_file(file_id: uuid.UUID) -> DrawingRevision | None:
+    """Load the latest finalized drawing revision for a file."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        return (
+            await session.execute(
+                select(DrawingRevision)
+                .where(DrawingRevision.source_file_id == file_id)
+                .order_by(
+                    DrawingRevision.revision_sequence.desc(),
+                    DrawingRevision.id.desc(),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+
+async def _create_quantity_takeoff_job(
+    *,
+    project_id: uuid.UUID,
+    file_id: uuid.UUID,
+    base_revision_id: uuid.UUID,
+    parent_job_id: uuid.UUID,
+    status: str,
+    attempts: int = 0,
+    max_attempts: int = 3,
+) -> Job:
+    """Persist a quantity_takeoff job linked to an ingest lineage chain."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    quantity_job = Job(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        file_id=file_id,
+        extraction_profile_id=None,
+        base_revision_id=base_revision_id,
+        parent_job_id=parent_job_id,
+        job_type=JobType.QUANTITY_TAKEOFF.value,
+        status=status,
+        attempts=attempts,
+        max_attempts=max_attempts,
+        cancel_requested=False,
+    )
+
+    async with session_maker() as session:
+        session.add(quantity_job)
+        await session.commit()
+
+    return await _get_job(quantity_job.id)
 
 
 async def _update_job(
@@ -2320,6 +2375,47 @@ class TestJobs:
         assert updated_job.cancel_requested is True
         assert updated_job.status in {"pending", "cancelled"}
 
+    async def test_cancel_job_preserves_quantity_takeoff_lineage_fields(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Cancel should not rewrite quantity job lineage metadata."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+        )
+        original = await _get_job(quantity_job.id)
+        assert original.extraction_profile_id is None
+
+        response = await async_client.post(f"/v1/jobs/{quantity_job.id}/cancel")
+
+        assert response.status_code == 202
+        updated = await _get_job(quantity_job.id)
+        assert updated.cancel_requested is True
+        assert updated.project_id == original.project_id
+        assert updated.file_id == original.file_id
+        assert updated.job_type == original.job_type
+        assert updated.extraction_profile_id == original.extraction_profile_id
+        assert updated.extraction_profile_id is None
+        assert updated.base_revision_id == original.base_revision_id
+        assert updated.parent_job_id == original.parent_job_id
+
     async def test_cancel_job_returns_404_for_unknown_job(
         self,
         async_client: httpx.AsyncClient,
@@ -2524,6 +2620,285 @@ class TestJobs:
         updated = await _get_job(job.id)
         assert updated.status == "pending"
         assert updated.enqueue_status == "pending"
+
+    async def test_publish_job_enqueue_intent_skips_quantity_takeoff_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Quantity jobs should never claim or publish the ingest worker outbox."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+        )
+        last_attempted_at = datetime.now(UTC) - timedelta(minutes=5)
+        unchanged_token = uuid.uuid4()
+        await _update_job(
+            quantity_job.id,
+            enqueue_status="pending",
+            enqueue_attempts=7,
+            enqueue_owner_token=unchanged_token,
+            enqueue_lease_expires_at=datetime.now(UTC) - timedelta(minutes=1),
+            enqueue_last_attempted_at=last_attempted_at,
+        )
+
+        published = await worker_module.publish_job_enqueue_intent(quantity_job.id)
+
+        assert published is False
+        updated = await _get_job(quantity_job.id)
+        assert updated.status == "pending"
+        assert updated.enqueue_status == "pending"
+        assert updated.extraction_profile_id is None
+        assert updated.enqueue_attempts == 7
+        assert updated.enqueue_owner_token == unchanged_token
+        assert updated.enqueue_lease_expires_at is not None
+        assert updated.enqueue_last_attempted_at == last_attempted_at
+        assert updated.enqueue_published_at is None
+
+    async def test_retry_job_noops_for_quantity_takeoff_without_ingest_publisher(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should return 202 without requeueing unsupported quantity jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
+            retried_job_ids.append(str(job_id))
+            return True
+
+        monkeypatch.setattr(
+            jobs_api,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+        )
+        await _update_job(
+            quantity_job.id,
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message="quantity worker unavailable",
+            enqueue_status="pending",
+            enqueue_attempts=2,
+        )
+        original = await _get_job(quantity_job.id)
+        assert original.extraction_profile_id is None
+
+        response = await async_client.post(f"/v1/jobs/{quantity_job.id}/retry")
+
+        assert response.status_code == 202
+        assert retried_job_ids == []
+        unchanged = await _get_job(quantity_job.id)
+        assert unchanged.status == "failed"
+        assert unchanged.attempts == original.attempts
+        assert unchanged.error_code == original.error_code
+        assert unchanged.error_message == original.error_message
+        assert unchanged.enqueue_status == original.enqueue_status
+        assert unchanged.enqueue_attempts == original.enqueue_attempts
+        assert unchanged.project_id == original.project_id
+        assert unchanged.file_id == original.file_id
+        assert unchanged.job_type == original.job_type
+        assert unchanged.extraction_profile_id == original.extraction_profile_id
+        assert unchanged.extraction_profile_id is None
+        assert unchanged.base_revision_id == original.base_revision_id
+        assert unchanged.parent_job_id == original.parent_job_id
+
+    @pytest.mark.parametrize("status", ["pending", "running"])
+    async def test_recover_incomplete_ingest_jobs_skips_quantity_takeoff_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        status: str,
+    ) -> None:
+        """Startup recovery should ignore quantity jobs while no quantity worker exists."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status=status,
+            attempts=1 if status == "running" else 0,
+        )
+
+        if status == "running":
+            await _update_job(
+                quantity_job.id,
+                enqueue_status="published",
+                enqueue_attempts=1,
+            )
+            session_maker = session_module.AsyncSessionLocal
+            assert session_maker is not None
+            async with session_maker() as session:
+                persisted_job = await session.get(Job, quantity_job.id)
+                assert persisted_job is not None
+                persisted_job.started_at = (
+                    datetime.now(UTC)
+                    - worker_module._RUNNING_JOB_STALE_AFTER
+                    - timedelta(seconds=1)
+                )
+                persisted_job.attempt_token = uuid.uuid4()
+                persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+                await session.commit()
+        else:
+            await _update_job(
+                quantity_job.id,
+                enqueue_status="pending",
+                enqueue_attempts=0,
+            )
+
+        original = await _get_job(quantity_job.id)
+
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
+
+        assert requeued == []
+        assert recovered_job_ids == []
+        unchanged = await _get_job(quantity_job.id)
+        assert unchanged.status == original.status
+        assert unchanged.attempts == original.attempts
+        assert unchanged.started_at == original.started_at
+        assert unchanged.attempt_token == original.attempt_token
+        assert unchanged.attempt_lease_expires_at == original.attempt_lease_expires_at
+        assert unchanged.enqueue_status == original.enqueue_status
+        assert unchanged.enqueue_attempts == original.enqueue_attempts
+        assert unchanged.project_id == original.project_id
+        assert unchanged.file_id == original.file_id
+        assert unchanged.job_type == original.job_type
+        assert unchanged.extraction_profile_id == original.extraction_profile_id
+        assert unchanged.extraction_profile_id is None
+        assert unchanged.base_revision_id == original.base_revision_id
+        assert unchanged.parent_job_id == original.parent_job_id
+
+    async def test_process_ingest_job_skips_quantity_takeoff_jobs_without_mutation(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Direct ingest-worker delivery should no-op for quantity jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+            attempts=1,
+        )
+        await _update_job(
+            quantity_job.id,
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message="quantity worker unavailable",
+            enqueue_status="pending",
+            enqueue_attempts=2,
+            enqueue_owner_token=uuid.uuid4(),
+            enqueue_lease_expires_at=datetime.now(UTC) + timedelta(minutes=5),
+            enqueue_last_attempted_at=datetime.now(UTC) - timedelta(minutes=1),
+            enqueue_published_at=datetime.now(UTC) - timedelta(minutes=2),
+        )
+        original = await _get_job(quantity_job.id)
+        assert original.extraction_profile_id is None
+        assert original.attempt_token is None
+        assert original.attempt_lease_expires_at is None
+
+        await worker_module.process_ingest_job(quantity_job.id)
+
+        unchanged = await _get_job(quantity_job.id)
+        assert unchanged.status == original.status
+        assert unchanged.attempts == original.attempts
+        assert unchanged.started_at == original.started_at
+        assert unchanged.finished_at == original.finished_at
+        assert unchanged.attempt_token == original.attempt_token
+        assert unchanged.attempt_lease_expires_at == original.attempt_lease_expires_at
+        assert unchanged.cancel_requested == original.cancel_requested
+        assert unchanged.error_code == original.error_code
+        assert unchanged.error_message == original.error_message
+        assert unchanged.enqueue_status == original.enqueue_status
+        assert unchanged.enqueue_attempts == original.enqueue_attempts
+        assert unchanged.enqueue_owner_token == original.enqueue_owner_token
+        assert unchanged.enqueue_lease_expires_at == original.enqueue_lease_expires_at
+        assert unchanged.enqueue_last_attempted_at == original.enqueue_last_attempted_at
+        assert unchanged.enqueue_published_at == original.enqueue_published_at
+        assert unchanged.project_id == original.project_id
+        assert unchanged.file_id == original.file_id
+        assert unchanged.job_type == original.job_type
+        assert unchanged.extraction_profile_id == original.extraction_profile_id
+        assert unchanged.extraction_profile_id is None
+        assert unchanged.base_revision_id == original.base_revision_id
+        assert unchanged.parent_job_id == original.parent_job_id
 
     async def test_retry_job_succeeds_when_enqueue_claim_raises_after_commit(
         self,

--- a/tests/test_jobs_revision_scoped_contract_migration.py
+++ b/tests/test_jobs_revision_scoped_contract_migration.py
@@ -1,0 +1,714 @@
+"""Guard tests for the revision-scoped jobs contract migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import text
+
+import app.db.session as session_module
+from tests.conftest import requires_database
+
+
+def _load_revision_scoped_jobs_migration() -> Any:
+    """Load the revision-scoped jobs migration module directly from disk."""
+
+    migration_path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "2026_05_14_0016_add_revision_scoped_job_contract.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_14_0016_add_revision_scoped_job_contract",
+        migration_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_pre_0016_schema(sync_conn: sa.Connection) -> None:
+    """Create the minimal pre-0016 schema needed to exercise the migration."""
+
+    metadata = sa.MetaData()
+
+    projects = sa.Table(
+        "projects",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+    )
+    sa.Table(
+        "files",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            sa.ForeignKey(projects.c.id, ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("id", "project_id", name="uq_files_id_project_id"),
+    )
+    sa.Table(
+        "extraction_profiles",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            sa.ForeignKey(projects.c.id, ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_extraction_profiles_id_project_id",
+        ),
+    )
+    sa.Table(
+        "drawing_revisions",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            sa.ForeignKey(projects.c.id, ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("source_file_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="RESTRICT",
+            name="fk_drawing_revisions_source_file_id_project_id_files",
+        ),
+        sa.UniqueConstraint(
+            "id",
+            "project_id",
+            name="uq_drawing_revisions_id_project_id",
+        ),
+    )
+    sa.Table(
+        "jobs",
+        metadata,
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.Uuid(),
+            sa.ForeignKey(projects.c.id, ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("file_id", sa.Uuid(), nullable=False),
+        sa.Column("extraction_profile_id", sa.Uuid(), nullable=True),
+        sa.Column("base_revision_id", sa.Uuid(), nullable=True),
+        sa.Column("job_type", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="RESTRICT",
+            name="fk_jobs_file_id_project_id_files",
+        ),
+        sa.ForeignKeyConstraint(
+            ["extraction_profile_id", "project_id"],
+            ["extraction_profiles.id", "extraction_profiles.project_id"],
+            ondelete="RESTRICT",
+            name="fk_jobs_extraction_profile_id_project_id_extraction_profiles",
+        ),
+        sa.ForeignKeyConstraint(
+            ["base_revision_id"],
+            ["drawing_revisions.id"],
+            ondelete="RESTRICT",
+            name="fk_jobs_base_revision_id_drawing_revisions",
+        ),
+        sa.CheckConstraint(
+            "job_type IN ('ingest', 'reprocess')",
+            name="ck_jobs_job_type_valid",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'running', 'succeeded', 'failed', 'cancelled')",
+            name="ck_jobs_status_valid",
+        ),
+        sa.CheckConstraint(
+            "job_type NOT IN ('ingest', 'reprocess') OR extraction_profile_id IS NOT NULL",
+            name="ck_jobs_ingest_extraction_profile_required",
+        ),
+        sa.CheckConstraint(
+            "job_type != 'reprocess' OR base_revision_id IS NOT NULL",
+            name="ck_jobs_reprocess_base_revision_required",
+        ),
+        sa.CheckConstraint(
+            "job_type != 'ingest' OR base_revision_id IS NULL",
+            name="ck_jobs_ingest_base_revision_forbidden",
+        ),
+    )
+    metadata.create_all(sync_conn)
+
+
+def _run_migration_upgrade(sync_conn: sa.Connection, migration: Any) -> None:
+    """Run the migration upgrade against a live connection."""
+
+    migration_context = MigrationContext.configure(sync_conn)
+    migration.op = Operations(migration_context)
+    migration.upgrade()
+
+
+def _run_migration_downgrade(sync_conn: sa.Connection, migration: Any) -> None:
+    """Run the migration downgrade against a live connection."""
+
+    migration_context = MigrationContext.configure(sync_conn)
+    migration.op = Operations(migration_context)
+    migration.downgrade()
+
+
+async def _job_column_exists(conn: Any, schema_name: str, column_name: str) -> bool:
+    """Return whether the jobs table contains the requested column."""
+
+    result = await conn.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = :schema_name
+                  AND table_name = 'jobs'
+                  AND column_name = :column_name
+            )
+            """
+        ),
+        {"schema_name": schema_name, "column_name": column_name},
+    )
+    return cast(bool, result.scalar())
+
+
+async def _seed_revision_scoped_references(conn: Any) -> dict[str, uuid.UUID]:
+    """Insert the shared project/file/profile/revision reference rows."""
+
+    ids = {
+        "project_a": uuid.uuid4(),
+        "project_b": uuid.uuid4(),
+        "file_a1": uuid.uuid4(),
+        "file_a2": uuid.uuid4(),
+        "file_b1": uuid.uuid4(),
+        "profile_a1": uuid.uuid4(),
+        "profile_a2": uuid.uuid4(),
+        "profile_b1": uuid.uuid4(),
+        "revision_a1": uuid.uuid4(),
+        "revision_a2": uuid.uuid4(),
+        "revision_b1": uuid.uuid4(),
+    }
+
+    await conn.execute(
+        text("INSERT INTO projects (id) VALUES (:project_a), (:project_b)"),
+        {"project_a": ids["project_a"], "project_b": ids["project_b"]},
+    )
+    await conn.execute(
+        text(
+            """
+            INSERT INTO files (id, project_id)
+            VALUES
+                (:file_a1, :project_a),
+                (:file_a2, :project_a),
+                (:file_b1, :project_b)
+            """
+        ),
+        ids,
+    )
+    await conn.execute(
+        text(
+            """
+            INSERT INTO extraction_profiles (id, project_id)
+            VALUES
+                (:profile_a1, :project_a),
+                (:profile_a2, :project_a),
+                (:profile_b1, :project_b)
+            """
+        ),
+        ids,
+    )
+    await conn.execute(
+        text(
+            """
+            INSERT INTO drawing_revisions (id, project_id, source_file_id)
+            VALUES
+                (:revision_a1, :project_a, :file_a1),
+                (:revision_a2, :project_a, :file_a2),
+                (:revision_b1, :project_b, :file_b1)
+            """
+        ),
+        ids,
+    )
+    return ids
+
+
+async def _insert_job(
+    conn: Any,
+    *,
+    job_id: uuid.UUID,
+    project_id: uuid.UUID,
+    file_id: uuid.UUID,
+    extraction_profile_id: uuid.UUID | None,
+    base_revision_id: uuid.UUID | None,
+    parent_job_id: uuid.UUID | None,
+    job_type: str,
+    status: str = "pending",
+) -> None:
+    """Insert a job row into the migrated jobs table."""
+
+    await conn.execute(
+        text(
+            """
+            INSERT INTO jobs (
+                id,
+                project_id,
+                file_id,
+                extraction_profile_id,
+                base_revision_id,
+                parent_job_id,
+                job_type,
+                status
+            ) VALUES (
+                :job_id,
+                :project_id,
+                :file_id,
+                :extraction_profile_id,
+                :base_revision_id,
+                :parent_job_id,
+                :job_type,
+                :status
+            )
+            """
+        ),
+        {
+            "job_id": job_id,
+            "project_id": project_id,
+            "file_id": file_id,
+            "extraction_profile_id": extraction_profile_id,
+            "base_revision_id": base_revision_id,
+            "parent_job_id": parent_job_id,
+            "job_type": job_type,
+            "status": status,
+        },
+    )
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_revision_scoped_contract_upgrade_enforces_revision_and_parent_guards() -> None:
+    """Upgrade should accept valid revision-scoped jobs and reject cross-scope pins."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jrsc_up_{uuid.uuid4().hex}"
+    migration = _load_revision_scoped_jobs_migration()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0016_schema)
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+            ids = await _seed_revision_scoped_references(conn)
+            parent_reprocess_id = uuid.uuid4()
+            quantity_child_id = uuid.uuid4()
+            quantity_unparented_id = uuid.uuid4()
+            sibling_parent_id = uuid.uuid4()
+            foreign_parent_id = uuid.uuid4()
+
+            await _insert_job(
+                conn,
+                job_id=uuid.uuid4(),
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=ids["profile_a1"],
+                base_revision_id=None,
+                parent_job_id=None,
+                job_type="ingest",
+            )
+            await _insert_job(
+                conn,
+                job_id=parent_reprocess_id,
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=ids["profile_a1"],
+                base_revision_id=ids["revision_a1"],
+                parent_job_id=None,
+                job_type="reprocess",
+            )
+            await _insert_job(
+                conn,
+                job_id=quantity_child_id,
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=None,
+                base_revision_id=ids["revision_a1"],
+                parent_job_id=parent_reprocess_id,
+                job_type="quantity_takeoff",
+            )
+            await _insert_job(
+                conn,
+                job_id=quantity_unparented_id,
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=None,
+                base_revision_id=ids["revision_a1"],
+                parent_job_id=None,
+                job_type="quantity_takeoff",
+            )
+            await _insert_job(
+                conn,
+                job_id=sibling_parent_id,
+                project_id=ids["project_a"],
+                file_id=ids["file_a2"],
+                extraction_profile_id=ids["profile_a2"],
+                base_revision_id=None,
+                parent_job_id=None,
+                job_type="ingest",
+            )
+            await _insert_job(
+                conn,
+                job_id=foreign_parent_id,
+                project_id=ids["project_b"],
+                file_id=ids["file_b1"],
+                extraction_profile_id=ids["profile_b1"],
+                base_revision_id=None,
+                parent_job_id=None,
+                job_type="ingest",
+            )
+
+            assert await _job_column_exists(conn, schema_name, "parent_job_id")
+
+            rows = (
+                (
+                    await conn.execute(
+                        text(
+                            """
+                            SELECT
+                                id,
+                                job_type,
+                                extraction_profile_id,
+                                base_revision_id,
+                                parent_job_id
+                            FROM jobs
+                            WHERE id IN (
+                                :parent_reprocess_id,
+                                :quantity_child_id,
+                                :quantity_unparented_id
+                            )
+                            """
+                        ),
+                        {
+                            "parent_reprocess_id": parent_reprocess_id,
+                            "quantity_child_id": quantity_child_id,
+                            "quantity_unparented_id": quantity_unparented_id,
+                        },
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            rows_by_id = {row["id"]: dict(row) for row in rows}
+            assert rows_by_id == {
+                quantity_unparented_id: {
+                    "id": quantity_unparented_id,
+                    "job_type": "quantity_takeoff",
+                    "extraction_profile_id": None,
+                    "base_revision_id": ids["revision_a1"],
+                    "parent_job_id": None,
+                },
+                quantity_child_id: {
+                    "id": quantity_child_id,
+                    "job_type": "quantity_takeoff",
+                    "extraction_profile_id": None,
+                    "base_revision_id": ids["revision_a1"],
+                    "parent_job_id": parent_reprocess_id,
+                },
+                parent_reprocess_id: {
+                    "id": parent_reprocess_id,
+                    "job_type": "reprocess",
+                    "extraction_profile_id": ids["profile_a1"],
+                    "base_revision_id": ids["revision_a1"],
+                    "parent_job_id": None,
+                },
+            }
+
+        invalid_cases = [
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": None,
+                "base_revision_id": None,
+                "parent_job_id": None,
+                "job_type": "quantity_takeoff",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": ids["revision_a1"],
+                "parent_job_id": None,
+                "job_type": "quantity_takeoff",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": ids["revision_a1"],
+                "parent_job_id": None,
+                "job_type": "ingest",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": None,
+                "base_revision_id": ids["revision_a2"],
+                "parent_job_id": None,
+                "job_type": "quantity_takeoff",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": None,
+                "base_revision_id": ids["revision_b1"],
+                "parent_job_id": None,
+                "job_type": "quantity_takeoff",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": ids["revision_a2"],
+                "parent_job_id": None,
+                "job_type": "reprocess",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": ids["revision_b1"],
+                "parent_job_id": None,
+                "job_type": "reprocess",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": None,
+                "parent_job_id": sibling_parent_id,
+                "job_type": "ingest",
+            },
+            {
+                "job_id": uuid.uuid4(),
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": None,
+                "parent_job_id": foreign_parent_id,
+                "job_type": "ingest",
+            },
+        ]
+
+        self_parent_id = uuid.uuid4()
+        invalid_cases.append(
+            {
+                "job_id": self_parent_id,
+                "project_id": ids["project_a"],
+                "file_id": ids["file_a1"],
+                "extraction_profile_id": ids["profile_a1"],
+                "base_revision_id": None,
+                "parent_job_id": self_parent_id,
+                "job_type": "ingest",
+            }
+        )
+
+        for params in invalid_cases:
+            with pytest.raises(sa.exc.IntegrityError):
+                async with engine.begin() as conn:
+                    await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                    await _insert_job(conn, **params)
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_revision_scoped_contract_downgrade_rejects_quantity_takeoff_rows() -> None:
+    """Downgrade should refuse to remove quantity-takeoff rows."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jrsc_down_qty_{uuid.uuid4().hex}"
+    migration = _load_revision_scoped_jobs_migration()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0016_schema)
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+            ids = await _seed_revision_scoped_references(conn)
+            await _insert_job(
+                conn,
+                job_id=uuid.uuid4(),
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=None,
+                base_revision_id=ids["revision_a1"],
+                parent_job_id=None,
+                job_type="quantity_takeoff",
+            )
+
+        with pytest.raises(RuntimeError, match="quantity_takeoff jobs"):
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(
+                    lambda sync_conn: _run_migration_downgrade(sync_conn, migration)
+                )
+
+        async with engine.begin() as conn:
+            assert await _job_column_exists(conn, schema_name, "parent_job_id")
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_revision_scoped_contract_downgrade_rejects_parented_rows() -> None:
+    """Downgrade should refuse to remove parent lineage rows."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jrsc_down_parent_{uuid.uuid4().hex}"
+    migration = _load_revision_scoped_jobs_migration()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0016_schema)
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+            ids = await _seed_revision_scoped_references(conn)
+            parent_job_id = uuid.uuid4()
+            await _insert_job(
+                conn,
+                job_id=parent_job_id,
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=ids["profile_a1"],
+                base_revision_id=None,
+                parent_job_id=None,
+                job_type="ingest",
+            )
+            await _insert_job(
+                conn,
+                job_id=uuid.uuid4(),
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=ids["profile_a1"],
+                base_revision_id=ids["revision_a1"],
+                parent_job_id=parent_job_id,
+                job_type="reprocess",
+            )
+
+        with pytest.raises(RuntimeError, match="parent_job_id lineage rows"):
+            async with engine.begin() as conn:
+                await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+                await conn.run_sync(
+                    lambda sync_conn: _run_migration_downgrade(sync_conn, migration)
+                )
+
+        async with engine.begin() as conn:
+            assert await _job_column_exists(conn, schema_name, "parent_job_id")
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))
+
+
+@requires_database
+@pytest.mark.asyncio
+async def test_jobs_revision_scoped_contract_downgrade_succeeds_for_legacy_rows() -> None:
+    """Downgrade should succeed once only legacy ingest/reprocess rows remain."""
+
+    engine = session_module.get_engine()
+    assert engine is not None
+
+    schema_name = f"t_jrsc_down_ok_{uuid.uuid4().hex}"
+    migration = _load_revision_scoped_jobs_migration()
+
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'CREATE SCHEMA "{schema_name}"'))
+
+        async with engine.begin() as conn:
+            await conn.execute(text(f'SET search_path TO "{schema_name}"'))
+            await conn.run_sync(_install_pre_0016_schema)
+            await conn.run_sync(lambda sync_conn: _run_migration_upgrade(sync_conn, migration))
+
+            ids = await _seed_revision_scoped_references(conn)
+            await _insert_job(
+                conn,
+                job_id=uuid.uuid4(),
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=ids["profile_a1"],
+                base_revision_id=None,
+                parent_job_id=None,
+                job_type="ingest",
+            )
+            await _insert_job(
+                conn,
+                job_id=uuid.uuid4(),
+                project_id=ids["project_a"],
+                file_id=ids["file_a1"],
+                extraction_profile_id=ids["profile_a1"],
+                base_revision_id=ids["revision_a1"],
+                parent_job_id=None,
+                job_type="reprocess",
+                status="succeeded",
+            )
+
+            await conn.run_sync(lambda sync_conn: _run_migration_downgrade(sync_conn, migration))
+
+            assert not await _job_column_exists(conn, schema_name, "parent_job_id")
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema_name}" CASCADE'))

--- a/tests/test_jobs_revision_scoped_contract_migration.py
+++ b/tests/test_jobs_revision_scoped_contract_migration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib.util
 import uuid
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
 import pytest
 import sqlalchemy as sa
@@ -309,6 +309,16 @@ async def _insert_job(
     )
 
 
+class _JobInsertParams(TypedDict):
+    job_id: uuid.UUID
+    project_id: uuid.UUID
+    file_id: uuid.UUID
+    extraction_profile_id: uuid.UUID | None
+    base_revision_id: uuid.UUID | None
+    parent_job_id: uuid.UUID | None
+    job_type: str
+
+
 @requires_database
 @pytest.mark.asyncio
 async def test_jobs_revision_scoped_contract_upgrade_enforces_revision_and_parent_guards() -> None:
@@ -453,7 +463,7 @@ async def test_jobs_revision_scoped_contract_upgrade_enforces_revision_and_paren
                 },
             }
 
-        invalid_cases = [
+        invalid_cases: list[_JobInsertParams] = [
             {
                 "job_id": uuid.uuid4(),
                 "project_id": ids["project_a"],


### PR DESCRIPTION
Closes #182

## Summary
- generalize persisted jobs to support revision-scoped `quantity_takeoff` rows with a pinned base revision and optional parent job lineage
- add migration and regression coverage for same-project/file revision guards, parent lineage integrity, and downgrade refusal for incompatible rows
- prevent non-ingest job types from entering ingest retry, recovery, publish, or direct worker execution paths

## Test plan
- [x] `uv run ruff check app tests alembic/versions`
- [x] `uv run mypy app`
- [x] `uv build`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_validation_182_final2 uv run alembic upgrade head`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_validation_182_final2 uv run pytest tests/test_jobs.py tests/test_jobs_base_revision_migration.py tests/test_jobs_revision_scoped_contract_migration.py tests/test_ingest_output_persistence.py tests/test_extraction_profiles.py`