### PR TITLE
feat(jobs): execute quantity takeoff jobs

### DIFF
--- a/alembic/versions/2026_05_15_0018_align_quantity_constraints.py
+++ b/alembic/versions/2026_05_15_0018_align_quantity_constraints.py
@@ -1,0 +1,97 @@
+"""Align quantity item constraints and job error codes.
+
+Revision ID: 2026_05_15_0018
+Revises: 2026_05_15_0017
+Create Date: 2026-05-15 21:00:00.000000
+"""
+
+from collections.abc import Iterable
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2026_05_15_0018"
+down_revision = "2026_05_15_0017"
+branch_labels = None
+depends_on = None
+
+_QUANTITY_ITEM_CONSTRAINTS_TO_DROP = (
+    "ck_quantity_items_item_kind_valid",
+    "ck_quantity_items_source_entity_required",
+    "ck_quantity_items_total_without_source_entity",
+    "ck_quantity_items_kind_source_entity_contract",
+    "ck_quantity_items_kind_value_contract",
+    "ck_quantity_items_conflict_gate_review_only",
+)
+_JOB_CONSTRAINTS_TO_DROP = ("ck_jobs_error_code_valid",)
+
+
+def _drop_constraints_if_exists(table_name: str, constraint_names: Iterable[str]) -> None:
+    for constraint_name in constraint_names:
+        op.execute(
+            sa.text(
+                f"ALTER TABLE {table_name} DROP CONSTRAINT IF EXISTS {constraint_name}"
+            )
+        )
+
+
+def upgrade() -> None:
+    _drop_constraints_if_exists("quantity_items", _QUANTITY_ITEM_CONSTRAINTS_TO_DROP)
+    _drop_constraints_if_exists("jobs", _JOB_CONSTRAINTS_TO_DROP)
+
+    op.create_check_constraint(
+        "ck_quantity_items_item_kind_valid",
+        "quantity_items",
+        "item_kind IN ('contributor', 'aggregate', 'exclusion', 'conflict')",
+    )
+    op.create_check_constraint(
+        "ck_quantity_items_kind_source_entity_contract",
+        "quantity_items",
+        "((item_kind = 'contributor' AND source_entity_id IS NOT NULL) "
+        "OR (item_kind = 'aggregate' AND source_entity_id IS NULL) "
+        "OR (item_kind = 'exclusion' AND source_entity_id IS NOT NULL) "
+        "OR (item_kind = 'conflict' AND source_entity_id IS NOT NULL))",
+    )
+    op.create_check_constraint(
+        "ck_quantity_items_kind_value_contract",
+        "quantity_items",
+        "((item_kind = 'contributor' AND value IS NOT NULL) "
+        "OR (item_kind = 'aggregate' AND value IS NOT NULL) "
+        "OR (item_kind = 'exclusion' AND value IS NULL) "
+        "OR (item_kind = 'conflict' AND value IS NULL))",
+    )
+    op.create_check_constraint(
+        "ck_quantity_items_conflict_gate_review_only",
+        "quantity_items",
+        "item_kind <> 'conflict' OR quantity_gate IN ('review_gated', 'blocked')",
+    )
+    op.create_check_constraint(
+        "ck_jobs_error_code_valid",
+        "jobs",
+        "error_code IS NULL OR error_code IN ("
+        "'NOT_FOUND', "
+        "'INVALID_CURSOR', "
+        "'VALIDATION_ERROR', "
+        "'INPUT_INVALID', "
+        "'INPUT_UNSUPPORTED_FORMAT', "
+        "'ADAPTER_UNAVAILABLE', "
+        "'ADAPTER_TIMEOUT', "
+        "'ADAPTER_FAILED', "
+        "'STORAGE_FAILED', "
+        "'DB_CONFLICT', "
+        "'IDEMPOTENCY_CONFLICT', "
+        "'REVISION_CONFLICT', "
+        "'NORMALIZED_ENTITIES_NOT_MATERIALIZED', "
+        "'JOB_CANCELLED', "
+        "'INTERNAL_ERROR')",
+    )
+
+
+def downgrade() -> None:
+    # The expanded quantity item and job error code constraints are
+    # backward-compatible. Downgrading by restoring the prior contract would
+    # reject valid aggregate/exclusion rows and current job error codes, so
+    # this revision intentionally leaves the current constraints in place.
+    return None

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -27,10 +27,6 @@ from app.core.errors import ErrorCode
 from app.core.exceptions import raise_not_found
 from app.db.session import get_db
 from app.jobs.worker import (
-    enqueue_ingest_job as _enqueue_ingest_job,
-)
-from app.jobs.worker import (
-    is_ingest_worker_job_type,
     prepare_job_enqueue_intent,
     publish_job_enqueue_intent,
 )
@@ -45,11 +41,6 @@ jobs_router = APIRouter()
 _DEFAULT_EVENTS_LIMIT = 50
 _MAX_EVENTS_LIMIT = 200
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
-
-
-def enqueue_ingest_job(job_id: UUID) -> None:
-    """Compatibility wrapper kept for test fixture patching."""
-    _enqueue_ingest_job(job_id)
 
 
 async def _get_job_or_404(db: AsyncSession, job_id: UUID) -> Job:
@@ -440,19 +431,6 @@ async def retry_job(
             return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
         return job
 
-    if not is_ingest_worker_job_type(job.job_type):
-        if reservation is not None:
-            body = JobRead.model_validate(job).model_dump(mode="json")
-            await mark_idempotency_completed(
-                db,
-                reservation,
-                status_code=status.HTTP_202_ACCEPTED,
-                response_body=body,
-            )
-            await db.commit()
-            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
-        return job
-
     job.status = "pending"
     job.cancel_requested = False
     job.error_code = None
@@ -474,11 +452,7 @@ async def retry_job(
         )
 
     await db.commit()
-    await publish_job_enqueue_intent(
-        job.id,
-        publisher=enqueue_ingest_job,
-        suppress_exceptions=True,
-    )
+    await publish_job_enqueue_intent(job.id, suppress_exceptions=True)
 
     if reservation is not None:
         assert success_body is not None

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -3,12 +3,13 @@
 import asyncio
 import heapq
 import inspect
+import json
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from celery import Celery
@@ -20,6 +21,13 @@ from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
+from app.estimating.quantities.contracts import (
+    GateStatus,
+    QuantityEngineResult,
+    RevisionEntityInput,
+    RevisionGateMetadata,
+)
+from app.estimating.quantities.engine import compute_quantities
 from app.ingestion.contracts import AdapterTimeout, ProgressUpdate
 from app.ingestion.debug_overlay import plan_svg_debug_overlay
 from app.ingestion.finalization import IngestFinalizationPayload
@@ -31,6 +39,7 @@ from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
 from app.models.job_event import JobEvent
 from app.models.project import Project
+from app.models.quantity_takeoff import QuantityItem, QuantityItemKind, QuantityTakeoff
 from app.models.revision_materialization import (
     RevisionBlock,
     RevisionEntity,
@@ -45,6 +54,11 @@ from app.storage.keys import build_generated_artifact_storage_key
 logger = get_logger(__name__)
 
 _RECOVERABLE_INGEST_JOB_TYPES = (JobType.INGEST.value, JobType.REPROCESS.value)
+_RECOVERABLE_ENQUEUE_JOB_TYPES = (
+    JobType.INGEST.value,
+    JobType.REPROCESS.value,
+    JobType.QUANTITY_TAKEOFF.value,
+)
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _ENQUEUE_STATUS_PENDING = "pending"
 _ENQUEUE_STATUS_PUBLISHING = "publishing"
@@ -57,6 +71,8 @@ _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
 _ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
 _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
 _PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
+_FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to finalize quantity takeoff job"
+_PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Quantity takeoff job failed unexpectedly."
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
 _DEBUG_OVERLAY_ARTIFACT_KIND = "debug_overlay"
@@ -64,6 +80,23 @@ _DEBUG_OVERLAY_ARTIFACT_FORMAT = "svg"
 _DEBUG_OVERLAY_GENERATOR_NAME = "app.ingestion.debug_overlay"
 _DEBUG_OVERLAY_GENERATOR_VERSION = "1"
 _NORMALIZED_ENTITY_INSERT_CHUNK_SIZE = 500
+_QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE = (
+    "Quantity takeoff is blocked by the revision validation gate."
+)
+_QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE = (
+    "Quantity takeoff detected conflicting contributor inputs."
+)
+_QUANTITY_TAKEOFF_VALIDATION_REPORT_MISSING_ERROR_MESSAGE = (
+    "Quantity takeoff base revision is missing its validation report."
+)
+_QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE = (
+    "Quantity takeoff base revision is missing normalized entities."
+)
+_QUANTITY_CONFLICT_SUMMARY_LIMIT = 5
+_QUANTITY_CONFLICT_ENTITY_ID_LIMIT = 10
+_QUANTITY_CONFLICT_DETAIL_ITEM_LIMIT = 10
+_QUANTITY_CONFLICT_DETAIL_DEPTH_LIMIT = 3
+_QUANTITY_CONFLICT_TEXT_LIMIT = 200
 _CANONICAL_ENTITY_PROVENANCE_ORIGINS = frozenset(
     {
         "source_direct",
@@ -88,6 +121,23 @@ def is_ingest_worker_job_type(job_type: JobType | str) -> bool:
     """Return whether a job type is published to the ingest worker."""
     normalized_job_type = job_type.value if isinstance(job_type, JobType) else job_type
     return normalized_job_type in _RECOVERABLE_INGEST_JOB_TYPES
+
+
+def is_recoverable_enqueue_job_type(job_type: JobType | str) -> bool:
+    """Return whether a job type participates in durable queue publication/recovery."""
+    normalized_job_type = job_type.value if isinstance(job_type, JobType) else job_type
+    return normalized_job_type in _RECOVERABLE_ENQUEUE_JOB_TYPES
+
+
+def get_job_enqueue_publisher(job_type: JobType | str) -> Callable[[UUID], None] | None:
+    """Return the queue publisher registered for a persisted worker job type."""
+    normalized_job_type = job_type.value if isinstance(job_type, JobType) else job_type
+    registry: dict[str, Callable[[UUID], None]] = {
+        JobType.INGEST.value: enqueue_ingest_job,
+        JobType.REPROCESS.value: enqueue_ingest_job,
+        JobType.QUANTITY_TAKEOFF.value: enqueue_quantity_takeoff_job,
+    }
+    return registry.get(normalized_job_type)
 
 
 class _InactiveSourceError(Exception):
@@ -130,6 +180,18 @@ class _RevisionMaterializationRows:
 
 
 @dataclass(frozen=True, slots=True)
+class _QuantityTakeoffJobError(Exception):
+    """Raised for deterministic quantity takeoff failures."""
+
+    error_code: ErrorCode
+    message: str
+    details: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
 class _JobAttemptLease:
     """Persisted ownership token for a claimed job attempt."""
 
@@ -143,6 +205,26 @@ class _EnqueueIntentLease:
 
     token: UUID
     lease_expires_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class _ClaimedJobEnqueueIntent:
+    """Persisted enqueue claim bundled with the routed worker job type."""
+
+    lease: _EnqueueIntentLease
+    job_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class _QuantityTakeoffExecutionInput:
+    """Loaded immutable quantity takeoff execution inputs."""
+
+    drawing_revision_id: UUID
+    review_state: str
+    validation_status: str
+    quantity_gate: str
+    gate: RevisionGateMetadata
+    entities: list[RevisionEntityInput]
 
 
 @dataclass(frozen=True, slots=True)
@@ -474,6 +556,18 @@ async def _get_existing_adapter_run_output(
     return result.scalar_one_or_none()
 
 
+async def _get_existing_quantity_takeoff(
+    session: AsyncSession,
+    *,
+    source_job_id: UUID,
+) -> QuantityTakeoff | None:
+    """Load an existing committed quantity takeoff for a job."""
+    result = await session.execute(
+        select(QuantityTakeoff).where(QuantityTakeoff.source_job_id == source_job_id)
+    )
+    return result.scalar_one_or_none()
+
+
 async def _get_latest_drawing_revision(
     session: AsyncSession,
     *,
@@ -501,6 +595,60 @@ async def _get_drawing_revision(
     """Load a drawing revision row by identifier."""
 
     return await session.get(DrawingRevision, revision_id)
+
+
+async def _get_validation_report_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    drawing_revision_id: UUID,
+) -> ValidationReport | None:
+    """Load the canonical validation report for a drawing revision."""
+    result = await session.execute(
+        select(ValidationReport).where(
+            (ValidationReport.project_id == project_id)
+            & (ValidationReport.drawing_revision_id == drawing_revision_id)
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_revision_entity_manifest_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    source_file_id: UUID,
+    drawing_revision_id: UUID,
+) -> RevisionEntityManifest | None:
+    """Load the revision entity manifest for a drawing revision."""
+    result = await session.execute(
+        select(RevisionEntityManifest).where(
+            (RevisionEntityManifest.project_id == project_id)
+            & (RevisionEntityManifest.source_file_id == source_file_id)
+            & (RevisionEntityManifest.drawing_revision_id == drawing_revision_id)
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_revision_entities_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    source_file_id: UUID,
+    drawing_revision_id: UUID,
+) -> list[RevisionEntity]:
+    """Load deterministic materialized entities for a drawing revision."""
+    result = await session.execute(
+        select(RevisionEntity)
+        .where(
+            (RevisionEntity.project_id == project_id)
+            & (RevisionEntity.source_file_id == source_file_id)
+            & (RevisionEntity.drawing_revision_id == drawing_revision_id)
+        )
+        .order_by(RevisionEntity.sequence_index.asc(), RevisionEntity.id.asc())
+    )
+    return list(result.scalars().all())
 
 
 def _expected_revision_kind_for_job(job: Job) -> str:
@@ -1830,6 +1978,504 @@ async def _finalize_ingest_job(
     return True
 
 
+def _quantity_gate_details(
+    *,
+    drawing_revision_id: UUID,
+    review_state: str,
+    validation_status: str,
+    quantity_gate: str,
+) -> dict[str, Any]:
+    """Build stable structured metadata for quantity gate failures."""
+    return {
+        "drawing_revision_id": str(drawing_revision_id),
+        "review_state": review_state,
+        "validation_status": validation_status,
+        "quantity_gate": quantity_gate,
+    }
+
+
+def _manifest_entity_count(manifest: RevisionEntityManifest) -> int | None:
+    """Return the expected entity count when recorded on the manifest."""
+    raw_count = (
+        manifest.counts_json.get("entities")
+        if isinstance(manifest.counts_json, dict)
+        else None
+    )
+    return raw_count if isinstance(raw_count, int) else None
+
+
+def _build_quantity_gate_metadata(report: ValidationReport) -> RevisionGateMetadata:
+    """Build quantity engine gate metadata from the persisted validation report."""
+    return RevisionGateMetadata(
+        status=cast(GateStatus, report.quantity_gate),
+        validation_status=report.validation_status,
+        reason=report.review_state if report.quantity_gate in {"review_gated", "blocked"} else None,
+        details={
+            "drawing_revision_id": str(report.drawing_revision_id),
+            "review_state": report.review_state,
+            "effective_confidence": report.effective_confidence,
+        },
+    )
+
+
+def _build_revision_entity_input(entity: RevisionEntity) -> RevisionEntityInput:
+    """Map a materialized revision entity row to the quantity engine contract."""
+    return RevisionEntityInput(
+        entity_id=entity.entity_id,
+        entity_type=entity.entity_type,
+        sequence_index=entity.sequence_index,
+        geometry_json=entity.geometry_json,
+        properties_json=entity.properties_json,
+        provenance_json=entity.provenance_json,
+        canonical_entity_json=(
+            entity.canonical_entity_json if entity.canonical_entity_json is not None else {}
+        ),
+        source_identity=entity.source_identity,
+        source_hash=entity.source_hash,
+    )
+
+
+def _nonempty_quantity_type(value: str | None) -> str:
+    """Normalize persisted quantity type labels to non-empty strings."""
+    if value is None:
+        return "unknown"
+    normalized = value.strip()
+    return normalized or "unknown"
+
+
+def _nonempty_quantity_unit(value: str | None) -> str:
+    """Normalize persisted quantity units to non-empty strings."""
+    if value is None:
+        return "unknown"
+    normalized = value.strip()
+    return normalized or "unknown"
+
+
+def _duplicate_entity_ids_json(values: tuple[str, ...]) -> list[str]:
+    """Copy duplicate contributor lineage ids into a JSON-safe list."""
+    return [value for value in values if value]
+
+
+def _serialize_quantity_context(context: Any) -> str | None:
+    """Render quantity context as a deterministic persisted label suffix."""
+    if context is None:
+        return None
+    if isinstance(context, str):
+        normalized = context.strip()
+        return normalized or None
+
+    try:
+        serialized = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    except TypeError:
+        serialized = str(context).strip()
+
+    return serialized or None
+
+
+def _quantity_item_type_label(quantity_type: str | None, context: Any) -> str:
+    """Persist the quantity type with stable quantity-context disambiguation."""
+    normalized_quantity_type = _nonempty_quantity_type(quantity_type)
+    serialized_context = _serialize_quantity_context(context)
+    if serialized_context is None:
+        return normalized_quantity_type
+
+    return f"{normalized_quantity_type}:{serialized_context}"
+
+
+def _bounded_conflict_text(value: Any) -> str | None:
+    """Return a bounded string payload for persisted conflict metadata."""
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+    return normalized[:_QUANTITY_CONFLICT_TEXT_LIMIT]
+
+
+def _bounded_conflict_json(value: Any, *, depth: int = 0) -> Any:
+    """Bound persisted conflict details to stable JSON-safe payloads."""
+    if value is None or isinstance(value, bool | int | float):
+        return value
+    if isinstance(value, str):
+        return value[:_QUANTITY_CONFLICT_TEXT_LIMIT]
+    if depth >= _QUANTITY_CONFLICT_DETAIL_DEPTH_LIMIT:
+        return _bounded_conflict_text(value)
+    if isinstance(value, dict):
+        bounded: dict[str, Any] = {}
+        for key, nested_value in list(value.items())[:_QUANTITY_CONFLICT_DETAIL_ITEM_LIMIT]:
+            normalized_key = _bounded_conflict_text(key)
+            if normalized_key is None:
+                continue
+            bounded[normalized_key] = _bounded_conflict_json(nested_value, depth=depth + 1)
+        return bounded
+    if isinstance(value, list | tuple):
+        return [
+            _bounded_conflict_json(item, depth=depth + 1)
+            for item in list(value)[:_QUANTITY_CONFLICT_DETAIL_ITEM_LIMIT]
+        ]
+    return _bounded_conflict_text(value)
+
+
+def _bounded_conflict_entity_ids(entity_ids: Any) -> list[str]:
+    """Copy contributor conflict entity ids into a bounded JSON-safe list."""
+    if not isinstance(entity_ids, tuple | list):
+        return []
+
+    bounded_ids: list[str] = []
+    for entity_id in entity_ids[:_QUANTITY_CONFLICT_ENTITY_ID_LIMIT]:
+        normalized = _bounded_conflict_text(entity_id)
+        if normalized is not None:
+            bounded_ids.append(normalized)
+    return bounded_ids
+
+
+def _build_quantity_conflict_summaries(conflicts: Sequence[Any]) -> list[dict[str, Any]]:
+    """Build bounded persisted summaries for deterministic quantity conflicts."""
+    summaries: list[dict[str, Any]] = []
+    for conflict in conflicts[:_QUANTITY_CONFLICT_SUMMARY_LIMIT]:
+        summaries.append(
+            {
+                "dedup_key": _bounded_conflict_text(getattr(conflict, "dedup_key", None)),
+                "entity_ids": _bounded_conflict_entity_ids(
+                    getattr(conflict, "entity_ids", ())
+                ),
+                "reason": _bounded_conflict_text(getattr(conflict, "reason", None)),
+                "details": _bounded_conflict_json(getattr(conflict, "details", None)),
+            }
+        )
+    return summaries
+
+
+def _build_quantity_items(
+    *,
+    quantity_takeoff_id: UUID,
+    project_id: UUID,
+    drawing_revision_id: UUID,
+    review_state: str,
+    validation_status: str,
+    quantity_gate: str,
+    result: QuantityEngineResult,
+) -> list[QuantityItem]:
+    """Build immutable quantity item rows for a takeoff result."""
+    items: list[QuantityItem] = []
+
+    for contributor in result.contributors:
+        items.append(
+            QuantityItem(
+                id=uuid.uuid4(),
+                quantity_takeoff_id=quantity_takeoff_id,
+                project_id=project_id,
+                drawing_revision_id=drawing_revision_id,
+                item_kind=QuantityItemKind.CONTRIBUTOR.value,
+                quantity_type=_quantity_item_type_label(
+                    contributor.quantity_type,
+                    getattr(contributor, "context", None),
+                ),
+                value=contributor.value,
+                unit=_nonempty_quantity_unit(contributor.unit),
+                review_state=review_state,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+                source_entity_id=contributor.entity_id,
+                excluded_source_entity_ids_json=_duplicate_entity_ids_json(
+                    contributor.duplicate_entity_ids
+                ),
+            )
+        )
+
+    for aggregate in result.aggregates:
+        items.append(
+            QuantityItem(
+                id=uuid.uuid4(),
+                quantity_takeoff_id=quantity_takeoff_id,
+                project_id=project_id,
+                drawing_revision_id=drawing_revision_id,
+                item_kind=QuantityItemKind.AGGREGATE.value,
+                quantity_type=_quantity_item_type_label(
+                    aggregate.quantity_type,
+                    getattr(aggregate, "context", None),
+                ),
+                value=aggregate.total,
+                unit=_nonempty_quantity_unit(aggregate.unit),
+                review_state=review_state,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+                source_entity_id=None,
+                excluded_source_entity_ids_json=[],
+            )
+        )
+
+    for exclusion in result.exclusions:
+        items.append(
+            QuantityItem(
+                id=uuid.uuid4(),
+                quantity_takeoff_id=quantity_takeoff_id,
+                project_id=project_id,
+                drawing_revision_id=drawing_revision_id,
+                item_kind=QuantityItemKind.EXCLUSION.value,
+                quantity_type=_quantity_item_type_label(
+                    exclusion.quantity_type,
+                    getattr(exclusion, "context", None),
+                ),
+                value=None,
+                unit="unknown",
+                review_state=review_state,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+                source_entity_id=exclusion.entity_id,
+                excluded_source_entity_ids_json=[],
+            )
+        )
+
+    return items
+
+
+async def _build_quantity_takeoff_execution_input(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> _QuantityTakeoffExecutionInput:
+    """Load unlocked quantity engine inputs for a claimed persisted job."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
+        if job.job_type != JobType.QUANTITY_TAKEOFF.value:
+            raise ValueError(f"Unsupported quantity takeoff job type '{job.job_type}'")
+        if job.base_revision_id is None:
+            raise _RevisionConflictError(
+                message="Quantity takeoff job is missing its finalized base revision.",
+                details={
+                    "base_revision_id": None,
+                    "current_revision_id": None,
+                },
+            )
+
+        drawing_revision = await _get_drawing_revision(session, revision_id=job.base_revision_id)
+        if drawing_revision is None:
+            raise _RevisionConflictError(
+                message="Quantity takeoff base revision no longer exists.",
+                details={
+                    "base_revision_id": str(job.base_revision_id),
+                    "current_revision_id": None,
+                },
+            )
+        if (
+            drawing_revision.project_id != job.project_id
+            or drawing_revision.source_file_id != job.file_id
+        ):
+            raise ValueError("Quantity takeoff base revision does not belong to the source file")
+
+        report = await _get_validation_report_for_revision(
+            session,
+            project_id=job.project_id,
+            drawing_revision_id=drawing_revision.id,
+        )
+        if report is None:
+            raise _QuantityTakeoffJobError(
+                error_code=ErrorCode.NOT_FOUND,
+                message=_QUANTITY_TAKEOFF_VALIDATION_REPORT_MISSING_ERROR_MESSAGE,
+                details={"drawing_revision_id": str(drawing_revision.id)},
+            )
+
+        if report.quantity_gate in {"review_gated", "blocked"}:
+            return _QuantityTakeoffExecutionInput(
+                drawing_revision_id=drawing_revision.id,
+                review_state=report.review_state,
+                validation_status=report.validation_status,
+                quantity_gate=report.quantity_gate,
+                gate=_build_quantity_gate_metadata(report),
+                entities=[],
+            )
+
+        manifest = await _get_revision_entity_manifest_for_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=job.file_id,
+            drawing_revision_id=drawing_revision.id,
+        )
+        if manifest is None:
+            raise _QuantityTakeoffJobError(
+                error_code=ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED,
+                message=_QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE,
+                details={"drawing_revision_id": str(drawing_revision.id)},
+            )
+
+        entities = await _get_revision_entities_for_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=job.file_id,
+            drawing_revision_id=drawing_revision.id,
+        )
+        expected_entity_count = _manifest_entity_count(manifest)
+        if expected_entity_count is not None and expected_entity_count != len(entities):
+            raise _QuantityTakeoffJobError(
+                error_code=ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED,
+                message=_QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE,
+                details={
+                    "drawing_revision_id": str(drawing_revision.id),
+                    "expected_entities": expected_entity_count,
+                    "loaded_entities": len(entities),
+                },
+            )
+
+        return _QuantityTakeoffExecutionInput(
+            drawing_revision_id=drawing_revision.id,
+            review_state=report.review_state,
+            validation_status=report.validation_status,
+            quantity_gate=report.quantity_gate,
+            gate=_build_quantity_gate_metadata(report),
+            entities=[_build_revision_entity_input(entity) for entity in entities],
+        )
+
+
+async def _finalize_quantity_takeoff_job(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    execution: _QuantityTakeoffExecutionInput,
+    result: QuantityEngineResult,
+) -> bool:
+    """Atomically publish quantity takeoff rows and terminal job success."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    if result.conflicts:
+        raise ValueError("Conflicting quantity results cannot be finalized")
+
+    async with session_maker() as session:
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "quantity_takeoff_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            logger.info(
+                "quantity_takeoff_job_completion_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
+            await session.commit()
+            logger.info("quantity_takeoff_job_cancelled", job_id=str(job_id))
+            return False
+
+        if job.status != "running":
+            logger.info(
+                "quantity_takeoff_job_completion_skipped_non_running_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if (
+            locked_source.project.deleted_at is not None
+            or locked_source.source_file is None
+            or locked_source.source_file.deleted_at is not None
+        ):
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            logger.info("quantity_takeoff_job_cancelled_inactive_source", job_id=str(job_id))
+            return False
+
+        if job.base_revision_id != execution.drawing_revision_id:
+            raise _RevisionConflictError(
+                message="Quantity takeoff base revision changed before finalization.",
+                details={
+                    "base_revision_id": (
+                        str(job.base_revision_id) if job.base_revision_id is not None else None
+                    ),
+                    "drawing_revision_id": str(execution.drawing_revision_id),
+                },
+            )
+
+        existing_takeoff = await _get_existing_quantity_takeoff(session, source_job_id=job.id)
+        if existing_takeoff is not None:
+            logger.info(
+                "quantity_takeoff_job_completion_skipped_existing_takeoff",
+                job_id=str(job_id),
+                quantity_takeoff_id=str(existing_takeoff.id),
+            )
+            return False
+
+        quantity_takeoff_id = uuid.uuid4()
+        quantity_items = _build_quantity_items(
+            quantity_takeoff_id=quantity_takeoff_id,
+            project_id=job.project_id,
+            drawing_revision_id=execution.drawing_revision_id,
+            review_state=execution.review_state,
+            validation_status=execution.validation_status,
+            quantity_gate=execution.quantity_gate,
+            result=result,
+        )
+
+        session.add(
+            QuantityTakeoff(
+                id=quantity_takeoff_id,
+                project_id=job.project_id,
+                source_file_id=job.file_id,
+                drawing_revision_id=execution.drawing_revision_id,
+                source_job_id=job.id,
+                source_job_type=JobType.QUANTITY_TAKEOFF.value,
+                review_state=execution.review_state,
+                validation_status=execution.validation_status,
+                quantity_gate=execution.quantity_gate,
+                trusted_totals=result.trusted_totals,
+            )
+        )
+        session.add_all(quantity_items)
+
+        job.status = "succeeded"
+        job.finished_at = _utcnow()
+        job.error_code = None
+        job.error_message = None
+        _clear_job_attempt_lease(job)
+        await emit_job_event(
+            job.id,
+            level="info",
+            message="Job succeeded",
+            data_json={
+                "status": "succeeded",
+                "attempts": job.attempts,
+                "quantity_takeoff_id": str(quantity_takeoff_id),
+                "quantity_item_count": len(quantity_items),
+                "trusted_totals": result.trusted_totals,
+                "quantity_gate": execution.quantity_gate,
+            },
+            session=session,
+        )
+        await session.commit()
+
+    return True
+
+
 async def emit_job_event(
     job_id: UUID,
     *,
@@ -2069,6 +2715,23 @@ async def _mark_job_failed(
             )
             return False
 
+        if attempt_token is not None and job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
+            await session.commit()
+            logger.info(
+                "ingest_job_failure_mark_preferred_cancelled",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
         await _persist_job_failed(
             session,
             job,
@@ -2177,7 +2840,7 @@ async def _mark_job_failed_if_recovery_safe(
     return True
 
 
-async def _claim_job_enqueue_intent(job_id: UUID) -> _EnqueueIntentLease | None:
+async def _claim_job_enqueue_intent(job_id: UUID) -> _ClaimedJobEnqueueIntent | None:
     """Claim a durable enqueue intent for best-effort or recovery publication."""
     session_maker = get_session_maker()
     if session_maker is None:
@@ -2189,7 +2852,7 @@ async def _claim_job_enqueue_intent(job_id: UUID) -> _EnqueueIntentLease | None:
         if job is None:
             raise LookupError(f"Job with identifier '{job_id}' not found")
 
-        if not is_ingest_worker_job_type(job.job_type) or job.status != "pending":
+        if not is_recoverable_enqueue_job_type(job.job_type) or job.status != "pending":
             return None
 
         if job.enqueue_status == _ENQUEUE_STATUS_PUBLISHED:
@@ -2203,7 +2866,7 @@ async def _claim_job_enqueue_intent(job_id: UUID) -> _EnqueueIntentLease | None:
 
         lease = _claim_enqueue_intent_lease(job, now=now)
         await session.commit()
-        return lease
+        return _ClaimedJobEnqueueIntent(lease=lease, job_type=job.job_type)
 
 
 async def _release_job_enqueue_intent(job_id: UUID, *, lease_token: UUID) -> bool:
@@ -2269,15 +2932,18 @@ async def publish_job_enqueue_intent(
 ) -> bool:
     """Best-effort publish for a durable enqueue intent recorded in Postgres."""
     try:
-        lease = await _claim_job_enqueue_intent(job_id)
-        if lease is None:
+        claimed_intent = await _claim_job_enqueue_intent(job_id)
+        if claimed_intent is None:
             return False
 
-        publish = publisher or enqueue_ingest_job
+        publish = publisher or get_job_enqueue_publisher(claimed_intent.job_type)
+        if publish is None:
+            await _release_job_enqueue_intent(job_id, lease_token=claimed_intent.lease.token)
+            return False
         try:
             publish(job_id)
         except Exception:
-            await _release_job_enqueue_intent(job_id, lease_token=lease.token)
+            await _release_job_enqueue_intent(job_id, lease_token=claimed_intent.lease.token)
             if recovery:
                 await _mark_recovery_enqueue_failed(job_id)
             else:
@@ -2288,7 +2954,7 @@ async def publish_job_enqueue_intent(
                 )
             return False
 
-        await _mark_job_enqueue_published(job_id, lease_token=lease.token)
+        await _mark_job_enqueue_published(job_id, lease_token=claimed_intent.lease.token)
         return True
     except Exception:
         if not suppress_exceptions:
@@ -2481,6 +3147,130 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
     return None
 
 
+async def _begin_or_resume_quantity_takeoff_job(job_id: UUID) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted quantity takeoff job under a row lock."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    now = _utcnow()
+
+    async with session_maker() as session:
+        bootstrap = await _get_job_lock_bootstrap(session, job_id)
+        if bootstrap is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        project = await _get_project(session, bootstrap.project_id, for_update=True)
+        if project is None:
+            raise LookupError(
+                f"Project with identifier '{bootstrap.project_id}' for job '{job_id}' not found"
+            )
+
+        job = await _get_job_for_update_with_metadata(
+            session,
+            job_id,
+            expected_project_id=bootstrap.project_id,
+            expected_file_id=bootstrap.file_id,
+        )
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.job_type != JobType.QUANTITY_TAKEOFF.value:
+            logger.info(
+                "quantity_takeoff_job_unsupported_type_skipped",
+                job_id=str(job_id),
+                job_type=job.job_type,
+                status=job.status,
+            )
+            return None
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "quantity_takeoff_job_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return None
+
+        if project.deleted_at is not None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info("quantity_takeoff_job_cancelled_inactive_source", job_id=str(job_id))
+            return None
+
+        source_file = await _get_source_file(
+            session,
+            project_id=job.project_id,
+            file_id=job.file_id,
+            for_update=True,
+        )
+        if source_file is None or source_file.deleted_at is not None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info("quantity_takeoff_job_cancelled_inactive_source", job_id=str(job_id))
+            return None
+
+        if not job.cancel_requested:
+            if job.status == "running":
+                if _is_stale_running_job(job, now=now):
+                    lease = _claim_job_attempt_lease(job, now=now, increment_attempt=True)
+                    await emit_job_event(
+                        job.id,
+                        level="info",
+                        message="Job started",
+                        data_json={
+                            "status": "running",
+                            "attempts": job.attempts,
+                            "reclaimed": True,
+                        },
+                        session=session,
+                    )
+                    await session.commit()
+                    logger.warning(
+                        "quantity_takeoff_job_reclaimed_stale_running_status",
+                        job_id=str(job_id),
+                        status=job.status,
+                    )
+                    return lease
+
+                logger.info(
+                    "quantity_takeoff_job_duplicate_delivery_skipped_running_attempt",
+                    job_id=str(job_id),
+                    status=job.status,
+                )
+                return None
+
+            lease = _claim_job_attempt_lease(job, now=now, increment_attempt=True)
+            await emit_job_event(
+                job.id,
+                level="info",
+                message="Job started",
+                data_json={"status": "running", "attempts": job.attempts, "reclaimed": False},
+                session=session,
+            )
+            await session.commit()
+            return lease
+
+        _finalize_job_cancelled(job)
+        await emit_job_event(
+            job.id,
+            level="warning",
+            message="Job cancelled",
+            data_json={"status": "cancelled"},
+            session=session,
+        )
+        await session.commit()
+
+    logger.info("quantity_takeoff_job_cancelled", job_id=str(job_id))
+    return None
+
+
 async def process_ingest_job(job_id: UUID) -> None:
     """Load a persisted ingest job, run ingestion, and persist state transitions."""
     session_maker = get_session_maker()
@@ -2622,7 +3412,7 @@ async def process_ingest_job(job_id: UUID) -> None:
 
 
 async def recover_incomplete_ingest_jobs() -> list[UUID]:
-    """Requeue incomplete persisted ingest/reprocess jobs on worker startup."""
+    """Requeue incomplete persisted ingest/reprocess/quantity jobs on worker startup."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -2633,7 +3423,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
         result = await session.execute(
             select(Job)
             .where(
-                (Job.job_type.in_(_RECOVERABLE_INGEST_JOB_TYPES))
+                (Job.job_type.in_(_RECOVERABLE_ENQUEUE_JOB_TYPES))
                 & (
                     (Job.status == "running")
                     | (
@@ -2692,7 +3482,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
 
 
 def recover_incomplete_ingest_jobs_on_worker_start(**_: object) -> None:
-    """Requeue incomplete ingest/reprocess jobs when a worker starts."""
+    """Requeue incomplete ingest/reprocess/quantity jobs when a worker starts."""
     try:
         recovered_job_ids = asyncio.run(recover_incomplete_ingest_jobs())
     except Exception as exc:
@@ -2723,3 +3513,173 @@ def run_ingest_job(job_id: str) -> None:
 def enqueue_ingest_job(job_id: UUID) -> None:
     """Publish a persisted ingest job to Celery."""
     run_ingest_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)
+
+
+async def process_quantity_takeoff_job(job_id: UUID) -> None:
+    """Load a persisted quantity takeoff job and atomically persist its result."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    lease = await _begin_or_resume_quantity_takeoff_job(job_id)
+    if lease is None:
+        return
+
+    try:
+        execution = await _build_quantity_takeoff_execution_input(job_id, attempt_token=lease.token)
+        if execution.quantity_gate in {"review_gated", "blocked"}:
+            error_details = _quantity_gate_details(
+                drawing_revision_id=execution.drawing_revision_id,
+                review_state=execution.review_state,
+                validation_status=execution.validation_status,
+                quantity_gate=execution.quantity_gate,
+            )
+            await _mark_job_failed(
+                job_id,
+                error_message=_QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE,
+                error_code=ErrorCode.INPUT_INVALID,
+                attempt_token=lease.token,
+                error_details=error_details,
+            )
+            logger.warning(
+                "quantity_takeoff_job_gate_blocked",
+                job_id=str(job_id),
+                error_code=ErrorCode.INPUT_INVALID.value,
+                **error_details,
+            )
+            return
+
+        result = compute_quantities(execution.gate, execution.entities)
+        if result.conflicts:
+            error_details = {
+                "drawing_revision_id": str(execution.drawing_revision_id),
+                "quantity_gate": execution.quantity_gate,
+                "conflict_count": len(result.conflicts),
+                "conflicts": _build_quantity_conflict_summaries(result.conflicts),
+            }
+            await _mark_job_failed(
+                job_id,
+                error_message=_QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE,
+                error_code=ErrorCode.INPUT_INVALID,
+                attempt_token=lease.token,
+                error_details=error_details,
+            )
+            logger.warning(
+                "quantity_takeoff_job_conflicts_detected",
+                job_id=str(job_id),
+                error_code=ErrorCode.INPUT_INVALID.value,
+                **error_details,
+            )
+            return
+    except _StaleJobAttemptError:
+        logger.info("quantity_takeoff_job_stale_attempt_skipped", job_id=str(job_id))
+        return
+    except _RevisionConflictError as exc:
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=ErrorCode.REVISION_CONFLICT,
+            attempt_token=lease.token,
+            error_details=exc.details,
+        )
+        logger.warning(
+            "quantity_takeoff_job_revision_conflict",
+            job_id=str(job_id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            **exc.details,
+        )
+        return
+    except _QuantityTakeoffJobError as exc:
+        failure_details: dict[str, Any] | None = exc.details
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=exc.error_code,
+            attempt_token=lease.token,
+            error_details=failure_details,
+        )
+        logger.warning(
+            "quantity_takeoff_job_input_failed",
+            job_id=str(job_id),
+            error_code=exc.error_code.value,
+            **(failure_details or {}),
+        )
+        return
+    except asyncio.CancelledError:
+        await _mark_job_cancelled(job_id, attempt_token=lease.token)
+        logger.info("quantity_takeoff_job_cancelled_during_execution", job_id=str(job_id))
+        raise
+    except Exception:
+        await _mark_job_failed(
+            job_id,
+            error_message=_PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+            attempt_token=lease.token,
+        )
+        logger.error(
+            "quantity_takeoff_job_failed",
+            job_id=str(job_id),
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message=_PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+            exc_info=True,
+        )
+        raise
+
+    try:
+        finalized = await _finalize_quantity_takeoff_job(
+            job_id,
+            attempt_token=lease.token,
+            execution=execution,
+            result=result,
+        )
+    except asyncio.CancelledError:
+        await _mark_job_cancelled(job_id, attempt_token=lease.token)
+        logger.info("quantity_takeoff_job_cancelled_during_finalization", job_id=str(job_id))
+        raise
+    except _RevisionConflictError as exc:
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=ErrorCode.REVISION_CONFLICT,
+            attempt_token=lease.token,
+            error_details=exc.details,
+        )
+        logger.warning(
+            "quantity_takeoff_job_revision_conflict",
+            job_id=str(job_id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            **exc.details,
+        )
+        return
+    except Exception:
+        await _mark_job_failed(
+            job_id,
+            error_message=_FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+            attempt_token=lease.token,
+        )
+        logger.error(
+            "quantity_takeoff_job_finalization_failed",
+            job_id=str(job_id),
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message=_FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+            exc_info=True,
+        )
+        raise
+
+    if finalized:
+        logger.info("quantity_takeoff_job_succeeded", job_id=str(job_id))
+
+
+@celery_app.task(
+    name="app.jobs.worker.run_quantity_takeoff_job",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def run_quantity_takeoff_job(job_id: str) -> None:
+    """Celery task wrapper for persisted quantity takeoff jobs."""
+    asyncio.run(process_quantity_takeoff_job(UUID(job_id)))
+
+
+def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
+    """Publish a persisted quantity takeoff job to Celery."""
+    run_quantity_takeoff_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -2426,6 +2426,18 @@ async def _finalize_quantity_takeoff_job(
             return False
 
         quantity_takeoff_id = uuid.uuid4()
+        quantity_takeoff = QuantityTakeoff(
+            id=quantity_takeoff_id,
+            project_id=job.project_id,
+            source_file_id=job.file_id,
+            drawing_revision_id=execution.drawing_revision_id,
+            source_job_id=job.id,
+            source_job_type=JobType.QUANTITY_TAKEOFF.value,
+            review_state=execution.review_state,
+            validation_status=execution.validation_status,
+            quantity_gate=execution.quantity_gate,
+            trusted_totals=result.trusted_totals,
+        )
         quantity_items = _build_quantity_items(
             quantity_takeoff_id=quantity_takeoff_id,
             project_id=job.project_id,
@@ -2436,20 +2448,8 @@ async def _finalize_quantity_takeoff_job(
             result=result,
         )
 
-        session.add(
-            QuantityTakeoff(
-                id=quantity_takeoff_id,
-                project_id=job.project_id,
-                source_file_id=job.file_id,
-                drawing_revision_id=execution.drawing_revision_id,
-                source_job_id=job.id,
-                source_job_type=JobType.QUANTITY_TAKEOFF.value,
-                review_state=execution.review_state,
-                validation_status=execution.validation_status,
-                quantity_gate=execution.quantity_gate,
-                trusted_totals=result.trusted_totals,
-            )
-        )
+        session.add(quantity_takeoff)
+        await session.flush()
         session.add_all(quantity_items)
 
         job.status = "succeeded"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -397,14 +397,15 @@ ingest(file)
 ```
 
 `ingest(file)` produces a `drawing_revision` that becomes the pinned input for
-later revision-scoped work. A future `quantity_takeoff(drawing_revision)` job
-will run against exactly one persisted revision rather than against the mutable
-file head.
+later revision-scoped work. `quantity_takeoff(drawing_revision)` worker
+execution runs against exactly one persisted revision rather than against the
+mutable file head.
 
 For MVP every step is triggered explicitly via API. A later iteration may add an
 auto-chain configuration on the project that fires the next step on success.
-The quantity worker/API remains deferred; this DAG documents the persisted job
-shape and lineage model, not a shipped downstream quantity surface.
+Quantity worker execution exists for this DAG and persisted lineage model, while
+manual/API creation and read surfaces for quantity takeoffs remain separate
+deferred work.
 
 Workers must:
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -351,8 +351,11 @@ Persisted quantity takeoff lineage requirements:
 - `source_job_id` must be unique across persisted quantity takeoffs.
 - The source job must be a `quantity_takeoff` job for the same project, file,
   and pinned `base_revision_id` as the persisted takeoff.
-- Trusted totals require `quantity_gate = allowed`; other gate states may retain
-  quantity lineage, but they must not be documented as trusted totals.
+- Trusted totals require `quantity_gate = allowed`.
+- `allowed_provisional` runs may persist provisional quantity lineage, but they
+  must not be documented as trusted totals.
+- `review_gated` and `blocked` jobs fail without publishing trusted or persisted
+  quantity takeoff output.
 
 Persisted quantity item kinds:
 
@@ -1212,8 +1215,8 @@ Probe rules:
   - `allowed` revisions may publish normal quantity totals.
   - `allowed_provisional` revisions may publish quantities only with explicit
     provisional labeling and provenance.
-  - `review_gated` revisions may publish blockage metadata, but not trusted
-    quantity totals.
+  - `review_gated` and `blocked` revisions may publish blockage metadata, but
+    not trusted or persisted quantity takeoff totals.
   - entity-level exclusions caused by review/validation findings must remain
     traceable in provenance rather than silently disappearing.
 

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -920,10 +920,18 @@ class TestEndpointIdempotency:
             (await _upload_pdf(async_client, project_id=project["id"])).json(),
         )
 
-        def _record_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _record_retry_enqueue(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             enqueued_job_ids.append(str(job_id))
+            return True
 
-        monkeypatch.setattr(jobs_api, "enqueue_ingest_job", _record_retry_enqueue)
+        monkeypatch.setattr(jobs_api, "publish_job_enqueue_intent", _record_retry_enqueue)
 
         job = await _get_job_for_file(uploaded["id"])
         await _mark_job_failed(str(job.id))
@@ -958,10 +966,18 @@ class TestEndpointIdempotency:
             (await _upload_pdf(async_client, project_id=project["id"])).json(),
         )
 
-        def _record_retry_enqueue(job_id: uuid.UUID) -> None:
+        async def _record_retry_enqueue(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
             enqueued_job_ids.append(str(job_id))
+            return True
 
-        monkeypatch.setattr(jobs_api, "enqueue_ingest_job", _record_retry_enqueue)
+        monkeypatch.setattr(jobs_api, "publish_job_enqueue_intent", _record_retry_enqueue)
 
         job = await _get_job_for_file(uploaded["id"])
         await _mark_job_failed(
@@ -1007,10 +1023,19 @@ class TestEndpointIdempotency:
         await _mark_job_failed(str(job.id))
         key = "job-retry-enqueue-failure-1"
 
-        def _fail_enqueue(_: uuid.UUID, **__: Any) -> None:
+        async def _fail_enqueue(
+            _: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _unused = (publisher, suppress_exceptions, kwargs)
+            if suppress_exceptions:
+                return False
             raise RuntimeError("broker unavailable")
 
-        monkeypatch.setattr(jobs_api, "enqueue_ingest_job", _fail_enqueue)
+        monkeypatch.setattr(jobs_api, "publish_job_enqueue_intent", _fail_enqueue)
 
         first = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=_headers(key))
         second = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=_headers(key))

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,6 +6,7 @@ import types
 import uuid
 from collections.abc import Callable
 from contextlib import suppress
+from copy import deepcopy
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -38,6 +39,7 @@ from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
 from app.models.job_event import JobEvent
 from app.models.project import Project
+from app.models.quantity_takeoff import QuantityItem, QuantityTakeoff
 from tests.conftest import requires_database
 
 _FAKE_RUNNER_ADAPTER_KEY = "tests.fake_ingestion_runner"
@@ -219,6 +221,153 @@ def _build_fake_ingest_payload(
     )
 
 
+def _build_fake_contract_entity(
+    *,
+    entity_id: str,
+    entity_type: str,
+    layer_ref: str,
+    source_id: str,
+    source_hash: str | None = None,
+    geometry_json: dict[str, Any] | None = None,
+    properties_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a contract-shaped canonical entity payload for quantity tests."""
+    return {
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "entity_schema_version": _FAKE_RUNNER_CANONICAL_SCHEMA_VERSION,
+        "layout_ref": "Model",
+        "layer_ref": layer_ref,
+        "confidence_score": _FAKE_RUNNER_CONFIDENCE_SCORE,
+        "confidence_json": {"score": _FAKE_RUNNER_CONFIDENCE_SCORE, "basis": "adapter"},
+        "geometry_json": deepcopy(geometry_json) if geometry_json is not None else {},
+        "properties_json": {"layer": layer_ref, **(properties_json or {})},
+        "provenance_json": {
+            "origin": "adapter_normalized",
+            "adapter": {"key": _FAKE_RUNNER_ADAPTER_KEY},
+            "source_ref": None,
+            "source_identity": source_id,
+            "source_hash": source_hash,
+            "extraction_path": [],
+            "notes": [],
+        },
+    }
+
+
+def _replace_fake_canonical_payload(
+    payload: IngestFinalizationPayload,
+    *,
+    entities: list[dict[str, Any]],
+) -> IngestFinalizationPayload:
+    """Replace canonical fake payload entities and refresh derived counts/checksum."""
+    canonical_json = {
+        **payload.canonical_json,
+        "canonical_entity_schema_version": payload.canonical_entity_schema_version,
+        "schema_version": payload.canonical_entity_schema_version,
+        "layouts": [{"layout_ref": "Model", "name": "Model"}],
+        "layers": [{"layer_ref": "A-WALL", "name": "A-WALL"}],
+        "blocks": [],
+        "entities": deepcopy(entities),
+        "entity_counts": {
+            "layouts": 1,
+            "layers": 1,
+            "blocks": 0,
+            "entities": len(entities),
+        },
+    }
+    report_json = deepcopy(payload.report_json)
+    summary = report_json.get("summary")
+    if isinstance(summary, dict):
+        report_json["summary"] = {
+            **summary,
+            "entity_counts": canonical_json["entity_counts"],
+        }
+    result_envelope = {
+        "adapter_key": payload.adapter_key,
+        "adapter_version": payload.adapter_version,
+        "input_family": payload.input_family,
+        "canonical_entity_schema_version": payload.canonical_entity_schema_version,
+        "canonical_json": canonical_json,
+        "provenance_json": payload.provenance_json,
+        "confidence_json": payload.confidence_json,
+        "confidence_score": payload.confidence_score,
+        "warnings_json": payload.warnings_json,
+        "diagnostics_json": payload.diagnostics_json,
+    }
+    return replace(
+        payload,
+        canonical_json=canonical_json,
+        report_json=report_json,
+        result_checksum_sha256=compute_adapter_result_checksum(result_envelope),
+    )
+
+
+def _replace_fake_validation_outcome(
+    payload: IngestFinalizationPayload,
+    *,
+    review_state: str,
+    validation_status: str,
+    quantity_gate: str,
+) -> IngestFinalizationPayload:
+    """Replace fake validation gate metadata while preserving deterministic payload shape."""
+    confidence_json = {
+        **payload.confidence_json,
+        "review_state": review_state,
+        "effective_confidence": payload.effective_confidence,
+    }
+    report_json = deepcopy(payload.report_json)
+    summary = report_json.get("summary")
+    if isinstance(summary, dict):
+        report_json["summary"] = {
+            **summary,
+            "validation_status": validation_status,
+            "review_state": review_state,
+            "quantity_gate": quantity_gate,
+            "effective_confidence": payload.effective_confidence,
+        }
+    report_json["validation_status"] = validation_status
+    report_json["review_state"] = review_state
+    report_json["quantity_gate"] = quantity_gate
+    report_json["effective_confidence"] = payload.effective_confidence
+    return replace(
+        payload,
+        confidence_json=confidence_json,
+        validation_status=validation_status,
+        review_state=review_state,
+        quantity_gate=quantity_gate,
+        report_json=report_json,
+    )
+
+
+def _build_fake_quantity_ingest_payload(
+    request: IngestionRunRequest,
+    *,
+    review_state: str,
+    validation_status: str,
+    quantity_gate: str,
+    entities: list[dict[str, Any]] | None = None,
+) -> IngestFinalizationPayload:
+    """Build a quantity-friendly fake ingest payload with configurable gate semantics."""
+    payload = _replace_fake_canonical_payload(
+        _build_fake_ingest_payload(request),
+        entities=entities
+        or [
+            _build_fake_contract_entity(
+                entity_id="entity-quantity-001",
+                entity_type="line",
+                layer_ref="A-WALL",
+                source_id="entity-source-quantity-001",
+            )
+        ],
+    )
+    return _replace_fake_validation_outcome(
+        payload,
+        review_state=review_state,
+        validation_status=validation_status,
+        quantity_gate=quantity_gate,
+    )
+
+
 async def _get_job_for_file(file_id: str) -> Job:
     """Load the ingest job associated with a file id."""
     session_maker = session_module.AsyncSessionLocal
@@ -263,6 +412,40 @@ async def _get_latest_revision_for_file(file_id: uuid.UUID) -> DrawingRevision |
         ).scalar_one_or_none()
 
 
+async def _get_quantity_takeoffs_for_job(job_id: uuid.UUID) -> list[QuantityTakeoff]:
+    """Load persisted quantity takeoffs for a source job."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        takeoffs = (
+            await session.execute(
+                select(QuantityTakeoff)
+                .where(QuantityTakeoff.source_job_id == job_id)
+                .order_by(QuantityTakeoff.created_at.asc(), QuantityTakeoff.id.asc())
+            )
+        ).scalars().all()
+
+    return list(takeoffs)
+
+
+async def _get_quantity_items_for_takeoff(quantity_takeoff_id: uuid.UUID) -> list[QuantityItem]:
+    """Load persisted quantity items for a takeoff."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        items = (
+            await session.execute(
+                select(QuantityItem)
+                .where(QuantityItem.quantity_takeoff_id == quantity_takeoff_id)
+                .order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc())
+            )
+        ).scalars().all()
+
+    return list(items)
+
+
 async def _create_quantity_takeoff_job(
     *,
     project_id: uuid.UUID,
@@ -296,6 +479,28 @@ async def _create_quantity_takeoff_job(
         await session.commit()
 
     return await _get_job(quantity_job.id)
+
+
+async def _create_ready_quantity_takeoff_job(
+    async_client: httpx.AsyncClient,
+) -> tuple[dict[str, Any], dict[str, Any], Job, DrawingRevision, Job]:
+    """Create a project/file/revision and pending quantity job for worker tests."""
+    project = await _create_project(async_client)
+    uploaded = await _upload_file(async_client, project["id"])
+    ingest_job = await _get_job_for_file(str(uploaded["id"]))
+    await worker_module.process_ingest_job(ingest_job.id)
+    base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+    assert base_revision is not None
+
+    quantity_job = await _create_quantity_takeoff_job(
+        project_id=uuid.UUID(project["id"]),
+        file_id=uuid.UUID(uploaded["id"]),
+        base_revision_id=base_revision.id,
+        parent_job_id=ingest_job.id,
+        status="pending",
+    )
+
+    return project, uploaded, ingest_job, base_revision, quantity_job
 
 
 async def _update_job(
@@ -2621,16 +2826,29 @@ class TestJobs:
         assert updated.status == "pending"
         assert updated.enqueue_status == "pending"
 
-    async def test_publish_job_enqueue_intent_skips_quantity_takeoff_jobs(
+    async def test_publish_job_enqueue_intent_routes_quantity_takeoff_jobs(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Quantity jobs should never claim or publish the ingest worker outbox."""
+        """Quantity jobs should claim the durable outbox and use the quantity publisher."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
+
+        quantity_enqueued_job_ids: list[str] = []
+        ingest_enqueued_job_ids: list[str] = []
+
+        def _fake_quantity_enqueue(job_id: uuid.UUID) -> None:
+            quantity_enqueued_job_ids.append(str(job_id))
+
+        def _fake_ingest_enqueue(job_id: uuid.UUID) -> None:
+            ingest_enqueued_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(worker_module, "enqueue_quantity_takeoff_job", _fake_quantity_enqueue)
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_ingest_enqueue)
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
@@ -2659,25 +2877,28 @@ class TestJobs:
 
         published = await worker_module.publish_job_enqueue_intent(quantity_job.id)
 
-        assert published is False
+        assert published is True
+        assert quantity_enqueued_job_ids == [str(quantity_job.id)]
+        assert ingest_enqueued_job_ids == []
         updated = await _get_job(quantity_job.id)
         assert updated.status == "pending"
-        assert updated.enqueue_status == "pending"
+        assert updated.enqueue_status == "published"
         assert updated.extraction_profile_id is None
-        assert updated.enqueue_attempts == 7
-        assert updated.enqueue_owner_token == unchanged_token
-        assert updated.enqueue_lease_expires_at is not None
-        assert updated.enqueue_last_attempted_at == last_attempted_at
-        assert updated.enqueue_published_at is None
+        assert updated.enqueue_attempts == 8
+        assert updated.enqueue_owner_token is None
+        assert updated.enqueue_lease_expires_at is None
+        assert updated.enqueue_last_attempted_at is not None
+        assert updated.enqueue_last_attempted_at >= last_attempted_at
+        assert updated.enqueue_published_at is not None
 
-    async def test_retry_job_noops_for_quantity_takeoff_without_ingest_publisher(
+    async def test_retry_job_requeues_failed_quantity_takeoff_job(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Retry should return 202 without requeueing unsupported quantity jobs."""
+        """Retry should route failed quantity jobs through durable queue publication."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
@@ -2691,7 +2912,8 @@ class TestJobs:
             suppress_exceptions: bool = False,
             **kwargs: Any,
         ) -> bool:
-            _ = (publisher, suppress_exceptions, kwargs)
+            assert publisher is None
+            _ = (suppress_exceptions, kwargs)
             retried_job_ids.append(str(job_id))
             return True
 
@@ -2731,24 +2953,24 @@ class TestJobs:
         response = await async_client.post(f"/v1/jobs/{quantity_job.id}/retry")
 
         assert response.status_code == 202
-        assert retried_job_ids == []
-        unchanged = await _get_job(quantity_job.id)
-        assert unchanged.status == "failed"
-        assert unchanged.attempts == original.attempts
-        assert unchanged.error_code == original.error_code
-        assert unchanged.error_message == original.error_message
-        assert unchanged.enqueue_status == original.enqueue_status
-        assert unchanged.enqueue_attempts == original.enqueue_attempts
-        assert unchanged.project_id == original.project_id
-        assert unchanged.file_id == original.file_id
-        assert unchanged.job_type == original.job_type
-        assert unchanged.extraction_profile_id == original.extraction_profile_id
-        assert unchanged.extraction_profile_id is None
-        assert unchanged.base_revision_id == original.base_revision_id
-        assert unchanged.parent_job_id == original.parent_job_id
+        assert retried_job_ids == [str(quantity_job.id)]
+        retried = await _get_job(quantity_job.id)
+        assert retried.status == "pending"
+        assert retried.attempts == original.attempts
+        assert retried.error_code is None
+        assert retried.error_message is None
+        assert retried.enqueue_status == "pending"
+        assert retried.enqueue_attempts == 0
+        assert retried.project_id == original.project_id
+        assert retried.file_id == original.file_id
+        assert retried.job_type == original.job_type
+        assert retried.extraction_profile_id == original.extraction_profile_id
+        assert retried.extraction_profile_id is None
+        assert retried.base_revision_id == original.base_revision_id
+        assert retried.parent_job_id == original.parent_job_id
 
     @pytest.mark.parametrize("status", ["pending", "running"])
-    async def test_recover_incomplete_ingest_jobs_skips_quantity_takeoff_jobs(
+    async def test_recover_incomplete_ingest_jobs_requeues_quantity_takeoff_jobs(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
@@ -2756,17 +2978,26 @@ class TestJobs:
         monkeypatch: pytest.MonkeyPatch,
         status: str,
     ) -> None:
-        """Startup recovery should ignore quantity jobs while no quantity worker exists."""
+        """Startup recovery should route quantity jobs through the quantity publisher."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
 
-        recovered_job_ids: list[str] = []
+        quantity_recovered_job_ids: list[str] = []
+        ingest_recovered_job_ids: list[str] = []
 
-        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
-            recovered_job_ids.append(str(job_id))
+        def _fake_quantity_recovery_enqueue(job_id: uuid.UUID) -> None:
+            quantity_recovered_job_ids.append(str(job_id))
 
-        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+        def _fake_ingest_recovery_enqueue(job_id: uuid.UUID) -> None:
+            ingest_recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            worker_module,
+            "enqueue_quantity_takeoff_job",
+            _fake_quantity_recovery_enqueue,
+        )
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_ingest_recovery_enqueue)
 
         project = await _create_project(async_client)
         uploaded = await _upload_file(async_client, project["id"])
@@ -2814,23 +3045,24 @@ class TestJobs:
 
         requeued = await worker_module.recover_incomplete_ingest_jobs()
 
-        assert requeued == []
-        assert recovered_job_ids == []
-        unchanged = await _get_job(quantity_job.id)
-        assert unchanged.status == original.status
-        assert unchanged.attempts == original.attempts
-        assert unchanged.started_at == original.started_at
-        assert unchanged.attempt_token == original.attempt_token
-        assert unchanged.attempt_lease_expires_at == original.attempt_lease_expires_at
-        assert unchanged.enqueue_status == original.enqueue_status
-        assert unchanged.enqueue_attempts == original.enqueue_attempts
-        assert unchanged.project_id == original.project_id
-        assert unchanged.file_id == original.file_id
-        assert unchanged.job_type == original.job_type
-        assert unchanged.extraction_profile_id == original.extraction_profile_id
-        assert unchanged.extraction_profile_id is None
-        assert unchanged.base_revision_id == original.base_revision_id
-        assert unchanged.parent_job_id == original.parent_job_id
+        assert requeued == [quantity_job.id]
+        assert quantity_recovered_job_ids == [str(quantity_job.id)]
+        assert ingest_recovered_job_ids == []
+        recovered = await _get_job(quantity_job.id)
+        assert recovered.status == "pending"
+        assert recovered.attempts == original.attempts
+        assert recovered.started_at is None
+        assert recovered.attempt_token is None
+        assert recovered.attempt_lease_expires_at is None
+        assert recovered.enqueue_status == "published"
+        assert recovered.enqueue_attempts == 1
+        assert recovered.project_id == original.project_id
+        assert recovered.file_id == original.file_id
+        assert recovered.job_type == original.job_type
+        assert recovered.extraction_profile_id == original.extraction_profile_id
+        assert recovered.extraction_profile_id is None
+        assert recovered.base_revision_id == original.base_revision_id
+        assert recovered.parent_job_id == original.parent_job_id
 
     async def test_process_ingest_job_skips_quantity_takeoff_jobs_without_mutation(
         self,
@@ -2899,6 +3131,779 @@ class TestJobs:
         assert unchanged.extraction_profile_id is None
         assert unchanged.base_revision_id == original.base_revision_id
         assert unchanged.parent_job_id == original.parent_job_id
+
+    @pytest.mark.parametrize(
+        ("review_state", "validation_status", "quantity_gate", "trusted_totals"),
+        [
+            ("approved", "valid", "allowed", True),
+            ("provisional", "valid", "allowed_provisional", False),
+        ],
+    )
+    async def test_process_quantity_takeoff_job_persists_expected_takeoff(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        review_state: str,
+        validation_status: str,
+        quantity_gate: str,
+        trusted_totals: bool,
+    ) -> None:
+        """Quantity worker should persist trusted outputs for allowed gates."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state=review_state,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
+        assert updated_job.finished_at is not None
+        assert len(takeoffs) == 1
+
+        takeoff = takeoffs[0]
+        assert takeoff.project_id == uuid.UUID(project["id"])
+        assert takeoff.source_file_id == uuid.UUID(uploaded["id"])
+        assert takeoff.drawing_revision_id == base_revision.id
+        assert takeoff.source_job_id == quantity_job.id
+        assert takeoff.review_state == review_state
+        assert takeoff.validation_status == validation_status
+        assert takeoff.quantity_gate == quantity_gate
+        assert takeoff.trusted_totals is trusted_totals
+
+        items = await _get_quantity_items_for_takeoff(takeoff.id)
+        assert len(items) == 4
+        assert {item.item_kind for item in items} == {"aggregate", "contributor"}
+        assert all(item.review_state == review_state for item in items)
+        assert all(item.validation_status == validation_status for item in items)
+        assert all(item.quantity_gate == quantity_gate for item in items)
+        assert sum(item.item_kind == "aggregate" for item in items) == 2
+        assert sum(item.item_kind == "contributor" for item in items) == 2
+        contributor_quantity_types = {
+            item.quantity_type for item in items if item.item_kind == "contributor"
+        }
+        aggregate_quantity_types = {
+            item.quantity_type for item in items if item.item_kind == "aggregate"
+        }
+        assert len(contributor_quantity_types) == 2
+        assert aggregate_quantity_types == contributor_quantity_types
+        assert all(":" in quantity_type for quantity_type in contributor_quantity_types)
+        assert all(item.source_entity_id is None for item in items if item.item_kind == "aggregate")
+        assert all(
+            item.source_entity_id is not None for item in items if item.item_kind == "contributor"
+        )
+
+    @pytest.mark.parametrize(
+        ("review_state", "validation_status", "quantity_gate"),
+        [
+            ("review_required", "needs_review", "review_gated"),
+            ("rejected", "invalid", "blocked"),
+        ],
+    )
+    async def test_process_quantity_takeoff_job_short_circuits_gate_before_materialization(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        review_state: str,
+        validation_status: str,
+        quantity_gate: str,
+    ) -> None:
+        """Gate failures should not require normalized entity materialization lookups."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_review_gated_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state=review_state,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+            )
+
+        async def _unexpected_manifest_lookup(*_: Any, **__: Any) -> None:
+            raise AssertionError("Quantity gate failures must short-circuit before materialization")
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_review_gated_ingestion)
+        _, _, _, _, quantity_job = await _create_ready_quantity_takeoff_job(async_client)
+        monkeypatch.setattr(
+            worker_module,
+            "_get_revision_entity_manifest_for_revision",
+            _unexpected_manifest_lookup,
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert (
+            updated_job.error_message
+            == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
+        )
+        assert takeoffs == []
+
+    @pytest.mark.parametrize(
+        ("review_state", "validation_status", "quantity_gate"),
+        [
+            ("review_required", "needs_review", "review_gated"),
+            ("rejected", "invalid", "blocked"),
+        ],
+    )
+    async def test_process_quantity_takeoff_job_fails_review_only_gate_without_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        review_state: str,
+        validation_status: str,
+        quantity_gate: str,
+    ) -> None:
+        """Quantity worker should fail terminally when validation gate blocks execution."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_review_gated_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state=review_state,
+                validation_status=validation_status,
+                quantity_gate=quantity_gate,
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_review_gated_ingestion)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.attempts == 1
+        assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert (
+            updated_job.error_message
+            == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
+        )
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["error_code"] == ErrorCode.INPUT_INVALID.value
+        assert (
+            event_payload["error_message"]
+            == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
+        )
+        assert event_payload["details"]["quantity_gate"] == quantity_gate
+
+    async def test_process_quantity_takeoff_job_fails_conflicts_without_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity worker should fail allowed jobs when dedup conflicts remain."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_conflicting_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            duplicate_hash = "a" * 64
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+                entities=[
+                    _build_fake_contract_entity(
+                        entity_id="entity-conflict-001",
+                        entity_type="line",
+                        layer_ref="A-WALL",
+                        source_id="entity-source-conflict-001",
+                        source_hash=duplicate_hash,
+                        properties_json={"label": "first"},
+                    ),
+                    _build_fake_contract_entity(
+                        entity_id="entity-conflict-002",
+                        entity_type="line",
+                        layer_ref="A-WALL",
+                        source_id="entity-source-conflict-002",
+                        source_hash=duplicate_hash,
+                        properties_json={"label": "second"},
+                    ),
+                ],
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_conflicting_ingestion)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.attempts == 1
+        assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert updated_job.error_message == worker_module._QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["error_code"] == ErrorCode.INPUT_INVALID.value
+        assert (
+            event_payload["error_message"]
+            == worker_module._QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE
+        )
+        assert event_payload["details"]["conflict_count"] == 2
+        conflict_summaries = event_payload["details"]["conflicts"]
+        assert len(conflict_summaries) == 2
+        assert all(
+            set(summary) == {"dedup_key", "entity_ids", "reason", "details"}
+            for summary in conflict_summaries
+        )
+        assert any(summary["dedup_key"] is not None for summary in conflict_summaries)
+        assert any(
+            {"entity-conflict-001", "entity-conflict-002"}.issubset(set(summary["entity_ids"]))
+            for summary in conflict_summaries
+        )
+        assert all(summary["reason"] is not None for summary in conflict_summaries)
+        assert all(summary["details"] is not None for summary in conflict_summaries)
+
+    async def test_process_quantity_takeoff_job_fails_missing_validation_report(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity worker should surface missing validation reports as NOT_FOUND."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        async def _missing_validation_report(*_: Any, **__: Any) -> None:
+            return None
+
+        monkeypatch.setattr(
+            worker_module,
+            "_get_validation_report_for_revision",
+            _missing_validation_report,
+        )
+
+        quantity_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            status="pending",
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.attempts == 1
+        assert updated_job.error_code == ErrorCode.NOT_FOUND.value
+        assert (
+            updated_job.error_message
+            == worker_module._QUANTITY_TAKEOFF_VALIDATION_REPORT_MISSING_ERROR_MESSAGE
+        )
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["error_code"] == ErrorCode.NOT_FOUND.value
+        assert (
+            event_payload["error_message"]
+            == worker_module._QUANTITY_TAKEOFF_VALIDATION_REPORT_MISSING_ERROR_MESSAGE
+        )
+        assert event_payload["details"]["drawing_revision_id"] == str(base_revision.id)
+
+    async def test_process_quantity_takeoff_job_fails_missing_materialization_without_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity worker should fail safely when revision materialization is missing."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        async def _missing_manifest(*_: Any, **__: Any) -> None:
+            return None
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+        _, _, _, base_revision, quantity_job = await _create_ready_quantity_takeoff_job(
+            async_client
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "_get_revision_entity_manifest_for_revision",
+            _missing_manifest,
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        assert (
+            updated_job.error_message
+            == worker_module._QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE
+        )
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["error_code"] == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        assert event_payload["details"]["drawing_revision_id"] == str(base_revision.id)
+
+    async def test_process_quantity_takeoff_job_fails_materialization_mismatch_without_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity worker should fail when manifest and entity rows disagree."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        async def _no_entities(*_: Any, **__: Any) -> list[Any]:
+            return []
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+        _, _, _, base_revision, quantity_job = await _create_ready_quantity_takeoff_job(
+            async_client
+        )
+        monkeypatch.setattr(worker_module, "_get_revision_entities_for_revision", _no_entities)
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["details"] == {
+            "drawing_revision_id": str(base_revision.id),
+            "expected_entities": 1,
+            "loaded_entities": 0,
+        }
+
+    async def test_process_quantity_takeoff_job_honors_cancel_before_finalization(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity finalization should re-check cancellation before publishing output."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        original_build_execution_input = worker_module._build_quantity_takeoff_execution_input
+
+        async def _cancel_after_input_load(
+            job_id: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+        ) -> Any:
+            execution = await original_build_execution_input(job_id, attempt_token=attempt_token)
+            await _update_job(job_id, cancel_requested=True)
+            return execution
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+        _, _, _, _, quantity_job = await _create_ready_quantity_takeoff_job(async_client)
+        monkeypatch.setattr(
+            worker_module,
+            "_build_quantity_takeoff_execution_input",
+            _cancel_after_input_load,
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.attempts == 1
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        assert response.json()["items"][-1]["data_json"] == {"status": "cancelled"}
+
+    @pytest.mark.parametrize("failure_mode", ["gate", "conflict"])
+    async def test_process_quantity_takeoff_job_prefers_cancelled_for_deterministic_failures(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        failure_mode: str,
+    ) -> None:
+        """Cancel requests should win over deterministic gate and conflict failures."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        if failure_mode == "gate":
+
+            async def _run_test_ingestion(
+                request: IngestionRunRequest,
+            ) -> IngestFinalizationPayload:
+                return _build_fake_quantity_ingest_payload(
+                    request,
+                    review_state="rejected",
+                    validation_status="invalid",
+                    quantity_gate="blocked",
+                )
+
+        else:
+
+            async def _run_test_ingestion(
+                request: IngestionRunRequest,
+            ) -> IngestFinalizationPayload:
+                duplicate_hash = "b" * 64
+                return _build_fake_quantity_ingest_payload(
+                    request,
+                    review_state="approved",
+                    validation_status="valid",
+                    quantity_gate="allowed",
+                    entities=[
+                        _build_fake_contract_entity(
+                            entity_id="entity-conflict-cancel-001",
+                            entity_type="line",
+                            layer_ref="A-WALL",
+                            source_id="entity-source-conflict-cancel-001",
+                            source_hash=duplicate_hash,
+                        ),
+                        _build_fake_contract_entity(
+                            entity_id="entity-conflict-cancel-002",
+                            entity_type="line",
+                            layer_ref="A-WALL",
+                            source_id="entity-source-conflict-cancel-002",
+                            source_hash=duplicate_hash,
+                        ),
+                    ],
+                )
+
+        original_build_execution_input = worker_module._build_quantity_takeoff_execution_input
+
+        async def _cancel_after_input_load(
+            job_id: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+        ) -> Any:
+            execution = await original_build_execution_input(job_id, attempt_token=attempt_token)
+            await _update_job(job_id, cancel_requested=True)
+            return execution
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_test_ingestion)
+        _, _, _, _, quantity_job = await _create_ready_quantity_takeoff_job(async_client)
+        monkeypatch.setattr(
+            worker_module,
+            "_build_quantity_takeoff_execution_input",
+            _cancel_after_input_load,
+        )
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.attempts == 1
+        assert updated_job.cancel_requested is True
+        assert updated_job.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated_job.error_message is None
+        assert takeoffs == []
+
+        response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response.status_code == 200
+        assert response.json()["items"][-1]["data_json"] == {"status": "cancelled"}
+
+    async def test_process_quantity_takeoff_job_terminal_redelivery_does_not_duplicate_takeoff(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A duplicate delivery after success should not create another takeoff."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+        _, _, _, _, quantity_job = await _create_ready_quantity_takeoff_job(async_client)
+
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+        response_before = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response_before.status_code == 200
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        response_after = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
+        assert response_after.status_code == 200
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1
+        assert len(takeoffs) == 1
+        assert response_after.json()["items"] == response_before.json()["items"]
+
+    async def test_process_quantity_takeoff_job_rolls_back_partial_rows_on_item_failure(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity takeoff and items should commit atomically with no partial rows."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        def _invalid_quantity_items(**kwargs: Any) -> list[QuantityItem]:
+            return [
+                QuantityItem(
+                    id=uuid.uuid4(),
+                    quantity_takeoff_id=kwargs["quantity_takeoff_id"],
+                    project_id=kwargs["project_id"],
+                    drawing_revision_id=kwargs["drawing_revision_id"],
+                    item_kind="contributor",
+                    quantity_type="length",
+                    value=-1.0,
+                    unit="m",
+                    review_state=kwargs["review_state"],
+                    validation_status=kwargs["validation_status"],
+                    quantity_gate=kwargs["quantity_gate"],
+                    source_entity_id="missing-entity",
+                    excluded_source_entity_ids_json=[],
+                )
+            ]
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+        _, _, _, _, quantity_job = await _create_ready_quantity_takeoff_job(async_client)
+        monkeypatch.setattr(worker_module, "_build_quantity_items", _invalid_quantity_items)
+
+        with pytest.raises(IntegrityError):
+            await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        updated_job = await _get_job(quantity_job.id)
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert takeoffs == []
+
+    async def test_quantity_takeoff_source_job_uniqueness_remains_enforced(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The DB should still reject duplicate takeoffs for one source job."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        async def _run_quantity_ready_ingestion(
+            request: IngestionRunRequest,
+        ) -> IngestFinalizationPayload:
+            return _build_fake_quantity_ingest_payload(
+                request,
+                review_state="approved",
+                validation_status="valid",
+                quantity_gate="allowed",
+            )
+
+        monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+        _, uploaded, _, base_revision, quantity_job = await _create_ready_quantity_takeoff_job(
+            async_client
+        )
+        await worker_module.process_quantity_takeoff_job(quantity_job.id)
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            session.add(
+                QuantityTakeoff(
+                    id=uuid.uuid4(),
+                    project_id=quantity_job.project_id,
+                    source_file_id=uuid.UUID(uploaded["id"]),
+                    drawing_revision_id=base_revision.id,
+                    source_job_id=quantity_job.id,
+                    source_job_type=JobType.QUANTITY_TAKEOFF.value,
+                    review_state="approved",
+                    validation_status="valid",
+                    quantity_gate="allowed",
+                    trusted_totals=True,
+                )
+            )
+            with pytest.raises(IntegrityError):
+                await session.commit()
+
+        takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+        assert len(takeoffs) == 1
 
     async def test_retry_job_succeeds_when_enqueue_claim_raises_after_commit(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -3204,13 +3204,18 @@ class TestJobs:
         assert takeoff.trusted_totals is trusted_totals
 
         items = await _get_quantity_items_for_takeoff(takeoff.id)
-        assert len(items) == 4
-        assert {item.item_kind for item in items} == {"aggregate", "contributor"}
+        assert len(items) == 5
+        assert {item.item_kind for item in items} == {
+            "aggregate",
+            "contributor",
+            "exclusion",
+        }
         assert all(item.review_state == review_state for item in items)
         assert all(item.validation_status == validation_status for item in items)
         assert all(item.quantity_gate == quantity_gate for item in items)
         assert sum(item.item_kind == "aggregate" for item in items) == 2
         assert sum(item.item_kind == "contributor" for item in items) == 2
+        assert sum(item.item_kind == "exclusion" for item in items) == 1
         contributor_quantity_types = {
             item.quantity_type for item in items if item.item_kind == "contributor"
         }
@@ -3222,8 +3227,11 @@ class TestJobs:
         assert all(":" in quantity_type for quantity_type in contributor_quantity_types)
         assert all(item.source_entity_id is None for item in items if item.item_kind == "aggregate")
         assert all(
-            item.source_entity_id is not None for item in items if item.item_kind == "contributor"
+            item.source_entity_id is not None
+            for item in items
+            if item.item_kind in {"contributor", "exclusion"}
         )
+        assert all(item.value is None for item in items if item.item_kind == "exclusion")
 
     @pytest.mark.parametrize(
         ("review_state", "validation_status", "quantity_gate"),
@@ -3557,7 +3565,10 @@ class TestJobs:
         updated_job = await _get_job(quantity_job.id)
         takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
         assert updated_job.status == "failed"
-        assert updated_job.error_code == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        assert (
+            updated_job.error_code
+            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        )
         assert (
             updated_job.error_message
             == worker_module._QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE
@@ -3568,7 +3579,10 @@ class TestJobs:
         assert response.status_code == 200
         event_payload = response.json()["items"][-1]["data_json"]
         assert event_payload["status"] == "failed"
-        assert event_payload["error_code"] == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        assert (
+            event_payload["error_code"]
+            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        )
         assert event_payload["details"]["drawing_revision_id"] == str(base_revision.id)
 
     async def test_process_quantity_takeoff_job_fails_materialization_mismatch_without_rows(
@@ -3607,12 +3621,19 @@ class TestJobs:
         updated_job = await _get_job(quantity_job.id)
         takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
         assert updated_job.status == "failed"
-        assert updated_job.error_code == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        assert (
+            updated_job.error_code
+            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        )
         assert takeoffs == []
 
         response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
         assert response.status_code == 200
         event_payload = response.json()["items"][-1]["data_json"]
+        assert (
+            event_payload["error_code"]
+            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
+        )
         assert event_payload["details"] == {
             "drawing_revision_id": str(base_revision.id),
             "expected_entities": 1,


### PR DESCRIPTION
Closes #185

## Summary
- add quantity takeoff job routing, retry, recovery, and worker execution on pinned revisions
- persist takeoff outputs atomically with gate, cancellation, duplicate-delivery, and conflict safeguards
- add quantity worker edge-case coverage and update architecture/TRD docs for provisional vs blocked behavior

## Test plan
- [x] uv run ruff check app/jobs/worker.py app/api/v1/jobs.py tests/test_jobs.py tests/test_quantity_takeoff_persistence.py
- [x] uv run mypy app/jobs/worker.py app/api/v1/jobs.py tests/test_jobs.py tests/test_quantity_takeoff_persistence.py
- [x] uv run pytest tests/test_jobs.py tests/test_quantity_takeoff_persistence.py