### PR TITLE
feat(api): add revision quantity takeoff endpoints

### DIFF
--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -4,13 +4,23 @@ import base64
 import binascii
 from datetime import datetime
 from typing import Annotated
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.idempotency import (
+    IdempotencyReplay,
+    IdempotencyReservation,
+    build_idempotency_fingerprint,
+    claim_idempotency,
+    get_idempotency_key,
+    mark_idempotency_completed,
+    replay_idempotency,
+)
 from app.api.pagination import (
     decode_cursor_payload,
     encode_cursor_payload,
@@ -19,11 +29,15 @@ from app.api.pagination import (
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
+from app.jobs.worker import enqueue_quantity_takeoff_job as _enqueue_quantity_takeoff_job
+from app.jobs.worker import prepare_job_enqueue_intent, publish_job_enqueue_intent
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
+from app.models.job import Job, JobType
 from app.models.project import Project
+from app.models.quantity_takeoff import QuantityGate, QuantityItem, QuantityTakeoff
 from app.models.revision_materialization import (
     RevisionBlock,
     RevisionEntity,
@@ -32,6 +46,13 @@ from app.models.revision_materialization import (
     RevisionLayout,
 )
 from app.models.validation_report import ValidationReport
+from app.schemas.job import JobRead
+from app.schemas.quantity_takeoff import (
+    QuantityItemListResponse,
+    QuantityItemRead,
+    QuantityTakeoffListResponse,
+    QuantityTakeoffRead,
+)
 from app.schemas.revision import (
     AdapterRunOutputRead,
     DrawingRevisionListResponse,
@@ -114,6 +135,30 @@ def _encode_materialization_cursor(sequence_index: int, row_id: UUID) -> str:
     )
 
 
+def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+
+    _enqueue_quantity_takeoff_job(job_id)
+
+
+def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
+    """Encode an opaque timestamp/id pagination cursor."""
+
+    return encode_cursor_payload({"created_at": created_at.isoformat(), "id": str(row_id)})
+
+
+def _decode_timestamp_cursor(cursor: str) -> tuple[datetime, UUID]:
+    """Decode a timestamp/id pagination cursor."""
+
+    try:
+        cursor_data = decode_cursor_payload(cursor)
+        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(
+            str(cursor_data["id"])
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
+
+
 def _decode_materialization_cursor(cursor: str) -> tuple[int, UUID]:
     """Decode a materialization cursor into typed values."""
 
@@ -158,10 +203,12 @@ async def _get_active_file(file_id: UUID, db: AsyncSession) -> File | None:
 async def _get_active_revision(
     revision_id: UUID,
     db: AsyncSession,
+    *,
+    for_update: bool = False,
 ) -> DrawingRevision | None:
     """Return an active revision visible through a non-deleted file and project."""
 
-    result = await db.execute(
+    query = (
         select(DrawingRevision)
         .join(
             File,
@@ -175,7 +222,57 @@ async def _get_active_revision(
             & (Project.deleted_at.is_(None))
         )
     )
+    if for_update:
+        query = query.with_for_update(
+            of=(DrawingRevision.__table__, File.__table__, Project.__table__)
+        )
+
+    result = await db.execute(query)
     return result.scalar_one_or_none()
+
+
+async def _get_active_validation_report(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> ValidationReport | None:
+    """Return the persisted validation report for an active revision, if present."""
+
+    result = await db.execute(
+        select(ValidationReport)
+        .join(
+            DrawingRevision,
+            DrawingRevision.id == ValidationReport.drawing_revision_id,
+        )
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (ValidationReport.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_active_validation_report_or_404(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> ValidationReport:
+    """Return an active revision validation report or raise not found."""
+
+    report = await _get_active_validation_report(revision_id, db)
+    if report is None:
+        revision = await _get_active_revision(revision_id, db)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+        raise_not_found("Validation report", str(revision_id))
+
+    assert report is not None
+    return report
 
 
 async def _get_revision_manifest(
@@ -216,6 +313,55 @@ def _manifest_counts(
     """Convert persisted manifest counts to the public schema."""
 
     return RevisionMaterializationCounts.model_validate(manifest.counts_json)
+
+
+def _raise_quantity_takeoff_gate_invalid(report: ValidationReport) -> None:
+    """Raise the standard pre-enqueue error for non-runnable quantity gates."""
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INPUT_INVALID,
+            message=(
+                "Quantity takeoff requires a revision with an allowed quantity gate."
+            ),
+            details={
+                "quantity_gate": report.quantity_gate,
+                "review_state": report.review_state,
+                "validation_status": report.validation_status,
+            },
+        ),
+    )
+
+
+async def _get_revision_quantity_takeoff_or_404(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: AsyncSession,
+) -> QuantityTakeoff:
+    """Return a committed quantity takeoff scoped to an active revision."""
+
+    result = await db.execute(
+        select(QuantityTakeoff)
+        .join(
+            File,
+            (File.id == QuantityTakeoff.source_file_id)
+            & (File.project_id == QuantityTakeoff.project_id),
+        )
+        .join(Project, Project.id == QuantityTakeoff.project_id)
+        .where(
+            (QuantityTakeoff.id == takeoff_id)
+            & (QuantityTakeoff.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    takeoff = result.scalar_one_or_none()
+    if takeoff is None:
+        raise_not_found("Quantity takeoff", str(takeoff_id))
+
+    assert takeoff is not None
+    return takeoff
 
 
 @revisions_router.get("/files/{file_id}/revisions", response_model=DrawingRevisionListResponse)
@@ -723,6 +869,245 @@ async def get_revision_entity(
 
 
 @revisions_router.get(
+    "/revisions/{revision_id}/quantity-takeoffs",
+    response_model=QuantityTakeoffListResponse,
+)
+async def list_revision_quantity_takeoffs(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> QuantityTakeoffListResponse:
+    """List committed quantity takeoffs for an active drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
+    query = (
+        select(QuantityTakeoff)
+        .join(
+            File,
+            (File.id == QuantityTakeoff.source_file_id)
+            & (File.project_id == QuantityTakeoff.project_id),
+        )
+        .join(Project, Project.id == QuantityTakeoff.project_id)
+        .where(
+            (QuantityTakeoff.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        created_at, row_id = pagination_cursor
+        query = query.where(
+            (QuantityTakeoff.created_at > created_at)
+            | ((QuantityTakeoff.created_at == created_at) & (QuantityTakeoff.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(QuantityTakeoff.created_at.asc(), QuantityTakeoff.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
+
+    return QuantityTakeoffListResponse(
+        items=[QuantityTakeoffRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@revisions_router.get(
+    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}",
+    response_model=QuantityTakeoffRead,
+)
+async def get_revision_quantity_takeoff(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> QuantityTakeoffRead:
+    """Return a committed quantity takeoff for an active drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    return QuantityTakeoffRead.model_validate(takeoff)
+
+
+@revisions_router.get(
+    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/items",
+    response_model=QuantityItemListResponse,
+)
+async def list_revision_quantity_takeoff_items(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> QuantityItemListResponse:
+    """List committed quantity items for a revision-scoped takeoff."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
+    query = (
+        select(QuantityItem)
+        .join(
+            QuantityTakeoff,
+            (QuantityTakeoff.id == QuantityItem.quantity_takeoff_id)
+            & (QuantityTakeoff.project_id == QuantityItem.project_id)
+            & (QuantityTakeoff.drawing_revision_id == QuantityItem.drawing_revision_id)
+            & (QuantityTakeoff.quantity_gate == QuantityItem.quantity_gate),
+        )
+        .join(
+            File,
+            (File.id == QuantityTakeoff.source_file_id)
+            & (File.project_id == QuantityTakeoff.project_id),
+        )
+        .join(Project, Project.id == QuantityTakeoff.project_id)
+        .where(
+            (QuantityItem.quantity_takeoff_id == takeoff_id)
+            & (QuantityItem.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        created_at, row_id = pagination_cursor
+        query = query.where(
+            (QuantityItem.created_at > created_at)
+            | ((QuantityItem.created_at == created_at) & (QuantityItem.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
+
+    return QuantityItemListResponse(
+        items=[QuantityItemRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@revisions_router.post(
+    "/revisions/{revision_id}/quantity-takeoffs",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_revision_quantity_takeoff(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> Job | Response:
+    """Create a pending quantity takeoff job for an active drawing revision."""
+
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = build_idempotency_fingerprint(
+            f"revisions.quantity_takeoffs:{revision_id}",
+            {"revision_id": str(revision_id)},
+        )
+        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        if replay is not None:
+            return replay.response
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
+    await _get_active_revision_manifest_or_409(revision_id, db)
+    report = await _get_active_validation_report_or_404(revision_id, db)
+    if report.quantity_gate in {
+        QuantityGate.REVIEW_GATED.value,
+        QuantityGate.BLOCKED.value,
+    }:
+        _raise_quantity_takeoff_gate_invalid(report)
+
+    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
+    if locked_revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    revision = locked_revision
+    assert revision is not None
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await claim_idempotency(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path=f"/revisions/{revision_id}/quantity-takeoffs",
+        )
+        if isinstance(claim, IdempotencyReplay):
+            return claim.response
+        reservation = claim
+
+    quantity_job = Job(
+        id=uuid4(),
+        project_id=revision.project_id,
+        file_id=revision.source_file_id,
+        extraction_profile_id=None,
+        base_revision_id=revision.id,
+        parent_job_id=None,
+        job_type=JobType.QUANTITY_TAKEOFF.value,
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        enqueue_status="pending",
+        enqueue_attempts=0,
+        cancel_requested=False,
+        error_code=None,
+        error_message=None,
+        started_at=None,
+        finished_at=None,
+    )
+    db.add(quantity_job)
+    prepare_job_enqueue_intent(quantity_job)
+    await db.flush()
+    await db.refresh(quantity_job)
+
+    success_body: dict[str, object] | None = None
+    if reservation is not None:
+        success_body = JobRead.model_validate(quantity_job).model_dump(mode="json")
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status.HTTP_202_ACCEPTED,
+            response_body=success_body,
+        )
+
+    await db.commit()
+    await publish_job_enqueue_intent(
+        quantity_job.id,
+        publisher=enqueue_quantity_takeoff_job,
+        suppress_exceptions=True,
+    )
+
+    if reservation is not None:
+        assert success_body is not None
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
+
+    return quantity_job
+
+
+@revisions_router.get(
     "/revisions/{revision_id}/validation-report",
     response_model=ValidationReportResponse,
 )
@@ -731,45 +1116,5 @@ async def get_validation_report(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ValidationReportResponse:
     """Return the persisted canonical validation report for a drawing revision."""
-    result = await db.execute(
-        select(ValidationReport)
-        .join(
-            DrawingRevision,
-            DrawingRevision.id == ValidationReport.drawing_revision_id,
-        )
-        .join(
-            File,
-            (File.id == DrawingRevision.source_file_id)
-            & (File.project_id == DrawingRevision.project_id),
-        )
-        .join(Project, Project.id == DrawingRevision.project_id)
-        .where(
-            (ValidationReport.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    report = result.scalar_one_or_none()
-    if report is None:
-        revision_result = await db.execute(
-            select(DrawingRevision)
-            .join(
-                File,
-                (File.id == DrawingRevision.source_file_id)
-                & (File.project_id == DrawingRevision.project_id),
-            )
-            .join(Project, Project.id == DrawingRevision.project_id)
-            .where(
-                (DrawingRevision.id == revision_id)
-                & (File.deleted_at.is_(None))
-                & (Project.deleted_at.is_(None))
-            )
-        )
-        revision = revision_result.scalar_one_or_none()
-        if revision is None:
-            raise_not_found("Drawing revision", str(revision_id))
-        raise_not_found("Validation report", str(revision_id))
-
-    assert report is not None
-
+    report = await _get_active_validation_report_or_404(revision_id, db)
     return build_validation_report_response(report)

--- a/app/schemas/quantity_takeoff.py
+++ b/app/schemas/quantity_takeoff.py
@@ -1,0 +1,63 @@
+"""Quantity takeoff API schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class QuantityTakeoffRead(BaseModel):
+    """Committed quantity takeoff payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    project_id: UUID
+    source_file_id: UUID
+    drawing_revision_id: UUID
+    source_job_id: UUID
+    source_job_type: str
+    review_state: str
+    validation_status: str
+    quantity_gate: str
+    trusted_totals: bool
+    created_at: datetime
+
+
+class QuantityTakeoffListResponse(BaseModel):
+    """Cursor-paginated committed takeoff page."""
+
+    items: list[QuantityTakeoffRead]
+    next_cursor: str | None = None
+
+
+class QuantityItemRead(BaseModel):
+    """Committed quantity item payload."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: UUID
+    quantity_takeoff_id: UUID
+    project_id: UUID
+    drawing_revision_id: UUID
+    item_kind: str
+    quantity_type: str
+    value: float | None
+    unit: str
+    review_state: str
+    validation_status: str
+    quantity_gate: str
+    source_entity_id: str | None
+    excluded_source_entity_ids: list[str] = Field(
+        validation_alias="excluded_source_entity_ids_json"
+    )
+    created_at: datetime
+
+
+class QuantityItemListResponse(BaseModel):
+    """Cursor-paginated committed quantity item page."""
+
+    items: list[QuantityItemRead]
+    next_cursor: str | None = None

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -213,6 +213,11 @@ instead of updating an earlier takeoff in place. Each persisted takeoff is tied
 to one unique `source_job_id`, and that source job must remain constrained to
 the same project, file, `base_revision_id`, and `quantity_takeoff` job type.
 
+The API now exposes explicit revision-scoped create/read surfaces for this
+persisted quantity data: clients may trigger `quantity_takeoff` for one pinned
+revision and later list/read the resulting takeoff headers and item rows. This
+remains an explicit API action in MVP rather than an automatic downstream chain.
+
 Revisions marked `review_required`, `rejected`, or `superseded` are not eligible
 for quantity generation.
 
@@ -403,9 +408,9 @@ mutable file head.
 
 For MVP every step is triggered explicitly via API. A later iteration may add an
 auto-chain configuration on the project that fires the next step on success.
-Quantity worker execution exists for this DAG and persisted lineage model, while
-manual/API creation and read surfaces for quantity takeoffs remain separate
-deferred work.
+Quantity takeoff creation and readback are available as explicit revision-scoped
+API surfaces layered on top of the same worker execution and persisted lineage
+model.
 
 Workers must:
 

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -599,6 +599,104 @@ Additional gate rules:
   entities/findings caused the block, but they must not publish trusted quantity
   totals.
 
+#### Revision-Scoped Quantity Takeoff Endpoints
+
+- `POST /v1/revisions/{revision_id}/quantity-takeoffs`
+- `GET /v1/revisions/{revision_id}/quantity-takeoffs`
+- `GET /v1/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}`
+- `GET /v1/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/items`
+
+These endpoints expose explicit API-triggered quantity takeoff creation and
+readback for one pinned drawing revision. They do not imply automatic chaining
+from ingestion or validation.
+
+Create behavior:
+
+- `POST /v1/revisions/{revision_id}/quantity-takeoffs` enqueues a
+  revision-scoped quantity-takeoff job and returns `202 Accepted` with a
+  `JobRead` response.
+- Create idempotency is keyed by `Idempotency-Key`. Replaying the same key for
+  the same effective request fingerprint returns the original `JobRead`
+  response and prevents duplicate jobs from being created.
+- The endpoint does not search for an existing completed takeoff when no
+  `Idempotency-Key` is supplied.
+- The persisted takeoff remains append-only once finalized. A materially changed
+  request or rerun outside the same idempotent replay case produces a new
+  takeoff/result set rather than mutating an older one.
+
+List/read behavior:
+
+- Cursor pagination follows the global API convention: `?cursor=` and `?limit=`
+  returning `{ items, next_cursor }`, default limit 50, max 200.
+- `GET /v1/revisions/{revision_id}/quantity-takeoffs` lists persisted takeoffs
+  for that exact revision.
+- `GET /v1/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}` returns the
+  takeoff header/summary record for one persisted takeoff.
+- `GET /v1/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/items`
+  returns the paginated item rows for that takeoff using the same
+  `{ items, next_cursor }` envelope.
+
+Minimum takeoff header shape:
+
+```text
+{
+  id,
+  project_id,
+  source_file_id,
+  drawing_revision_id,
+  source_job_id,
+  source_job_type,
+  review_state,
+  validation_status,
+  quantity_gate,
+  trusted_totals,
+  created_at
+}
+```
+
+Minimum takeoff item shape:
+
+```text
+{
+  id,
+  quantity_takeoff_id,
+  project_id,
+  drawing_revision_id,
+  item_kind,
+  quantity_type,
+  value,
+  unit,
+  review_state,
+  validation_status,
+  quantity_gate,
+  source_entity_id,
+  excluded_source_entity_ids,
+  created_at
+}
+```
+
+HTTP/status semantics:
+
+- `200` - list/read succeeded
+- `202` - create accepted a new explicit quantity-takeoff request, or replayed
+  the original idempotent `JobRead` response
+- `404` with `NOT_FOUND` - revision or takeoff does not exist in scope
+- `400` with `INPUT_INVALID` - revision exists but is not eligible for enqueue
+  because `quantity_gate` is `review_gated` or `blocked`; details include
+  `quantity_gate`, `review_state`, and `validation_status`
+
+Gate semantics:
+
+- `review_gated` revisions are not eligible for a trusted takeoff create. The
+  API rejects the create before enqueue with `400 INPUT_INVALID` and details
+  including `quantity_gate`, `review_state`, and `validation_status`.
+- `blocked` revisions are not eligible for quantity generation at all.
+  The API rejects the create before enqueue with `400 INPUT_INVALID` and
+  details including `quantity_gate`, `review_state`, and
+  `validation_status`.
+- `allowed_provisional` takeoffs may be created, listed, and read, but their
+  provisional status must remain explicit in the returned takeoff/item data.
+
 ## Estimation Engine
 
 The estimation engine must be deterministic and auditable.

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -1,0 +1,930 @@
+"""API tests for revision quantity takeoff routes."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.idempotency import IdempotencyReplay, IdempotencyReservation
+from app.api.v1 import revisions as revisions_module
+from app.api.v1.revisions import revisions_router
+from app.db import session as session_module
+from app.db.session import get_db
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.drawing_revision import DrawingRevision
+from app.models.extraction_profile import ExtractionProfile
+from app.models.file import File
+from app.models.job import Job, JobType
+from app.models.project import Project
+from app.models.quantity_takeoff import (
+    QuantityGate,
+    QuantityItem,
+    QuantityItemKind,
+    QuantityTakeoff,
+)
+from tests.conftest import requires_database
+
+
+class _ScalarResultStub:
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def scalars(self) -> _ScalarResultStub:
+        return self
+
+    def all(self) -> list[Any]:
+        if isinstance(self._value, list):
+            return self._value
+        raise AssertionError("Expected list result")
+
+    def scalar_one_or_none(self) -> Any:
+        return self._value
+
+
+class _AsyncSessionStub:
+    def __init__(self, *, execute_results: list[Any] | None = None) -> None:
+        self._execute_results: deque[Any] = deque(execute_results or [])
+        self.added: list[Any] = []
+        self.commits = 0
+
+    async def execute(self, _statement: Any) -> _ScalarResultStub:
+        if not self._execute_results:
+            raise AssertionError("Unexpected execute call")
+        return _ScalarResultStub(self._execute_results.popleft())
+
+    def add(self, value: Any) -> None:
+        self.added.append(value)
+
+    async def flush(self) -> None:
+        return None
+
+    async def refresh(self, value: Any) -> None:
+        if getattr(value, "created_at", None) is None:
+            value.created_at = datetime.now(UTC)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+@dataclass(slots=True)
+class _QuantityLineageSeed:
+    project_id: UUID
+    file_id: UUID
+    revision_id: UUID
+    takeoff_id: UUID
+
+
+def _build_app(session: _AsyncSessionStub) -> FastAPI:
+    app = FastAPI()
+    app.include_router(revisions_router, prefix="/v1")
+
+    async def override_db() -> AsyncIterator[AsyncSession]:
+        yield session  # type: ignore[misc]
+
+    app.dependency_overrides[get_db] = override_db
+    return app
+
+
+def _build_revision(*, revision_id: UUID | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=revision_id or uuid4(),
+        project_id=uuid4(),
+        source_file_id=uuid4(),
+    )
+
+
+def _build_validation_report(*, quantity_gate: str = QuantityGate.ALLOWED.value) -> SimpleNamespace:
+    return SimpleNamespace(
+        quantity_gate=quantity_gate,
+        review_state="approved",
+        validation_status="valid",
+    )
+
+
+async def _seed_quantity_lineage() -> _QuantityLineageSeed:
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    project_id = uuid4()
+    file_id = uuid4()
+    profile_id = uuid4()
+    ingest_job_id = uuid4()
+    adapter_output_id = uuid4()
+    revision_id = uuid4()
+    quantity_job_id = uuid4()
+    takeoff_id = uuid4()
+
+    async with session_factory() as db:
+        project = Project(id=project_id, name="Quantity visibility test")
+        file = File(
+            id=file_id,
+            project_id=project_id,
+            original_filename="plan.pdf",
+            media_type="application/pdf",
+            detected_format="pdf",
+            storage_uri=f"file:///tmp/{file_id}.pdf",
+            size_bytes=128,
+            checksum_sha256="0" * 64,
+            immutable=True,
+            initial_job_id=None,
+            initial_extraction_profile_id=None,
+        )
+        profile = ExtractionProfile(
+            id=profile_id,
+            project_id=project_id,
+            profile_version="1",
+            layout_mode="model_space",
+            xref_handling="bind",
+            block_handling="keep",
+            text_extraction=True,
+            dimension_extraction=True,
+            pdf_page_range=None,
+            raster_calibration=None,
+            confidence_threshold=0.6,
+        )
+        ingest_job = Job(
+            id=ingest_job_id,
+            project_id=project_id,
+            file_id=file_id,
+            extraction_profile_id=profile_id,
+            base_revision_id=None,
+            parent_job_id=None,
+            job_type=JobType.INGEST.value,
+            status="succeeded",
+            attempts=1,
+            max_attempts=3,
+            enqueue_status="published",
+            enqueue_attempts=1,
+            cancel_requested=False,
+            error_code=None,
+            error_message=None,
+            started_at=None,
+            finished_at=None,
+        )
+        adapter_output = AdapterRunOutput(
+            id=adapter_output_id,
+            project_id=project_id,
+            source_file_id=file_id,
+            extraction_profile_id=profile_id,
+            source_job_id=ingest_job_id,
+            adapter_key="test-adapter",
+            adapter_version="1.0.0",
+            input_family="pdf_vector",
+            canonical_entity_schema_version="1.0.0",
+            canonical_json={},
+            provenance_json={},
+            confidence_json={},
+            confidence_score=1.0,
+            warnings_json=[],
+            diagnostics_json={},
+            result_checksum_sha256="1" * 64,
+        )
+        revision = DrawingRevision(
+            id=revision_id,
+            project_id=project_id,
+            source_file_id=file_id,
+            extraction_profile_id=profile_id,
+            source_job_id=ingest_job_id,
+            adapter_run_output_id=adapter_output_id,
+            predecessor_revision_id=None,
+            revision_sequence=1,
+            revision_kind="ingest",
+            review_state="approved",
+            canonical_entity_schema_version="1.0.0",
+            confidence_score=1.0,
+        )
+        quantity_job = Job(
+            id=quantity_job_id,
+            project_id=project_id,
+            file_id=file_id,
+            extraction_profile_id=None,
+            base_revision_id=revision_id,
+            parent_job_id=None,
+            job_type=JobType.QUANTITY_TAKEOFF.value,
+            status="succeeded",
+            attempts=1,
+            max_attempts=3,
+            enqueue_status="published",
+            enqueue_attempts=1,
+            cancel_requested=False,
+            error_code=None,
+            error_message=None,
+            started_at=None,
+            finished_at=None,
+        )
+        takeoff = QuantityTakeoff(
+            id=takeoff_id,
+            project_id=project_id,
+            source_file_id=file_id,
+            drawing_revision_id=revision_id,
+            source_job_id=quantity_job_id,
+            source_job_type=JobType.QUANTITY_TAKEOFF.value,
+            review_state="approved",
+            validation_status="valid",
+            quantity_gate=QuantityGate.ALLOWED.value,
+            trusted_totals=True,
+        )
+        item = QuantityItem(
+            quantity_takeoff_id=takeoff_id,
+            project_id=project_id,
+            drawing_revision_id=revision_id,
+            item_kind=QuantityItemKind.AGGREGATE.value,
+            quantity_type="area",
+            value=42.0,
+            unit="sq_ft",
+            review_state="approved",
+            validation_status="valid",
+            quantity_gate=QuantityGate.ALLOWED.value,
+            source_entity_id=None,
+            excluded_source_entity_ids_json=[],
+        )
+
+        db.add(project)
+        await db.commit()
+
+        db.add(file)
+        db.add(profile)
+        await db.commit()
+
+        db.add(ingest_job)
+        await db.commit()
+
+        db.add(adapter_output)
+        await db.commit()
+
+        db.add(revision)
+        await db.commit()
+
+        db.add(quantity_job)
+        await db.commit()
+
+        db.add(takeoff)
+        await db.commit()
+
+        db.add(item)
+        await db.commit()
+
+    return _QuantityLineageSeed(
+        project_id=project_id,
+        file_id=file_id,
+        revision_id=revision_id,
+        takeoff_id=takeoff_id,
+    )
+
+
+async def _soft_delete_lineage(seed: _QuantityLineageSeed, *, target: str) -> None:
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    async with session_factory() as db:
+        if target == "file":
+            file = await db.get(File, seed.file_id)
+            assert file is not None
+            file.deleted_at = datetime.now(UTC)
+        else:
+            project = await db.get(Project, seed.project_id)
+            assert project is not None
+            project.deleted_at = datetime.now(UTC)
+        await db.commit()
+
+
+def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    manifest = SimpleNamespace(id=uuid4())
+    idempotency_state: dict[str, dict[str, Any]] = {}
+    enqueued_job_ids: list[UUID] = []
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_manifest(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace | None:
+        _ = db
+        return manifest if revision_id == revision.id else None
+
+    async def fake_get_validation_report(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id:
+            raise AssertionError("Unexpected revision lookup")
+        return _build_validation_report()
+
+    async def fake_replay_idempotency(
+        db: AsyncSession,
+        *,
+        key: str,
+        fingerprint: str,
+    ) -> IdempotencyReplay | None:
+        _ = db
+        record = idempotency_state.get(key)
+        if record is None or record["fingerprint"] != fingerprint or not record["completed"]:
+            return None
+        return IdempotencyReplay(
+            response=JSONResponse(
+                status_code=record["status_code"],
+                content=record["response_body"],
+            )
+        )
+
+    async def fake_claim_idempotency(
+        db: AsyncSession,
+        *,
+        key: str,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation:
+        _ = (db, method, path)
+        record = idempotency_state.get(key)
+        if record is None:
+            record = {
+                "fingerprint": fingerprint,
+                "completed": False,
+            }
+            idempotency_state[key] = record
+        return IdempotencyReservation(record_id=uuid4())
+
+    async def fake_mark_idempotency_completed(
+        db: AsyncSession,
+        reservation: IdempotencyReservation,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> None:
+        _ = (db, reservation)
+        idempotency_state["quantity-1"].update(
+            completed=True,
+            status_code=status_code,
+            response_body=response_body,
+        )
+
+    def fake_prepare_job_enqueue_intent(job: Any) -> None:
+        _ = job
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = suppress_exceptions
+        assert publisher is revisions_module.enqueue_quantity_takeoff_job
+        publisher(job_id)
+
+    def fake_enqueue_quantity_takeoff_job(job_id: UUID) -> None:
+        enqueued_job_ids.append(job_id)
+
+    def fail_enqueue_ingest_job(job_id: UUID) -> None:
+        raise AssertionError(f"unexpected ingest enqueue for {job_id}")
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(revisions_module, "_get_revision_manifest", fake_get_revision_manifest)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_active_validation_report_or_404",
+        fake_get_validation_report,
+    )
+    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
+    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
+    monkeypatch.setattr(
+        revisions_module,
+        "mark_idempotency_completed",
+        fake_mark_idempotency_completed,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "prepare_job_enqueue_intent",
+        fake_prepare_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_enqueue_quantity_takeoff_job",
+        fake_enqueue_quantity_takeoff_job,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_enqueue_ingest_job",
+        fail_enqueue_ingest_job,
+        raising=False,
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs",
+        headers={"Idempotency-Key": "quantity-1"},
+    )
+
+    assert response.status_code == 202
+    first_body = response.json()
+    assert first_body["job_type"] == "quantity_takeoff"
+    assert first_body["base_revision_id"] == str(revision.id)
+    assert len(session.added) == 1
+    assert enqueued_job_ids == [UUID(first_body["id"])]
+
+    replay_response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs",
+        headers={"Idempotency-Key": "quantity-1"},
+    )
+
+    assert replay_response.status_code == 202
+    assert replay_response.json() == first_body
+    assert len(session.added) == 1
+
+
+def test_list_and_get_revision_quantity_takeoffs(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    created_at = datetime(2026, 5, 16, tzinfo=UTC)
+    first_takeoff = SimpleNamespace(
+        id=uuid4(),
+        project_id=revision.project_id,
+        source_file_id=revision.source_file_id,
+        drawing_revision_id=revision.id,
+        source_job_id=uuid4(),
+        source_job_type="quantity_takeoff",
+        review_state="approved",
+        validation_status="valid",
+        quantity_gate="allowed",
+        trusted_totals=True,
+        created_at=created_at,
+    )
+    second_takeoff = SimpleNamespace(
+        id=uuid4(),
+        project_id=revision.project_id,
+        source_file_id=revision.source_file_id,
+        drawing_revision_id=revision.id,
+        source_job_id=uuid4(),
+        source_job_type="quantity_takeoff",
+        review_state="provisional",
+        validation_status="valid_with_warnings",
+        quantity_gate="allowed_provisional",
+        trusted_totals=False,
+        created_at=created_at.replace(second=1),
+    )
+    session = _AsyncSessionStub(execute_results=[[first_takeoff, second_takeoff], first_takeoff])
+    app = _build_app(session)
+    client = TestClient(app)
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    list_response = client.get(f"/v1/revisions/{revision.id}/quantity-takeoffs?limit=1")
+
+    assert list_response.status_code == 200
+    list_body = list_response.json()
+    assert [item["id"] for item in list_body["items"]] == [str(first_takeoff.id)]
+    assert list_body["next_cursor"] is not None
+
+    read_response = client.get(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{first_takeoff.id}"
+    )
+
+    assert read_response.status_code == 200
+    assert read_response.json()["id"] == str(first_takeoff.id)
+
+
+def test_list_revision_quantity_takeoff_items(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    takeoff = SimpleNamespace(id=uuid4())
+    created_at = datetime(2026, 5, 16, tzinfo=UTC)
+    first_item = SimpleNamespace(
+        id=uuid4(),
+        quantity_takeoff_id=takeoff.id,
+        project_id=revision.project_id,
+        drawing_revision_id=revision.id,
+        item_kind="aggregate",
+        quantity_type="area",
+        value=120.5,
+        unit="sq_ft",
+        review_state="approved",
+        validation_status="valid",
+        quantity_gate="allowed",
+        source_entity_id=None,
+        excluded_source_entity_ids_json=[],
+        created_at=created_at,
+    )
+    second_item = SimpleNamespace(
+        id=uuid4(),
+        quantity_takeoff_id=takeoff.id,
+        project_id=revision.project_id,
+        drawing_revision_id=revision.id,
+        item_kind="contributor",
+        quantity_type="area",
+        value=20.0,
+        unit="sq_ft",
+        review_state="approved",
+        validation_status="valid",
+        quantity_gate="allowed",
+        source_entity_id="entity-1",
+        excluded_source_entity_ids_json=["entity-2"],
+        created_at=created_at.replace(second=1),
+    )
+    session = _AsyncSessionStub(execute_results=[takeoff, [first_item, second_item]])
+    app = _build_app(session)
+    client = TestClient(app)
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    response = client.get(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/items?limit=1"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"][0]["id"] == str(first_item.id)
+    assert body["items"][0]["excluded_source_entity_ids"] == []
+    assert body["next_cursor"] is not None
+    assert session.commits == 0
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("soft_delete_target", ["file", "project"])
+@requires_database
+async def test_list_revision_quantity_takeoffs_hides_soft_deleted_lineage_after_stale_check(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+    soft_delete_target: str,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    await _soft_delete_lineage(seed, target=soft_delete_target)
+    stale_revision = _build_revision(revision_id=seed.revision_id)
+    stale_revision.project_id = seed.project_id
+    stale_revision.source_file_id = seed.file_id
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return stale_revision if revision_id == seed.revision_id else None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    response = await async_client.get(f"/v1/revisions/{seed.revision_id}/quantity-takeoffs")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "next_cursor": None}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("soft_delete_target", ["file", "project"])
+@requires_database
+async def test_get_revision_quantity_takeoff_hides_soft_deleted_lineage_after_stale_check(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+    soft_delete_target: str,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    await _soft_delete_lineage(seed, target=soft_delete_target)
+    stale_revision = _build_revision(revision_id=seed.revision_id)
+    stale_revision.project_id = seed.project_id
+    stale_revision.source_file_id = seed.file_id
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return stale_revision if revision_id == seed.revision_id else None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    response = await async_client.get(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}"
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("soft_delete_target", ["file", "project"])
+@requires_database
+async def test_list_revision_quantity_takeoff_items_hides_soft_deleted_lineage_after_stale_checks(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+    soft_delete_target: str,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    await _soft_delete_lineage(seed, target=soft_delete_target)
+    stale_revision = _build_revision(revision_id=seed.revision_id)
+    stale_revision.project_id = seed.project_id
+    stale_revision.source_file_id = seed.file_id
+    stale_takeoff = SimpleNamespace(id=seed.takeoff_id)
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return stale_revision if revision_id == seed.revision_id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        assert revision_id == seed.revision_id
+        assert takeoff_id == seed.takeoff_id
+        return stale_takeoff
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+
+    response = await async_client.get(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}/items"
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "next_cursor": None}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("soft_delete_target", ["file", "project"])
+@requires_database
+async def test_create_revision_quantity_takeoff_rechecks_locked_lineage_before_insert(
+    async_client: AsyncClient,
+    enqueued_job_ids: list[UUID],
+    monkeypatch: Any,
+    soft_delete_target: str,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    await _soft_delete_lineage(seed, target=soft_delete_target)
+    stale_revision = _build_revision(revision_id=seed.revision_id)
+    stale_revision.project_id = seed.project_id
+    stale_revision.source_file_id = seed.file_id
+    original_get_active_revision = revisions_module._get_active_revision
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> Any:
+        if revision_id != seed.revision_id:
+            return None
+        if for_update:
+            return await original_get_active_revision(revision_id, db, for_update=True)
+        return stale_revision
+
+    async def fake_get_active_revision_manifest_or_409(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        assert revision_id == seed.revision_id
+        return SimpleNamespace(id=uuid4())
+
+    async def fake_get_active_validation_report_or_404(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        assert revision_id == seed.revision_id
+        return _build_validation_report()
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_active_revision_manifest_or_409",
+        fake_get_active_revision_manifest_or_409,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_active_validation_report_or_404",
+        fake_get_active_validation_report_or_404,
+    )
+
+    response = await async_client.post(f"/v1/revisions/{seed.revision_id}/quantity-takeoffs")
+
+    assert response.status_code == 404
+    assert enqueued_job_ids == []
+
+
+@pytest.mark.parametrize(
+    "quantity_gate",
+    [QuantityGate.REVIEW_GATED.value, QuantityGate.BLOCKED.value],
+)
+def test_create_revision_quantity_takeoff_rejects_review_gated_or_blocked(
+    monkeypatch: Any,
+    quantity_gate: str,
+) -> None:
+    revision = _build_revision()
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    manifest = SimpleNamespace(id=uuid4())
+    enqueue_calls: list[UUID] = []
+    publish_calls: list[UUID] = []
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_manifest(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace | None:
+        _ = db
+        return manifest if revision_id == revision.id else None
+
+    async def fake_get_validation_report(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id:
+            raise AssertionError("Unexpected revision lookup")
+        return _build_validation_report(quantity_gate=quantity_gate)
+
+    def fake_prepare_job_enqueue_intent(job: Any) -> None:
+        raise AssertionError(f"unexpected prepare for {job.id}")
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    def fake_enqueue_quantity_takeoff_job(job_id: UUID) -> None:
+        enqueue_calls.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(revisions_module, "_get_revision_manifest", fake_get_revision_manifest)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_active_validation_report_or_404",
+        fake_get_validation_report,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "prepare_job_enqueue_intent",
+        fake_prepare_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "enqueue_quantity_takeoff_job",
+        fake_enqueue_quantity_takeoff_job,
+    )
+
+    response = client.post(f"/v1/revisions/{revision.id}/quantity-takeoffs")
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert session.added == []
+    assert session.commits == 0
+    assert publish_calls == []
+    assert enqueue_calls == []
+
+
+def test_revision_quantity_takeoff_routes_return_404_for_unknown_revision(
+    monkeypatch: Any,
+) -> None:
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    unknown_revision_id = uuid4()
+    unknown_takeoff_id = uuid4()
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (revision_id, db, for_update)
+        return None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    create_response = client.post(f"/v1/revisions/{unknown_revision_id}/quantity-takeoffs")
+    list_response = client.get(f"/v1/revisions/{unknown_revision_id}/quantity-takeoffs")
+    read_response = client.get(
+        f"/v1/revisions/{unknown_revision_id}/quantity-takeoffs/{unknown_takeoff_id}"
+    )
+    items_response = client.get(
+        f"/v1/revisions/{unknown_revision_id}/quantity-takeoffs/{unknown_takeoff_id}/items"
+    )
+
+    for response in (create_response, list_response, read_response, items_response):
+        assert response.status_code == 404
+
+
+def test_list_revision_quantity_takeoffs_rejects_invalid_cursor(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    response = client.get(f"/v1/revisions/{revision.id}/quantity-takeoffs?cursor=not-base64")
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INVALID_CURSOR"
+
+
+def test_list_revision_quantity_takeoff_items_rejects_invalid_cursor(
+    monkeypatch: Any,
+) -> None:
+    revision = _build_revision()
+    takeoff = SimpleNamespace(id=uuid4())
+    session = _AsyncSessionStub(execute_results=[takeoff])
+    app = _build_app(session)
+    client = TestClient(app)
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+
+    response = client.get(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/items?cursor=not-base64"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INVALID_CURSOR"


### PR DESCRIPTION
Closes #186

## Summary
- expose explicit revision-scoped quantity takeoff APIs so clients can request and inspect Phase 6 outputs instead of relying on internal worker behavior
- reject review-gated or blocked revisions before enqueue so the API returns clear contract-level errors rather than creating unusable jobs
- document the new API contract and add coverage for idempotency, pagination, visibility, and soft-delete lineage behavior

## Test plan
- [x] `uv run ruff check app/api/v1/revisions.py app/schemas/quantity_takeoff.py tests/test_quantity_takeoff_api.py`
- [x] `uv run mypy app/api/v1/revisions.py app/schemas/quantity_takeoff.py tests/test_quantity_takeoff_api.py`
- [x] `uv run python -m compileall app tests`
- [x] `uv run pytest tests/test_quantity_takeoff_api.py tests/test_revision_materialization_api.py tests/test_jobs.py tests/test_idempotency.py`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_quantity_takeoff_api.py -q`

## Notes
- non-blocking follow-up: review round 2 noted the idempotency claim commit releases lineage locks before job insert when `Idempotency-Key` is present