### PR TITLE
feat(db): add versioned estimation catalog schema

### DIFF
--- a/alembic/versions/2026_05_16_0019_add_estimation_catalog_schema.py
+++ b/alembic/versions/2026_05_16_0019_add_estimation_catalog_schema.py
@@ -1,0 +1,673 @@
+# ruff: noqa: I001
+
+"""add estimation catalog schema
+
+Revision ID: 2026_05_16_0019
+Revises: 2026_05_15_0018
+Create Date: 2026-05-16 00:19:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "2026_05_16_0019"
+down_revision = "2026_05_15_0018"
+branch_labels = None
+depends_on = None
+
+
+CHECKSUM_PATTERN = "^[0-9a-f]{64}$"
+
+
+def _attach_append_only_guards(table_name: str) -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_{table_name}_append_only_row_guard
+            BEFORE UPDATE OR DELETE ON {table_name}
+            FOR EACH ROW
+            EXECUTE FUNCTION enforce_append_only_lineage_row()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_{table_name}_append_only_truncate_guard
+            BEFORE TRUNCATE ON {table_name}
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION enforce_append_only_lineage_truncate()
+            """
+        )
+    )
+
+
+def _detach_append_only_guards(table_name: str) -> None:
+    op.execute(
+        sa.text(
+            f"DROP TRIGGER IF EXISTS trg_{table_name}_append_only_truncate_guard "
+            f"ON {table_name}"
+        )
+    )
+    op.execute(
+        sa.text(
+            f"DROP TRIGGER IF EXISTS trg_{table_name}_append_only_row_guard "
+            f"ON {table_name}"
+        )
+    )
+
+
+def _assert_table_empty(table_name: str) -> None:
+    op.execute(
+        sa.text(
+            f"""
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM {table_name} LIMIT 1) THEN
+                    RAISE EXCEPTION 'downgrade blocked: table {table_name} contains data';
+                END IF;
+            END
+            $$;
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.execute(sa.text("CREATE EXTENSION IF NOT EXISTS btree_gist"))
+
+    op.create_table(
+        "rate_catalog_entries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope_type", sa.String(length=16), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("rate_key", sa.String(length=255), nullable=False),
+        sa.Column("source", sa.String(length=64), nullable=False),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("item_type", sa.String(length=64), nullable=False),
+        sa.Column("per_unit", sa.String(length=64), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("amount", sa.Numeric(18, 6), nullable=False),
+        sa.Column("effective_from", sa.Date(), nullable=False),
+        sa.Column("effective_to", sa.Date(), nullable=True),
+        sa.Column("checksum_sha256", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "scope_type IN ('global', 'project')",
+            name="ck_rate_catalog_entries_scope_type",
+        ),
+        sa.CheckConstraint(
+            "(scope_type = 'global' AND project_id IS NULL) OR "
+            "(scope_type = 'project' AND project_id IS NOT NULL)",
+            name="ck_rate_catalog_entries_scope_project_id",
+        ),
+        sa.CheckConstraint(
+            "effective_to IS NULL OR effective_to > effective_from",
+            name="ck_rate_catalog_entries_effective_window",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(metadata_json) = 'object'",
+            name="ck_rate_catalog_entries_metadata_json_object",
+        ),
+        sa.CheckConstraint(
+            f"checksum_sha256 ~ '{CHECKSUM_PATTERN}'",
+            name="ck_rate_catalog_entries_checksum_sha256",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="fk_rate_catalog_entries_project_id_projects",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_rate_catalog_entries"),
+    )
+    op.create_index(
+        "ix_rate_catalog_entries_lookup",
+        "rate_catalog_entries",
+        [
+            "scope_type",
+            "project_id",
+            "rate_key",
+            "item_type",
+            "per_unit",
+            "currency",
+            "effective_from",
+        ],
+        unique=False,
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE rate_catalog_entries
+            ADD CONSTRAINT ex_rate_catalog_entries_global_no_overlap
+            EXCLUDE USING gist (
+                rate_key WITH =,
+                item_type WITH =,
+                per_unit WITH =,
+                currency WITH =,
+                daterange(effective_from, effective_to, '[)') WITH &&
+            )
+            WHERE (scope_type = 'global' AND project_id IS NULL)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE rate_catalog_entries
+            ADD CONSTRAINT ex_rate_catalog_entries_project_no_overlap
+            EXCLUDE USING gist (
+                project_id WITH =,
+                rate_key WITH =,
+                item_type WITH =,
+                per_unit WITH =,
+                currency WITH =,
+                daterange(effective_from, effective_to, '[)') WITH &&
+            )
+            WHERE (scope_type = 'project' AND project_id IS NOT NULL)
+            """
+        )
+    )
+
+    op.create_table(
+        "material_catalog_entries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope_type", sa.String(length=16), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("material_key", sa.String(length=255), nullable=False),
+        sa.Column("source", sa.String(length=64), nullable=False),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("unit", sa.String(length=64), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("unit_cost", sa.Numeric(18, 6), nullable=False),
+        sa.Column("effective_from", sa.Date(), nullable=False),
+        sa.Column("effective_to", sa.Date(), nullable=True),
+        sa.Column("checksum_sha256", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "scope_type IN ('global', 'project')",
+            name="ck_material_catalog_entries_scope_type",
+        ),
+        sa.CheckConstraint(
+            "(scope_type = 'global' AND project_id IS NULL) OR "
+            "(scope_type = 'project' AND project_id IS NOT NULL)",
+            name="ck_material_catalog_entries_scope_project_id",
+        ),
+        sa.CheckConstraint(
+            "effective_to IS NULL OR effective_to > effective_from",
+            name="ck_material_catalog_entries_effective_window",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(metadata_json) = 'object'",
+            name="ck_material_catalog_entries_metadata_json_object",
+        ),
+        sa.CheckConstraint(
+            f"checksum_sha256 ~ '{CHECKSUM_PATTERN}'",
+            name="ck_material_catalog_entries_checksum_sha256",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="fk_material_catalog_entries_project_id_projects",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_material_catalog_entries"),
+    )
+    op.create_index(
+        "ix_material_catalog_entries_lookup",
+        "material_catalog_entries",
+        ["scope_type", "project_id", "material_key", "unit", "currency", "effective_from"],
+        unique=False,
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE material_catalog_entries
+            ADD CONSTRAINT ex_material_catalog_entries_global_no_overlap
+            EXCLUDE USING gist (
+                material_key WITH =,
+                unit WITH =,
+                currency WITH =,
+                daterange(effective_from, effective_to, '[)') WITH &&
+            )
+            WHERE (scope_type = 'global' AND project_id IS NULL)
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            ALTER TABLE material_catalog_entries
+            ADD CONSTRAINT ex_material_catalog_entries_project_no_overlap
+            EXCLUDE USING gist (
+                project_id WITH =,
+                material_key WITH =,
+                unit WITH =,
+                currency WITH =,
+                daterange(effective_from, effective_to, '[)') WITH &&
+            )
+            WHERE (scope_type = 'project' AND project_id IS NOT NULL)
+            """
+        )
+    )
+
+    op.create_table(
+        "formula_definitions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scope_type", sa.String(length=16), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("formula_id", sa.String(length=255), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("dsl_version", sa.String(length=32), nullable=False),
+        sa.Column("output_key", sa.String(length=255), nullable=False),
+        sa.Column("output_contract_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("declared_inputs_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("expression_json", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("rounding_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("checksum_sha256", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "scope_type IN ('global', 'project')",
+            name="ck_formula_definitions_scope_type",
+        ),
+        sa.CheckConstraint(
+            "(scope_type = 'global' AND project_id IS NULL) OR "
+            "(scope_type = 'project' AND project_id IS NOT NULL)",
+            name="ck_formula_definitions_scope_project_id",
+        ),
+        sa.CheckConstraint(
+            "version > 0",
+            name="ck_formula_definitions_version_positive",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(output_contract_json) = 'object'",
+            name="ck_formula_definitions_output_contract_json_object",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(declared_inputs_json) = 'array'",
+            name="ck_formula_definitions_declared_inputs_json_array",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(expression_json) = 'object'",
+            name="ck_formula_definitions_expression_json_object",
+        ),
+        sa.CheckConstraint(
+            "rounding_json IS NULL OR jsonb_typeof(rounding_json) = 'object'",
+            name="ck_formula_definitions_rounding_json_object",
+        ),
+        sa.CheckConstraint(
+            f"checksum_sha256 ~ '{CHECKSUM_PATTERN}'",
+            name="ck_formula_definitions_checksum_sha256",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="fk_formula_definitions_project_id_projects",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_formula_definitions"),
+    )
+    op.create_index(
+        "ix_formula_definitions_lookup",
+        "formula_definitions",
+        ["scope_type", "project_id", "formula_id", "version"],
+        unique=False,
+    )
+    op.create_index(
+        "uq_formula_definitions_global_version",
+        "formula_definitions",
+        ["formula_id", "version"],
+        unique=True,
+        postgresql_where=sa.text("scope_type = 'global' AND project_id IS NULL"),
+    )
+    op.create_index(
+        "uq_formula_definitions_project_version",
+        "formula_definitions",
+        ["project_id", "formula_id", "version"],
+        unique=True,
+        postgresql_where=sa.text("scope_type = 'project' AND project_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_formula_definitions_global_checksum",
+        "formula_definitions",
+        ["formula_id", "checksum_sha256"],
+        unique=True,
+        postgresql_where=sa.text("scope_type = 'global' AND project_id IS NULL"),
+    )
+    op.create_index(
+        "uq_formula_definitions_project_checksum",
+        "formula_definitions",
+        ["project_id", "formula_id", "checksum_sha256"],
+        unique=True,
+        postgresql_where=sa.text("scope_type = 'project' AND project_id IS NOT NULL"),
+    )
+
+    op.create_table(
+        "rate_catalog_entry_supersessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("predecessor_rate_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("successor_rate_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "predecessor_rate_id <> successor_rate_id",
+            name="ck_rate_catalog_entry_supersessions_distinct_nodes",
+        ),
+        sa.ForeignKeyConstraint(
+            ["predecessor_rate_id"],
+            ["rate_catalog_entries.id"],
+            name="fk_rate_catalog_entry_supersessions_predecessor_rate_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["successor_rate_id"],
+            ["rate_catalog_entries.id"],
+            name="fk_rate_catalog_entry_supersessions_successor_rate_id",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_rate_catalog_entry_supersessions"),
+        sa.UniqueConstraint(
+            "predecessor_rate_id",
+            name="uq_rate_catalog_entry_supersessions_predecessor_rate_id",
+        ),
+        sa.UniqueConstraint(
+            "successor_rate_id",
+            name="uq_rate_catalog_entry_supersessions_successor_rate_id",
+        ),
+    )
+
+    op.create_table(
+        "material_catalog_entry_supersessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("predecessor_material_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("successor_material_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "predecessor_material_id <> successor_material_id",
+            name="ck_material_catalog_entry_supersessions_distinct_nodes",
+        ),
+        sa.ForeignKeyConstraint(
+            ["predecessor_material_id"],
+            ["material_catalog_entries.id"],
+            name="fk_material_catalog_entry_supersessions_predecessor_material_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["successor_material_id"],
+            ["material_catalog_entries.id"],
+            name="fk_material_catalog_entry_supersessions_successor_material_id",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_material_catalog_entry_supersessions"),
+        sa.UniqueConstraint(
+            "predecessor_material_id",
+            name="uq_material_catalog_entry_supersessions_predecessor_material_id",
+        ),
+        sa.UniqueConstraint(
+            "successor_material_id",
+            name="uq_material_catalog_entry_supersessions_successor_material_id",
+        ),
+    )
+
+    op.create_table(
+        "formula_definition_supersessions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("predecessor_formula_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("successor_formula_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "predecessor_formula_id <> successor_formula_id",
+            name="ck_formula_definition_supersessions_distinct_nodes",
+        ),
+        sa.ForeignKeyConstraint(
+            ["predecessor_formula_id"],
+            ["formula_definitions.id"],
+            name="fk_formula_definition_supersessions_predecessor_formula_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["successor_formula_id"],
+            ["formula_definitions.id"],
+            name="fk_formula_definition_supersessions_successor_formula_id",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_formula_definition_supersessions"),
+        sa.UniqueConstraint(
+            "predecessor_formula_id",
+            name="uq_formula_definition_supersessions_predecessor_formula_id",
+        ),
+        sa.UniqueConstraint(
+            "successor_formula_id",
+            name="uq_formula_definition_supersessions_successor_formula_id",
+        ),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE FUNCTION validate_rate_catalog_entry_supersession()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                predecessor rate_catalog_entries%ROWTYPE;
+                successor rate_catalog_entries%ROWTYPE;
+            BEGIN
+                SELECT * INTO predecessor
+                FROM rate_catalog_entries
+                WHERE id = NEW.predecessor_rate_id;
+
+                SELECT * INTO successor
+                FROM rate_catalog_entries
+                WHERE id = NEW.successor_rate_id;
+
+                IF predecessor.scope_type <> successor.scope_type
+                    OR predecessor.project_id IS DISTINCT FROM successor.project_id
+                    OR predecessor.rate_key <> successor.rate_key
+                    OR predecessor.item_type <> successor.item_type
+                    OR predecessor.per_unit <> successor.per_unit
+                    OR predecessor.currency <> successor.currency THEN
+                    RAISE EXCEPTION 'rate supersession must preserve rate key and scope';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE FUNCTION validate_material_catalog_entry_supersession()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                predecessor material_catalog_entries%ROWTYPE;
+                successor material_catalog_entries%ROWTYPE;
+            BEGIN
+                SELECT * INTO predecessor
+                FROM material_catalog_entries
+                WHERE id = NEW.predecessor_material_id;
+
+                SELECT * INTO successor
+                FROM material_catalog_entries
+                WHERE id = NEW.successor_material_id;
+
+                IF predecessor.scope_type <> successor.scope_type
+                    OR predecessor.project_id IS DISTINCT FROM successor.project_id
+                    OR predecessor.material_key <> successor.material_key
+                    OR predecessor.unit <> successor.unit
+                    OR predecessor.currency <> successor.currency THEN
+                    RAISE EXCEPTION 'material supersession must preserve material key and scope';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE FUNCTION validate_formula_definition_supersession()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                predecessor formula_definitions%ROWTYPE;
+                successor formula_definitions%ROWTYPE;
+            BEGIN
+                SELECT * INTO predecessor
+                FROM formula_definitions
+                WHERE id = NEW.predecessor_formula_id;
+
+                SELECT * INTO successor
+                FROM formula_definitions
+                WHERE id = NEW.successor_formula_id;
+
+                IF predecessor.scope_type <> successor.scope_type
+                    OR predecessor.project_id IS DISTINCT FROM successor.project_id
+                    OR predecessor.formula_id <> successor.formula_id THEN
+                    RAISE EXCEPTION 'formula supersession must preserve formula key and scope';
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER trg_rate_catalog_entry_supersessions_validate_lineage
+            BEFORE INSERT ON rate_catalog_entry_supersessions
+            FOR EACH ROW
+            EXECUTE FUNCTION validate_rate_catalog_entry_supersession()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER trg_material_catalog_entry_supersessions_validate_lineage
+            BEFORE INSERT ON material_catalog_entry_supersessions
+            FOR EACH ROW
+            EXECUTE FUNCTION validate_material_catalog_entry_supersession()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER trg_formula_definition_supersessions_validate_lineage
+            BEFORE INSERT ON formula_definition_supersessions
+            FOR EACH ROW
+            EXECUTE FUNCTION validate_formula_definition_supersession()
+            """
+        )
+    )
+
+    for table_name in (
+        "rate_catalog_entries",
+        "material_catalog_entries",
+        "formula_definitions",
+        "rate_catalog_entry_supersessions",
+        "material_catalog_entry_supersessions",
+        "formula_definition_supersessions",
+    ):
+        _attach_append_only_guards(table_name)
+
+
+def downgrade() -> None:
+    for table_name in (
+        "formula_definition_supersessions",
+        "material_catalog_entry_supersessions",
+        "rate_catalog_entry_supersessions",
+        "formula_definitions",
+        "material_catalog_entries",
+        "rate_catalog_entries",
+    ):
+        _assert_table_empty(table_name)
+
+    for table_name in (
+        "formula_definition_supersessions",
+        "material_catalog_entry_supersessions",
+        "rate_catalog_entry_supersessions",
+        "formula_definitions",
+        "material_catalog_entries",
+        "rate_catalog_entries",
+    ):
+        _detach_append_only_guards(table_name)
+
+    op.execute(
+        sa.text(
+            "DROP TRIGGER IF EXISTS "
+            "trg_formula_definition_supersessions_validate_lineage "
+            "ON formula_definition_supersessions"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DROP TRIGGER IF EXISTS "
+            "trg_material_catalog_entry_supersessions_validate_lineage "
+            "ON material_catalog_entry_supersessions"
+        )
+    )
+    op.execute(
+        sa.text(
+            "DROP TRIGGER IF EXISTS "
+            "trg_rate_catalog_entry_supersessions_validate_lineage "
+            "ON rate_catalog_entry_supersessions"
+        )
+    )
+
+    op.execute(sa.text("DROP FUNCTION IF EXISTS validate_formula_definition_supersession()"))
+    op.execute(sa.text("DROP FUNCTION IF EXISTS validate_material_catalog_entry_supersession()"))
+    op.execute(sa.text("DROP FUNCTION IF EXISTS validate_rate_catalog_entry_supersession()"))
+
+    op.drop_table("formula_definition_supersessions")
+    op.drop_table("material_catalog_entry_supersessions")
+    op.drop_table("rate_catalog_entry_supersessions")
+    op.drop_index("uq_formula_definitions_project_checksum", table_name="formula_definitions")
+    op.drop_index("uq_formula_definitions_global_checksum", table_name="formula_definitions")
+    op.drop_index("uq_formula_definitions_project_version", table_name="formula_definitions")
+    op.drop_index("uq_formula_definitions_global_version", table_name="formula_definitions")
+    op.drop_index("ix_formula_definitions_lookup", table_name="formula_definitions")
+    op.drop_table("formula_definitions")
+    op.drop_index("ix_material_catalog_entries_lookup", table_name="material_catalog_entries")
+    op.drop_table("material_catalog_entries")
+    op.drop_index("ix_rate_catalog_entries_lookup", table_name="rate_catalog_entries")
+    op.drop_table("rate_catalog_entries")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ for Alembic autogenerate support. Example:
 
 from . import adapter_run_output as adapter_run_output
 from . import drawing_revision as drawing_revision
+from . import estimation_catalog as estimation_catalog
 from . import extraction_profile as extraction_profile
 from . import file as file
 from . import generated_artifact as generated_artifact

--- a/app/models/estimation_catalog.py
+++ b/app/models/estimation_catalog.py
@@ -1,0 +1,379 @@
+# ruff: noqa: I001
+
+"""Versioned estimation catalog models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any
+
+from sqlalchemy import CheckConstraint, Date, DateTime, ForeignKey, Index, Integer
+from sqlalchemy import Numeric, String, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+from app.db.base import Base
+
+
+class CatalogScopeType(StrEnum):
+    GLOBAL = "global"
+    PROJECT = "project"
+
+
+class EstimationRate(Base):
+    __tablename__ = "rate_catalog_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    scope_type: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", name="fk_rate_catalog_entries_project_id_projects"),
+        nullable=True,
+    )
+    rate_key: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    source: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    name: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    item_type: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    per_unit: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    currency: Mapped[str] = mapped_column(String(length=3), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    effective_from: Mapped[date] = mapped_column(Date, nullable=False)
+    effective_to: Mapped[date | None] = mapped_column(Date, nullable=True)
+    checksum_sha256: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "scope_type IN ('global', 'project')",
+            name="ck_rate_catalog_entries_scope_type",
+        ),
+        CheckConstraint(
+            "(scope_type = 'global' AND project_id IS NULL) OR "
+            "(scope_type = 'project' AND project_id IS NOT NULL)",
+            name="ck_rate_catalog_entries_scope_project_id",
+        ),
+        CheckConstraint(
+            "effective_to IS NULL OR effective_to > effective_from",
+            name="ck_rate_catalog_entries_effective_window",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(metadata_json) = 'object'",
+            name="ck_rate_catalog_entries_metadata_json_object",
+        ),
+        CheckConstraint(
+            "checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_rate_catalog_entries_checksum_sha256",
+        ),
+        Index(
+            "ix_rate_catalog_entries_lookup",
+            "scope_type",
+            "project_id",
+            "rate_key",
+            "item_type",
+            "per_unit",
+            "currency",
+            "effective_from",
+        ),
+    )
+
+
+class EstimationMaterial(Base):
+    __tablename__ = "material_catalog_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    scope_type: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", name="fk_material_catalog_entries_project_id_projects"),
+        nullable=True,
+    )
+    material_key: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    source: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    metadata_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    name: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    unit: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    currency: Mapped[str] = mapped_column(String(length=3), nullable=False)
+    unit_cost: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    effective_from: Mapped[date] = mapped_column(Date, nullable=False)
+    effective_to: Mapped[date | None] = mapped_column(Date, nullable=True)
+    checksum_sha256: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "scope_type IN ('global', 'project')",
+            name="ck_material_catalog_entries_scope_type",
+        ),
+        CheckConstraint(
+            "(scope_type = 'global' AND project_id IS NULL) OR "
+            "(scope_type = 'project' AND project_id IS NOT NULL)",
+            name="ck_material_catalog_entries_scope_project_id",
+        ),
+        CheckConstraint(
+            "effective_to IS NULL OR effective_to > effective_from",
+            name="ck_material_catalog_entries_effective_window",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(metadata_json) = 'object'",
+            name="ck_material_catalog_entries_metadata_json_object",
+        ),
+        CheckConstraint(
+            "checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_material_catalog_entries_checksum_sha256",
+        ),
+        Index(
+            "ix_material_catalog_entries_lookup",
+            "scope_type",
+            "project_id",
+            "material_key",
+            "unit",
+            "currency",
+            "effective_from",
+        ),
+    )
+
+
+class EstimationFormula(Base):
+    __tablename__ = "formula_definitions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    scope_type: Mapped[str] = mapped_column(String(length=16), nullable=False)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", name="fk_formula_definitions_project_id_projects"),
+        nullable=True,
+    )
+    formula_id: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    dsl_version: Mapped[str] = mapped_column(String(length=32), nullable=False)
+    output_key: Mapped[str] = mapped_column(String(length=255), nullable=False)
+    output_contract_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    declared_inputs_json: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    expression_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    rounding_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    checksum_sha256: Mapped[str] = mapped_column(String(length=64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "scope_type IN ('global', 'project')",
+            name="ck_formula_definitions_scope_type",
+        ),
+        CheckConstraint(
+            "(scope_type = 'global' AND project_id IS NULL) OR "
+            "(scope_type = 'project' AND project_id IS NOT NULL)",
+            name="ck_formula_definitions_scope_project_id",
+        ),
+        CheckConstraint(
+            "version > 0",
+            name="ck_formula_definitions_version_positive",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(output_contract_json) = 'object'",
+            name="ck_formula_definitions_output_contract_json_object",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(declared_inputs_json) = 'array'",
+            name="ck_formula_definitions_declared_inputs_json_array",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(expression_json) = 'object'",
+            name="ck_formula_definitions_expression_json_object",
+        ),
+        CheckConstraint(
+            "rounding_json IS NULL OR jsonb_typeof(rounding_json) = 'object'",
+            name="ck_formula_definitions_rounding_json_object",
+        ),
+        CheckConstraint(
+            "checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_formula_definitions_checksum_sha256",
+        ),
+        Index(
+            "ix_formula_definitions_lookup",
+            "scope_type",
+            "project_id",
+            "formula_id",
+            "version",
+        ),
+        Index(
+            "uq_formula_definitions_global_version",
+            "formula_id",
+            "version",
+            unique=True,
+            postgresql_where=text("scope_type = 'global' AND project_id IS NULL"),
+        ),
+        Index(
+            "uq_formula_definitions_project_version",
+            "project_id",
+            "formula_id",
+            "version",
+            unique=True,
+            postgresql_where=text("scope_type = 'project' AND project_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_formula_definitions_global_checksum",
+            "formula_id",
+            "checksum_sha256",
+            unique=True,
+            postgresql_where=text("scope_type = 'global' AND project_id IS NULL"),
+        ),
+        Index(
+            "uq_formula_definitions_project_checksum",
+            "project_id",
+            "formula_id",
+            "checksum_sha256",
+            unique=True,
+            postgresql_where=text("scope_type = 'project' AND project_id IS NOT NULL"),
+        ),
+    )
+
+
+class EstimationRateSupersession(Base):
+    __tablename__ = "rate_catalog_entry_supersessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    predecessor_rate_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "rate_catalog_entries.id",
+            name="fk_rate_catalog_entry_supersessions_predecessor_rate_id",
+        ),
+        nullable=False,
+        unique=True,
+    )
+    successor_rate_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "rate_catalog_entries.id",
+            name="fk_rate_catalog_entry_supersessions_successor_rate_id",
+        ),
+        nullable=False,
+        unique=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "predecessor_rate_id <> successor_rate_id",
+            name="ck_rate_catalog_entry_supersessions_distinct_nodes",
+        ),
+    )
+
+
+class EstimationMaterialSupersession(Base):
+    __tablename__ = "material_catalog_entry_supersessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    predecessor_material_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "material_catalog_entries.id",
+            name="fk_material_catalog_entry_supersessions_predecessor_material_id",
+        ),
+        nullable=False,
+        unique=True,
+    )
+    successor_material_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "material_catalog_entries.id",
+            name="fk_material_catalog_entry_supersessions_successor_material_id",
+        ),
+        nullable=False,
+        unique=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "predecessor_material_id <> successor_material_id",
+            name="ck_material_catalog_entry_supersessions_distinct_nodes",
+        ),
+    )
+
+
+class EstimationFormulaSupersession(Base):
+    __tablename__ = "formula_definition_supersessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    predecessor_formula_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "formula_definitions.id",
+            name="fk_formula_definition_supersessions_predecessor_formula_id",
+        ),
+        nullable=False,
+        unique=True,
+    )
+    successor_formula_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(
+            "formula_definitions.id",
+            name="fk_formula_definition_supersessions_successor_formula_id",
+        ),
+        nullable=False,
+        unique=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "predecessor_formula_id <> successor_formula_id",
+            name="ck_formula_definition_supersessions_distinct_nodes",
+        ),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,12 +36,25 @@ APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
     "revision_blocks",
     "revision_entities",
 )
+_PROJECT_TRUNCATE_CASCADE_CATALOG_TABLES: tuple[str, ...] = (
+    "formula_definition_supersessions",
+    "material_catalog_entry_supersessions",
+    "rate_catalog_entry_supersessions",
+    "formula_definitions",
+    "material_catalog_entries",
+    "rate_catalog_entries",
+)
+_PROJECT_TRUNCATE_CASCADE_APPEND_ONLY_TABLES: tuple[str, ...] = (
+    *APPEND_ONLY_PROTECTED_TABLES,
+    *_PROJECT_TRUNCATE_CASCADE_CATALOG_TABLES,
+)
 APPEND_ONLY_ROW_TRIGGER_NAME = "trg_append_only_row_guard"
 APPEND_ONLY_TRUNCATE_TRIGGER_NAME = "trg_append_only_truncate_guard"
-_APPEND_ONLY_TRIGGER_NAMES: tuple[str, ...] = (
+_LEGACY_APPEND_ONLY_TRIGGER_NAMES: tuple[str, ...] = (
     APPEND_ONLY_ROW_TRIGGER_NAME,
     APPEND_ONLY_TRUNCATE_TRIGGER_NAME,
 )
+_TEST_ONLY_CLEANUP_TABLES: tuple[str, ...] = ("idempotency_keys",)
 
 # Marker for tests that require a running database
 requires_database = pytest.mark.skipif(
@@ -133,14 +146,20 @@ async def _load_existing_append_only_triggers(
     """Return append-only triggers currently installed in the test database."""
 
     existing_triggers: list[tuple[str, str]] = []
-    for table_name in APPEND_ONLY_PROTECTED_TABLES:
-        for trigger_name in _APPEND_ONLY_TRIGGER_NAMES:
-            if await _append_only_trigger_exists(
-                session,
-                table_name=table_name,
-                trigger_name=trigger_name,
-            ):
-                existing_triggers.append((table_name, trigger_name))
+    for table_name in _PROJECT_TRUNCATE_CASCADE_APPEND_ONLY_TABLES:
+        trigger_names = await session.scalars(
+            text(
+                """
+                SELECT tgname
+                FROM pg_trigger
+                WHERE tgrelid = to_regclass(:table_name)
+                  AND tgname LIKE '%append_only%'
+                ORDER BY tgname
+                """
+            ),
+            {"table_name": table_name},
+        )
+        existing_triggers.extend((table_name, trigger_name) for trigger_name in trigger_names)
 
     return existing_triggers
 
@@ -184,8 +203,15 @@ async def _assert_append_only_triggers_enabled(
         assert normalized_state == "O"
 
 
+async def _truncate_test_only_cleanup_tables(session: AsyncSession) -> None:
+    """Truncate test-only standalone tables that do not cascade from projects."""
+
+    table_names = ", ".join(f'"{table_name}"' for table_name in _TEST_ONLY_CLEANUP_TABLES)
+    await session.execute(text(f"TRUNCATE TABLE {table_names}"))
+
+
 async def truncate_projects_cascade_for_cleanup() -> None:
-    """Hard-clean projects by temporarily disabling only append-only triggers."""
+    """Hard-clean test data, preserving append-only trigger handling for projects."""
 
     if not os.environ.get("DATABASE_URL"):
         return
@@ -209,6 +235,7 @@ async def truncate_projects_cascade_for_cleanup() -> None:
                         enabled=False,
                     )
                     triggers_disabled = True
+                await _truncate_test_only_cleanup_tables(session)
                 await session.execute(text("TRUNCATE TABLE projects CASCADE"))
             finally:
                 if triggers_disabled:
@@ -240,10 +267,12 @@ async def async_client(app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
 
 @pytest_asyncio.fixture
 async def cleanup_projects() -> AsyncGenerator[None, None]:
-    """Truncate projects table after each test to ensure clean DB state."""
+    """Clean test DB state before and after each test when using DATABASE_URL."""
     if not os.environ.get("DATABASE_URL"):
         yield
         return
+
+    await truncate_projects_cascade_for_cleanup()
 
     yield
 

--- a/tests/test_estimation_catalog_persistence.py
+++ b/tests/test_estimation_catalog_persistence.py
@@ -1,0 +1,834 @@
+"""Database persistence tests for estimation catalog constraints."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Callable, Sequence
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.estimation_catalog import (
+    EstimationFormula,
+    EstimationFormulaSupersession,
+    EstimationMaterial,
+    EstimationMaterialSupersession,
+    EstimationRate,
+    EstimationRateSupersession,
+)
+from tests.conftest import requires_database
+
+pytestmark = [pytest.mark.asyncio, requires_database]
+
+CatalogBuilder = Callable[..., Any]
+CATALOG_TABLES: tuple[str, ...] = (
+    "formula_definition_supersessions",
+    "material_catalog_entry_supersessions",
+    "rate_catalog_entry_supersessions",
+    "formula_definitions",
+    "material_catalog_entries",
+    "rate_catalog_entries",
+)
+
+
+async def _cleanup_catalog_tables() -> None:
+    """Remove persisted catalog rows and related projects between tests."""
+
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        try:
+            for table_name in CATALOG_TABLES:
+                await session.execute(text(f'ALTER TABLE "{table_name}" DISABLE TRIGGER ALL'))
+
+            await session.execute(
+                text(
+                    "TRUNCATE TABLE "
+                    "formula_definition_supersessions, "
+                    "material_catalog_entry_supersessions, "
+                    "rate_catalog_entry_supersessions, "
+                    "formula_definitions, "
+                    "material_catalog_entries, "
+                    "rate_catalog_entries"
+                )
+            )
+
+            for table_name in CATALOG_TABLES:
+                await session.execute(text(f'ALTER TABLE "{table_name}" ENABLE TRIGGER ALL'))
+
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest_asyncio.fixture
+async def cleanup_estimation_catalog() -> AsyncGenerator[None, None]:
+    """Clear catalog tables after each test, including append-only tables."""
+
+    await _cleanup_catalog_tables()
+    yield
+    await _cleanup_catalog_tables()
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_estimation_catalog: None) -> AsyncGenerator[AsyncSession, None]:
+    """Provide a clean async session for catalog persistence tests."""
+
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+def _checksum(seed: str) -> str:
+    return (seed.encode("utf-8").hex() + ("0" * 64))[:64]
+
+
+async def _create_project(session: AsyncSession) -> uuid.UUID:
+    column_rows = (
+        await session.execute(
+            text(
+                """
+                SELECT column_name, data_type, is_nullable, column_default, udt_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = 'projects'
+                ORDER BY ordinal_position
+                """
+            )
+        )
+    ).all()
+
+    values: dict[str, object] = {}
+    for column_name, data_type, is_nullable, column_default, udt_name in column_rows:
+        if column_default is not None or is_nullable == "YES":
+            continue
+        values[column_name] = await _project_column_value(
+            session,
+            column_name=column_name,
+            data_type=data_type,
+            udt_name=udt_name,
+        )
+
+    if values:
+        columns = ", ".join(f'"{column_name}"' for column_name in values)
+        params = ", ".join(f":{column_name}" for column_name in values)
+        insert_sql = f"INSERT INTO projects ({columns}) VALUES ({params}) RETURNING id"
+        result = await session.execute(text(insert_sql), values)
+    else:
+        result = await session.execute(text("INSERT INTO projects DEFAULT VALUES RETURNING id"))
+
+    project_id = result.scalar_one()
+    await session.commit()
+    return project_id
+
+
+async def _project_column_value(
+    session: AsyncSession,
+    *,
+    column_name: str,
+    data_type: str,
+    udt_name: str | None,
+) -> object:
+    normalized_type = data_type.lower()
+
+    if column_name == "id" or normalized_type == "uuid":
+        return uuid.uuid4()
+    if normalized_type in {"character varying", "character", "text"}:
+        return f"test-{column_name}-{uuid.uuid4().hex[:8]}"
+    if normalized_type in {"smallint", "integer", "bigint"}:
+        return 1
+    if normalized_type in {"numeric", "real", "double precision"}:
+        return Decimal("1")
+    if normalized_type == "boolean":
+        return False
+    if normalized_type == "date":
+        return date(2026, 1, 1)
+    if normalized_type.startswith("timestamp"):
+        return datetime.now(UTC)
+    if normalized_type in {"json", "jsonb"}:
+        return {}
+    if normalized_type == "array":
+        return []
+    if normalized_type == "user-defined" and udt_name is not None:
+        enum_value = await session.scalar(
+            text(
+                """
+                SELECT enumlabel
+                FROM pg_type
+                JOIN pg_enum ON pg_type.oid = pg_enum.enumtypid
+                WHERE typname = :udt_name
+                ORDER BY enumsortorder
+                LIMIT 1
+                """
+            ),
+            {"udt_name": udt_name},
+        )
+        if enum_value is not None:
+            return enum_value
+
+    raise AssertionError(
+        f"Unsupported required projects column {column_name!r} with type {data_type!r}"
+    )
+
+
+async def _persist(session: AsyncSession, *objects: object) -> None:
+    session.add_all(list(objects))
+    await session.commit()
+
+
+async def _assert_commit_fails(
+    session: AsyncSession,
+    objects: object | Sequence[object],
+    expected_substring: str | Sequence[str],
+) -> None:
+    pending_objects = [objects] if not isinstance(objects, Sequence) else list(objects)
+    session.add_all(pending_objects)
+    expected_substrings = (
+        [expected_substring]
+        if isinstance(expected_substring, str)
+        else list(expected_substring)
+    )
+
+    try:
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        constraint_name = getattr(getattr(exc, "orig", None), "constraint_name", None)
+        if constraint_name in expected_substrings:
+            return
+
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert any(substring.lower() in message for substring in expected_substrings)
+    else:
+        pytest.fail(f"Expected database error containing {expected_substrings!r}")
+
+
+async def _assert_append_only_sql_mutation_fails(
+    session: AsyncSession,
+    statement: str,
+    *,
+    table_name: str,
+    operation: str,
+    params: dict[str, object] | None = None,
+    expected_substring: str | Sequence[str] | None = None,
+) -> None:
+    expected_substrings = (
+        [expected_substring]
+        if isinstance(expected_substring, str)
+        else list(expected_substring)
+        if expected_substring is not None
+        else [f"append-only trigger blocked {operation} on {table_name}"]
+    )
+
+    try:
+        await session.execute(text(statement), params or {})
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert any(substring.lower() in message for substring in expected_substrings)
+    else:
+        pytest.fail(
+            "Expected append-only mutation failure for "
+            f"{operation} on {table_name}"
+        )
+
+
+def _build_rate(**overrides: Any) -> EstimationRate:
+    payload: dict[str, Any] = {
+        "scope_type": "global",
+        "project_id": None,
+        "rate_key": "labour.install",
+        "source": "tests",
+        "metadata_json": {"fixture": True},
+        "name": "Labour install",
+        "item_type": "labour",
+        "per_unit": "m2",
+        "currency": "GBP",
+        "amount": Decimal("10.000000"),
+        "effective_from": date(2026, 1, 1),
+        "effective_to": date(2026, 2, 1),
+        "checksum_sha256": _checksum("rate-default"),
+    }
+    payload.update(overrides)
+    return EstimationRate(**payload)
+
+
+def _build_material(**overrides: Any) -> EstimationMaterial:
+    payload: dict[str, Any] = {
+        "scope_type": "global",
+        "project_id": None,
+        "material_key": "material.board",
+        "source": "tests",
+        "metadata_json": {"fixture": True},
+        "name": "Board",
+        "unit": "sheet",
+        "currency": "GBP",
+        "unit_cost": Decimal("12.500000"),
+        "effective_from": date(2026, 1, 1),
+        "effective_to": date(2026, 2, 1),
+        "checksum_sha256": _checksum("material-default"),
+    }
+    payload.update(overrides)
+    return EstimationMaterial(**payload)
+
+
+def _build_formula(**overrides: Any) -> EstimationFormula:
+    payload: dict[str, Any] = {
+        "scope_type": "global",
+        "project_id": None,
+        "formula_id": "formula.paint",
+        "version": 1,
+        "name": "Paint formula",
+        "dsl_version": "1.0",
+        "output_key": "estimate.total",
+        "output_contract_json": {"type": "money"},
+        "declared_inputs_json": [{"key": "quantity"}],
+        "expression_json": {"op": "sum", "args": []},
+        "rounding_json": {},
+        "checksum_sha256": _checksum("formula-default"),
+    }
+    payload.update(overrides)
+    return EstimationFormula(**payload)
+
+
+async def test_rate_catalog_global_overlap_rejects_adjacent_windows_allowed(
+    db_session: AsyncSession,
+) -> None:
+    await _persist(db_session, _build_rate())
+
+    await _assert_commit_fails(
+        db_session,
+        _build_rate(
+            effective_from=date(2026, 1, 15),
+            effective_to=date(2026, 2, 15),
+            checksum_sha256=_checksum("rate-overlap"),
+        ),
+        "ex_rate_catalog_entries_global_no_overlap",
+    )
+
+    await _persist(
+        db_session,
+        _build_rate(
+            effective_from=date(2026, 2, 1),
+            effective_to=date(2026, 3, 1),
+            checksum_sha256=_checksum("rate-adjacent"),
+        ),
+    )
+
+    assert await db_session.scalar(select(func.count()).select_from(EstimationRate)) == 2
+
+
+async def test_material_catalog_project_overlap_rejects_adjacent_windows_allowed(
+    db_session: AsyncSession,
+) -> None:
+    project_id = await _create_project(db_session)
+
+    await _persist(
+        db_session,
+        _build_material(scope_type="project", project_id=project_id),
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        _build_material(
+            scope_type="project",
+            project_id=project_id,
+            effective_from=date(2026, 1, 15),
+            effective_to=date(2026, 2, 15),
+            checksum_sha256=_checksum("material-overlap"),
+        ),
+        "ex_material_catalog_entries_project_no_overlap",
+    )
+
+    await _persist(
+        db_session,
+        _build_material(
+            scope_type="project",
+            project_id=project_id,
+            effective_from=date(2026, 2, 1),
+            effective_to=date(2026, 3, 1),
+            checksum_sha256=_checksum("material-adjacent"),
+        ),
+    )
+
+    assert await db_session.scalar(select(func.count()).select_from(EstimationMaterial)) == 2
+
+
+@pytest.mark.parametrize(
+    ("builder", "scope_constraint", "scope_project_constraint", "checksum_constraint"),
+    [
+        pytest.param(
+            _build_rate,
+            "ck_rate_catalog_entries_scope_type",
+            "ck_rate_catalog_entries_scope_project_id",
+            "ck_rate_catalog_entries_checksum_sha256",
+            id="rate",
+        ),
+        pytest.param(
+            _build_material,
+            "ck_material_catalog_entries_scope_type",
+            "ck_material_catalog_entries_scope_project_id",
+            "ck_material_catalog_entries_checksum_sha256",
+            id="material",
+        ),
+        pytest.param(
+            _build_formula,
+            "ck_formula_definitions_scope_type",
+            "ck_formula_definitions_scope_project_id",
+            "ck_formula_definitions_checksum_sha256",
+            id="formula",
+        ),
+    ],
+)
+async def test_catalog_rows_reject_invalid_scope_project_and_checksum(
+    db_session: AsyncSession,
+    builder: CatalogBuilder,
+    scope_constraint: str,
+    scope_project_constraint: str,
+    checksum_constraint: str,
+) -> None:
+    project_id = await _create_project(db_session)
+
+    await _assert_commit_fails(
+        db_session,
+        builder(scope_type="invalid", checksum_sha256=_checksum(f"{scope_constraint}-scope")),
+        (scope_constraint, scope_project_constraint),
+    )
+    await _assert_commit_fails(
+        db_session,
+        builder(
+            scope_type="global",
+            project_id=project_id,
+            checksum_sha256=_checksum(f"{scope_project_constraint}-scope-project"),
+        ),
+        scope_project_constraint,
+    )
+    await _assert_commit_fails(
+        db_session,
+        builder(
+            scope_type="project",
+            project_id=uuid.uuid4(),
+            checksum_sha256=_checksum(f"{scope_project_constraint}-foreign-key"),
+        ),
+        "foreign key constraint",
+    )
+    await _assert_commit_fails(
+        db_session,
+        builder(checksum_sha256="not-a-valid-checksum"),
+        checksum_constraint,
+    )
+
+
+async def test_formula_definitions_reject_duplicate_version_and_checksum_per_scope(
+    db_session: AsyncSession,
+) -> None:
+    await _persist(
+        db_session,
+        _build_formula(
+            formula_id="formula.global",
+            version=1,
+            checksum_sha256=_checksum("formula-global-v1"),
+        ),
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        _build_formula(
+            formula_id="formula.global",
+            version=1,
+            checksum_sha256=_checksum("formula-global-v1-dup-version"),
+        ),
+        "uq_formula_definitions_global_version",
+    )
+    await _assert_commit_fails(
+        db_session,
+        _build_formula(
+            formula_id="formula.global",
+            version=2,
+            checksum_sha256=_checksum("formula-global-v1"),
+        ),
+        "uq_formula_definitions_global_checksum",
+    )
+
+    project_id = await _create_project(db_session)
+    await _persist(
+        db_session,
+        _build_formula(
+            scope_type="project",
+            project_id=project_id,
+            formula_id="formula.project",
+            version=1,
+            checksum_sha256=_checksum("formula-project-v1"),
+        ),
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        _build_formula(
+            scope_type="project",
+            project_id=project_id,
+            formula_id="formula.project",
+            version=1,
+            checksum_sha256=_checksum("formula-project-v1-dup-version"),
+        ),
+        "uq_formula_definitions_project_version",
+    )
+    await _assert_commit_fails(
+        db_session,
+        _build_formula(
+            scope_type="project",
+            project_id=project_id,
+            formula_id="formula.project",
+            version=2,
+            checksum_sha256=_checksum("formula-project-v1"),
+        ),
+        "uq_formula_definitions_project_checksum",
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "builder",
+        "same_row_overrides",
+        "predecessor_overrides",
+        "successor_overrides",
+        "supersession_type",
+        "predecessor_attr",
+        "successor_attr",
+        "same_row_message",
+        "mismatched_key_message",
+    ),
+    [
+        pytest.param(
+            _build_rate,
+            {
+                "rate_key": "labour.same-row",
+                "effective_from": date(2026, 4, 1),
+                "effective_to": date(2026, 5, 1),
+                "checksum_sha256": _checksum("rate-same-row"),
+            },
+            {
+                "rate_key": "labour.base",
+                "effective_from": date(2026, 6, 1),
+                "effective_to": date(2026, 7, 1),
+                "checksum_sha256": _checksum("rate-predecessor"),
+            },
+            {
+                "rate_key": "labour.other",
+                "effective_from": date(2026, 6, 1),
+                "effective_to": date(2026, 7, 1),
+                "checksum_sha256": _checksum("rate-successor"),
+            },
+            EstimationRateSupersession,
+            "predecessor_rate_id",
+            "successor_rate_id",
+            "ck_rate_catalog_entry_supersessions_distinct_nodes",
+            "rate supersession must preserve rate key and scope",
+            id="rate",
+        ),
+        pytest.param(
+            _build_material,
+            {
+                "material_key": "material.same-row",
+                "effective_from": date(2026, 4, 1),
+                "effective_to": date(2026, 5, 1),
+                "checksum_sha256": _checksum("material-same-row"),
+            },
+            {
+                "material_key": "material.base",
+                "effective_from": date(2026, 6, 1),
+                "effective_to": date(2026, 7, 1),
+                "checksum_sha256": _checksum("material-predecessor"),
+            },
+            {
+                "material_key": "material.other",
+                "effective_from": date(2026, 6, 1),
+                "effective_to": date(2026, 7, 1),
+                "checksum_sha256": _checksum("material-successor"),
+            },
+            EstimationMaterialSupersession,
+            "predecessor_material_id",
+            "successor_material_id",
+            "ck_material_catalog_entry_supersessions_distinct_nodes",
+            "material supersession must preserve material key and scope",
+            id="material",
+        ),
+        pytest.param(
+            _build_formula,
+            {
+                "formula_id": "formula.same-row",
+                "version": 1,
+                "checksum_sha256": _checksum("formula-same-row"),
+            },
+            {
+                "formula_id": "formula.base",
+                "version": 1,
+                "checksum_sha256": _checksum("formula-predecessor"),
+            },
+            {
+                "formula_id": "formula.other",
+                "version": 1,
+                "checksum_sha256": _checksum("formula-successor"),
+            },
+            EstimationFormulaSupersession,
+            "predecessor_formula_id",
+            "successor_formula_id",
+            "ck_formula_definition_supersessions_distinct_nodes",
+            "formula supersession must preserve formula key and scope",
+            id="formula",
+        ),
+    ],
+)
+async def test_supersessions_reject_same_row_and_mismatched_key_pairs(
+    db_session: AsyncSession,
+    builder: CatalogBuilder,
+    same_row_overrides: dict[str, Any],
+    predecessor_overrides: dict[str, Any],
+    successor_overrides: dict[str, Any],
+    supersession_type: type[Any],
+    predecessor_attr: str,
+    successor_attr: str,
+    same_row_message: str,
+    mismatched_key_message: str,
+) -> None:
+    same_row = builder(**same_row_overrides)
+    predecessor = builder(**predecessor_overrides)
+    successor = builder(**successor_overrides)
+
+    await _persist(db_session, same_row)
+
+    await _assert_commit_fails(
+        db_session,
+        supersession_type(
+            **{
+                predecessor_attr: same_row.id,
+                successor_attr: same_row.id,
+            }
+        ),
+        same_row_message,
+    )
+
+    await _persist(db_session, predecessor, successor)
+
+    await _assert_commit_fails(
+        db_session,
+        supersession_type(
+            **{
+                predecessor_attr: predecessor.id,
+                successor_attr: successor.id,
+            }
+        ),
+        mismatched_key_message,
+    )
+
+
+@pytest.mark.parametrize(
+    ("builder", "table_name", "supersession_table_name"),
+    [
+        pytest.param(
+            _build_rate,
+            "rate_catalog_entries",
+            "rate_catalog_entry_supersessions",
+            id="rate",
+        ),
+        pytest.param(
+            _build_material,
+            "material_catalog_entries",
+            "material_catalog_entry_supersessions",
+            id="material",
+        ),
+        pytest.param(
+            _build_formula,
+            "formula_definitions",
+            "formula_definition_supersessions",
+            id="formula",
+        ),
+    ],
+)
+async def test_catalog_tables_reject_append_only_mutations(
+    db_session: AsyncSession,
+    builder: CatalogBuilder,
+    table_name: str,
+    supersession_table_name: str,
+) -> None:
+    row = builder(checksum_sha256=_checksum(f"{table_name}-append-only"))
+    await _persist(db_session, row)
+    row_id = row.id
+
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        f"UPDATE \"{table_name}\" SET created_at = created_at + INTERVAL '1 second' "
+        "WHERE id = :row_id",
+        table_name=table_name,
+        operation="UPDATE",
+        params={"row_id": row_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        f'DELETE FROM "{table_name}" WHERE id = :row_id',
+        table_name=table_name,
+        operation="DELETE",
+        params={"row_id": row_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        f'TRUNCATE TABLE "{table_name}", "{supersession_table_name}"',
+        table_name=table_name,
+        operation="TRUNCATE",
+        expected_substring=(
+            f"append-only trigger blocked TRUNCATE on {table_name}",
+            f"append-only trigger blocked TRUNCATE on {supersession_table_name}",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "builder",
+        "predecessor_overrides",
+        "successor_overrides",
+        "supersession_type",
+        "predecessor_attr",
+        "successor_attr",
+        "table_name",
+    ),
+    [
+        pytest.param(
+            _build_rate,
+            {
+                "rate_key": "labour.append-only",
+                "effective_from": date(2026, 8, 1),
+                "effective_to": date(2026, 9, 1),
+                "checksum_sha256": _checksum("rate-append-only-predecessor"),
+            },
+            {
+                "rate_key": "labour.append-only",
+                "effective_from": date(2026, 9, 1),
+                "effective_to": date(2026, 10, 1),
+                "checksum_sha256": _checksum("rate-append-only-successor"),
+            },
+            EstimationRateSupersession,
+            "predecessor_rate_id",
+            "successor_rate_id",
+            "rate_catalog_entry_supersessions",
+            id="rate",
+        ),
+        pytest.param(
+            _build_material,
+            {
+                "material_key": "material.append-only",
+                "effective_from": date(2026, 8, 1),
+                "effective_to": date(2026, 9, 1),
+                "checksum_sha256": _checksum("material-append-only-predecessor"),
+            },
+            {
+                "material_key": "material.append-only",
+                "effective_from": date(2026, 9, 1),
+                "effective_to": date(2026, 10, 1),
+                "checksum_sha256": _checksum("material-append-only-successor"),
+            },
+            EstimationMaterialSupersession,
+            "predecessor_material_id",
+            "successor_material_id",
+            "material_catalog_entry_supersessions",
+            id="material",
+        ),
+        pytest.param(
+            _build_formula,
+            {
+                "formula_id": "formula.append-only",
+                "version": 1,
+                "checksum_sha256": _checksum("formula-append-only-predecessor"),
+            },
+            {
+                "formula_id": "formula.append-only",
+                "version": 2,
+                "checksum_sha256": _checksum("formula-append-only-successor"),
+            },
+            EstimationFormulaSupersession,
+            "predecessor_formula_id",
+            "successor_formula_id",
+            "formula_definition_supersessions",
+            id="formula",
+        ),
+    ],
+)
+async def test_supersession_tables_reject_append_only_mutations(
+    db_session: AsyncSession,
+    builder: CatalogBuilder,
+    predecessor_overrides: dict[str, Any],
+    successor_overrides: dict[str, Any],
+    supersession_type: type[Any],
+    predecessor_attr: str,
+    successor_attr: str,
+    table_name: str,
+) -> None:
+    predecessor = builder(**predecessor_overrides)
+    successor = builder(**successor_overrides)
+    await _persist(db_session, predecessor, successor)
+
+    supersession = supersession_type(
+        **{
+            predecessor_attr: predecessor.id,
+            successor_attr: successor.id,
+        }
+    )
+    await _persist(db_session, supersession)
+    supersession_id = supersession.id
+
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        f"UPDATE \"{table_name}\" SET created_at = created_at + INTERVAL '1 second' "
+        "WHERE id = :row_id",
+        table_name=table_name,
+        operation="UPDATE",
+        params={"row_id": supersession_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        f'DELETE FROM "{table_name}" WHERE id = :row_id',
+        table_name=table_name,
+        operation="DELETE",
+        params={"row_id": supersession_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        f'TRUNCATE TABLE "{table_name}"',
+        table_name=table_name,
+        operation="TRUNCATE",
+    )

--- a/tests/test_estimation_catalog_persistence.py
+++ b/tests/test_estimation_catalog_persistence.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import AsyncGenerator, Callable, Sequence
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import pytest_asyncio
@@ -133,7 +133,7 @@ async def _create_project(session: AsyncSession) -> uuid.UUID:
     else:
         result = await session.execute(text("INSERT INTO projects DEFAULT VALUES RETURNING id"))
 
-    project_id = result.scalar_one()
+    project_id = cast(uuid.UUID, result.scalar_one())
     await session.commit()
     return project_id
 


### PR DESCRIPTION
Closes #196

## Summary
- add immutable rate, material, and formula catalog tables with append-only supersession lineage
- enforce scope, checksum, uniqueness, and half-open effective-date overlap constraints in the new migration
- add persistence coverage and test DB cleanup updates to keep fresh-db validation deterministic

## Test plan
- [x] uv run ruff check app tests alembic
- [x] uv run mypy app
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_issue196_validation uv run alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_issue196_validation uv run pytest