### PR TITLE
feat(estimation): add deterministic catalog selector

### DIFF
--- a/app/estimating/catalog/__init__.py
+++ b/app/estimating/catalog/__init__.py
@@ -1,0 +1,37 @@
+"""Estimation catalog selection contracts and deterministic selectors."""
+
+from .contracts import (
+    CatalogFormulaAutoSelectRequest,
+    CatalogFormulaMatch,
+    CatalogFormulaRef,
+    CatalogMaterialAutoSelectRequest,
+    CatalogMaterialMatch,
+    CatalogMaterialRef,
+    CatalogRateAutoSelectRequest,
+    CatalogRateMatch,
+    CatalogRateRef,
+)
+from .selection import (
+    CatalogSelectionError,
+    SelectedFormula,
+    select_formula,
+    select_material,
+    select_rate,
+)
+
+__all__ = [
+    "CatalogFormulaAutoSelectRequest",
+    "CatalogFormulaMatch",
+    "CatalogFormulaRef",
+    "CatalogMaterialAutoSelectRequest",
+    "CatalogMaterialMatch",
+    "CatalogMaterialRef",
+    "CatalogRateAutoSelectRequest",
+    "CatalogRateMatch",
+    "CatalogRateRef",
+    "CatalogSelectionError",
+    "SelectedFormula",
+    "select_formula",
+    "select_material",
+    "select_rate",
+]

--- a/app/estimating/catalog/contracts.py
+++ b/app/estimating/catalog/contracts.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+_HEX_CHARACTERS = frozenset("0123456789abcdef")
+
+
+def _validate_checksum_sha256(value: str) -> None:
+    if len(value) != 64 or any(character not in _HEX_CHARACTERS for character in value):
+        raise ValueError("checksum_sha256 must be raw lowercase 64-char SHA-256 hex")
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogRateRef:
+    id: UUID
+    checksum_sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_checksum_sha256(self.checksum_sha256)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogMaterialRef:
+    id: UUID
+    checksum_sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_checksum_sha256(self.checksum_sha256)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogFormulaRef:
+    id: UUID
+    checksum_sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_checksum_sha256(self.checksum_sha256)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogRateMatch:
+    id: UUID
+    project_id: UUID | None
+    rate_key: str
+    item_type: str
+    unit: str
+    currency: str
+    value: Decimal
+    effective_start: date
+    effective_end: date | None
+    checksum_sha256: str
+    superseded_by_id: UUID | None = None
+    metadata: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_checksum_sha256(self.checksum_sha256)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogMaterialMatch:
+    id: UUID
+    project_id: UUID | None
+    material_key: str
+    unit: str
+    currency: str
+    value: Decimal
+    effective_start: date
+    effective_end: date | None
+    checksum_sha256: str
+    superseded_by_id: UUID | None = None
+    metadata: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_checksum_sha256(self.checksum_sha256)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogFormulaMatch:
+    id: UUID
+    formula_id: str
+    version: int
+    project_id: UUID | None
+    checksum_sha256: str
+    expression: dict[str, Any]
+    scope_type: str = "global"
+    name: str = ""
+    dsl_version: str = "1.0"
+    output_key: str = ""
+    output_contract: dict[str, Any] = field(default_factory=dict)
+    declared_inputs: list[dict[str, Any]] = field(default_factory=list)
+    rounding: dict[str, Any] | None = None
+    superseded_by_id: UUID | None = None
+    metadata: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_checksum_sha256(self.checksum_sha256)
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogRateAutoSelectRequest:
+    project_id: UUID | None
+    rate_key: str
+    item_type: str
+    unit: str
+    currency: str
+    as_of: date
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogMaterialAutoSelectRequest:
+    project_id: UUID | None
+    material_key: str
+    unit: str
+    currency: str
+    as_of: date
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogFormulaAutoSelectRequest:
+    project_id: UUID | None
+    formula_id: str
+    version: int | None = None

--- a/app/estimating/catalog/resolver.py
+++ b/app/estimating/catalog/resolver.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.estimating.catalog.contracts import (
+    CatalogFormulaAutoSelectRequest,
+    CatalogFormulaMatch,
+    CatalogFormulaRef,
+    CatalogMaterialAutoSelectRequest,
+    CatalogMaterialMatch,
+    CatalogMaterialRef,
+    CatalogRateAutoSelectRequest,
+    CatalogRateMatch,
+    CatalogRateRef,
+)
+from app.estimating.catalog.selection import (
+    SelectedFormula,
+    select_formula,
+    select_material,
+    select_rate,
+)
+from app.models.estimation_catalog import (
+    EstimationFormula,
+    EstimationFormulaSupersession,
+    EstimationMaterial,
+    EstimationMaterialSupersession,
+    EstimationRate,
+    EstimationRateSupersession,
+)
+
+
+async def resolve_rate(
+    session: AsyncSession,
+    *,
+    auto: CatalogRateAutoSelectRequest | None = None,
+    ref: CatalogRateRef | None = None,
+) -> CatalogRateMatch:
+    query = _build_rate_query(auto=auto, ref=ref)
+    result = await session.execute(query)
+    candidates = [
+        _map_rate_candidate(rate_entry, superseded_by_id)
+        for rate_entry, superseded_by_id in result.all()
+    ]
+    return select_rate(candidates, auto=auto, ref=ref)
+
+
+async def resolve_material(
+    session: AsyncSession,
+    *,
+    auto: CatalogMaterialAutoSelectRequest | None = None,
+    ref: CatalogMaterialRef | None = None,
+) -> CatalogMaterialMatch:
+    query = _build_material_query(auto=auto, ref=ref)
+    result = await session.execute(query)
+    candidates = [
+        _map_material_candidate(material_entry, superseded_by_id)
+        for material_entry, superseded_by_id in result.all()
+    ]
+    return select_material(candidates, auto=auto, ref=ref)
+
+
+async def resolve_formula(
+    session: AsyncSession,
+    *,
+    auto: CatalogFormulaAutoSelectRequest | None = None,
+    ref: CatalogFormulaRef | None = None,
+) -> SelectedFormula:
+    query = _build_formula_query(auto=auto, ref=ref)
+    result = await session.execute(query)
+    candidates = [
+        _map_formula_candidate(formula_definition, superseded_by_id)
+        for formula_definition, superseded_by_id in result.all()
+    ]
+    return select_formula(candidates, auto=auto, ref=ref)
+
+
+def _build_rate_query(
+    *,
+    auto: CatalogRateAutoSelectRequest | None,
+    ref: CatalogRateRef | None,
+) -> Select[tuple[EstimationRate, Any]]:
+    query = (
+        select(EstimationRate, EstimationRateSupersession.successor_rate_id)
+        .outerjoin(
+            EstimationRateSupersession,
+            EstimationRateSupersession.predecessor_rate_id == EstimationRate.id,
+        )
+    )
+    if ref is not None:
+        return query.where(EstimationRate.id == ref.id)
+    if auto is None:
+        return query
+    return query.where(
+        EstimationRate.rate_key == auto.rate_key,
+        EstimationRate.item_type == auto.item_type,
+        EstimationRate.per_unit == auto.unit,
+        EstimationRate.currency == auto.currency,
+    )
+
+
+def _build_material_query(
+    *,
+    auto: CatalogMaterialAutoSelectRequest | None,
+    ref: CatalogMaterialRef | None,
+) -> Select[tuple[EstimationMaterial, Any]]:
+    query = (
+        select(EstimationMaterial, EstimationMaterialSupersession.successor_material_id)
+        .outerjoin(
+            EstimationMaterialSupersession,
+            EstimationMaterialSupersession.predecessor_material_id == EstimationMaterial.id,
+        )
+    )
+    if ref is not None:
+        return query.where(EstimationMaterial.id == ref.id)
+    if auto is None:
+        return query
+    return query.where(
+        EstimationMaterial.material_key == auto.material_key,
+        EstimationMaterial.unit == auto.unit,
+        EstimationMaterial.currency == auto.currency,
+    )
+
+
+def _build_formula_query(
+    *,
+    auto: CatalogFormulaAutoSelectRequest | None,
+    ref: CatalogFormulaRef | None,
+) -> Select[tuple[EstimationFormula, Any]]:
+    query = (
+        select(EstimationFormula, EstimationFormulaSupersession.successor_formula_id)
+        .outerjoin(
+            EstimationFormulaSupersession,
+            EstimationFormulaSupersession.predecessor_formula_id == EstimationFormula.id,
+        )
+    )
+    if ref is not None:
+        return query.where(EstimationFormula.id == ref.id)
+    if auto is None:
+        return query
+
+    query = query.where(EstimationFormula.formula_id == auto.formula_id)
+    if auto.version is not None:
+        query = query.where(EstimationFormula.version == auto.version)
+    return query
+
+
+def _map_rate_candidate(
+    entry: EstimationRate,
+    superseded_by_id: Any,
+) -> CatalogRateMatch:
+    return CatalogRateMatch(
+        id=entry.id,
+        project_id=entry.project_id,
+        rate_key=entry.rate_key,
+        item_type=entry.item_type,
+        unit=entry.per_unit,
+        currency=entry.currency,
+        value=entry.amount,
+        effective_start=entry.effective_from,
+        effective_end=entry.effective_to,
+        checksum_sha256=entry.checksum_sha256,
+        superseded_by_id=superseded_by_id,
+        metadata=entry.metadata_json,
+    )
+
+
+def _map_material_candidate(
+    entry: EstimationMaterial,
+    superseded_by_id: Any,
+) -> CatalogMaterialMatch:
+    return CatalogMaterialMatch(
+        id=entry.id,
+        project_id=entry.project_id,
+        material_key=entry.material_key,
+        unit=entry.unit,
+        currency=entry.currency,
+        value=entry.unit_cost,
+        effective_start=entry.effective_from,
+        effective_end=entry.effective_to,
+        checksum_sha256=entry.checksum_sha256,
+        superseded_by_id=superseded_by_id,
+        metadata=entry.metadata_json,
+    )
+
+
+def _map_formula_candidate(
+    definition: EstimationFormula,
+    superseded_by_id: Any,
+) -> CatalogFormulaMatch:
+    return CatalogFormulaMatch(
+        id=definition.id,
+        scope_type=definition.scope_type,
+        formula_id=definition.formula_id,
+        version=definition.version,
+        project_id=definition.project_id,
+        name=definition.name,
+        dsl_version=definition.dsl_version,
+        output_key=definition.output_key,
+        output_contract=definition.output_contract_json,
+        declared_inputs=definition.declared_inputs_json,
+        checksum_sha256=definition.checksum_sha256,
+        expression=definition.expression_json,
+        rounding=definition.rounding_json,
+        superseded_by_id=superseded_by_id,
+    )

--- a/app/estimating/catalog/selection.py
+++ b/app/estimating/catalog/selection.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+from uuid import UUID
+
+from .contracts import (
+    CatalogFormulaAutoSelectRequest,
+    CatalogFormulaMatch,
+    CatalogFormulaRef,
+    CatalogMaterialAutoSelectRequest,
+    CatalogMaterialMatch,
+    CatalogMaterialRef,
+    CatalogRateAutoSelectRequest,
+    CatalogRateMatch,
+    CatalogRateRef,
+)
+
+ChecksumRef = CatalogRateRef | CatalogMaterialRef
+TimedMatch = CatalogRateMatch | CatalogMaterialMatch
+ProjectScopedMatch = CatalogRateMatch | CatalogMaterialMatch | CatalogFormulaMatch
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedFormula:
+    definition_id: UUID
+    scope_type: str
+    project_id: UUID | None
+    formula_id: str
+    version: int
+    name: str
+    dsl_version: str
+    output_key: str
+    output_contract: dict[str, Any]
+    declared_inputs: list[dict[str, Any]]
+    checksum_sha256: str
+    expression: dict[str, Any]
+    rounding: dict[str, Any] | None
+
+
+class CatalogSelectionError(ValueError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        conflicting_candidate_ids: tuple[UUID, ...] = (),
+    ) -> None:
+        self.conflicting_candidate_ids = conflicting_candidate_ids
+        detail = (
+            f" conflicting_candidate_ids={conflicting_candidate_ids}"
+            if conflicting_candidate_ids
+            else ""
+        )
+        super().__init__(f"{message}{detail}")
+
+
+def select_rate(
+    candidates: Iterable[CatalogRateMatch],
+    *,
+    auto: CatalogRateAutoSelectRequest | None = None,
+    ref: CatalogRateRef | None = None,
+) -> CatalogRateMatch:
+    return _select_timed(candidates, auto=auto, ref=ref)
+
+
+def select_material(
+    candidates: Iterable[CatalogMaterialMatch],
+    *,
+    auto: CatalogMaterialAutoSelectRequest | None = None,
+    ref: CatalogMaterialRef | None = None,
+) -> CatalogMaterialMatch:
+    return _select_timed(candidates, auto=auto, ref=ref)
+
+
+def select_formula(
+    candidates: Iterable[CatalogFormulaMatch],
+    *,
+    auto: CatalogFormulaAutoSelectRequest | None = None,
+    ref: CatalogFormulaRef | None = None,
+) -> SelectedFormula:
+    if (auto is None) == (ref is None):
+        raise CatalogSelectionError("select_formula requires exactly one selector")
+
+    filtered = _non_stale(candidates)
+    if ref is not None:
+        match = _select_by_formula_ref(filtered, ref)
+    else:
+        assert auto is not None
+        match = _select_formula_auto(filtered, auto)
+
+    return SelectedFormula(
+        definition_id=match.id,
+        scope_type=match.scope_type,
+        project_id=match.project_id,
+        formula_id=match.formula_id,
+        version=match.version,
+        name=match.name,
+        dsl_version=match.dsl_version,
+        output_key=match.output_key,
+        output_contract=match.output_contract,
+        declared_inputs=match.declared_inputs,
+        checksum_sha256=match.checksum_sha256,
+        expression=match.expression,
+        rounding=match.rounding,
+    )
+
+
+def _select_timed[
+    TMatch: TimedMatch,
+    TAuto: CatalogRateAutoSelectRequest | CatalogMaterialAutoSelectRequest,
+    TRef: ChecksumRef,
+](
+    candidates: Iterable[TMatch],
+    *,
+    auto: TAuto | None,
+    ref: TRef | None,
+) -> TMatch:
+    if (auto is None) == (ref is None):
+        raise CatalogSelectionError("selector requires exactly one of auto or ref")
+
+    filtered = _non_stale(candidates)
+    if ref is not None:
+        return _select_by_checksum_ref(filtered, ref)
+
+    assert auto is not None
+    return _select_timed_auto(filtered, auto)
+
+
+def _non_stale[TMatch: ProjectScopedMatch](candidates: Iterable[TMatch]) -> list[TMatch]:
+    return [candidate for candidate in candidates if candidate.superseded_by_id is None]
+
+
+def _select_by_checksum_ref[TMatch: TimedMatch, TRef: ChecksumRef](
+    candidates: Iterable[TMatch],
+    ref: TRef,
+) -> TMatch:
+    matched = [candidate for candidate in candidates if candidate.id == ref.id]
+    if not matched:
+        raise CatalogSelectionError("explicit reference is stale or missing")
+
+    if len(matched) > 1:
+        raise CatalogSelectionError("explicit reference matched multiple catalog rows")
+
+    candidate = matched[0]
+    if candidate.checksum_sha256 != ref.checksum_sha256:
+        raise CatalogSelectionError("explicit reference checksum mismatch")
+    return candidate
+
+
+def _select_by_formula_ref(
+    candidates: Iterable[CatalogFormulaMatch],
+    ref: CatalogFormulaRef,
+) -> CatalogFormulaMatch:
+    matched = [candidate for candidate in candidates if candidate.id == ref.id]
+    if not matched:
+        raise CatalogSelectionError("explicit formula reference is stale or missing")
+    if len(matched) > 1:
+        raise CatalogSelectionError(
+            "explicit formula reference matched multiple catalog rows",
+            conflicting_candidate_ids=_sorted_candidate_ids(matched),
+        )
+
+    candidate = matched[0]
+    if candidate.checksum_sha256 != ref.checksum_sha256:
+        raise CatalogSelectionError("explicit formula reference checksum mismatch")
+    return candidate
+
+
+def _select_timed_auto[TMatch: TimedMatch](
+    candidates: Iterable[TMatch],
+    auto: CatalogRateAutoSelectRequest | CatalogMaterialAutoSelectRequest,
+) -> TMatch:
+    active = [
+        candidate
+        for candidate in candidates
+        if _matches_timed_request(candidate, auto) and _is_effective(candidate, auto.as_of)
+    ]
+    return _resolve_project_scope(active, auto.project_id)
+
+
+def _select_formula_auto(
+    candidates: Iterable[CatalogFormulaMatch],
+    auto: CatalogFormulaAutoSelectRequest,
+) -> CatalogFormulaMatch:
+    matched = [candidate for candidate in candidates if candidate.formula_id == auto.formula_id]
+    if auto.version is not None:
+        matched = [candidate for candidate in matched if candidate.version == auto.version]
+    return _resolve_project_scope(matched, auto.project_id)
+
+
+def _resolve_project_scope[TMatch: ProjectScopedMatch](
+    candidates: Iterable[TMatch],
+    project_id: UUID | None,
+) -> TMatch:
+    candidate_list = list(candidates)
+    if project_id is not None:
+        project_matches = [
+            candidate for candidate in candidate_list if candidate.project_id == project_id
+        ]
+        if project_matches:
+            return _require_single(project_matches, "project")
+
+    global_matches = [candidate for candidate in candidate_list if candidate.project_id is None]
+    if global_matches:
+        return _require_single(global_matches, "global")
+
+    raise CatalogSelectionError("no non-stale catalog match found")
+
+
+def _require_single[TMatch: ProjectScopedMatch](candidates: list[TMatch], scope: str) -> TMatch:
+    if len(candidates) == 1:
+        return candidates[0]
+    raise CatalogSelectionError(
+        f"multiple non-stale {scope} catalog matches found",
+        conflicting_candidate_ids=_sorted_candidate_ids(candidates),
+    )
+
+
+def _sorted_candidate_ids[TMatch: ProjectScopedMatch](
+    candidates: Iterable[TMatch],
+) -> tuple[UUID, ...]:
+    return tuple(
+        sorted(
+            (candidate.id for candidate in candidates),
+            key=lambda candidate_id: candidate_id.hex,
+        )
+    )
+
+
+def _is_effective(candidate: TimedMatch, as_of: date) -> bool:
+    if candidate.effective_start > as_of:
+        return False
+    if candidate.effective_end is None:
+        return True
+    return as_of < candidate.effective_end
+
+
+def _matches_timed_request(
+    candidate: TimedMatch,
+    auto: CatalogRateAutoSelectRequest | CatalogMaterialAutoSelectRequest,
+) -> bool:
+    if isinstance(candidate, CatalogRateMatch) and isinstance(auto, CatalogRateAutoSelectRequest):
+        return (
+            candidate.rate_key == auto.rate_key
+            and candidate.item_type == auto.item_type
+            and candidate.unit == auto.unit
+            and candidate.currency == auto.currency
+        )
+
+    if isinstance(candidate, CatalogMaterialMatch) and isinstance(
+        auto, CatalogMaterialAutoSelectRequest
+    ):
+        return (
+            candidate.material_key == auto.material_key
+            and candidate.unit == auto.unit
+            and candidate.currency == auto.currency
+        )
+
+    return False

--- a/tests/test_estimation_catalog_resolver.py
+++ b/tests/test_estimation_catalog_resolver.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib
+from datetime import date
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.estimating.catalog.contracts import (
+    CatalogFormulaRef,
+    CatalogMaterialAutoSelectRequest,
+    CatalogRateAutoSelectRequest,
+    CatalogRateRef,
+)
+from app.estimating.catalog.resolver import resolve_formula, resolve_material, resolve_rate
+from app.estimating.catalog.selection import CatalogSelectionError
+from app.models.estimation_catalog import EstimationRateSupersession
+from tests.test_estimation_catalog_persistence import (
+    _build_formula,
+    _build_material,
+    _build_rate,
+    _checksum,
+    _create_project,
+    _persist,
+)
+
+requires_database = importlib.import_module(
+    "tests.test_estimation_catalog_persistence"
+).requires_database
+pytestmark = [pytest.mark.asyncio, cast(Any, requires_database)]
+
+
+async def test_resolve_formula_explicit_ref_uses_row_uuid_and_returns_snapshot_metadata(
+    db_session: AsyncSession,
+) -> None:
+    project_id = await _create_project(db_session)
+    formula = _build_formula(
+        scope_type="project",
+        project_id=project_id,
+        formula_id="formula.explicit",
+        name="Explicit formula",
+        output_key="estimate.paint_total",
+        output_contract_json={"type": "money", "currency": "GBP"},
+        declared_inputs_json=[{"key": "quantity", "type": "decimal"}],
+        expression_json={"op": "literal", "value": "12.34"},
+        rounding_json={"mode": "ROUND_HALF_UP", "scale": 2},
+        checksum_sha256=_checksum("formula-explicit"),
+    )
+    await _persist(db_session, formula)
+
+    resolved = await resolve_formula(
+        db_session,
+        ref=CatalogFormulaRef(id=formula.id, checksum_sha256=formula.checksum_sha256),
+    )
+
+    assert resolved.definition_id == formula.id
+    assert resolved.scope_type == "project"
+    assert resolved.project_id == project_id
+    assert resolved.formula_id == "formula.explicit"
+    assert resolved.version == formula.version
+    assert resolved.name == "Explicit formula"
+    assert resolved.dsl_version == formula.dsl_version
+    assert resolved.output_key == "estimate.paint_total"
+    assert resolved.output_contract == {"type": "money", "currency": "GBP"}
+    assert resolved.declared_inputs == [{"key": "quantity", "type": "decimal"}]
+    assert resolved.expression == {"op": "literal", "value": "12.34"}
+    assert resolved.rounding == {"mode": "ROUND_HALF_UP", "scale": 2}
+    assert resolved.checksum_sha256 == formula.checksum_sha256
+
+
+async def test_resolve_material_auto_prefers_project_scope_over_global(
+    db_session: AsyncSession,
+) -> None:
+    project_id = await _create_project(db_session)
+    global_material = _build_material(
+        material_key="material.precedence",
+        checksum_sha256=_checksum("material-global"),
+    )
+    project_material = _build_material(
+        scope_type="project",
+        project_id=project_id,
+        material_key="material.precedence",
+        unit_cost="18.750000",
+        checksum_sha256=_checksum("material-project"),
+    )
+    await _persist(db_session, global_material, project_material)
+
+    resolved = await resolve_material(
+        db_session,
+        auto=CatalogMaterialAutoSelectRequest(
+            project_id=project_id,
+            material_key="material.precedence",
+            unit=project_material.unit,
+            currency=project_material.currency,
+            as_of=date(2026, 1, 15),
+        ),
+    )
+
+    assert resolved.id == project_material.id
+    assert resolved.project_id == project_id
+    assert resolved.value == project_material.unit_cost
+
+
+async def test_resolve_rate_rejects_stale_explicit_ref_and_falls_back_to_successor(
+    db_session: AsyncSession,
+) -> None:
+    predecessor = _build_rate(
+        rate_key="labour.superseded",
+        checksum_sha256=_checksum("rate-predecessor"),
+    )
+    successor = _build_rate(
+        rate_key="labour.superseded",
+        amount="11.500000",
+        checksum_sha256=_checksum("rate-successor"),
+    )
+    await _persist(db_session, predecessor, successor)
+    await _persist(
+        db_session,
+        EstimationRateSupersession(
+            predecessor_rate_id=predecessor.id,
+            successor_rate_id=successor.id,
+        ),
+    )
+
+    with pytest.raises(CatalogSelectionError, match="stale or missing"):
+        await resolve_rate(
+            db_session,
+            ref=CatalogRateRef(
+                id=predecessor.id,
+                checksum_sha256=predecessor.checksum_sha256,
+            ),
+        )
+
+    resolved = await resolve_rate(
+        db_session,
+        auto=CatalogRateAutoSelectRequest(
+            project_id=None,
+            rate_key="labour.superseded",
+            item_type=successor.item_type,
+            unit=successor.per_unit,
+            currency=successor.currency,
+            as_of=date(2026, 1, 15),
+        ),
+    )
+
+    assert resolved.id == successor.id
+    assert resolved.superseded_by_id is None
+    assert resolved.value == successor.amount

--- a/tests/test_estimation_catalog_resolver.py
+++ b/tests/test_estimation_catalog_resolver.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import AsyncGenerator
 from datetime import date
 from typing import Any, cast
 
 import pytest
+import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.estimating.catalog.contracts import (
@@ -21,6 +23,7 @@ from tests.test_estimation_catalog_persistence import (
     _build_material,
     _build_rate,
     _checksum,
+    _cleanup_catalog_tables,
     _create_project,
     _persist,
 )
@@ -29,6 +32,26 @@ requires_database = importlib.import_module(
     "tests.test_estimation_catalog_persistence"
 ).requires_database
 pytestmark = [pytest.mark.asyncio, cast(Any, requires_database)]
+
+
+@pytest_asyncio.fixture
+async def cleanup_estimation_catalog() -> AsyncGenerator[None, None]:
+    await _cleanup_catalog_tables()
+    yield
+    await _cleanup_catalog_tables()
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_estimation_catalog: None) -> AsyncGenerator[AsyncSession, None]:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
 
 
 async def test_resolve_formula_explicit_ref_uses_row_uuid_and_returns_snapshot_metadata(
@@ -107,6 +130,8 @@ async def test_resolve_rate_rejects_stale_explicit_ref_and_falls_back_to_success
 ) -> None:
     predecessor = _build_rate(
         rate_key="labour.superseded",
+        effective_from=date(2025, 12, 1),
+        effective_to=date(2026, 1, 1),
         checksum_sha256=_checksum("rate-predecessor"),
     )
     successor = _build_rate(

--- a/tests/test_estimation_catalog_selection.py
+++ b/tests/test_estimation_catalog_selection.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.estimating.catalog.contracts import (
+    CatalogFormulaAutoSelectRequest,
+    CatalogFormulaMatch,
+    CatalogFormulaRef,
+    CatalogMaterialAutoSelectRequest,
+    CatalogMaterialMatch,
+    CatalogMaterialRef,
+    CatalogRateAutoSelectRequest,
+    CatalogRateMatch,
+    CatalogRateRef,
+)
+from app.estimating.catalog.selection import (
+    CatalogSelectionError,
+    select_formula,
+    select_material,
+    select_rate,
+)
+
+CHECKSUM_A = "a" * 64
+CHECKSUM_B = "b" * 64
+
+
+def make_rate(**overrides: object) -> CatalogRateMatch:
+    id_value = overrides.get("id")
+    project_id = overrides.get("project_id")
+    rate_key = overrides.get("rate_key")
+    item_type = overrides.get("item_type")
+    unit = overrides.get("unit")
+    currency = overrides.get("currency")
+    value = overrides.get("value")
+    effective_start = overrides.get("effective_start")
+    effective_end = overrides.get("effective_end")
+    checksum_sha256 = overrides.get("checksum_sha256")
+    superseded_by_id = overrides.get("superseded_by_id")
+
+    return CatalogRateMatch(
+        id=id_value if isinstance(id_value, UUID) else uuid4(),
+        project_id=project_id if isinstance(project_id, UUID) else None,
+        rate_key=rate_key if isinstance(rate_key, str) else "labour",
+        item_type=item_type if isinstance(item_type, str) else "wall",
+        unit=unit if isinstance(unit, str) else "m2",
+        currency=currency if isinstance(currency, str) else "GBP",
+        value=value if isinstance(value, Decimal) else Decimal("12.34"),
+        effective_start=(
+            effective_start if isinstance(effective_start, date) else date(2025, 1, 1)
+        ),
+        effective_end=effective_end if isinstance(effective_end, date) else None,
+        checksum_sha256=(
+            checksum_sha256 if isinstance(checksum_sha256, str) else CHECKSUM_A
+        ),
+        superseded_by_id=(
+            superseded_by_id if isinstance(superseded_by_id, UUID) else None
+        ),
+    )
+
+
+def make_material(**overrides: object) -> CatalogMaterialMatch:
+    id_value = overrides.get("id")
+    project_id = overrides.get("project_id")
+    material_key = overrides.get("material_key")
+    unit = overrides.get("unit")
+    currency = overrides.get("currency")
+    value = overrides.get("value")
+    effective_start = overrides.get("effective_start")
+    effective_end = overrides.get("effective_end")
+    checksum_sha256 = overrides.get("checksum_sha256")
+    superseded_by_id = overrides.get("superseded_by_id")
+
+    return CatalogMaterialMatch(
+        id=id_value if isinstance(id_value, UUID) else uuid4(),
+        project_id=project_id if isinstance(project_id, UUID) else None,
+        material_key=material_key if isinstance(material_key, str) else "brick",
+        unit=unit if isinstance(unit, str) else "ea",
+        currency=currency if isinstance(currency, str) else "GBP",
+        value=value if isinstance(value, Decimal) else Decimal("1.23"),
+        effective_start=(
+            effective_start if isinstance(effective_start, date) else date(2025, 1, 1)
+        ),
+        effective_end=effective_end if isinstance(effective_end, date) else None,
+        checksum_sha256=(
+            checksum_sha256 if isinstance(checksum_sha256, str) else CHECKSUM_A
+        ),
+        superseded_by_id=(
+            superseded_by_id if isinstance(superseded_by_id, UUID) else None
+        ),
+    )
+
+
+def make_formula(**overrides: object) -> CatalogFormulaMatch:
+    id_value = overrides.get("id")
+    formula_id = overrides.get("formula_id")
+    version = overrides.get("version")
+    project_id = overrides.get("project_id")
+    checksum_sha256 = overrides.get("checksum_sha256")
+    expression = overrides.get("expression")
+    superseded_by_id = overrides.get("superseded_by_id")
+
+    return CatalogFormulaMatch(
+        id=id_value if isinstance(id_value, UUID) else uuid4(),
+        formula_id=formula_id if isinstance(formula_id, str) else "wall-area",
+        version=version if isinstance(version, int) else 1,
+        project_id=project_id if isinstance(project_id, UUID) else None,
+        checksum_sha256=(
+            checksum_sha256 if isinstance(checksum_sha256, str) else CHECKSUM_A
+        ),
+        expression=(
+            expression
+            if isinstance(expression, dict)
+            else {"op": "input", "name": "quantity"}
+        ),
+        superseded_by_id=(
+            superseded_by_id if isinstance(superseded_by_id, UUID) else None
+        ),
+    )
+
+
+def test_explicit_rate_ref_validates_checksum() -> None:
+    rate = make_rate()
+
+    selected = select_rate(
+        [rate],
+        ref=CatalogRateRef(id=rate.id, checksum_sha256=rate.checksum_sha256),
+    )
+
+    assert selected == rate
+
+
+def test_explicit_rate_ref_rejects_checksum_mismatch() -> None:
+    rate = make_rate()
+
+    with pytest.raises(CatalogSelectionError, match="checksum mismatch"):
+        select_rate([rate], ref=CatalogRateRef(id=rate.id, checksum_sha256=CHECKSUM_B))
+
+
+def test_explicit_rate_ref_rejects_stale_row() -> None:
+    rate = make_rate(superseded_by_id=uuid4())
+
+    with pytest.raises(CatalogSelectionError, match="stale or missing"):
+        select_rate([rate], ref=CatalogRateRef(id=rate.id, checksum_sha256=rate.checksum_sha256))
+
+
+def test_auto_rate_prefers_non_stale_project_match() -> None:
+    project_id = uuid4()
+    stale_project = make_rate(project_id=project_id, superseded_by_id=uuid4())
+    project_rate = make_rate(project_id=project_id, checksum_sha256=CHECKSUM_B)
+    global_rate = make_rate(project_id=None, rate_key="ignore-me")
+
+    selected = select_rate(
+        [stale_project, global_rate, project_rate],
+        auto=CatalogRateAutoSelectRequest(
+            project_id=project_id,
+            rate_key="labour",
+            item_type="wall",
+            unit="m2",
+            currency="GBP",
+            as_of=date(2025, 6, 1),
+        ),
+    )
+
+    assert selected == project_rate
+
+
+def test_auto_rate_falls_back_to_global_only_when_no_non_stale_project_match_remains() -> None:
+    project_id = uuid4()
+    stale_project = make_rate(project_id=project_id, superseded_by_id=uuid4())
+    global_rate = make_rate(project_id=None)
+
+    selected = select_rate(
+        [stale_project, global_rate],
+        auto=CatalogRateAutoSelectRequest(
+            project_id=project_id,
+            rate_key="labour",
+            item_type="wall",
+            unit="m2",
+            currency="GBP",
+            as_of=date(2025, 6, 1),
+        ),
+    )
+
+    assert selected == global_rate
+
+
+def test_auto_rate_rejects_multiple_project_matches() -> None:
+    project_id = uuid4()
+    first_id = UUID("00000000-0000-0000-0000-000000000002")
+    second_id = UUID("00000000-0000-0000-0000-000000000001")
+
+    with pytest.raises(CatalogSelectionError, match="multiple non-stale project") as exc_info:
+        select_rate(
+            [
+                make_rate(project_id=project_id, id=first_id),
+                make_rate(project_id=project_id, id=second_id, checksum_sha256=CHECKSUM_B),
+            ],
+            auto=CatalogRateAutoSelectRequest(
+                project_id=project_id,
+                rate_key="labour",
+                item_type="wall",
+                unit="m2",
+                currency="GBP",
+                as_of=date(2025, 6, 1),
+            ),
+        )
+
+    assert exc_info.value.conflicting_candidate_ids == (second_id, first_id)
+    assert str(exc_info.value).endswith(
+        f"conflicting_candidate_ids={(second_id, first_id)}"
+    )
+
+
+def test_auto_rate_rejects_multiple_global_matches() -> None:
+    with pytest.raises(CatalogSelectionError, match="multiple non-stale global"):
+        select_rate(
+            [make_rate(project_id=None), make_rate(project_id=None, checksum_sha256=CHECKSUM_B)],
+            auto=CatalogRateAutoSelectRequest(
+                project_id=None,
+                rate_key="labour",
+                item_type="wall",
+                unit="m2",
+                currency="GBP",
+                as_of=date(2025, 6, 1),
+            ),
+        )
+
+
+def test_auto_rate_uses_half_open_effective_dates() -> None:
+    ending = make_rate(effective_end=date(2025, 6, 1))
+    newer = make_rate(effective_start=date(2025, 6, 1), checksum_sha256=CHECKSUM_B)
+
+    selected = select_rate(
+        [ending, newer],
+        auto=CatalogRateAutoSelectRequest(
+            project_id=None,
+            rate_key="labour",
+            item_type="wall",
+            unit="m2",
+            currency="GBP",
+            as_of=date(2025, 6, 1),
+        ),
+    )
+
+    assert selected == newer
+
+
+def test_explicit_material_ref_validates_checksum() -> None:
+    material = make_material()
+
+    selected = select_material(
+        [material],
+        ref=CatalogMaterialRef(id=material.id, checksum_sha256=material.checksum_sha256),
+    )
+
+    assert selected == material
+
+
+def test_auto_material_prefers_project_then_global() -> None:
+    project_id = uuid4()
+    project_material = make_material(project_id=project_id)
+    global_material = make_material(project_id=None, checksum_sha256=CHECKSUM_B)
+
+    selected = select_material(
+        [global_material, project_material],
+        auto=CatalogMaterialAutoSelectRequest(
+            project_id=project_id,
+            material_key="brick",
+            unit="ea",
+            currency="GBP",
+            as_of=date(2025, 6, 1),
+        ),
+    )
+
+    assert selected == project_material
+
+
+def test_explicit_formula_ref_validates_checksum() -> None:
+    formula = make_formula()
+
+    selected = select_formula(
+        [formula],
+        ref=CatalogFormulaRef(id=formula.id, checksum_sha256=formula.checksum_sha256),
+    )
+
+    assert selected.formula_id == formula.formula_id
+    assert selected.version == formula.version
+    assert selected.definition_id == formula.id
+
+
+def test_explicit_formula_ref_rejects_stale_row() -> None:
+    formula = make_formula(superseded_by_id=uuid4())
+
+    with pytest.raises(CatalogSelectionError, match="stale or missing"):
+        select_formula(
+            [formula],
+            ref=CatalogFormulaRef(id=formula.id, checksum_sha256=formula.checksum_sha256),
+        )
+
+
+def test_auto_formula_requires_explicit_version_when_multiple_versions_exist() -> None:
+    first_id = UUID("00000000-0000-0000-0000-00000000000a")
+    second_id = UUID("00000000-0000-0000-0000-000000000009")
+
+    with pytest.raises(CatalogSelectionError, match="multiple non-stale global") as exc_info:
+        select_formula(
+            [
+                make_formula(id=first_id, version=1),
+                make_formula(id=second_id, version=2, checksum_sha256=CHECKSUM_B),
+            ],
+            auto=CatalogFormulaAutoSelectRequest(
+                project_id=None,
+                formula_id="wall-area",
+                version=None,
+            ),
+        )
+
+    assert exc_info.value.conflicting_candidate_ids == (second_id, first_id)
+    assert str(exc_info.value).endswith(
+        f"conflicting_candidate_ids={(second_id, first_id)}"
+    )
+
+
+def test_auto_formula_uses_requested_version() -> None:
+    v1 = make_formula(version=1)
+    v2 = make_formula(version=2, checksum_sha256=CHECKSUM_B)
+
+    selected = select_formula(
+        [v1, v2],
+        auto=CatalogFormulaAutoSelectRequest(project_id=None, formula_id="wall-area", version=2),
+    )
+
+    assert selected.version == 2
+    assert selected.checksum_sha256 == CHECKSUM_B
+
+
+def test_rate_contract_rejects_non_raw_checksum() -> None:
+    with pytest.raises(ValueError, match="raw lowercase 64-char"):
+        make_rate(checksum_sha256=f"sha256:{CHECKSUM_A}")
+
+
+@pytest.mark.parametrize("checksum", [CHECKSUM_A, CHECKSUM_B])
+def test_checksums_are_raw_lowercase_sha256_hex(checksum: str) -> None:
+    assert len(checksum) == 64
+    assert checksum == checksum.lower()
+    assert all(character in "0123456789abcdef" for character in checksum)


### PR DESCRIPTION
Closes #197

## Summary
- add a dedicated catalog selection service for rates, materials, and formulas so estimate workflows can freeze reproducible catalog inputs
- enforce deterministic selection rules around explicit UUID+checksum refs, stale supersession filtering, project-over-global precedence, and half-open effective-date windows
- add unit coverage plus DB-gated resolver smoke tests to lock down precedence, ambiguity, and stale-reference behavior

## Test plan
- [x] `uv run ruff check app tests`
- [x] `uv run mypy app tests`
- [x] `uv run pytest tests/test_estimation_catalog_selection.py tests/test_estimation_catalog_resolver.py`

## Notes
- No breaking changes.