### PR TITLE
feat(db): add estimate version header persistence

### DIFF
--- a/alembic/versions/2026_05_17_0020_add_estimate_versions.py
+++ b/alembic/versions/2026_05_17_0020_add_estimate_versions.py
@@ -1,0 +1,218 @@
+"""add estimate versions
+
+Revision ID: 2026_05_17_0020
+Revises: 2026_05_16_0019
+Create Date: 2026-05-17 21:10:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2026_05_17_0020"
+down_revision = "2026_05_16_0019"
+branch_labels = None
+depends_on = None
+
+
+def _attach_append_only_triggers(table_name: str) -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_append_only_row_guard
+            BEFORE UPDATE OR DELETE ON \"{table_name}\"
+            FOR EACH ROW
+            EXECUTE FUNCTION enforce_append_only_lineage_row()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_append_only_truncate_guard
+            BEFORE TRUNCATE ON \"{table_name}\"
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION enforce_append_only_lineage_truncate()
+            """
+        )
+    )
+
+
+def _drop_append_only_triggers(table_name: str) -> None:
+    op.execute(sa.text(f'DROP TRIGGER IF EXISTS trg_append_only_row_guard ON "{table_name}"'))
+    op.execute(
+        sa.text(f'DROP TRIGGER IF EXISTS trg_append_only_truncate_guard ON "{table_name}"')
+    )
+
+
+def _assert_estimate_versions_empty() -> None:
+    bind = op.get_bind()
+    row_count = bind.execute(sa.text('SELECT COUNT(*) FROM "estimate_versions"')).scalar_one()
+    if row_count:
+        raise RuntimeError(
+            "Refusing to downgrade migration 2026_05_17_0020 while estimate_versions "
+            f"contains {row_count} row(s)."
+        )
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_quantity_takeoffs_id_project_rev_gate_trusted",
+        "quantity_takeoffs",
+        ["id", "project_id", "drawing_revision_id", "quantity_gate", "trusted_totals"],
+    )
+
+    op.create_table(
+        "estimate_versions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.Uuid(), nullable=False),
+        sa.Column("source_file_id", sa.Uuid(), nullable=False),
+        sa.Column("drawing_revision_id", sa.Uuid(), nullable=False),
+        sa.Column("quantity_takeoff_id", sa.Uuid(), nullable=False),
+        sa.Column("source_job_id", sa.Uuid(), nullable=False),
+        sa.Column("quantity_gate", sa.String(length=32), nullable=False),
+        sa.Column("trusted_totals", sa.Boolean(), nullable=False),
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default=sa.text("'GBP'"),
+        ),
+        sa.Column("subtotal_amount", sa.Numeric(18, 2), nullable=False),
+        sa.Column("tax_amount", sa.Numeric(18, 2), nullable=False),
+        sa.Column("total_amount", sa.Numeric(18, 2), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "quantity_gate = 'allowed'",
+            name="ck_estimate_versions_quantity_gate_allowed",
+        ),
+        sa.CheckConstraint(
+            "trusted_totals = TRUE",
+            name="ck_estimate_versions_trusted_totals_true",
+        ),
+        sa.CheckConstraint(
+            "currency = 'GBP'",
+            name="ck_estimate_versions_currency_gbp",
+        ),
+        sa.CheckConstraint(
+            "subtotal_amount::text <> 'NaN' AND subtotal_amount >= 0::numeric",
+            name="ck_estimate_versions_subtotal_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "tax_amount::text <> 'NaN' AND tax_amount >= 0::numeric",
+            name="ck_estimate_versions_tax_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "total_amount::text <> 'NaN' AND total_amount >= 0::numeric",
+            name="ck_estimate_versions_total_amount_nonnegative",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="fk_estimate_versions_project_id_projects",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            name="fk_estimate_versions_source_file_id_project_id_files",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id", "source_file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            name="fk_estimate_versions_revision_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ],
+            [
+                "quantity_takeoffs.id",
+                "quantity_takeoffs.project_id",
+                "quantity_takeoffs.drawing_revision_id",
+                "quantity_takeoffs.quantity_gate",
+                "quantity_takeoffs.trusted_totals",
+            ],
+            name="fk_estimate_versions_takeoff_contract",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_job_id", "project_id", "source_file_id"],
+            ["jobs.id", "jobs.project_id", "jobs.file_id"],
+            name="fk_estimate_versions_source_job_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "id",
+            "project_id",
+            "drawing_revision_id",
+            name="uq_estimate_versions_id_project_id_drawing_revision_id",
+        ),
+        sa.UniqueConstraint(
+            "source_job_id",
+            name="uq_estimate_versions_source_job_id",
+        ),
+    )
+    op.create_index(
+        "ix_estimate_versions_project_id",
+        "estimate_versions",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_estimate_versions_source_file_id",
+        "estimate_versions",
+        ["source_file_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_estimate_versions_quantity_takeoff_id",
+        "estimate_versions",
+        ["quantity_takeoff_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_estimate_versions_drawing_revision_id",
+        "estimate_versions",
+        ["drawing_revision_id"],
+        unique=False,
+    )
+
+    _attach_append_only_triggers("estimate_versions")
+
+
+def downgrade() -> None:
+    _assert_estimate_versions_empty()
+
+    _drop_append_only_triggers("estimate_versions")
+
+    op.drop_index("ix_estimate_versions_drawing_revision_id", table_name="estimate_versions")
+    op.drop_index("ix_estimate_versions_quantity_takeoff_id", table_name="estimate_versions")
+    op.drop_index("ix_estimate_versions_source_file_id", table_name="estimate_versions")
+    op.drop_index("ix_estimate_versions_project_id", table_name="estimate_versions")
+    op.drop_table("estimate_versions")
+
+    op.drop_constraint(
+        "uq_quantity_takeoffs_id_project_rev_gate_trusted",
+        "quantity_takeoffs",
+        type_="unique",
+    )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ for Alembic autogenerate support. Example:
 
 from . import adapter_run_output as adapter_run_output
 from . import drawing_revision as drawing_revision
+from . import estimate_version as estimate_version
 from . import estimation_catalog as estimation_catalog
 from . import extraction_profile as extraction_profile
 from . import file as file

--- a/app/models/estimate_version.py
+++ b/app/models/estimate_version.py
@@ -1,0 +1,183 @@
+"""Append-only estimate version header persistence model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Numeric,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, validates
+
+from app.db.base import Base
+
+
+class EstimateVersion(Base):
+    """Immutable estimate header persisted from finalized estimation runs."""
+
+    __tablename__ = "estimate_versions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="RESTRICT",
+            name="fk_estimate_versions_source_file_id_project_id_files",
+        ),
+        ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id", "source_file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_versions_revision_lineage",
+        ),
+        ForeignKeyConstraint(
+            [
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ],
+            [
+                "quantity_takeoffs.id",
+                "quantity_takeoffs.project_id",
+                "quantity_takeoffs.drawing_revision_id",
+                "quantity_takeoffs.quantity_gate",
+                "quantity_takeoffs.trusted_totals",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_versions_takeoff_contract",
+        ),
+        ForeignKeyConstraint(
+            ["source_job_id", "project_id", "source_file_id"],
+            ["jobs.id", "jobs.project_id", "jobs.file_id"],
+            ondelete="RESTRICT",
+            name="fk_estimate_versions_source_job_lineage",
+        ),
+        CheckConstraint(
+            "quantity_gate = 'allowed'",
+            name="ck_estimate_versions_quantity_gate_allowed",
+        ),
+        CheckConstraint(
+            "trusted_totals = TRUE",
+            name="ck_estimate_versions_trusted_totals_true",
+        ),
+        CheckConstraint(
+            "currency = 'GBP'",
+            name="ck_estimate_versions_currency_gbp",
+        ),
+        CheckConstraint(
+            "subtotal_amount::text <> 'NaN' AND subtotal_amount >= 0::numeric",
+            name="ck_estimate_versions_subtotal_amount_nonnegative",
+        ),
+        CheckConstraint(
+            "tax_amount::text <> 'NaN' AND tax_amount >= 0::numeric",
+            name="ck_estimate_versions_tax_amount_nonnegative",
+        ),
+        CheckConstraint(
+            "total_amount::text <> 'NaN' AND total_amount >= 0::numeric",
+            name="ck_estimate_versions_total_amount_nonnegative",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            "drawing_revision_id",
+            name="uq_estimate_versions_id_project_id_drawing_revision_id",
+        ),
+        UniqueConstraint(
+            "source_job_id",
+            name="uq_estimate_versions_source_job_id",
+        ),
+        Index("ix_estimate_versions_source_file_id", "source_file_id"),
+        Index("ix_estimate_versions_quantity_takeoff_id", "quantity_takeoff_id"),
+        Index("ix_estimate_versions_drawing_revision_id", "drawing_revision_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique estimate version identifier (UUID v4)",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(
+            "projects.id",
+            name="fk_estimate_versions_project_id_projects",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier",
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Immutable source file identifier inherited from the pinned revision",
+    )
+    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Pinned drawing revision identifier used to finalize this estimate",
+    )
+    quantity_takeoff_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Pinned quantity takeoff identifier used as the estimate input",
+    )
+    source_job_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Job identifier that finalized this immutable estimate version",
+    )
+    quantity_gate: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Frozen estimate input gate copied from the referenced quantity takeoff",
+    )
+    trusted_totals: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        comment="Frozen trusted-input posture copied from the referenced quantity takeoff",
+    )
+    currency: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        default="GBP",
+        comment="Frozen estimate currency. MVP estimates persist GBP only",
+    )
+    subtotal_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2),
+        nullable=False,
+        comment="Frozen subtotal monetary amount for this estimate version",
+    )
+    tax_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2),
+        nullable=False,
+        comment="Frozen tax monetary amount for this estimate version",
+    )
+    total_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2),
+        nullable=False,
+        comment="Frozen total monetary amount for this estimate version",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Estimate version creation timestamp",
+    )
+
+    @validates("subtotal_amount", "tax_amount", "total_amount")
+    def _validate_monetary_amount(self, field_name: str, value: Decimal) -> Decimal:
+        if value.is_nan():
+            raise ValueError(f"{field_name} must not be NaN")
+        return value

--- a/app/models/quantity_takeoff.py
+++ b/app/models/quantity_takeoff.py
@@ -164,6 +164,14 @@ class QuantityTakeoff(Base):
             name="uq_quantity_takeoffs_id_project_rev_gate",
         ),
         UniqueConstraint(
+            "id",
+            "project_id",
+            "drawing_revision_id",
+            "quantity_gate",
+            "trusted_totals",
+            name="uq_quantity_takeoffs_id_project_rev_gate_trusted",
+        ),
+        UniqueConstraint(
             "source_job_id",
             name="uq_quantity_takeoffs_source_job_id",
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
     "validation_reports",
     "generated_artifacts",
     "job_events",
+    "estimate_versions",
     "quantity_takeoffs",
     "quantity_items",
     "revision_entity_manifests",

--- a/tests/test_append_only_lineage_tables.py
+++ b/tests/test_append_only_lineage_tables.py
@@ -22,6 +22,7 @@ import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
+from tests import test_estimate_version_persistence as estimate_version_persistence
 from tests.conftest import (
     APPEND_ONLY_PROTECTED_TABLES,
     APPEND_ONLY_ROW_TRIGGER_NAME,
@@ -63,6 +64,7 @@ class _ProtectedRowIds:
     validation_report_id: uuid.UUID
     generated_artifact_id: uuid.UUID
     job_event_id: uuid.UUID
+    estimate_version_id: uuid.UUID
     quantity_takeoff_id: uuid.UUID
     quantity_item_id: uuid.UUID
     revision_entity_manifest_id: uuid.UUID
@@ -163,6 +165,7 @@ def _row_id_for_table(row_ids: _ProtectedRowIds, table_name: str) -> uuid.UUID:
         "validation_reports": row_ids.validation_report_id,
         "generated_artifacts": row_ids.generated_artifact_id,
         "job_events": row_ids.job_event_id,
+        "estimate_versions": row_ids.estimate_version_id,
         "quantity_takeoffs": row_ids.quantity_takeoff_id,
         "quantity_items": row_ids.quantity_item_id,
         "revision_entity_manifests": row_ids.revision_entity_manifest_id,
@@ -186,6 +189,21 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         str(quantity_seed.project_id)
     )
     job_events = await _load_job_events(quantity_seed.ingest_job_id)
+    estimate_source_job_id = await estimate_version_persistence._create_estimate_source_job(
+        quantity_seed
+    )
+
+    estimate_version = estimate_version_persistence._build_estimate_version(
+        quantity_seed,
+        source_job_id=estimate_source_job_id,
+        quantity_takeoff_id=quantity_seed.quantity_takeoff_id,
+    )
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+    async with session_maker() as session:
+        session.add(estimate_version)
+        await session.commit()
 
     assert len(adapter_outputs) == 1
     assert len(drawing_revisions) == 1
@@ -208,6 +226,7 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         validation_report_id=validation_reports[0].id,
         generated_artifact_id=generated_artifacts[0].id,
         job_event_id=job_events[0].id,
+        estimate_version_id=estimate_version.id,
         quantity_takeoff_id=quantity_seed.quantity_takeoff_id,
         quantity_item_id=quantity_seed.quantity_item_id,
         revision_entity_manifest_id=manifests[0].id,
@@ -1318,6 +1337,7 @@ class TestAppendOnlyLineageTables:
             ("validation_reports", "validator_version", "mutated"),
             ("generated_artifacts", "name", "mutated-debug-overlay.svg"),
             ("job_events", "message", "mutated job event"),
+            ("estimate_versions", "total_amount", "121.00"),
             ("quantity_takeoffs", "review_state", "review_required"),
             ("quantity_items", "quantity_type", "mutated_quantity_type"),
             (

--- a/tests/test_estimate_version_persistence.py
+++ b/tests/test_estimate_version_persistence.py
@@ -1,0 +1,598 @@
+"""Integration tests for append-only estimate version persistence."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, Table, UniqueConstraint, select, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+from app.models.estimate_version import EstimateVersion
+from app.models.job import Job, JobStatus, JobType
+from app.models.quantity_takeoff import QuantityTakeoff
+from tests import test_quantity_takeoff_persistence as quantity_takeoff_persistence
+from tests.conftest import requires_database
+
+pytest_plugins = ("tests.test_quantity_takeoff_persistence",)
+pytestmark = [pytest.mark.asyncio, requires_database]
+_ESTIMATE_VERSION_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "2026_05_17_0020_add_estimate_versions.py"
+)
+
+
+def _normalize_ondelete(raw_foreign_key: Mapping[str, Any]) -> str:
+    options = raw_foreign_key.get("options")
+    if isinstance(options, dict):
+        return str(options.get("ondelete") or "").upper()
+    return ""
+
+
+def _normalize_constraint_sqltext(sqltext: str) -> str:
+    normalized = sqltext
+    for pg_cast in (
+        "::boolean",
+        "::character varying",
+        "::numeric",
+        "::text",
+    ):
+        normalized = normalized.replace(pg_cast, "")
+    normalized = normalized.replace('"', " ")
+    normalized = normalized.replace("(", " ").replace(")", " ")
+    return " ".join(normalized.split())
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_projects: None) -> AsyncGenerator[AsyncSession, None]:
+    _ = cleanup_projects
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+def _inspect_estimate_version_schema(sync_connection: sa.Connection) -> dict[str, Any]:
+    inspector = sa.inspect(sync_connection)
+    tables = ("jobs", "quantity_takeoffs", "estimate_versions")
+    return {
+        "columns": {
+            table_name: {
+                str(column["name"]): {"nullable": bool(column["nullable"])}
+                for column in inspector.get_columns(table_name)
+            }
+            for table_name in tables
+        },
+        "unique_constraints": {
+            table_name: {
+                tuple(constraint["column_names"]): str(constraint["name"])
+                for constraint in inspector.get_unique_constraints(table_name)
+            }
+            for table_name in tables
+        },
+        "indexes": {
+            table_name: {
+                tuple(index["column_names"]): str(index["name"])
+                for index in inspector.get_indexes(table_name)
+            }
+            for table_name in tables
+        },
+        "check_constraints": {
+            table_name: {
+                str(constraint["name"]): str(constraint["sqltext"])
+                for constraint in inspector.get_check_constraints(table_name)
+            }
+            for table_name in ("estimate_versions",)
+        },
+        "foreign_keys": {
+            table_name: {
+                (
+                    tuple(foreign_key["constrained_columns"]),
+                    str(foreign_key["referred_table"]),
+                    tuple(foreign_key["referred_columns"]),
+                ): _normalize_ondelete(foreign_key)
+                for foreign_key in inspector.get_foreign_keys(table_name)
+            }
+            for table_name in ("estimate_versions",)
+        },
+    }
+
+
+async def _load_estimate_version_schema() -> dict[str, Any]:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        connection = await session.connection()
+        return await connection.run_sync(_inspect_estimate_version_schema)
+
+
+async def _create_estimate_source_job(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+) -> uuid.UUID:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    job_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(
+            Job(
+                id=job_id,
+                project_id=seed.project_id,
+                file_id=seed.file_id,
+                extraction_profile_id=seed.extraction_profile_id,
+                base_revision_id=seed.drawing_revision_id,
+                job_type=JobType.REPROCESS.value,
+                status=JobStatus.SUCCEEDED.value,
+                enqueue_status="published",
+                enqueue_attempts=0,
+                cancel_requested=False,
+            )
+        )
+        await session.commit()
+
+    return job_id
+
+
+async def _assert_commit_fails(
+    session: AsyncSession,
+    obj: object,
+    expected_substring: str | tuple[str, ...],
+) -> None:
+    session.add(obj)
+    expected_substrings = (
+        [expected_substring] if isinstance(expected_substring, str) else list(expected_substring)
+    )
+
+    try:
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        constraint_name = getattr(getattr(exc, "orig", None), "constraint_name", None)
+        if constraint_name in expected_substrings:
+            return
+
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert any(substring.lower() in message for substring in expected_substrings)
+    else:
+        pytest.fail(f"Expected database error containing {expected_substrings!r}")
+
+
+async def _assert_append_only_sql_mutation_fails(
+    session: AsyncSession,
+    statement: str,
+    *,
+    operation: str,
+    params: dict[str, object] | None = None,
+) -> None:
+    try:
+        await session.execute(text(statement), params or {})
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert f"append-only trigger blocked {operation.lower()} on estimate_versions" in message
+    else:
+        pytest.fail(f"Expected append-only mutation failure for {operation} on estimate_versions")
+
+
+def _build_estimate_version(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    *,
+    source_job_id: uuid.UUID,
+    quantity_takeoff_id: uuid.UUID,
+    drawing_revision_id: uuid.UUID | None = None,
+    quantity_gate: str = "allowed",
+    trusted_totals: bool = True,
+    currency: str = "GBP",
+    subtotal_amount: Decimal = Decimal("100.00"),
+    tax_amount: Decimal = Decimal("20.00"),
+    total_amount: Decimal = Decimal("120.00"),
+) -> EstimateVersion:
+    return EstimateVersion(
+        id=uuid.uuid4(),
+        project_id=seed.project_id,
+        source_file_id=seed.file_id,
+        drawing_revision_id=drawing_revision_id or seed.drawing_revision_id,
+        quantity_takeoff_id=quantity_takeoff_id,
+        source_job_id=source_job_id,
+        quantity_gate=quantity_gate,
+        trusted_totals=trusted_totals,
+        currency=currency,
+        subtotal_amount=subtotal_amount,
+        tax_amount=tax_amount,
+        total_amount=total_amount,
+    )
+
+
+async def test_estimate_version_schema_matches_contract() -> None:
+    schema = await _load_estimate_version_schema()
+    columns = schema["columns"]
+    unique_constraints = schema["unique_constraints"]
+    indexes = schema["indexes"]
+    check_constraints = schema["check_constraints"]["estimate_versions"]
+    foreign_keys = schema["foreign_keys"]["estimate_versions"]
+
+    assert (
+        "id",
+        "project_id",
+        "drawing_revision_id",
+        "quantity_gate",
+        "trusted_totals",
+    ) in unique_constraints["quantity_takeoffs"]
+    assert (
+        "id",
+        "project_id",
+        "file_id",
+        "base_revision_id",
+        "job_type",
+    ) in unique_constraints["jobs"]
+
+    estimate_columns = columns["estimate_versions"]
+    for required_column in (
+        "project_id",
+        "source_file_id",
+        "drawing_revision_id",
+        "quantity_takeoff_id",
+        "source_job_id",
+        "quantity_gate",
+        "trusted_totals",
+        "currency",
+        "subtotal_amount",
+        "tax_amount",
+        "total_amount",
+        "created_at",
+    ):
+        assert required_column in estimate_columns
+        assert estimate_columns[required_column]["nullable"] is False
+
+    assert ("source_job_id",) in unique_constraints["estimate_versions"]
+    assert ("id", "project_id", "drawing_revision_id") in unique_constraints[
+        "estimate_versions"
+    ]
+    assert ("project_id",) in indexes["estimate_versions"]
+    assert ("source_file_id",) in indexes["estimate_versions"]
+    assert ("quantity_takeoff_id",) in indexes["estimate_versions"]
+    assert ("drawing_revision_id",) in indexes["estimate_versions"]
+
+    for constraint_name in (
+        "ck_estimate_versions_quantity_gate_allowed",
+        "ck_estimate_versions_trusted_totals_true",
+        "ck_estimate_versions_currency_gbp",
+        "ck_estimate_versions_subtotal_amount_nonnegative",
+        "ck_estimate_versions_tax_amount_nonnegative",
+        "ck_estimate_versions_total_amount_nonnegative",
+    ):
+        assert constraint_name in check_constraints
+
+    quantity_gate_sql = _normalize_constraint_sqltext(
+        check_constraints["ck_estimate_versions_quantity_gate_allowed"]
+    ).lower()
+    trusted_totals_sql = _normalize_constraint_sqltext(
+        check_constraints["ck_estimate_versions_trusted_totals_true"]
+    ).lower()
+    currency_sql = _normalize_constraint_sqltext(
+        check_constraints["ck_estimate_versions_currency_gbp"]
+    ).lower()
+    assert "quantity_gate = 'allowed'" in quantity_gate_sql
+    assert "trusted_totals = true" in trusted_totals_sql
+    assert "currency = 'gbp'" in currency_sql
+
+    assert foreign_keys[(("project_id",), "projects", ("id",))] == "RESTRICT"
+    assert foreign_keys[
+        (("source_file_id", "project_id"), "files", ("id", "project_id"))
+    ] == "RESTRICT"
+    assert foreign_keys[
+        (
+            ("drawing_revision_id", "project_id", "source_file_id"),
+            "drawing_revisions",
+            ("id", "project_id", "source_file_id"),
+        )
+    ] == "RESTRICT"
+    assert foreign_keys[
+        (
+            (
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ),
+            "quantity_takeoffs",
+            (
+                "id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ),
+        )
+    ] == "RESTRICT"
+    assert foreign_keys[
+        (
+            ("source_job_id", "project_id", "source_file_id"),
+            "jobs",
+            ("id", "project_id", "file_id"),
+        )
+    ] == "RESTRICT"
+
+    quantity_takeoff_table = cast(Table, QuantityTakeoff.__table__)
+    quantity_takeoff_model_uniques = {
+        tuple(constraint.columns.keys()): constraint.name
+        for constraint in quantity_takeoff_table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+    assert (
+        "id",
+        "project_id",
+        "drawing_revision_id",
+        "quantity_gate",
+        "trusted_totals",
+    ) in quantity_takeoff_model_uniques
+
+    estimate_version_table = cast(Table, EstimateVersion.__table__)
+    estimate_version_model_checks = {
+        str(constraint.name): str(constraint.sqltext)
+        for constraint in estimate_version_table.constraints
+        if isinstance(constraint, CheckConstraint)
+    }
+    for column_name, constraint_name in (
+        ("subtotal_amount", "ck_estimate_versions_subtotal_amount_nonnegative"),
+        ("tax_amount", "ck_estimate_versions_tax_amount_nonnegative"),
+        ("total_amount", "ck_estimate_versions_total_amount_nonnegative"),
+    ):
+        sqltext = estimate_version_model_checks[constraint_name]
+        assert f"{column_name}::text <> 'NaN'" in sqltext
+        assert f"{column_name} >= 0::numeric" in sqltext
+
+    migration_sql = _ESTIMATE_VERSION_MIGRATION_PATH.read_text(encoding="utf-8")
+    for column_name in ("subtotal_amount", "tax_amount", "total_amount"):
+        assert f'"{column_name}::text <> \'NaN\' AND {column_name} >= 0::numeric"' in migration_sql
+
+
+async def test_estimate_version_persists_allowed_trusted_header(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+
+    estimate_version = _build_estimate_version(
+        seed,
+        source_job_id=source_job_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+    )
+    db_session.add(estimate_version)
+    await db_session.commit()
+
+    persisted = await db_session.scalar(
+        select(EstimateVersion).where(EstimateVersion.id == estimate_version.id)
+    )
+    assert persisted is not None
+    assert persisted.quantity_gate == "allowed"
+    assert persisted.trusted_totals is True
+    assert persisted.currency == "GBP"
+    assert persisted.subtotal_amount == Decimal("100.00")
+    assert persisted.tax_amount == Decimal("20.00")
+    assert persisted.total_amount == Decimal("120.00")
+
+
+async def test_estimate_version_rejects_takeoff_without_allowed_trusted_contract(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+    provisional_takeoff_id = await quantity_takeoff_persistence._create_quantity_takeoff(
+        seed,
+        review_state="provisional",
+        validation_status="valid_with_warnings",
+        quantity_gate="allowed_provisional",
+        trusted_totals=False,
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        _build_estimate_version(
+            seed,
+            source_job_id=source_job_id,
+            quantity_takeoff_id=provisional_takeoff_id,
+            quantity_gate="allowed",
+            trusted_totals=True,
+        ),
+        "fk_estimate_versions_takeoff_contract",
+    )
+
+
+async def test_estimate_version_rejects_revision_mismatch(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+    mismatched_revision_id = await quantity_takeoff_persistence._create_additional_drawing_revision(
+        seed
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        _build_estimate_version(
+            seed,
+            source_job_id=source_job_id,
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            drawing_revision_id=mismatched_revision_id,
+        ),
+        "fk_estimate_versions_takeoff_contract",
+    )
+
+
+async def test_estimate_version_rejects_invalid_currency(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+
+    await _assert_commit_fails(
+        db_session,
+        _build_estimate_version(
+            seed,
+            source_job_id=source_job_id,
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            currency="USD",
+        ),
+        "ck_estimate_versions_currency_gbp",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "constraint_name"),
+    (
+        ("subtotal_amount", Decimal("-0.01"), "ck_estimate_versions_subtotal_amount_nonnegative"),
+        ("tax_amount", Decimal("-0.01"), "ck_estimate_versions_tax_amount_nonnegative"),
+        ("total_amount", Decimal("-0.01"), "ck_estimate_versions_total_amount_nonnegative"),
+    ),
+)
+async def test_estimate_version_rejects_negative_amounts(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    field_name: str,
+    field_value: Decimal,
+    constraint_name: str,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+    estimate_version = _build_estimate_version(
+        seed,
+        source_job_id=source_job_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+    )
+    setattr(estimate_version, field_name, field_value)
+
+    await _assert_commit_fails(
+        db_session,
+        estimate_version,
+        constraint_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    (
+        "subtotal_amount",
+        "tax_amount",
+        "total_amount",
+    ),
+)
+async def test_estimate_version_rejects_nan_amounts(
+    async_client: httpx.AsyncClient,
+    field_name: str,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+    estimate_version = _build_estimate_version(
+        seed,
+        source_job_id=source_job_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+    )
+    with pytest.raises(ValueError, match=f"{field_name} must not be NaN"):
+        setattr(estimate_version, field_name, Decimal("NaN"))
+
+
+async def test_estimate_version_rejects_duplicate_source_job_id(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+
+    first_estimate_version = _build_estimate_version(
+        seed,
+        source_job_id=source_job_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+    )
+    db_session.add(first_estimate_version)
+    await db_session.commit()
+
+    await _assert_commit_fails(
+        db_session,
+        _build_estimate_version(
+            seed,
+            source_job_id=source_job_id,
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            subtotal_amount=Decimal("101.00"),
+            total_amount=Decimal("121.00"),
+        ),
+        (
+            "uq_estimate_versions_source_job_id",
+            "estimate_versions_source_job_id_key",
+            "source_job_id",
+        ),
+    )
+
+
+async def test_estimate_versions_reject_append_only_mutations(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await _create_estimate_source_job(seed)
+
+    estimate_version = _build_estimate_version(
+        seed,
+        source_job_id=source_job_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+    )
+    estimate_version_id = estimate_version.id
+    db_session.add(estimate_version)
+    await db_session.commit()
+
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        'UPDATE "estimate_versions" SET total_amount = total_amount + 1 WHERE id = :row_id',
+        operation="UPDATE",
+        params={"row_id": estimate_version_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        'DELETE FROM "estimate_versions" WHERE id = :row_id',
+        operation="DELETE",
+        params={"row_id": estimate_version_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        'TRUNCATE TABLE "estimate_versions"',
+        operation="TRUNCATE",
+    )


### PR DESCRIPTION
Closes #198

## Summary
- add append-only `estimate_versions` header persistence to freeze estimate lineage against trusted allowed quantity takeoffs
- enforce GBP-only finite non-negative totals and preserve the estimate-to-takeoff contract in both the model and migration
- extend persistence and append-only coverage so estimate headers are validated alongside the existing lineage tables

## Test plan
- [x] uv run ruff check app/models/estimate_version.py app/models/quantity_takeoff.py tests/test_estimate_version_persistence.py alembic/versions/2026_05_17_0020_add_estimate_versions.py
- [x] uv run mypy app/models/estimate_version.py app/models/quantity_takeoff.py tests/test_estimate_version_persistence.py
- [x] uv run python -m compileall app/models/estimate_version.py app/models/quantity_takeoff.py tests/test_estimate_version_persistence.py alembic/versions/2026_05_17_0020_add_estimate_versions.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_estimate_version_persistence.py tests/test_append_only_lineage_tables.py

## Notes
- no breaking changes
- follow-up: add a direct downgrade fail-closed test for populated `estimate_versions`