### PR TITLE
feat(db): add estimate snapshot item persistence (#199)

### DIFF
--- a/alembic/versions/2026_05_18_0021_add_estimate_snapshot_items.py
+++ b/alembic/versions/2026_05_18_0021_add_estimate_snapshot_items.py
@@ -1,0 +1,863 @@
+"""add estimate snapshot entries and line items
+
+Revision ID: 2026_05_18_0021
+Revises: 2026_05_17_0020
+Create Date: 2026-05-18 10:35:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2026_05_18_0021"
+down_revision = "2026_05_17_0020"
+branch_labels = None
+depends_on = None
+
+
+ESTIMATE_SNAPSHOT_ENTRIES_CURRENCY_BY_TYPE = (
+    "((entry_type IN ('rate', 'material') AND currency = 'GBP') "
+    "OR (entry_type NOT IN ('rate', 'material') AND currency IS NULL))"
+)
+ESTIMATE_SNAPSHOT_ENTRIES_UNIT_AMOUNT_BY_TYPE = (
+    "((entry_type IN ('rate', 'material') AND unit_amount IS NOT NULL) "
+    "OR (entry_type NOT IN ('rate', 'material') AND unit_amount IS NULL))"
+)
+ESTIMATE_SNAPSHOT_ENTRIES_SOURCE_FIELDS_BY_TYPE = (
+    "((entry_type = 'rate' "
+    "AND source_rate_id IS NOT NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NOT NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NOT NULL "
+    "AND length(btrim(unit)) > 0 "
+    "AND effective_date IS NOT NULL) "
+    "OR (entry_type = 'material' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NOT NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NOT NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NOT NULL "
+    "AND length(btrim(unit)) > 0 "
+    "AND effective_date IS NOT NULL) "
+    "OR (entry_type = 'formula' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NOT NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NOT NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NULL "
+    "AND effective_date IS NULL) "
+    "OR (entry_type = 'assumption' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NULL "
+    "AND effective_date IS NULL) "
+    "OR (entry_type = 'quantity_input' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NOT NULL "
+    "AND source_checksum_sha256 IS NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND unit IS NOT NULL "
+    "AND length(btrim(unit)) > 0 "
+    "AND effective_date IS NULL))"
+)
+ESTIMATE_ITEMS_SNAPSHOT_ENTRY_TYPE_CONSTANTS = (
+    "rate_snapshot_entry_type = 'rate' "
+    "AND material_snapshot_entry_type = 'material' "
+    "AND formula_snapshot_entry_type = 'formula' "
+    "AND assumption_snapshot_entry_type = 'assumption' "
+    "AND quantity_snapshot_entry_type = 'quantity_input'"
+)
+ESTIMATE_ITEMS_SOURCE_FIELDS_BY_LINE_TYPE = (
+    "((line_type = 'rate' "
+    "AND rate_snapshot_entry_id IS NOT NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NULL "
+    "AND quantity_snapshot_entry_id IS NOT NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND quantity_unit IS NOT NULL "
+    "AND length(btrim(quantity_unit)) > 0 "
+    "AND unit_rate_amount IS NOT NULL "
+    "AND effective_date IS NOT NULL) "
+    "OR (line_type = 'material' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NOT NULL "
+    "AND formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NULL "
+    "AND quantity_snapshot_entry_id IS NOT NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND quantity_unit IS NOT NULL "
+    "AND length(btrim(quantity_unit)) > 0 "
+    "AND unit_rate_amount IS NOT NULL "
+    "AND effective_date IS NOT NULL) "
+    "OR (line_type = 'formula' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND formula_snapshot_entry_id IS NOT NULL "
+    "AND assumption_snapshot_entry_id IS NULL "
+    "AND ((quantity_snapshot_entry_id IS NULL "
+    "AND quantity_value IS NULL "
+    "AND quantity_unit IS NULL) "
+    "OR (quantity_snapshot_entry_id IS NOT NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND quantity_unit IS NOT NULL "
+    "AND length(btrim(quantity_unit)) > 0)) "
+    "AND unit_rate_amount IS NULL "
+    "AND TRUE) "
+    "OR (line_type = 'assumption' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NOT NULL "
+    "AND quantity_snapshot_entry_id IS NULL "
+    "AND quantity_value IS NULL "
+    "AND quantity_unit IS NULL "
+    "AND unit_rate_amount IS NULL "
+    "AND effective_date IS NULL) "
+    "OR (line_type = 'adjustment' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND ((formula_snapshot_entry_id IS NOT NULL "
+    "AND assumption_snapshot_entry_id IS NULL) "
+    "OR (formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NOT NULL)) "
+    "AND quantity_snapshot_entry_id IS NULL "
+    "AND quantity_value IS NULL "
+    "AND quantity_unit IS NULL "
+    "AND unit_rate_amount IS NULL "
+    "AND effective_date IS NULL))"
+)
+
+
+def _attach_append_only_triggers(table_name: str) -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_append_only_row_guard
+            BEFORE UPDATE OR DELETE ON "{table_name}"
+            FOR EACH ROW
+            EXECUTE FUNCTION enforce_append_only_lineage_row()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_append_only_truncate_guard
+            BEFORE TRUNCATE ON "{table_name}"
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION enforce_append_only_lineage_truncate()
+            """
+        )
+    )
+
+
+def _drop_append_only_triggers(table_name: str) -> None:
+    op.execute(sa.text(f'DROP TRIGGER IF EXISTS trg_append_only_row_guard ON "{table_name}"'))
+    op.execute(
+        sa.text(f'DROP TRIGGER IF EXISTS trg_append_only_truncate_guard ON "{table_name}"')
+    )
+
+
+def _assert_estimate_reproducibility_tables_empty() -> None:
+    bind = op.get_bind()
+    for table_name in ("estimate_items", "estimate_snapshot_entries"):
+        row_count = bind.execute(sa.text(f'SELECT COUNT(*) FROM "{table_name}"')).scalar_one()
+        if row_count:
+            raise RuntimeError(
+                "Refusing to downgrade migration 2026_05_18_0021 while "
+                f"{table_name} contains {row_count} row(s)."
+            )
+
+
+def upgrade() -> None:
+    op.create_unique_constraint(
+        "uq_estimate_versions_id_project_rev_quantity_takeoff_id",
+        "estimate_versions",
+        ["id", "project_id", "drawing_revision_id", "quantity_takeoff_id"],
+    )
+    op.create_unique_constraint(
+        "uq_quantity_items_id_takeoff_project_drawing_revision",
+        "quantity_items",
+        ["id", "quantity_takeoff_id", "project_id", "drawing_revision_id"],
+    )
+
+    op.create_table(
+        "estimate_snapshot_entries",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Unique estimate snapshot entry identifier (UUID v4)",
+        ),
+        sa.Column(
+            "estimate_version_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning immutable estimate version identifier",
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning project identifier copied from the estimate version",
+        ),
+        sa.Column(
+            "drawing_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Pinned drawing revision identifier copied from the estimate version",
+        ),
+        sa.Column(
+            "entry_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="Frozen snapshot entry type",
+        ),
+        sa.Column(
+            "entry_key",
+            sa.String(length=128),
+            nullable=False,
+            comment="Deterministic snapshot entry key within the estimate version",
+        ),
+        sa.Column(
+            "entry_label",
+            sa.String(length=512),
+            nullable=False,
+            comment="Human-readable frozen snapshot entry label",
+        ),
+        sa.Column(
+            "sort_order",
+            sa.Integer(),
+            nullable=False,
+            comment="Deterministic snapshot entry order within the estimate version",
+        ),
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=True,
+            comment="Frozen currency for rate/material snapshots; null for non-monetary entries",
+        ),
+        sa.Column(
+            "quantity_value",
+            sa.Numeric(precision=18, scale=6),
+            nullable=True,
+            comment="Frozen quantity value for quantity-input snapshots",
+        ),
+        sa.Column(
+            "unit",
+            sa.String(length=64),
+            nullable=True,
+            comment="Frozen unit captured with the snapshot entry",
+        ),
+        sa.Column(
+            "effective_date",
+            sa.Date(),
+            nullable=True,
+            comment="Frozen effective date captured for catalog-backed snapshot entries",
+        ),
+        sa.Column(
+            "unit_amount",
+            sa.Numeric(precision=18, scale=6),
+            nullable=True,
+            comment="Frozen per-unit amount for rate/material snapshots",
+        ),
+        sa.Column(
+            "source_payload_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            comment="Frozen source payload used to reproduce estimate calculations",
+        ),
+        sa.Column(
+            "rounding_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            comment="Frozen rounding metadata for deterministic replay when applicable",
+        ),
+        sa.Column(
+            "source_rate_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Pinned source rate identifier for rate snapshot entries",
+        ),
+        sa.Column(
+            "source_material_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Pinned source material identifier for material snapshot entries",
+        ),
+        sa.Column(
+            "source_formula_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Pinned source formula identifier for formula snapshot entries",
+        ),
+        sa.Column(
+            "source_quantity_takeoff_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Pinned quantity takeoff source for quantity-input snapshot entries",
+        ),
+        sa.Column(
+            "source_quantity_item_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Pinned quantity item source for quantity-input snapshot entries",
+        ),
+        sa.Column(
+            "source_checksum_sha256",
+            sa.String(length=64),
+            nullable=True,
+            comment="Raw lowercase SHA-256 checksum for catalog-backed snapshot entries",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="Estimate snapshot entry creation timestamp",
+        ),
+        sa.CheckConstraint(
+            "entry_type IN ('rate', 'material', 'formula', 'assumption', 'quantity_input')",
+            name="ck_estimate_snapshot_entries_entry_type_valid",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(entry_key)) > 0",
+            name="ck_estimate_snapshot_entries_entry_key_nonempty",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(entry_label)) > 0",
+            name="ck_estimate_snapshot_entries_entry_label_nonempty",
+        ),
+        sa.CheckConstraint(
+            "sort_order >= 1",
+            name="ck_estimate_snapshot_entries_sort_order_positive",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(source_payload_json) = 'object'",
+            name="ck_estimate_snapshot_entries_source_payload_json_object",
+        ),
+        sa.CheckConstraint(
+            "rounding_json IS NULL OR jsonb_typeof(rounding_json) = 'object'",
+            name="ck_estimate_snapshot_entries_rounding_json_object",
+        ),
+        sa.CheckConstraint(
+            "source_checksum_sha256 IS NULL OR source_checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_estimate_snapshot_entries_source_checksum_sha256_format",
+        ),
+        sa.CheckConstraint(
+            "quantity_value IS NULL OR (quantity_value::text <> 'NaN' "
+            "AND quantity_value >= 0::numeric)",
+            name="ck_estimate_snapshot_entries_quantity_value_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "unit_amount IS NULL OR (unit_amount::text <> 'NaN' AND unit_amount >= 0::numeric)",
+            name="ck_estimate_snapshot_entries_unit_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            ESTIMATE_SNAPSHOT_ENTRIES_CURRENCY_BY_TYPE,
+            name="ck_estimate_snapshot_entries_currency_by_type",
+        ),
+        sa.CheckConstraint(
+            ESTIMATE_SNAPSHOT_ENTRIES_UNIT_AMOUNT_BY_TYPE,
+            name="ck_estimate_snapshot_entries_unit_amount_by_type",
+        ),
+        sa.CheckConstraint(
+            ESTIMATE_SNAPSHOT_ENTRIES_SOURCE_FIELDS_BY_TYPE,
+            name="ck_estimate_snapshot_entries_source_fields_by_type",
+        ),
+        sa.ForeignKeyConstraint(
+            ["estimate_version_id", "project_id", "drawing_revision_id"],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+            ],
+            name="fk_estimate_snapshot_entries_estimate_version_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_rate_id"],
+            ["rate_catalog_entries.id"],
+            name="fk_est_snapshot_entries_source_rate",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_material_id"],
+            ["material_catalog_entries.id"],
+            name="fk_est_snapshot_entries_source_material",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_formula_id"],
+            ["formula_definitions.id"],
+            name="fk_est_snapshot_entries_source_formula",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "source_quantity_takeoff_id",
+            ],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+                "estimate_versions.quantity_takeoff_id",
+            ],
+            name="fk_estimate_snapshot_entries_quantity_parent_takeoff",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "source_quantity_item_id",
+                "source_quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+            ],
+            [
+                "quantity_items.id",
+                "quantity_items.quantity_takeoff_id",
+                "quantity_items.project_id",
+                "quantity_items.drawing_revision_id",
+            ],
+            name="fk_est_snapshot_entries_source_quantity_item",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_estimate_snapshot_entries")),
+        sa.UniqueConstraint(
+            "id",
+            "estimate_version_id",
+            "project_id",
+            "drawing_revision_id",
+            "entry_type",
+            name="uq_est_snapshot_entries_id_estimate_version_project_rev_type",
+        ),
+        sa.UniqueConstraint(
+            "estimate_version_id",
+            "entry_key",
+            name="uq_estimate_snapshot_entries_estimate_version_id_entry_key",
+        ),
+        sa.UniqueConstraint(
+            "estimate_version_id",
+            "sort_order",
+            name="uq_estimate_snapshot_entries_estimate_version_id_sort_order",
+        ),
+    )
+    op.create_index(
+        "ix_estimate_snapshot_entries_estimate_version_id",
+        "estimate_snapshot_entries",
+        ["estimate_version_id"],
+    )
+    op.create_index(
+        "ix_estimate_snapshot_entries_source_quantity_takeoff_id",
+        "estimate_snapshot_entries",
+        ["source_quantity_takeoff_id"],
+    )
+
+    op.create_table(
+        "estimate_items",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Unique estimate line item identifier (UUID v4)",
+        ),
+        sa.Column(
+            "estimate_version_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning immutable estimate version identifier",
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning project identifier copied from the estimate version",
+        ),
+        sa.Column(
+            "drawing_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Pinned drawing revision identifier copied from the estimate version",
+        ),
+        sa.Column(
+            "line_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="Frozen estimate line item type",
+        ),
+        sa.Column(
+            "line_number",
+            sa.Integer(),
+            nullable=False,
+            comment="Deterministic line number within the estimate version",
+        ),
+        sa.Column(
+            "line_key",
+            sa.String(length=128),
+            nullable=False,
+            comment="Deterministic line key within the estimate version",
+        ),
+        sa.Column(
+            "description",
+            sa.String(length=512),
+            nullable=False,
+            comment="Human-readable frozen estimate line item description",
+        ),
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            server_default="GBP",
+            comment="Frozen estimate line item currency. MVP estimates persist GBP only",
+        ),
+        sa.Column(
+            "quantity_value",
+            sa.Numeric(precision=18, scale=6),
+            nullable=True,
+            comment="Frozen quantity basis for quantity-driven estimate line items",
+        ),
+        sa.Column(
+            "quantity_unit",
+            sa.String(length=64),
+            nullable=True,
+            comment="Frozen quantity unit for quantity-driven estimate line items",
+        ),
+        sa.Column(
+            "unit_rate_amount",
+            sa.Numeric(precision=18, scale=6),
+            nullable=True,
+            comment="Frozen per-unit rate amount for rate/material line items",
+        ),
+        sa.Column(
+            "effective_date",
+            sa.Date(),
+            nullable=True,
+            comment="Frozen effective date captured for priced estimate line items",
+        ),
+        sa.Column(
+            "subtotal_amount",
+            sa.Numeric(precision=18, scale=2),
+            nullable=False,
+            comment="Frozen line subtotal monetary amount",
+        ),
+        sa.Column(
+            "tax_amount",
+            sa.Numeric(precision=18, scale=2),
+            nullable=False,
+            comment="Frozen line tax monetary amount",
+        ),
+        sa.Column(
+            "total_amount",
+            sa.Numeric(precision=18, scale=2),
+            nullable=False,
+            comment="Frozen line total monetary amount",
+        ),
+        sa.Column(
+            "rounding_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            comment="Frozen line rounding metadata for deterministic replay when applicable",
+        ),
+        sa.Column(
+            "quantity_snapshot_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Referenced quantity-input snapshot entry for quantity-driven line items",
+        ),
+        sa.Column(
+            "quantity_snapshot_entry_type",
+            sa.String(length=32),
+            nullable=False,
+            server_default="quantity_input",
+            comment="Constant snapshot entry type discriminator for quantity-input refs",
+        ),
+        sa.Column(
+            "rate_snapshot_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Referenced rate snapshot entry when line_type=rate",
+        ),
+        sa.Column(
+            "rate_snapshot_entry_type",
+            sa.String(length=32),
+            nullable=False,
+            server_default="rate",
+            comment="Constant snapshot entry type discriminator for rate refs",
+        ),
+        sa.Column(
+            "material_snapshot_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Referenced material snapshot entry when line_type=material",
+        ),
+        sa.Column(
+            "material_snapshot_entry_type",
+            sa.String(length=32),
+            nullable=False,
+            server_default="material",
+            comment="Constant snapshot entry type discriminator for material refs",
+        ),
+        sa.Column(
+            "formula_snapshot_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Referenced formula snapshot entry when line_type=formula",
+        ),
+        sa.Column(
+            "formula_snapshot_entry_type",
+            sa.String(length=32),
+            nullable=False,
+            server_default="formula",
+            comment="Constant snapshot entry type discriminator for formula refs",
+        ),
+        sa.Column(
+            "assumption_snapshot_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Referenced assumption snapshot entry when line_type=assumption",
+        ),
+        sa.Column(
+            "assumption_snapshot_entry_type",
+            sa.String(length=32),
+            nullable=False,
+            server_default="assumption",
+            comment="Constant snapshot entry type discriminator for assumption refs",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="Estimate line item creation timestamp",
+        ),
+        sa.CheckConstraint(
+            "line_type IN ('rate', 'material', 'formula', 'assumption', 'adjustment')",
+            name="ck_estimate_items_line_type_valid",
+        ),
+        sa.CheckConstraint(
+            "line_number >= 1",
+            name="ck_estimate_items_line_number_positive",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(line_key)) > 0",
+            name="ck_estimate_items_line_key_nonempty",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(description)) > 0",
+            name="ck_estimate_items_description_nonempty",
+        ),
+        sa.CheckConstraint(
+            "currency = 'GBP'",
+            name="ck_estimate_items_currency_gbp",
+        ),
+        sa.CheckConstraint(
+            "rounding_json IS NULL OR jsonb_typeof(rounding_json) = 'object'",
+            name="ck_estimate_items_rounding_json_object",
+        ),
+        sa.CheckConstraint(
+            "quantity_value IS NULL OR (quantity_value::text <> 'NaN' "
+            "AND quantity_value >= 0::numeric)",
+            name="ck_estimate_items_quantity_value_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "unit_rate_amount IS NULL OR (unit_rate_amount::text <> 'NaN' "
+            "AND unit_rate_amount >= 0::numeric)",
+            name="ck_estimate_items_unit_rate_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "subtotal_amount::text <> 'NaN' AND subtotal_amount >= 0::numeric",
+            name="ck_estimate_items_subtotal_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "tax_amount::text <> 'NaN' AND tax_amount >= 0::numeric",
+            name="ck_estimate_items_tax_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "total_amount::text <> 'NaN' AND total_amount >= 0::numeric",
+            name="ck_estimate_items_total_amount_nonnegative",
+        ),
+        sa.CheckConstraint(
+            ESTIMATE_ITEMS_SNAPSHOT_ENTRY_TYPE_CONSTANTS,
+            name="ck_estimate_items_snapshot_entry_type_constants",
+        ),
+        sa.CheckConstraint(
+            ESTIMATE_ITEMS_SOURCE_FIELDS_BY_LINE_TYPE,
+            name="ck_estimate_items_source_fields_by_line_type",
+        ),
+        sa.ForeignKeyConstraint(
+            ["estimate_version_id", "project_id", "drawing_revision_id"],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+            ],
+            name="fk_estimate_items_estimate_version_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "quantity_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            name="fk_estimate_items_quantity_snapshot_entry",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "rate_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "rate_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            name="fk_estimate_items_rate_snapshot_entry",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "material_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "material_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            name="fk_estimate_items_material_snapshot_entry",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "formula_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "formula_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            name="fk_estimate_items_formula_snapshot_entry",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "assumption_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "assumption_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            name="fk_estimate_items_assumption_snapshot_entry",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_estimate_items")),
+        sa.UniqueConstraint(
+            "estimate_version_id",
+            "line_number",
+            name="uq_estimate_items_estimate_version_id_line_number",
+        ),
+        sa.UniqueConstraint(
+            "estimate_version_id",
+            "line_key",
+            name="uq_estimate_items_estimate_version_id_line_key",
+        ),
+    )
+    op.create_index(
+        "ix_estimate_items_estimate_version_id",
+        "estimate_items",
+        ["estimate_version_id"],
+    )
+
+    _attach_append_only_triggers("estimate_snapshot_entries")
+    _attach_append_only_triggers("estimate_items")
+
+
+def downgrade() -> None:
+    _assert_estimate_reproducibility_tables_empty()
+
+    _drop_append_only_triggers("estimate_items")
+    _drop_append_only_triggers("estimate_snapshot_entries")
+
+    op.drop_index("ix_estimate_items_estimate_version_id", table_name="estimate_items")
+    op.drop_table("estimate_items")
+
+    op.drop_index(
+        "ix_estimate_snapshot_entries_source_quantity_takeoff_id",
+        table_name="estimate_snapshot_entries",
+    )
+    op.drop_index(
+        "ix_estimate_snapshot_entries_estimate_version_id",
+        table_name="estimate_snapshot_entries",
+    )
+    op.drop_table("estimate_snapshot_entries")
+
+    op.drop_constraint(
+        "uq_quantity_items_id_takeoff_project_drawing_revision",
+        "quantity_items",
+        type_="unique",
+    )
+
+    op.drop_constraint(
+        "uq_estimate_versions_id_project_rev_quantity_takeoff_id",
+        "estimate_versions",
+        type_="unique",
+    )

--- a/app/models/estimate_version.py
+++ b/app/models/estimate_version.py
@@ -3,24 +3,157 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 
 from sqlalchemy import (
     Boolean,
     CheckConstraint,
+    Date,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
     Index,
+    Integer,
     Numeric,
     String,
     UniqueConstraint,
     func,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, validates
 
 from app.db.base import Base
+
+ESTIMATE_SNAPSHOT_ENTRIES_CURRENCY_BY_TYPE = (
+    "((entry_type IN ('rate', 'material') AND currency = 'GBP') "
+    "OR (entry_type NOT IN ('rate', 'material') AND currency IS NULL))"
+)
+ESTIMATE_SNAPSHOT_ENTRIES_UNIT_AMOUNT_BY_TYPE = (
+    "((entry_type IN ('rate', 'material') AND unit_amount IS NOT NULL) "
+    "OR (entry_type NOT IN ('rate', 'material') AND unit_amount IS NULL))"
+)
+ESTIMATE_SNAPSHOT_ENTRIES_SOURCE_FIELDS_BY_TYPE = (
+    "((entry_type = 'rate' "
+    "AND source_rate_id IS NOT NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NOT NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NOT NULL "
+    "AND length(btrim(unit)) > 0 "
+    "AND effective_date IS NOT NULL) "
+    "OR (entry_type = 'material' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NOT NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NOT NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NOT NULL "
+    "AND length(btrim(unit)) > 0 "
+    "AND effective_date IS NOT NULL) "
+    "OR (entry_type = 'formula' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NOT NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NOT NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NULL "
+    "AND effective_date IS NULL) "
+    "OR (entry_type = 'assumption' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NULL "
+    "AND source_quantity_item_id IS NULL "
+    "AND source_checksum_sha256 IS NULL "
+    "AND quantity_value IS NULL "
+    "AND unit IS NULL "
+    "AND effective_date IS NULL) "
+    "OR (entry_type = 'quantity_input' "
+    "AND source_rate_id IS NULL "
+    "AND source_material_id IS NULL "
+    "AND source_formula_id IS NULL "
+    "AND source_quantity_takeoff_id IS NOT NULL "
+    "AND source_checksum_sha256 IS NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND unit IS NOT NULL "
+    "AND length(btrim(unit)) > 0 "
+    "AND effective_date IS NULL))"
+)
+ESTIMATE_ITEMS_SNAPSHOT_ENTRY_TYPE_CONSTANTS = (
+    "rate_snapshot_entry_type = 'rate' "
+    "AND material_snapshot_entry_type = 'material' "
+    "AND formula_snapshot_entry_type = 'formula' "
+    "AND assumption_snapshot_entry_type = 'assumption' "
+    "AND quantity_snapshot_entry_type = 'quantity_input'"
+)
+ESTIMATE_ITEMS_SOURCE_FIELDS_BY_LINE_TYPE = (
+    "((line_type = 'rate' "
+    "AND rate_snapshot_entry_id IS NOT NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NULL "
+    "AND quantity_snapshot_entry_id IS NOT NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND quantity_unit IS NOT NULL "
+    "AND length(btrim(quantity_unit)) > 0 "
+    "AND unit_rate_amount IS NOT NULL "
+    "AND effective_date IS NOT NULL) "
+    "OR (line_type = 'material' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NOT NULL "
+    "AND formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NULL "
+    "AND quantity_snapshot_entry_id IS NOT NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND quantity_unit IS NOT NULL "
+    "AND length(btrim(quantity_unit)) > 0 "
+    "AND unit_rate_amount IS NOT NULL "
+    "AND effective_date IS NOT NULL) "
+    "OR (line_type = 'formula' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND formula_snapshot_entry_id IS NOT NULL "
+    "AND assumption_snapshot_entry_id IS NULL "
+    "AND ((quantity_snapshot_entry_id IS NULL "
+    "AND quantity_value IS NULL "
+    "AND quantity_unit IS NULL) "
+    "OR (quantity_snapshot_entry_id IS NOT NULL "
+    "AND quantity_value IS NOT NULL "
+    "AND quantity_unit IS NOT NULL "
+    "AND length(btrim(quantity_unit)) > 0)) "
+    "AND unit_rate_amount IS NULL "
+    "AND TRUE) "
+    "OR (line_type = 'assumption' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NOT NULL "
+    "AND quantity_snapshot_entry_id IS NULL "
+    "AND quantity_value IS NULL "
+    "AND quantity_unit IS NULL "
+    "AND unit_rate_amount IS NULL "
+    "AND effective_date IS NULL) "
+    "OR (line_type = 'adjustment' "
+    "AND rate_snapshot_entry_id IS NULL "
+    "AND material_snapshot_entry_id IS NULL "
+    "AND ((formula_snapshot_entry_id IS NOT NULL "
+    "AND assumption_snapshot_entry_id IS NULL) "
+    "OR (formula_snapshot_entry_id IS NULL "
+    "AND assumption_snapshot_entry_id IS NOT NULL)) "
+    "AND quantity_snapshot_entry_id IS NULL "
+    "AND quantity_value IS NULL "
+    "AND quantity_unit IS NULL "
+    "AND unit_rate_amount IS NULL "
+    "AND effective_date IS NULL))"
+)
 
 
 class EstimateVersion(Base):
@@ -97,6 +230,13 @@ class EstimateVersion(Base):
             "project_id",
             "drawing_revision_id",
             name="uq_estimate_versions_id_project_id_drawing_revision_id",
+        ),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            "drawing_revision_id",
+            "quantity_takeoff_id",
+            name="uq_estimate_versions_id_project_rev_quantity_takeoff_id",
         ),
         UniqueConstraint(
             "source_job_id",
@@ -179,5 +319,588 @@ class EstimateVersion(Base):
     @validates("subtotal_amount", "tax_amount", "total_amount")
     def _validate_monetary_amount(self, field_name: str, value: Decimal) -> Decimal:
         if value.is_nan():
+            raise ValueError(f"{field_name} must not be NaN")
+        return value
+
+
+class EstimateSnapshotEntry(Base):
+    """Immutable snapshot entry frozen into an estimate version."""
+
+    __tablename__ = "estimate_snapshot_entries"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["estimate_version_id", "project_id", "drawing_revision_id"],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_snapshot_entries_estimate_version_lineage",
+        ),
+        ForeignKeyConstraint(
+            [
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "source_quantity_takeoff_id",
+            ],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+                "estimate_versions.quantity_takeoff_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_snapshot_entries_quantity_parent_takeoff",
+        ),
+        ForeignKeyConstraint(
+            [
+                "source_quantity_item_id",
+                "source_quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+            ],
+            [
+                "quantity_items.id",
+                "quantity_items.quantity_takeoff_id",
+                "quantity_items.project_id",
+                "quantity_items.drawing_revision_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_est_snapshot_entries_source_quantity_item",
+        ),
+        CheckConstraint(
+            "entry_type IN ('rate', 'material', 'formula', 'assumption', 'quantity_input')",
+            name="ck_estimate_snapshot_entries_entry_type_valid",
+        ),
+        CheckConstraint(
+            "length(btrim(entry_key)) > 0",
+            name="ck_estimate_snapshot_entries_entry_key_nonempty",
+        ),
+        CheckConstraint(
+            "length(btrim(entry_label)) > 0",
+            name="ck_estimate_snapshot_entries_entry_label_nonempty",
+        ),
+        CheckConstraint(
+            "sort_order >= 1",
+            name="ck_estimate_snapshot_entries_sort_order_positive",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(source_payload_json) = 'object'",
+            name="ck_estimate_snapshot_entries_source_payload_json_object",
+        ),
+        CheckConstraint(
+            "rounding_json IS NULL OR jsonb_typeof(rounding_json) = 'object'",
+            name="ck_estimate_snapshot_entries_rounding_json_object",
+        ),
+        CheckConstraint(
+            "source_checksum_sha256 IS NULL OR source_checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_estimate_snapshot_entries_source_checksum_sha256_format",
+        ),
+        CheckConstraint(
+            "quantity_value IS NULL OR (quantity_value::text <> 'NaN' "
+            "AND quantity_value >= 0::numeric)",
+            name="ck_estimate_snapshot_entries_quantity_value_nonnegative",
+        ),
+        CheckConstraint(
+            "unit_amount IS NULL OR (unit_amount::text <> 'NaN' AND unit_amount >= 0::numeric)",
+            name="ck_estimate_snapshot_entries_unit_amount_nonnegative",
+        ),
+        CheckConstraint(
+            ESTIMATE_SNAPSHOT_ENTRIES_CURRENCY_BY_TYPE,
+            name="ck_estimate_snapshot_entries_currency_by_type",
+        ),
+        CheckConstraint(
+            ESTIMATE_SNAPSHOT_ENTRIES_UNIT_AMOUNT_BY_TYPE,
+            name="ck_estimate_snapshot_entries_unit_amount_by_type",
+        ),
+        CheckConstraint(
+            ESTIMATE_SNAPSHOT_ENTRIES_SOURCE_FIELDS_BY_TYPE,
+            name="ck_estimate_snapshot_entries_source_fields_by_type",
+        ),
+        UniqueConstraint(
+            "id",
+            "estimate_version_id",
+            "project_id",
+            "drawing_revision_id",
+            "entry_type",
+            name="uq_est_snapshot_entries_id_estimate_version_project_rev_type",
+        ),
+        UniqueConstraint(
+            "estimate_version_id",
+            "entry_key",
+            name="uq_estimate_snapshot_entries_estimate_version_id_entry_key",
+        ),
+        UniqueConstraint(
+            "estimate_version_id",
+            "sort_order",
+            name="uq_estimate_snapshot_entries_estimate_version_id_sort_order",
+        ),
+        Index(
+            "ix_estimate_snapshot_entries_estimate_version_id",
+            "estimate_version_id",
+        ),
+        Index(
+            "ix_estimate_snapshot_entries_source_quantity_takeoff_id",
+            "source_quantity_takeoff_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique estimate snapshot entry identifier (UUID v4)",
+    )
+    estimate_version_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Owning immutable estimate version identifier",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Owning project identifier copied from the estimate version",
+    )
+    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Pinned drawing revision identifier copied from the estimate version",
+    )
+    entry_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Frozen snapshot entry type",
+    )
+    entry_key: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Deterministic snapshot entry key within the estimate version",
+    )
+    entry_label: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+        comment="Human-readable frozen snapshot entry label",
+    )
+    sort_order: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Deterministic snapshot entry order within the estimate version",
+    )
+    currency: Mapped[str | None] = mapped_column(
+        String(3),
+        nullable=True,
+        comment="Frozen currency for rate/material snapshots; null for non-monetary entries",
+    )
+    quantity_value: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6),
+        nullable=True,
+        comment="Frozen quantity value for quantity-input snapshots",
+    )
+    unit: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Frozen unit captured with the snapshot entry",
+    )
+    effective_date: Mapped[date | None] = mapped_column(
+        Date,
+        nullable=True,
+        comment="Frozen effective date captured for catalog-backed snapshot entries",
+    )
+    unit_amount: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6),
+        nullable=True,
+        comment="Frozen per-unit amount for rate/material snapshots",
+    )
+    source_payload_json: Mapped[dict[str, object]] = mapped_column(
+        JSONB,
+        nullable=False,
+        comment="Frozen source payload used to reproduce estimate calculations",
+    )
+    rounding_json: Mapped[dict[str, object] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment="Frozen rounding metadata for deterministic replay when applicable",
+    )
+    source_rate_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "rate_catalog_entries.id",
+            name="fk_est_snapshot_entries_source_rate",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        comment="Pinned source rate identifier for rate snapshot entries",
+    )
+    source_material_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "material_catalog_entries.id",
+            name="fk_est_snapshot_entries_source_material",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        comment="Pinned source material identifier for material snapshot entries",
+    )
+    source_formula_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "formula_definitions.id",
+            name="fk_est_snapshot_entries_source_formula",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        comment="Pinned source formula identifier for formula snapshot entries",
+    )
+    source_quantity_takeoff_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Pinned quantity takeoff source for quantity-input snapshot entries",
+    )
+    source_quantity_item_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Pinned quantity item source for quantity-input snapshot entries",
+    )
+    source_checksum_sha256: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Raw lowercase SHA-256 checksum for catalog-backed snapshot entries",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Estimate snapshot entry creation timestamp",
+    )
+
+    @validates("quantity_value", "unit_amount")
+    def _validate_numeric_amounts(
+        self,
+        field_name: str,
+        value: Decimal | None,
+    ) -> Decimal | None:
+        if value is not None and value.is_nan():
+            raise ValueError(f"{field_name} must not be NaN")
+        return value
+
+
+class EstimateItem(Base):
+    """Immutable estimate line item frozen from deterministic inputs."""
+
+    __tablename__ = "estimate_items"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["estimate_version_id", "project_id", "drawing_revision_id"],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_items_estimate_version_lineage",
+        ),
+        ForeignKeyConstraint(
+            [
+                "rate_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "rate_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_items_rate_snapshot_entry",
+        ),
+        ForeignKeyConstraint(
+            [
+                "material_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "material_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_items_material_snapshot_entry",
+        ),
+        ForeignKeyConstraint(
+            [
+                "formula_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "formula_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_items_formula_snapshot_entry",
+        ),
+        ForeignKeyConstraint(
+            [
+                "assumption_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "assumption_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_items_assumption_snapshot_entry",
+        ),
+        ForeignKeyConstraint(
+            [
+                "quantity_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_snapshot_entry_type",
+            ],
+            [
+                "estimate_snapshot_entries.id",
+                "estimate_snapshot_entries.estimate_version_id",
+                "estimate_snapshot_entries.project_id",
+                "estimate_snapshot_entries.drawing_revision_id",
+                "estimate_snapshot_entries.entry_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_items_quantity_snapshot_entry",
+        ),
+        CheckConstraint(
+            "line_type IN ('rate', 'material', 'formula', 'assumption', 'adjustment')",
+            name="ck_estimate_items_line_type_valid",
+        ),
+        CheckConstraint(
+            "line_number >= 1",
+            name="ck_estimate_items_line_number_positive",
+        ),
+        CheckConstraint(
+            "length(btrim(line_key)) > 0",
+            name="ck_estimate_items_line_key_nonempty",
+        ),
+        CheckConstraint(
+            "length(btrim(description)) > 0",
+            name="ck_estimate_items_description_nonempty",
+        ),
+        CheckConstraint(
+            "currency = 'GBP'",
+            name="ck_estimate_items_currency_gbp",
+        ),
+        CheckConstraint(
+            "rounding_json IS NULL OR jsonb_typeof(rounding_json) = 'object'",
+            name="ck_estimate_items_rounding_json_object",
+        ),
+        CheckConstraint(
+            "quantity_value IS NULL OR (quantity_value::text <> 'NaN' "
+            "AND quantity_value >= 0::numeric)",
+            name="ck_estimate_items_quantity_value_nonnegative",
+        ),
+        CheckConstraint(
+            "unit_rate_amount IS NULL OR (unit_rate_amount::text <> 'NaN' "
+            "AND unit_rate_amount >= 0::numeric)",
+            name="ck_estimate_items_unit_rate_amount_nonnegative",
+        ),
+        CheckConstraint(
+            "subtotal_amount::text <> 'NaN' AND subtotal_amount >= 0::numeric",
+            name="ck_estimate_items_subtotal_amount_nonnegative",
+        ),
+        CheckConstraint(
+            "tax_amount::text <> 'NaN' AND tax_amount >= 0::numeric",
+            name="ck_estimate_items_tax_amount_nonnegative",
+        ),
+        CheckConstraint(
+            "total_amount::text <> 'NaN' AND total_amount >= 0::numeric",
+            name="ck_estimate_items_total_amount_nonnegative",
+        ),
+        CheckConstraint(
+            ESTIMATE_ITEMS_SNAPSHOT_ENTRY_TYPE_CONSTANTS,
+            name="ck_estimate_items_snapshot_entry_type_constants",
+        ),
+        CheckConstraint(
+            ESTIMATE_ITEMS_SOURCE_FIELDS_BY_LINE_TYPE,
+            name="ck_estimate_items_source_fields_by_line_type",
+        ),
+        UniqueConstraint(
+            "estimate_version_id",
+            "line_number",
+            name="uq_estimate_items_estimate_version_id_line_number",
+        ),
+        UniqueConstraint(
+            "estimate_version_id",
+            "line_key",
+            name="uq_estimate_items_estimate_version_id_line_key",
+        ),
+        Index("ix_estimate_items_estimate_version_id", "estimate_version_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        comment="Unique estimate line item identifier (UUID v4)",
+    )
+    estimate_version_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Owning immutable estimate version identifier",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Owning project identifier copied from the estimate version",
+    )
+    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Pinned drawing revision identifier copied from the estimate version",
+    )
+    line_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Frozen estimate line item type",
+    )
+    line_number: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Deterministic line number within the estimate version",
+    )
+    line_key: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Deterministic line key within the estimate version",
+    )
+    description: Mapped[str] = mapped_column(
+        String(512),
+        nullable=False,
+        comment="Human-readable frozen estimate line item description",
+    )
+    currency: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        default="GBP",
+        comment="Frozen estimate line item currency. MVP estimates persist GBP only",
+    )
+    quantity_value: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6),
+        nullable=True,
+        comment="Frozen quantity basis for quantity-driven estimate line items",
+    )
+    quantity_unit: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="Frozen quantity unit for quantity-driven estimate line items",
+    )
+    unit_rate_amount: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6),
+        nullable=True,
+        comment="Frozen per-unit rate amount for rate/material line items",
+    )
+    effective_date: Mapped[date | None] = mapped_column(
+        Date,
+        nullable=True,
+        comment="Frozen effective date captured for priced estimate line items",
+    )
+    subtotal_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2),
+        nullable=False,
+        comment="Frozen line subtotal monetary amount",
+    )
+    tax_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2),
+        nullable=False,
+        comment="Frozen line tax monetary amount",
+    )
+    total_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 2),
+        nullable=False,
+        comment="Frozen line total monetary amount",
+    )
+    rounding_json: Mapped[dict[str, object] | None] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment="Frozen line rounding metadata for deterministic replay when applicable",
+    )
+    quantity_snapshot_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Referenced quantity-input snapshot entry for quantity-driven line items",
+    )
+    quantity_snapshot_entry_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="quantity_input",
+        comment="Constant snapshot entry type discriminator for quantity-input refs",
+    )
+    rate_snapshot_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Referenced rate snapshot entry when line_type=rate",
+    )
+    rate_snapshot_entry_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="rate",
+        comment="Constant snapshot entry type discriminator for rate refs",
+    )
+    material_snapshot_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Referenced material snapshot entry when line_type=material",
+    )
+    material_snapshot_entry_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="material",
+        comment="Constant snapshot entry type discriminator for material refs",
+    )
+    formula_snapshot_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Referenced formula snapshot entry when line_type=formula",
+    )
+    formula_snapshot_entry_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="formula",
+        comment="Constant snapshot entry type discriminator for formula refs",
+    )
+    assumption_snapshot_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        comment="Referenced assumption snapshot entry when line_type=assumption",
+    )
+    assumption_snapshot_entry_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="assumption",
+        comment="Constant snapshot entry type discriminator for assumption refs",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Estimate line item creation timestamp",
+    )
+
+    @validates(
+        "quantity_value",
+        "unit_rate_amount",
+        "subtotal_amount",
+        "tax_amount",
+        "total_amount",
+    )
+    def _validate_numeric_amounts(
+        self,
+        field_name: str,
+        value: Decimal | None,
+    ) -> Decimal | None:
+        if value is not None and value.is_nan():
             raise ValueError(f"{field_name} must not be NaN")
         return value

--- a/app/models/quantity_takeoff.py
+++ b/app/models/quantity_takeoff.py
@@ -317,6 +317,13 @@ class QuantityItem(Base):
             "json_typeof(excluded_source_entity_ids_json) = 'array'",
             name="ck_quantity_items_excluded_source_entity_ids_json_array",
         ),
+        UniqueConstraint(
+            "id",
+            "quantity_takeoff_id",
+            "project_id",
+            "drawing_revision_id",
+            name="uq_quantity_items_id_takeoff_project_drawing_revision",
+        ),
         Index(
             "ix_quantity_items_drawing_revision_id_source_entity_id",
             "drawing_revision_id",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,8 @@ APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
     "generated_artifacts",
     "job_events",
     "estimate_versions",
+    "estimate_snapshot_entries",
+    "estimate_items",
     "quantity_takeoffs",
     "quantity_items",
     "revision_entity_manifests",

--- a/tests/test_append_only_lineage_tables.py
+++ b/tests/test_append_only_lineage_tables.py
@@ -7,6 +7,7 @@ import subprocess
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
+from decimal import Decimal
 from json import dumps
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,7 @@ import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry
 from tests import test_estimate_version_persistence as estimate_version_persistence
 from tests.conftest import (
     APPEND_ONLY_PROTECTED_TABLES,
@@ -65,6 +67,8 @@ class _ProtectedRowIds:
     generated_artifact_id: uuid.UUID
     job_event_id: uuid.UUID
     estimate_version_id: uuid.UUID
+    estimate_snapshot_entry_id: uuid.UUID
+    estimate_item_id: uuid.UUID
     quantity_takeoff_id: uuid.UUID
     quantity_item_id: uuid.UUID
     revision_entity_manifest_id: uuid.UUID
@@ -166,6 +170,8 @@ def _row_id_for_table(row_ids: _ProtectedRowIds, table_name: str) -> uuid.UUID:
         "generated_artifacts": row_ids.generated_artifact_id,
         "job_events": row_ids.job_event_id,
         "estimate_versions": row_ids.estimate_version_id,
+        "estimate_snapshot_entries": row_ids.estimate_snapshot_entry_id,
+        "estimate_items": row_ids.estimate_item_id,
         "quantity_takeoffs": row_ids.quantity_takeoff_id,
         "quantity_items": row_ids.quantity_item_id,
         "revision_entity_manifests": row_ids.revision_entity_manifest_id,
@@ -198,11 +204,46 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         source_job_id=estimate_source_job_id,
         quantity_takeoff_id=quantity_seed.quantity_takeoff_id,
     )
+    estimate_snapshot_entry = EstimateSnapshotEntry(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=quantity_seed.project_id,
+        drawing_revision_id=quantity_seed.drawing_revision_id,
+        entry_type="assumption",
+        entry_key="assumption:append-only",
+        entry_label="Append-only assumption",
+        sort_order=1,
+        source_payload_json={"kind": "assumption", "value": "seed"},
+    )
+    estimate_item = EstimateItem(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=quantity_seed.project_id,
+        drawing_revision_id=quantity_seed.drawing_revision_id,
+        line_type="assumption",
+        line_number=1,
+        line_key="line:assumption:append-only",
+        description="Append-only assumption line",
+        currency="GBP",
+        subtotal_amount=Decimal("0.00"),
+        tax_amount=Decimal("0.00"),
+        total_amount=Decimal("0.00"),
+        assumption_snapshot_entry_id=estimate_snapshot_entry.id,
+        quantity_snapshot_entry_type="quantity_input",
+        rate_snapshot_entry_type="rate",
+        material_snapshot_entry_type="material",
+        formula_snapshot_entry_type="formula",
+        assumption_snapshot_entry_type="assumption",
+    )
 
     session_maker = session_module.AsyncSessionLocal
     assert session_maker is not None
     async with session_maker() as session:
         session.add(estimate_version)
+        await session.flush()
+        session.add(estimate_snapshot_entry)
+        await session.flush()
+        session.add(estimate_item)
         await session.commit()
 
     assert len(adapter_outputs) == 1
@@ -227,6 +268,8 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         generated_artifact_id=generated_artifacts[0].id,
         job_event_id=job_events[0].id,
         estimate_version_id=estimate_version.id,
+        estimate_snapshot_entry_id=estimate_snapshot_entry.id,
+        estimate_item_id=estimate_item.id,
         quantity_takeoff_id=quantity_seed.quantity_takeoff_id,
         quantity_item_id=quantity_seed.quantity_item_id,
         revision_entity_manifest_id=manifests[0].id,
@@ -1338,6 +1381,8 @@ class TestAppendOnlyLineageTables:
             ("generated_artifacts", "name", "mutated-debug-overlay.svg"),
             ("job_events", "message", "mutated job event"),
             ("estimate_versions", "total_amount", "121.00"),
+            ("estimate_snapshot_entries", "entry_label", "mutated assumption"),
+            ("estimate_items", "description", "mutated estimate item"),
             ("quantity_takeoffs", "review_state", "review_required"),
             ("quantity_items", "quantity_type", "mutated_quantity_type"),
             (

--- a/tests/test_estimate_snapshot_item_persistence.py
+++ b/tests/test_estimate_snapshot_item_persistence.py
@@ -1,0 +1,782 @@
+"""Integration tests for append-only estimate snapshot and item persistence."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, Table, UniqueConstraint, select, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
+from app.models.estimation_catalog import EstimationFormula, EstimationMaterial, EstimationRate
+from tests import test_estimate_version_persistence as estimate_version_persistence
+from tests import test_quantity_takeoff_persistence as quantity_takeoff_persistence
+from tests.conftest import requires_database
+
+pytest_plugins = ("tests.test_quantity_takeoff_persistence",)
+pytestmark = [pytest.mark.asyncio, requires_database]
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "2026_05_18_0021_add_estimate_snapshot_items.py"
+)
+
+
+def _normalize_ondelete(raw_foreign_key: Mapping[str, Any]) -> str:
+    options = raw_foreign_key.get("options")
+    if isinstance(options, dict):
+        return str(options.get("ondelete") or "").upper()
+    return ""
+
+
+def _lineage_contract_state(sync_connection: sa.Connection) -> dict[str, bool]:
+    inspector = sa.inspect(sync_connection)
+    quantity_item_unique = {
+        tuple(constraint["column_names"])
+        for constraint in inspector.get_unique_constraints("quantity_items")
+    }
+    quantity_item_foreign_keys = inspector.get_foreign_keys("estimate_snapshot_entries")
+    source_quantity_item_fk = next(
+        (
+            foreign_key
+            for foreign_key in quantity_item_foreign_keys
+            if str(foreign_key.get("name")) == "fk_est_snapshot_entries_source_quantity_item"
+        ),
+        None,
+    )
+    return {
+        "has_quantity_item_lineage_unique": (
+            "id",
+            "quantity_takeoff_id",
+            "project_id",
+            "drawing_revision_id",
+        )
+        in quantity_item_unique,
+        "has_quantity_item_lineage_fk": source_quantity_item_fk is not None
+        and tuple(source_quantity_item_fk["constrained_columns"])
+        == (
+            "source_quantity_item_id",
+            "source_quantity_takeoff_id",
+            "project_id",
+            "drawing_revision_id",
+        )
+        and tuple(source_quantity_item_fk["referred_columns"])
+        == ("id", "quantity_takeoff_id", "project_id", "drawing_revision_id"),
+    }
+
+
+async def _ensure_quantity_item_lineage_contract(db_session: AsyncSession) -> None:
+    connection = await db_session.connection()
+    state = await connection.run_sync(_lineage_contract_state)
+
+    if not state["has_quantity_item_lineage_unique"]:
+        await db_session.execute(
+            text(
+                "ALTER TABLE quantity_items "
+                "ADD CONSTRAINT uq_quantity_items_id_takeoff_project_drawing_revision "
+                "UNIQUE (id, quantity_takeoff_id, project_id, drawing_revision_id)"
+            )
+        )
+
+    if not state["has_quantity_item_lineage_fk"]:
+        await db_session.execute(
+            text(
+                "ALTER TABLE estimate_snapshot_entries "
+                "DROP CONSTRAINT IF EXISTS fk_est_snapshot_entries_source_quantity_item"
+            )
+        )
+        await db_session.execute(
+            text(
+                "ALTER TABLE estimate_snapshot_entries "
+                "ADD CONSTRAINT fk_est_snapshot_entries_source_quantity_item "
+                "FOREIGN KEY ("
+                "source_quantity_item_id, source_quantity_takeoff_id, "
+                "project_id, drawing_revision_id"
+                ") REFERENCES quantity_items ("
+                "id, quantity_takeoff_id, project_id, drawing_revision_id"
+                ") ON DELETE RESTRICT NOT VALID"
+            )
+        )
+
+    if not state["has_quantity_item_lineage_unique"] or not state[
+        "has_quantity_item_lineage_fk"
+    ]:
+        await db_session.commit()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def ensure_quantity_item_lineage_contract() -> AsyncGenerator[None, None]:
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        await _ensure_quantity_item_lineage_contract(session)
+
+    yield
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_projects: None) -> AsyncGenerator[AsyncSession, None]:
+    _ = cleanup_projects
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+def _inspect_schema(sync_connection: sa.Connection) -> dict[str, Any]:
+    inspector = sa.inspect(sync_connection)
+    tables = (
+        "estimate_versions",
+        "estimate_snapshot_entries",
+        "estimate_items",
+        "quantity_items",
+    )
+    return {
+        "columns": {
+            table_name: {
+                str(column["name"]): {"nullable": bool(column["nullable"])}
+                for column in inspector.get_columns(table_name)
+            }
+            for table_name in tables
+        },
+        "unique_constraints": {
+            table_name: {
+                tuple(constraint["column_names"]): str(constraint["name"])
+                for constraint in inspector.get_unique_constraints(table_name)
+            }
+            for table_name in tables
+        },
+        "check_constraints": {
+            table_name: {
+                str(constraint["name"]): str(constraint["sqltext"])
+                for constraint in inspector.get_check_constraints(table_name)
+            }
+            for table_name in tables
+        },
+        "foreign_keys": {
+            table_name: {
+                (
+                    tuple(foreign_key["constrained_columns"]),
+                    str(foreign_key["referred_table"]),
+                    tuple(foreign_key["referred_columns"]),
+                ): _normalize_ondelete(foreign_key)
+                for foreign_key in inspector.get_foreign_keys(table_name)
+            }
+            for table_name in ("estimate_snapshot_entries", "estimate_items")
+        },
+    }
+
+
+async def _load_schema() -> dict[str, Any]:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        connection = await session.connection()
+        return await connection.run_sync(_inspect_schema)
+
+
+async def _assert_commit_fails(
+    session: AsyncSession,
+    obj: object,
+    expected_substring: str | tuple[str, ...],
+) -> None:
+    session.add(obj)
+    expected_substrings = (
+        [expected_substring] if isinstance(expected_substring, str) else list(expected_substring)
+    )
+
+    try:
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        constraint_name = getattr(getattr(exc, "orig", None), "constraint_name", None)
+        if constraint_name in expected_substrings:
+            return
+
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert any(substring.lower() in message for substring in expected_substrings)
+    else:
+        pytest.fail(f"Expected database error containing {expected_substrings!r}")
+
+
+async def _create_estimate_version(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> tuple[quantity_takeoff_persistence._QuantityPersistenceSeed, EstimateVersion]:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    source_job_id = await estimate_version_persistence._create_estimate_source_job(seed)
+    estimate_version = estimate_version_persistence._build_estimate_version(
+        seed,
+        source_job_id=source_job_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+    )
+    db_session.add(estimate_version)
+    await db_session.commit()
+    return seed, estimate_version
+
+
+async def _create_catalog_rows(
+    db_session: AsyncSession,
+    project_id: uuid.UUID,
+) -> tuple[EstimationRate, EstimationMaterial, EstimationFormula]:
+    rate = EstimationRate(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        rate_key="labour:installer",
+        source="test",
+        metadata_json={"source": "test"},
+        name="Installer labour",
+        item_type="linear_length",
+        per_unit="m",
+        currency="GBP",
+        amount=Decimal("12.345678"),
+        effective_from=date(2026, 1, 1),
+        checksum_sha256="a" * 64,
+    )
+    material = EstimationMaterial(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        material_key="cable:standard",
+        source="test",
+        metadata_json={"source": "test"},
+        name="Standard cable",
+        unit="m",
+        currency="GBP",
+        unit_cost=Decimal("3.210000"),
+        effective_from=date(2026, 1, 1),
+        checksum_sha256="b" * 64,
+    )
+    formula = EstimationFormula(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        formula_id="waste-factor",
+        version=1,
+        name="Waste factor",
+        dsl_version="0.1",
+        output_key="waste",
+        output_contract_json={"unit": "GBP"},
+        declared_inputs_json=[{"name": "base"}],
+        expression_json={"op": "multiply", "by": "0.10"},
+        rounding_json={"mode": "ROUND_HALF_UP"},
+        checksum_sha256="c" * 64,
+    )
+    db_session.add_all([rate, material, formula])
+    await db_session.commit()
+    return rate, material, formula
+
+
+def _quantity_snapshot(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    *,
+    sort_order: int = 1,
+    source_quantity_takeoff_id: uuid.UUID | None = None,
+    source_quantity_item_id: uuid.UUID | None = None,
+) -> EstimateSnapshotEntry:
+    return EstimateSnapshotEntry(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=seed.project_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        entry_type="quantity_input",
+        entry_key=f"quantity:{sort_order}",
+        entry_label="Frozen quantity input",
+        sort_order=sort_order,
+        source_quantity_takeoff_id=source_quantity_takeoff_id or seed.quantity_takeoff_id,
+        source_quantity_item_id=source_quantity_item_id or seed.quantity_item_id,
+        quantity_value=Decimal("12.500000"),
+        unit="m",
+        source_payload_json={
+            "quantity_item_id": str(source_quantity_item_id or seed.quantity_item_id)
+        },
+    )
+
+
+def _rate_snapshot(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    rate: EstimationRate,
+    *,
+    sort_order: int = 2,
+) -> EstimateSnapshotEntry:
+    return EstimateSnapshotEntry(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=seed.project_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        entry_type="rate",
+        entry_key=f"rate:{sort_order}",
+        entry_label="Frozen rate",
+        sort_order=sort_order,
+        source_rate_id=rate.id,
+        source_checksum_sha256=rate.checksum_sha256,
+        unit=rate.per_unit,
+        currency="GBP",
+        effective_date=rate.effective_from,
+        unit_amount=rate.amount,
+        source_payload_json={"rate_key": rate.rate_key},
+        rounding_json={"scale": 2},
+    )
+
+
+def _material_snapshot(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    material: EstimationMaterial,
+    *,
+    sort_order: int = 3,
+) -> EstimateSnapshotEntry:
+    return EstimateSnapshotEntry(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=seed.project_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        entry_type="material",
+        entry_key=f"material:{sort_order}",
+        entry_label="Frozen material",
+        sort_order=sort_order,
+        source_material_id=material.id,
+        source_checksum_sha256=material.checksum_sha256,
+        unit=material.unit,
+        currency="GBP",
+        effective_date=material.effective_from,
+        unit_amount=material.unit_cost,
+        source_payload_json={"material_key": material.material_key},
+    )
+
+
+def _formula_snapshot(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    formula: EstimationFormula,
+    *,
+    sort_order: int = 4,
+) -> EstimateSnapshotEntry:
+    return EstimateSnapshotEntry(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=seed.project_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        entry_type="formula",
+        entry_key=f"formula:{sort_order}",
+        entry_label="Frozen formula",
+        sort_order=sort_order,
+        source_formula_id=formula.id,
+        source_checksum_sha256=formula.checksum_sha256,
+        source_payload_json={"formula_id": formula.formula_id, "version": formula.version},
+        rounding_json={"scale": 2},
+    )
+
+
+def _assumption_snapshot(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    *,
+    sort_order: int = 5,
+) -> EstimateSnapshotEntry:
+    return EstimateSnapshotEntry(
+        id=uuid.uuid4(),
+        estimate_version_id=estimate_version.id,
+        project_id=seed.project_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        entry_type="assumption",
+        entry_key=f"assumption:{sort_order}",
+        entry_label="Frozen assumption",
+        sort_order=sort_order,
+        source_payload_json={"text": "Include preliminaries"},
+    )
+
+
+def _base_item_kwargs(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    *,
+    line_number: int,
+    line_type: str,
+) -> dict[str, object]:
+    return {
+        "id": uuid.uuid4(),
+        "estimate_version_id": estimate_version.id,
+        "project_id": seed.project_id,
+        "drawing_revision_id": seed.drawing_revision_id,
+        "line_type": line_type,
+        "line_number": line_number,
+        "line_key": f"line:{line_number}:{line_type}",
+        "description": f"{line_type.title()} line",
+        "currency": "GBP",
+        "subtotal_amount": Decimal("10.00"),
+        "tax_amount": Decimal("2.00"),
+        "total_amount": Decimal("12.00"),
+        "quantity_snapshot_entry_type": "quantity_input",
+        "rate_snapshot_entry_type": "rate",
+        "material_snapshot_entry_type": "material",
+        "formula_snapshot_entry_type": "formula",
+        "assumption_snapshot_entry_type": "assumption",
+    }
+
+
+async def _insert_full_snapshot_set(
+    db_session: AsyncSession,
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+) -> dict[str, EstimateSnapshotEntry]:
+    rate, material, formula = await _create_catalog_rows(db_session, seed.project_id)
+    snapshots = {
+        "quantity": _quantity_snapshot(seed, estimate_version),
+        "rate": _rate_snapshot(seed, estimate_version, rate),
+        "material": _material_snapshot(seed, estimate_version, material),
+        "formula": _formula_snapshot(seed, estimate_version, formula),
+        "assumption": _assumption_snapshot(seed, estimate_version),
+    }
+    db_session.add_all(snapshots.values())
+    await db_session.commit()
+    return snapshots
+
+
+def _line_items(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    estimate_version: EstimateVersion,
+    snapshots: dict[str, EstimateSnapshotEntry],
+) -> list[EstimateItem]:
+    return [
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=1, line_type="rate"),
+            quantity_snapshot_entry_id=snapshots["quantity"].id,
+            rate_snapshot_entry_id=snapshots["rate"].id,
+            quantity_value=Decimal("12.500000"),
+            quantity_unit="m",
+            unit_rate_amount=Decimal("12.345678"),
+            effective_date=date(2026, 1, 1),
+            rounding_json={"scale": 2},
+        ),
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=2, line_type="material"),
+            quantity_snapshot_entry_id=snapshots["quantity"].id,
+            material_snapshot_entry_id=snapshots["material"].id,
+            quantity_value=Decimal("12.500000"),
+            quantity_unit="m",
+            unit_rate_amount=Decimal("3.210000"),
+            effective_date=date(2026, 1, 1),
+        ),
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=3, line_type="formula"),
+            formula_snapshot_entry_id=snapshots["formula"].id,
+        ),
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=4, line_type="assumption"),
+            assumption_snapshot_entry_id=snapshots["assumption"].id,
+        ),
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=5, line_type="adjustment"),
+            formula_snapshot_entry_id=snapshots["formula"].id,
+        ),
+    ]
+
+
+async def test_estimate_snapshot_and_item_schema_matches_contract() -> None:
+    schema = await _load_schema()
+    columns = schema["columns"]
+    unique_constraints = schema["unique_constraints"]
+    check_constraints = schema["check_constraints"]
+    foreign_keys = schema["foreign_keys"]
+
+    assert (
+        "id",
+        "project_id",
+        "drawing_revision_id",
+        "quantity_takeoff_id",
+    ) in unique_constraints["estimate_versions"]
+    assert (
+        "id",
+        "quantity_takeoff_id",
+        "project_id",
+        "drawing_revision_id",
+    ) in unique_constraints["quantity_items"]
+
+    for required_column in (
+        "entry_type",
+        "entry_key",
+        "entry_label",
+        "source_payload_json",
+        "sort_order",
+        "created_at",
+    ):
+        assert columns["estimate_snapshot_entries"][required_column]["nullable"] is False
+    for required_column in (
+        "line_number",
+        "line_key",
+        "line_type",
+        "description",
+        "currency",
+        "subtotal_amount",
+        "tax_amount",
+        "total_amount",
+        "created_at",
+    ):
+        assert columns["estimate_items"][required_column]["nullable"] is False
+
+    assert ("estimate_version_id", "entry_key") in unique_constraints[
+        "estimate_snapshot_entries"
+    ]
+    assert ("estimate_version_id", "sort_order") in unique_constraints[
+        "estimate_snapshot_entries"
+    ]
+    assert ("estimate_version_id", "line_number") in unique_constraints["estimate_items"]
+    assert ("estimate_version_id", "line_key") in unique_constraints["estimate_items"]
+
+    for constraint_name in (
+        "ck_estimate_snapshot_entries_entry_type_valid",
+        "ck_estimate_snapshot_entries_source_payload_json_object",
+        "ck_estimate_snapshot_entries_source_checksum_sha256_format",
+        "ck_estimate_snapshot_entries_source_fields_by_type",
+        "ck_estimate_items_line_type_valid",
+        "ck_estimate_items_snapshot_entry_type_constants",
+        "ck_estimate_items_source_fields_by_line_type",
+    ):
+        assert constraint_name in {
+            **check_constraints["estimate_snapshot_entries"],
+            **check_constraints["estimate_items"],
+        }
+
+    assert foreign_keys["estimate_snapshot_entries"][
+        (
+            (
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "source_quantity_takeoff_id",
+            ),
+            "estimate_versions",
+            ("id", "project_id", "drawing_revision_id", "quantity_takeoff_id"),
+        )
+    ] == "RESTRICT"
+    assert foreign_keys["estimate_snapshot_entries"][
+        (
+            (
+                "source_quantity_item_id",
+                "source_quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+            ),
+            "quantity_items",
+            ("id", "quantity_takeoff_id", "project_id", "drawing_revision_id"),
+        )
+    ] == "RESTRICT"
+    assert foreign_keys["estimate_items"][
+        (
+            (
+                "rate_snapshot_entry_id",
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "rate_snapshot_entry_type",
+            ),
+            "estimate_snapshot_entries",
+            ("id", "estimate_version_id", "project_id", "drawing_revision_id", "entry_type"),
+        )
+    ] == "RESTRICT"
+
+    snapshot_table = cast(Table, EstimateSnapshotEntry.__table__)
+    item_table = cast(Table, EstimateItem.__table__)
+    model_checks = {
+        str(constraint.name)
+        for table in (snapshot_table, item_table)
+        for constraint in table.constraints
+        if isinstance(constraint, CheckConstraint)
+    }
+    assert "ck_estimate_snapshot_entries_source_fields_by_type" in model_checks
+    assert "ck_estimate_items_source_fields_by_line_type" in model_checks
+    assert any(
+        isinstance(constraint, UniqueConstraint)
+        and tuple(constraint.columns.keys()) == ("estimate_version_id", "line_key")
+        for constraint in item_table.constraints
+    )
+
+    migration_sql = _MIGRATION_PATH.read_text(encoding="utf-8")
+    assert "quantity_input" in migration_sql
+    assert "source_checksum_sha256 ~ '^[0-9a-f]{64}$'" in migration_sql
+    assert "uq_estimate_versions_id_project_rev_quantity_takeoff_id" in migration_sql
+    assert "uq_quantity_items_id_takeoff_project_drawing_revision" in migration_sql
+
+
+async def test_estimate_snapshots_and_items_persist_all_line_types(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+    snapshots = await _insert_full_snapshot_set(db_session, seed, estimate_version)
+    items = _line_items(seed, estimate_version, snapshots)
+    db_session.add_all(items)
+    await db_session.commit()
+
+    persisted_types = set(
+        await db_session.scalars(
+            select(EstimateItem.line_type).where(
+                EstimateItem.estimate_version_id == estimate_version.id
+            )
+        )
+    )
+    assert persisted_types == {"rate", "material", "formula", "assumption", "adjustment"}
+
+
+async def test_quantity_snapshot_requires_parent_estimate_takeoff(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+
+    await _assert_commit_fails(
+        db_session,
+        _quantity_snapshot(
+            seed,
+            estimate_version,
+            source_quantity_takeoff_id=uuid.uuid4(),
+        ),
+        "fk_estimate_snapshot_entries_quantity_parent_takeoff",
+    )
+
+
+async def test_quantity_snapshot_rejects_item_from_another_takeoff_or_revision(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+    other_seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+
+    await _assert_commit_fails(
+        db_session,
+        _quantity_snapshot(
+            seed,
+            estimate_version,
+            source_quantity_item_id=other_seed.quantity_item_id,
+        ),
+        "fk_est_snapshot_entries_source_quantity_item",
+    )
+
+
+async def test_item_snapshot_refs_are_type_safe(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+    snapshots = await _insert_full_snapshot_set(db_session, seed, estimate_version)
+
+    await _assert_commit_fails(
+        db_session,
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=1, line_type="rate"),
+            quantity_snapshot_entry_id=snapshots["quantity"].id,
+            rate_snapshot_entry_id=snapshots["assumption"].id,
+            quantity_value=Decimal("12.500000"),
+            quantity_unit="m",
+            unit_rate_amount=Decimal("12.345678"),
+            effective_date=date(2026, 1, 1),
+        ),
+        "fk_estimate_items_rate_snapshot_entry",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "constraint_name"),
+    (
+        ("source_checksum_sha256", "g" * 64, "source_checksum_sha256_format"),
+        ("source_payload_json", [], "source_payload_json_object"),
+        ("currency", "USD", "currency_by_type"),
+        ("unit_amount", Decimal("-0.000001"), "unit_amount_nonnegative"),
+    ),
+)
+async def test_snapshot_entries_reject_invalid_frozen_values(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    field_name: str,
+    field_value: object,
+    constraint_name: str,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+    rate, _, _ = await _create_catalog_rows(db_session, seed.project_id)
+    snapshot = _rate_snapshot(seed, estimate_version, rate)
+    setattr(snapshot, field_name, field_value)
+
+    await _assert_commit_fails(db_session, snapshot, constraint_name)
+
+
+async def test_items_reject_invalid_line_contracts(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+    snapshots = await _insert_full_snapshot_set(db_session, seed, estimate_version)
+
+    await _assert_commit_fails(
+        db_session,
+        EstimateItem(
+            **_base_item_kwargs(seed, estimate_version, line_number=1, line_type="assumption"),
+            assumption_snapshot_entry_id=snapshots["assumption"].id,
+            quantity_snapshot_entry_id=snapshots["quantity"].id,
+        ),
+        "ck_estimate_items_source_fields_by_line_type",
+    )
+
+
+async def test_estimate_snapshot_and_item_tables_are_append_only(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed, estimate_version = await _create_estimate_version(async_client, db_session)
+    snapshots = await _insert_full_snapshot_set(db_session, seed, estimate_version)
+    item = _line_items(seed, estimate_version, snapshots)[3]
+    db_session.add(item)
+    await db_session.commit()
+
+    for table_name, column_name, row_id in (
+        ("estimate_snapshot_entries", "entry_label", snapshots["assumption"].id),
+        ("estimate_items", "description", item.id),
+    ):
+        with pytest.raises(DBAPIError) as update_exc:
+            await db_session.execute(
+                text(f'UPDATE "{table_name}" SET "{column_name}" = :value WHERE id = :id'),
+                {"value": "mutated", "id": row_id},
+            )
+            await db_session.commit()
+        await db_session.rollback()
+        assert f"append-only trigger blocked UPDATE on {table_name}" in str(update_exc.value)
+
+        with pytest.raises(DBAPIError) as delete_exc:
+            await db_session.execute(
+                text(f'DELETE FROM "{table_name}" WHERE id = :id'),
+                {"id": row_id},
+            )
+            await db_session.commit()
+        await db_session.rollback()
+        assert f"append-only trigger blocked DELETE on {table_name}" in str(delete_exc.value)

--- a/tests/test_estimate_version_persistence.py
+++ b/tests/test_estimate_version_persistence.py
@@ -593,6 +593,6 @@ async def test_estimate_versions_reject_append_only_mutations(
     )
     await _assert_append_only_sql_mutation_fails(
         db_session,
-        'TRUNCATE TABLE "estimate_versions"',
+        'TRUNCATE TABLE "estimate_versions" CASCADE',
         operation="TRUNCATE",
     )

--- a/tests/test_estimation_catalog_persistence.py
+++ b/tests/test_estimation_catalog_persistence.py
@@ -28,6 +28,8 @@ pytestmark = [pytest.mark.asyncio, requires_database]
 
 CatalogBuilder = Callable[..., Any]
 CATALOG_TABLES: tuple[str, ...] = (
+    "estimate_items",
+    "estimate_snapshot_entries",
     "formula_definition_supersessions",
     "material_catalog_entry_supersessions",
     "rate_catalog_entry_supersessions",
@@ -54,6 +56,8 @@ async def _cleanup_catalog_tables() -> None:
             await session.execute(
                 text(
                     "TRUNCATE TABLE "
+                    "estimate_items, "
+                    "estimate_snapshot_entries, "
                     "formula_definition_supersessions, "
                     "material_catalog_entry_supersessions, "
                     "rate_catalog_entry_supersessions, "
@@ -707,10 +711,15 @@ async def test_catalog_tables_reject_append_only_mutations(
     )
     await _assert_append_only_sql_mutation_fails(
         db_session,
-        f'TRUNCATE TABLE "{table_name}", "{supersession_table_name}"',
+        (
+            f'TRUNCATE TABLE "estimate_items", "estimate_snapshot_entries", '
+            f'"{table_name}", "{supersession_table_name}"'
+        ),
         table_name=table_name,
         operation="TRUNCATE",
         expected_substring=(
+            "append-only trigger blocked TRUNCATE on estimate_items",
+            "append-only trigger blocked TRUNCATE on estimate_snapshot_entries",
             f"append-only trigger blocked TRUNCATE on {table_name}",
             f"append-only trigger blocked TRUNCATE on {supersession_table_name}",
         ),


### PR DESCRIPTION
Closes #199

## Summary
- add append-only estimate snapshot entry and item persistence for finalized estimates
- enforce typed same-estimate lineage constraints, including quantity-item composite lineage checks
- add migration, schema, append-only, and regression coverage for the new persistence contract

## Test plan
- [x] `uv run ruff check app tests alembic`
- [x] `uv run mypy app tests`
- [x] fresh throwaway DB: `uv run alembic upgrade head`
- [x] fresh throwaway DB: `uv run pytest tests/test_estimate_snapshot_item_persistence.py tests/test_append_only_lineage_tables.py tests/test_estimate_version_persistence.py tests/test_quantity_takeoff_persistence.py`