### PR TITLE
feat: add estimate job input contract

### DIFF
--- a/alembic/versions/2026_05_18_0022_add_estimate_job_input_contract.py
+++ b/alembic/versions/2026_05_18_0022_add_estimate_job_input_contract.py
@@ -1,0 +1,464 @@
+"""add estimate job input contract
+
+Revision ID: 2026_05_18_0022
+Revises: 2026_05_18_0021
+Create Date: 2026-05-18 11:20:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2026_05_18_0022"
+down_revision = "2026_05_18_0021"
+branch_labels = None
+depends_on = None
+
+_ESTIMATE_JOB_INPUT_CATALOG_REF_TYPED_CONTRACT = (
+    "(ref_type = 'rate' AND rate_catalog_entry_id IS NOT NULL "
+    "AND material_catalog_entry_id IS NULL AND formula_definition_id IS NULL) OR "
+    "(ref_type = 'material' AND material_catalog_entry_id IS NOT NULL "
+    "AND rate_catalog_entry_id IS NULL AND formula_definition_id IS NULL) OR "
+    "(ref_type = 'formula' AND formula_definition_id IS NOT NULL "
+    "AND rate_catalog_entry_id IS NULL AND material_catalog_entry_id IS NULL)"
+)
+
+
+def _attach_append_only_triggers(table_name: str) -> None:
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_append_only_row_guard
+            BEFORE UPDATE OR DELETE ON \"{table_name}\"
+            FOR EACH ROW
+            EXECUTE FUNCTION enforce_append_only_lineage_row()
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER trg_append_only_truncate_guard
+            BEFORE TRUNCATE ON \"{table_name}\"
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION enforce_append_only_lineage_truncate()
+            """
+        )
+    )
+
+
+def _drop_append_only_triggers(table_name: str) -> None:
+    op.execute(sa.text(f'DROP TRIGGER IF EXISTS trg_append_only_row_guard ON "{table_name}"'))
+    op.execute(sa.text(f'DROP TRIGGER IF EXISTS trg_append_only_truncate_guard ON "{table_name}"'))
+
+
+def _assert_estimate_job_input_tables_empty() -> None:
+    bind = op.get_bind()
+    for table_name in ("estimate_job_input_catalog_refs", "estimate_job_inputs"):
+        row_count = bind.execute(sa.text(f'SELECT COUNT(*) FROM "{table_name}"')).scalar_one()
+        if row_count:
+            raise RuntimeError(
+                "Refusing to downgrade migration 2026_05_18_0022 while "
+                f"{table_name} contains {row_count} row(s)."
+            )
+
+    estimate_job_count = bind.execute(
+        sa.text("SELECT COUNT(*) FROM jobs WHERE job_type = 'estimate'")
+    ).scalar_one()
+    if estimate_job_count:
+        raise RuntimeError(
+            "Refusing to downgrade migration 2026_05_18_0022 while jobs contains "
+            f"{estimate_job_count} estimate job row(s)."
+        )
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_jobs_job_type_valid", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_job_type_valid",
+        "jobs",
+        "job_type IN ('ingest', 'reprocess', 'quantity_takeoff', 'estimate')",
+    )
+    op.drop_constraint("ck_jobs_reprocess_base_revision_required", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_revision_scoped_base_revision_required",
+        "jobs",
+        "job_type NOT IN ('reprocess', 'quantity_takeoff', 'estimate') "
+        "OR base_revision_id IS NOT NULL",
+    )
+    op.drop_constraint(
+        "ck_jobs_quantity_takeoff_extraction_profile_forbidden",
+        "jobs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_jobs_revision_scoped_extraction_profile_forbidden",
+        "jobs",
+        "job_type NOT IN ('quantity_takeoff', 'estimate') "
+        "OR extraction_profile_id IS NULL",
+    )
+
+    op.create_table(
+        "estimate_job_inputs",
+        sa.Column(
+            "estimate_job_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning immutable estimate job identifier",
+        ),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning project identifier copied from the estimate job",
+        ),
+        sa.Column(
+            "source_file_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Pinned source file identifier copied from the estimate job",
+        ),
+        sa.Column(
+            "drawing_revision_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Pinned drawing revision identifier copied from the estimate job",
+        ),
+        sa.Column(
+            "quantity_takeoff_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Trusted allowed quantity takeoff selected for the estimate job",
+        ),
+        sa.Column(
+            "source_job_type",
+            sa.String(length=64),
+            nullable=False,
+            comment="Denormalized job type used by the composite estimate-job contract",
+        ),
+        sa.Column(
+            "quantity_gate",
+            sa.String(length=32),
+            nullable=False,
+            comment="Persisted quantity gate contract copied from the selected takeoff",
+        ),
+        sa.Column(
+            "trusted_totals",
+            sa.Boolean(),
+            nullable=False,
+            comment="Persisted trusted-total contract copied from the selected takeoff",
+        ),
+        sa.Column(
+            "currency",
+            sa.String(length=3),
+            nullable=False,
+            comment="Pinned estimate currency contract resolved when the job was queued",
+        ),
+        sa.Column(
+            "pricing_effective_date",
+            sa.Date(),
+            nullable=False,
+            comment="Resolved pricing effective date captured when the estimate job was queued",
+        ),
+        sa.Column(
+            "pricing_mode",
+            sa.String(length=64),
+            nullable=False,
+            comment="Pricing-date resolution mode captured when the estimate job was queued",
+        ),
+        sa.Column(
+            "assumptions_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            comment="Estimate assumptions JSON object captured when the estimate job was queued",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            comment="Estimate job input capture timestamp",
+        ),
+        sa.CheckConstraint(
+            "source_job_type = 'estimate'",
+            name="ck_estimate_job_inputs_source_job_type_estimate",
+        ),
+        sa.CheckConstraint(
+            "quantity_gate = 'allowed'",
+            name="ck_estimate_job_inputs_quantity_gate_allowed",
+        ),
+        sa.CheckConstraint(
+            "trusted_totals = TRUE",
+            name="ck_estimate_job_inputs_trusted_totals_true",
+        ),
+        sa.CheckConstraint(
+            "currency = 'GBP'",
+            name="ck_estimate_job_inputs_currency_gbp",
+        ),
+        sa.CheckConstraint(
+            "pricing_mode IN ('explicit', 'derived_from_job_created_at_utc')",
+            name="ck_estimate_job_inputs_pricing_mode_valid",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(assumptions_json) = 'object'",
+            name="ck_estimate_job_inputs_assumptions_json_object",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="fk_estimate_job_inputs_project_id_projects",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            name="fk_estimate_job_inputs_source_file_id_project_id_files",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id", "source_file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            name="fk_estimate_job_inputs_revision_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "estimate_job_id",
+                "project_id",
+                "source_file_id",
+                "drawing_revision_id",
+                "source_job_type",
+            ],
+            [
+                "jobs.id",
+                "jobs.project_id",
+                "jobs.file_id",
+                "jobs.base_revision_id",
+                "jobs.job_type",
+            ],
+            name="fk_estimate_job_inputs_source_job_contract",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ],
+            [
+                "quantity_takeoffs.id",
+                "quantity_takeoffs.project_id",
+                "quantity_takeoffs.drawing_revision_id",
+                "quantity_takeoffs.quantity_gate",
+                "quantity_takeoffs.trusted_totals",
+            ],
+            name="fk_estimate_job_inputs_takeoff_contract",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("estimate_job_id"),
+        sa.UniqueConstraint(
+            "estimate_job_id",
+            "project_id",
+            "drawing_revision_id",
+            name="uq_estimate_job_inputs_id_project_id_drawing_revision_id",
+        ),
+    )
+    op.create_index(
+        "ix_estimate_job_inputs_project_id",
+        "estimate_job_inputs",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_estimate_job_inputs_source_file_id",
+        "estimate_job_inputs",
+        ["source_file_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_estimate_job_inputs_quantity_takeoff_id",
+        "estimate_job_inputs",
+        ["quantity_takeoff_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_estimate_job_inputs_drawing_revision_id",
+        "estimate_job_inputs",
+        ["drawing_revision_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "estimate_job_input_catalog_refs",
+        sa.Column(
+            "estimate_job_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning immutable estimate job identifier",
+        ),
+        sa.Column(
+            "ref_type",
+            sa.String(length=16),
+            nullable=False,
+            comment="Typed catalog reference discriminator captured for deterministic selection",
+        ),
+        sa.Column(
+            "selection_key",
+            sa.String(length=255),
+            nullable=False,
+            comment="Deterministic selection key within the estimate job input",
+        ),
+        sa.Column(
+            "ref_order",
+            sa.Integer(),
+            nullable=False,
+            comment="Deterministic catalog reference order within the estimate job input",
+        ),
+        sa.Column(
+            "rate_catalog_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Selected rate catalog entry identifier, when this ref is rate-typed",
+        ),
+        sa.Column(
+            "material_catalog_entry_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Selected material catalog entry identifier, when this ref is material-typed",
+        ),
+        sa.Column(
+            "formula_definition_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment="Selected formula definition identifier, when this ref is formula-typed",
+        ),
+        sa.Column(
+            "catalog_checksum_sha256",
+            sa.String(length=64),
+            nullable=False,
+            comment="Immutable catalog checksum snapshot copied when the ref was selected",
+        ),
+        sa.Column(
+            "selection_context_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            comment="Selection context JSON object captured when the catalog ref was chosen",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            comment="Catalog reference capture timestamp",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(selection_key)) > 0",
+            name="ck_estimate_job_input_catalog_refs_selection_key_nonblank",
+        ),
+        sa.CheckConstraint(
+            "ref_order >= 0",
+            name="ck_estimate_job_input_catalog_refs_ref_order_nonnegative",
+        ),
+        sa.CheckConstraint(
+            "ref_type IN ('rate', 'material', 'formula')",
+            name="ck_estimate_job_input_catalog_refs_ref_type_valid",
+        ),
+        sa.CheckConstraint(
+            _ESTIMATE_JOB_INPUT_CATALOG_REF_TYPED_CONTRACT,
+            name="ck_estimate_job_input_catalog_refs_typed_catalog_ref_match",
+        ),
+        sa.CheckConstraint(
+            "catalog_checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_estimate_job_input_catalog_refs_checksum_sha256_format",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(selection_context_json) = 'object'",
+            name="ck_est_job_input_catalog_refs_context_json_object",
+        ),
+        sa.ForeignKeyConstraint(
+            ["estimate_job_id"],
+            ["estimate_job_inputs.estimate_job_id"],
+            name="fk_estimate_job_input_catalog_refs_estimate_job_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["rate_catalog_entry_id"],
+            ["rate_catalog_entries.id"],
+            name="fk_estimate_job_input_catalog_refs_rate_catalog_entry_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["material_catalog_entry_id"],
+            ["material_catalog_entries.id"],
+            name="fk_estimate_job_input_catalog_refs_material_catalog_entry_id",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["formula_definition_id"],
+            ["formula_definitions.id"],
+            name="fk_estimate_job_input_catalog_refs_formula_definition_id",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("estimate_job_id", "ref_type", "selection_key"),
+        sa.UniqueConstraint(
+            "estimate_job_id",
+            "ref_type",
+            "selection_key",
+            name="uq_estimate_job_input_catalog_refs_job_ref_type_selection_key",
+        ),
+        sa.UniqueConstraint(
+            "estimate_job_id",
+            "ref_order",
+            name="uq_estimate_job_input_catalog_refs_estimate_job_id_ref_order",
+        ),
+    )
+
+    _attach_append_only_triggers("estimate_job_inputs")
+    _attach_append_only_triggers("estimate_job_input_catalog_refs")
+
+
+def downgrade() -> None:
+    _assert_estimate_job_input_tables_empty()
+
+    _drop_append_only_triggers("estimate_job_input_catalog_refs")
+    _drop_append_only_triggers("estimate_job_inputs")
+
+    op.drop_table("estimate_job_input_catalog_refs")
+    op.drop_table("estimate_job_inputs")
+
+    op.drop_constraint(
+        "ck_jobs_revision_scoped_extraction_profile_forbidden",
+        "jobs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_jobs_quantity_takeoff_extraction_profile_forbidden",
+        "jobs",
+        "job_type != 'quantity_takeoff' OR extraction_profile_id IS NULL",
+    )
+    op.drop_constraint(
+        "ck_jobs_revision_scoped_base_revision_required",
+        "jobs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_jobs_reprocess_base_revision_required",
+        "jobs",
+        "job_type NOT IN ('reprocess', 'quantity_takeoff') OR base_revision_id IS NOT NULL",
+    )
+    op.drop_constraint("ck_jobs_job_type_valid", "jobs", type_="check")
+    op.create_check_constraint(
+        "ck_jobs_job_type_valid",
+        "jobs",
+        "job_type IN ('ingest', 'reprocess', 'quantity_takeoff')",
+    )

--- a/alembic/versions/2026_05_18_0023_repair_quantity_gate_contract.py
+++ b/alembic/versions/2026_05_18_0023_repair_quantity_gate_contract.py
@@ -1,0 +1,67 @@
+"""repair quantity gate contract constraints
+
+Revision ID: 2026_05_18_0023
+Revises: 2026_05_18_0022
+Create Date: 2026-05-18 23:30:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2026_05_18_0023"
+down_revision = "2026_05_18_0022"
+branch_labels = None
+depends_on = None
+
+
+def _constraint_exists(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    return (
+        bind.execute(
+            sa.text(
+                """
+                SELECT 1
+                FROM pg_constraint
+                WHERE conrelid = to_regclass(:table_name)
+                  AND conname = :constraint_name
+                """
+            ),
+            {"table_name": table_name, "constraint_name": constraint_name},
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
+def upgrade() -> None:
+    """Restore the quantity item parent-gate contract when older DBs lack it."""
+
+    if not _constraint_exists(
+        "quantity_takeoffs",
+        "uq_quantity_takeoffs_id_project_rev_gate",
+    ):
+        op.create_unique_constraint(
+            "uq_quantity_takeoffs_id_project_rev_gate",
+            "quantity_takeoffs",
+            ["id", "project_id", "drawing_revision_id", "quantity_gate"],
+        )
+
+    if not _constraint_exists(
+        "quantity_items",
+        "fk_quantity_items_takeoff_gate_contract",
+    ):
+        op.create_foreign_key(
+            "fk_quantity_items_takeoff_gate_contract",
+            "quantity_items",
+            "quantity_takeoffs",
+            ["quantity_takeoff_id", "project_id", "drawing_revision_id", "quantity_gate"],
+            ["id", "project_id", "drawing_revision_id", "quantity_gate"],
+            ondelete="RESTRICT",
+        )
+
+
+def downgrade() -> None:
+    """Leave constraints owned by 2026_05_15_0017 for its downgrade step."""

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -27,6 +27,7 @@ from app.core.errors import ErrorCode
 from app.core.exceptions import raise_not_found
 from app.db.session import get_db
 from app.jobs.worker import (
+    is_recoverable_enqueue_job_type,
     prepare_job_enqueue_intent,
     publish_job_enqueue_intent,
 )
@@ -419,6 +420,19 @@ async def retry_job(
         return job
 
     if job.error_code == ErrorCode.REVISION_CONFLICT.value:
+        if reservation is not None:
+            body = JobRead.model_validate(job).model_dump(mode="json")
+            await mark_idempotency_completed(
+                db,
+                reservation,
+                status_code=status.HTTP_202_ACCEPTED,
+                response_body=body,
+            )
+            await db.commit()
+            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+        return job
+
+    if not is_recoverable_enqueue_job_type(job.job_type):
         if reservation is not None:
             body = JobRead.model_validate(job).model_dump(mode="json")
             await mark_idempotency_completed(

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -59,6 +59,7 @@ _RECOVERABLE_ENQUEUE_JOB_TYPES = (
     JobType.REPROCESS.value,
     JobType.QUANTITY_TAKEOFF.value,
 )
+_KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER = frozenset({JobType.ESTIMATE.value})
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _ENQUEUE_STATUS_PENDING = "pending"
 _ENQUEUE_STATUS_PUBLISHING = "publishing"
@@ -132,6 +133,9 @@ def is_recoverable_enqueue_job_type(job_type: JobType | str) -> bool:
 def get_job_enqueue_publisher(job_type: JobType | str) -> Callable[[UUID], None] | None:
     """Return the queue publisher registered for a persisted worker job type."""
     normalized_job_type = job_type.value if isinstance(job_type, JobType) else job_type
+    if normalized_job_type in _KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER:
+        return None
+
     registry: dict[str, Callable[[UUID], None]] = {
         JobType.INGEST.value: enqueue_ingest_job,
         JobType.REPROCESS.value: enqueue_ingest_job,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ for Alembic autogenerate support. Example:
 
 from . import adapter_run_output as adapter_run_output
 from . import drawing_revision as drawing_revision
+from . import estimate_job_input as estimate_job_input
 from . import estimate_version as estimate_version
 from . import estimation_catalog as estimation_catalog
 from . import extraction_profile as extraction_profile

--- a/app/models/estimate_job_input.py
+++ b/app/models/estimate_job_input.py
@@ -1,0 +1,311 @@
+"""Immutable estimate job input persistence models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+from app.models.job import JobType
+from app.models.quantity_takeoff import QuantityGate
+
+_ESTIMATE_JOB_INPUT_REF_TYPED_CATALOG_CONTRACT = (
+    "(ref_type = 'rate' AND rate_catalog_entry_id IS NOT NULL "
+    "AND material_catalog_entry_id IS NULL AND formula_definition_id IS NULL) OR "
+    "(ref_type = 'material' AND material_catalog_entry_id IS NOT NULL "
+    "AND rate_catalog_entry_id IS NULL AND formula_definition_id IS NULL) OR "
+    "(ref_type = 'formula' AND formula_definition_id IS NOT NULL "
+    "AND rate_catalog_entry_id IS NULL AND material_catalog_entry_id IS NULL)"
+)
+
+
+class EstimateJobInput(Base):
+    """Immutable estimate job lineage captured when an estimate job is queued."""
+
+    __tablename__ = "estimate_job_inputs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="RESTRICT",
+            name="fk_estimate_job_inputs_source_file_id_project_id_files",
+        ),
+        ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id", "source_file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_job_inputs_revision_lineage",
+        ),
+        ForeignKeyConstraint(
+            [
+                "estimate_job_id",
+                "project_id",
+                "source_file_id",
+                "drawing_revision_id",
+                "source_job_type",
+            ],
+            [
+                "jobs.id",
+                "jobs.project_id",
+                "jobs.file_id",
+                "jobs.base_revision_id",
+                "jobs.job_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_job_inputs_source_job_contract",
+        ),
+        ForeignKeyConstraint(
+            [
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ],
+            [
+                "quantity_takeoffs.id",
+                "quantity_takeoffs.project_id",
+                "quantity_takeoffs.drawing_revision_id",
+                "quantity_takeoffs.quantity_gate",
+                "quantity_takeoffs.trusted_totals",
+            ],
+            ondelete="RESTRICT",
+            name="fk_estimate_job_inputs_takeoff_contract",
+        ),
+        CheckConstraint(
+            f"source_job_type = '{JobType.ESTIMATE.value}'",
+            name="ck_estimate_job_inputs_source_job_type_estimate",
+        ),
+        CheckConstraint(
+            f"quantity_gate = '{QuantityGate.ALLOWED.value}'",
+            name="ck_estimate_job_inputs_quantity_gate_allowed",
+        ),
+        CheckConstraint(
+            "trusted_totals = TRUE",
+            name="ck_estimate_job_inputs_trusted_totals_true",
+        ),
+        CheckConstraint(
+            "currency = 'GBP'",
+            name="ck_estimate_job_inputs_currency_gbp",
+        ),
+        CheckConstraint(
+            "pricing_mode IN ('explicit', 'derived_from_job_created_at_utc')",
+            name="ck_estimate_job_inputs_pricing_mode_valid",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(assumptions_json) = 'object'",
+            name="ck_estimate_job_inputs_assumptions_json_object",
+        ),
+        UniqueConstraint(
+            "estimate_job_id",
+            "project_id",
+            "drawing_revision_id",
+            name="uq_estimate_job_inputs_id_project_id_drawing_revision_id",
+        ),
+        Index("ix_estimate_job_inputs_quantity_takeoff_id", "quantity_takeoff_id"),
+        Index("ix_estimate_job_inputs_drawing_revision_id", "drawing_revision_id"),
+    )
+
+    estimate_job_id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        comment="Owning immutable estimate job identifier",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(
+            "projects.id",
+            name="fk_estimate_job_inputs_project_id_projects",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier copied from the estimate job",
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Pinned source file identifier copied from the estimate job",
+    )
+    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Pinned drawing revision identifier copied from the estimate job",
+    )
+    quantity_takeoff_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        comment="Trusted allowed quantity takeoff selected for the estimate job",
+    )
+    source_job_type: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default=JobType.ESTIMATE.value,
+        comment="Denormalized job type used by the composite estimate-job contract",
+    )
+    quantity_gate: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default=QuantityGate.ALLOWED.value,
+        comment="Persisted quantity gate contract copied from the selected takeoff",
+    )
+    trusted_totals: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+        comment="Persisted trusted-total contract copied from the selected takeoff",
+    )
+    currency: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        comment="Pinned estimate currency contract resolved when the job was queued",
+    )
+    pricing_effective_date: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        comment="Resolved pricing effective date captured when the estimate job was queued",
+    )
+    pricing_mode: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Pricing-date resolution mode captured when the estimate job was queued",
+    )
+    assumptions_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        comment="Estimate assumptions JSON object captured when the estimate job was queued",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Estimate job input capture timestamp",
+    )
+
+
+class EstimateJobInputCatalogRef(Base):
+    """Immutable typed catalog references captured for an estimate job input."""
+
+    __tablename__ = "estimate_job_input_catalog_refs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["estimate_job_id"],
+            ["estimate_job_inputs.estimate_job_id"],
+            ondelete="RESTRICT",
+            name="fk_estimate_job_input_catalog_refs_estimate_job_id",
+        ),
+        CheckConstraint(
+            "length(btrim(selection_key)) > 0",
+            name="ck_estimate_job_input_catalog_refs_selection_key_nonblank",
+        ),
+        CheckConstraint(
+            "ref_order >= 0",
+            name="ck_estimate_job_input_catalog_refs_ref_order_nonnegative",
+        ),
+        CheckConstraint(
+            "ref_type IN ('rate', 'material', 'formula')",
+            name="ck_estimate_job_input_catalog_refs_ref_type_valid",
+        ),
+        CheckConstraint(
+            _ESTIMATE_JOB_INPUT_REF_TYPED_CATALOG_CONTRACT,
+            name="ck_estimate_job_input_catalog_refs_typed_catalog_ref_match",
+        ),
+        CheckConstraint(
+            "catalog_checksum_sha256 ~ '^[0-9a-f]{64}$'",
+            name="ck_estimate_job_input_catalog_refs_checksum_sha256_format",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(selection_context_json) = 'object'",
+            name="ck_est_job_input_catalog_refs_context_json_object",
+        ),
+        UniqueConstraint(
+            "estimate_job_id",
+            "ref_type",
+            "selection_key",
+            name="uq_estimate_job_input_catalog_refs_job_ref_type_selection_key",
+        ),
+        UniqueConstraint(
+            "estimate_job_id",
+            "ref_order",
+            name="uq_estimate_job_input_catalog_refs_estimate_job_id_ref_order",
+        ),
+    )
+
+    estimate_job_id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        comment="Owning immutable estimate job identifier",
+    )
+    ref_type: Mapped[str] = mapped_column(
+        String(16),
+        primary_key=True,
+        comment="Typed catalog reference discriminator captured for deterministic selection",
+    )
+    selection_key: Mapped[str] = mapped_column(
+        String(255),
+        primary_key=True,
+        comment="Deterministic selection key within the estimate job input",
+    )
+    ref_order: Mapped[int] = mapped_column(
+        Integer,
+        comment="Deterministic catalog reference order within the estimate job input",
+    )
+    rate_catalog_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "rate_catalog_entries.id",
+            name="fk_estimate_job_input_catalog_refs_rate_catalog_entry_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        comment="Selected rate catalog entry identifier, when this ref is rate-typed",
+    )
+    material_catalog_entry_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "material_catalog_entries.id",
+            name="fk_estimate_job_input_catalog_refs_material_catalog_entry_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        comment="Selected material catalog entry identifier, when this ref is material-typed",
+    )
+    formula_definition_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(
+            "formula_definitions.id",
+            name="fk_estimate_job_input_catalog_refs_formula_definition_id",
+            ondelete="RESTRICT",
+        ),
+        nullable=True,
+        comment="Selected formula definition identifier, when this ref is formula-typed",
+    )
+    catalog_checksum_sha256: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Immutable catalog checksum snapshot copied when the ref was selected",
+    )
+    selection_context_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        comment="Selection context JSON object captured when the catalog ref was chosen",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Catalog reference capture timestamp",
+    )

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -27,6 +27,7 @@ class JobType(StrEnum):
     INGEST = "ingest"
     REPROCESS = "reprocess"
     QUANTITY_TAKEOFF = "quantity_takeoff"
+    ESTIMATE = "estimate"
 
 
 class JobStatus(StrEnum):
@@ -47,6 +48,11 @@ _PROFILE_REQUIRED_JOB_TYPE_VALUES = (JobType.INGEST.value, JobType.REPROCESS.val
 _BASE_REQUIRED_JOB_TYPE_VALUES = (
     JobType.REPROCESS.value,
     JobType.QUANTITY_TAKEOFF.value,
+    JobType.ESTIMATE.value,
+)
+_EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES = (
+    JobType.QUANTITY_TAKEOFF.value,
+    JobType.ESTIMATE.value,
 )
 
 
@@ -116,12 +122,13 @@ class Job(Base):
             "job_type NOT IN "
             f"({_sql_in_list(_BASE_REQUIRED_JOB_TYPE_VALUES)}) "
             "OR base_revision_id IS NOT NULL",
-            name="ck_jobs_reprocess_base_revision_required",
+            name="ck_jobs_revision_scoped_base_revision_required",
         ),
         CheckConstraint(
-            f"job_type != '{JobType.QUANTITY_TAKEOFF.value}' "
+            "job_type NOT IN "
+            f"({_sql_in_list(_EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES)}) "
             "OR extraction_profile_id IS NULL",
-            name="ck_jobs_quantity_takeoff_extraction_profile_forbidden",
+            name="ck_jobs_revision_scoped_extraction_profile_forbidden",
         ),
         CheckConstraint(
             f"job_type != '{JobType.INGEST.value}' OR base_revision_id IS NULL",
@@ -195,7 +202,7 @@ class Job(Base):
     job_type: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
-        comment="Job type (e.g. ingest, reprocess, quantity_takeoff)",
+        comment="Job type (e.g. ingest, reprocess, quantity_takeoff, estimate)",
     )
     status: Mapped[str] = mapped_column(
         String(32),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,8 @@ APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
     "generated_artifacts",
     "job_events",
     "estimate_versions",
+    "estimate_job_inputs",
+    "estimate_job_input_catalog_refs",
     "estimate_snapshot_entries",
     "estimate_items",
     "quantity_takeoffs",

--- a/tests/test_append_only_lineage_tables.py
+++ b/tests/test_append_only_lineage_tables.py
@@ -7,6 +7,7 @@ import subprocess
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import date
 from decimal import Decimal
 from json import dumps
 from pathlib import Path
@@ -23,7 +24,10 @@ import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
+from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry
+from app.models.estimation_catalog import EstimationRate
+from app.models.job import Job, JobStatus, JobType
 from tests import test_estimate_version_persistence as estimate_version_persistence
 from tests.conftest import (
     APPEND_ONLY_PROTECTED_TABLES,
@@ -67,6 +71,8 @@ class _ProtectedRowIds:
     generated_artifact_id: uuid.UUID
     job_event_id: uuid.UUID
     estimate_version_id: uuid.UUID
+    estimate_job_input_id: uuid.UUID
+    estimate_job_input_catalog_ref_key: tuple[uuid.UUID, str, str]
     estimate_snapshot_entry_id: uuid.UUID
     estimate_item_id: uuid.UUID
     quantity_takeoff_id: uuid.UUID
@@ -170,6 +176,7 @@ def _row_id_for_table(row_ids: _ProtectedRowIds, table_name: str) -> uuid.UUID:
         "generated_artifacts": row_ids.generated_artifact_id,
         "job_events": row_ids.job_event_id,
         "estimate_versions": row_ids.estimate_version_id,
+        "estimate_job_inputs": row_ids.estimate_job_input_id,
         "estimate_snapshot_entries": row_ids.estimate_snapshot_entry_id,
         "estimate_items": row_ids.estimate_item_id,
         "quantity_takeoffs": row_ids.quantity_takeoff_id,
@@ -181,6 +188,33 @@ def _row_id_for_table(row_ids: _ProtectedRowIds, table_name: str) -> uuid.UUID:
         "revision_entities": row_ids.revision_entity_id,
     }
     return ids_by_table[table_name]
+
+
+def _row_filter_for_table(
+    row_ids: _ProtectedRowIds,
+    table_name: str,
+) -> tuple[str, dict[str, object]]:
+    """Return a WHERE clause and parameters for a protected table's seeded row."""
+
+    if table_name == "estimate_job_input_catalog_refs":
+        estimate_job_id, ref_type, selection_key = row_ids.estimate_job_input_catalog_ref_key
+        return (
+            "estimate_job_id = :estimate_job_id "
+            "AND ref_type = :ref_type "
+            "AND selection_key = :selection_key",
+            {
+                "estimate_job_id": estimate_job_id,
+                "ref_type": ref_type,
+                "selection_key": selection_key,
+            },
+        )
+    if table_name == "estimate_job_inputs":
+        return (
+            "estimate_job_id = :estimate_job_id",
+            {"estimate_job_id": row_ids.estimate_job_input_id},
+        )
+
+    return "id = :row_id", {"row_id": _row_id_for_table(row_ids, table_name)}
 
 
 async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRowIds:
@@ -235,10 +269,73 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         formula_snapshot_entry_type="formula",
         assumption_snapshot_entry_type="assumption",
     )
+    estimate_job_id = uuid.uuid4()
+    rate_id = uuid.uuid4()
+    rate_checksum = "d" * 64
+    estimate_job_input = EstimateJobInput(
+        estimate_job_id=estimate_job_id,
+        project_id=quantity_seed.project_id,
+        source_file_id=quantity_seed.file_id,
+        drawing_revision_id=quantity_seed.drawing_revision_id,
+        quantity_takeoff_id=quantity_seed.quantity_takeoff_id,
+        source_job_type=JobType.ESTIMATE.value,
+        quantity_gate="allowed",
+        trusted_totals=True,
+        currency="GBP",
+        pricing_effective_date=date(2026, 1, 1),
+        pricing_mode="explicit",
+        assumptions_json={"source": "append-only"},
+    )
+    estimate_job_input_ref = EstimateJobInputCatalogRef(
+        estimate_job_id=estimate_job_id,
+        ref_type="rate",
+        selection_key="rate:append-only",
+        ref_order=1,
+        rate_catalog_entry_id=rate_id,
+        catalog_checksum_sha256=rate_checksum,
+        selection_context_json={"source": "append-only"},
+    )
 
     session_maker = session_module.AsyncSessionLocal
     assert session_maker is not None
     async with session_maker() as session:
+        session.add(
+            EstimationRate(
+                id=rate_id,
+                scope_type="project",
+                project_id=quantity_seed.project_id,
+                rate_key="append-only:rate",
+                source="test",
+                metadata_json={"source": "append-only"},
+                name="Append-only rate",
+                item_type="linear_length",
+                per_unit="m",
+                currency="GBP",
+                amount=Decimal("1.000000"),
+                effective_from=date(2026, 1, 1),
+                checksum_sha256=rate_checksum,
+            )
+        )
+        await session.flush()
+        session.add(
+            Job(
+                id=estimate_job_id,
+                project_id=quantity_seed.project_id,
+                file_id=quantity_seed.file_id,
+                extraction_profile_id=None,
+                base_revision_id=quantity_seed.drawing_revision_id,
+                job_type=JobType.ESTIMATE.value,
+                status=JobStatus.SUCCEEDED.value,
+                enqueue_status="published",
+                enqueue_attempts=0,
+                cancel_requested=False,
+            )
+        )
+        await session.flush()
+        session.add(estimate_job_input)
+        await session.flush()
+        session.add(estimate_job_input_ref)
+        await session.flush()
         session.add(estimate_version)
         await session.flush()
         session.add(estimate_snapshot_entry)
@@ -268,6 +365,12 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         generated_artifact_id=generated_artifacts[0].id,
         job_event_id=job_events[0].id,
         estimate_version_id=estimate_version.id,
+        estimate_job_input_id=estimate_job_input.estimate_job_id,
+        estimate_job_input_catalog_ref_key=(
+            estimate_job_input_ref.estimate_job_id,
+            estimate_job_input_ref.ref_type,
+            estimate_job_input_ref.selection_key,
+        ),
         estimate_snapshot_entry_id=estimate_snapshot_entry.id,
         estimate_item_id=estimate_item.id,
         quantity_takeoff_id=quantity_seed.quantity_takeoff_id,
@@ -1381,6 +1484,12 @@ class TestAppendOnlyLineageTables:
             ("generated_artifacts", "name", "mutated-debug-overlay.svg"),
             ("job_events", "message", "mutated job event"),
             ("estimate_versions", "total_amount", "121.00"),
+            ("estimate_job_inputs", "currency", "USD"),
+            (
+                "estimate_job_input_catalog_refs",
+                "catalog_checksum_sha256",
+                "e" * 64,
+            ),
             ("estimate_snapshot_entries", "entry_label", "mutated assumption"),
             ("estimate_items", "description", "mutated estimate item"),
             ("quantity_takeoffs", "review_state", "review_required"),
@@ -1397,14 +1506,15 @@ class TestAppendOnlyLineageTables:
         )
 
         for table_name, column_name, replacement_value in update_cases:
+            row_filter, row_params = _row_filter_for_table(row_ids, table_name)
             await _run_sql_and_expect_append_only_failure(
                 (
                     f'UPDATE "{table_name}" SET "{column_name}" = :replacement_value '
-                    "WHERE id = :row_id"
+                    f"WHERE {row_filter}"
                 ),
-                {
+                row_params
+                | {
                     "replacement_value": replacement_value,
-                    "row_id": _row_id_for_table(row_ids, table_name),
                 },
                 operation="UPDATE",
                 table_name=table_name,
@@ -1581,9 +1691,10 @@ class TestAppendOnlyLineageTables:
         row_ids = await _seed_protected_rows(async_client)
 
         for table_name in APPEND_ONLY_PROTECTED_TABLES:
+            row_filter, row_params = _row_filter_for_table(row_ids, table_name)
             await _run_sql_and_expect_append_only_failure(
-                f'DELETE FROM "{table_name}" WHERE id = :row_id',
-                {"row_id": _row_id_for_table(row_ids, table_name)},
+                f'DELETE FROM "{table_name}" WHERE {row_filter}',
+                row_params,
                 operation="DELETE",
                 table_name=table_name,
             )

--- a/tests/test_estimate_job_input_contract.py
+++ b/tests/test_estimate_job_input_contract.py
@@ -1,0 +1,692 @@
+"""Integration tests for immutable estimate job input persistence contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from datetime import date
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+import app.jobs.worker as worker_module
+from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
+from app.models.job import Job, JobStatus, JobType
+from tests import test_estimate_snapshot_item_persistence as snapshot_item_persistence
+from tests import test_quantity_takeoff_persistence as quantity_takeoff_persistence
+from tests.conftest import requires_database
+
+pytest_plugins = ("tests.test_quantity_takeoff_persistence",)
+pytestmark = [pytest.mark.asyncio, requires_database]
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "2026_05_18_0022_add_estimate_job_input_contract.py"
+)
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_projects: None) -> AsyncGenerator[AsyncSession, None]:
+    _ = cleanup_projects
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+def _normalize_ondelete(raw_foreign_key: Mapping[str, Any]) -> str:
+    options = raw_foreign_key.get("options")
+    if isinstance(options, dict):
+        return str(options.get("ondelete") or "").upper()
+    return ""
+
+
+def _normalize_constraint_sqltext(sqltext: str) -> str:
+    normalized = sqltext
+    for pg_cast in (
+        "::boolean",
+        "::character varying",
+        "::text",
+    ):
+        normalized = normalized.replace(pg_cast, "")
+    normalized = normalized.replace('"', " ")
+    normalized = normalized.replace("(", " ").replace(")", " ")
+    return " ".join(normalized.split())
+
+
+def _inspect_schema(sync_connection: sa.Connection) -> dict[str, Any]:
+    inspector = sa.inspect(sync_connection)
+    tables = ("jobs", "estimate_job_inputs", "estimate_job_input_catalog_refs")
+    return {
+        "columns": {
+            table_name: {
+                str(column["name"]): {"nullable": bool(column["nullable"])}
+                for column in inspector.get_columns(table_name)
+            }
+            for table_name in tables
+        },
+        "unique_constraints": {
+            table_name: {
+                tuple(constraint["column_names"]): str(constraint["name"])
+                for constraint in inspector.get_unique_constraints(table_name)
+            }
+            for table_name in tables
+        },
+        "primary_keys": {
+            table_name: tuple(inspector.get_pk_constraint(table_name)["constrained_columns"])
+            for table_name in tables
+        },
+        "check_constraints": {
+            table_name: {
+                str(constraint["name"]): _normalize_constraint_sqltext(str(constraint["sqltext"]))
+                for constraint in inspector.get_check_constraints(table_name)
+            }
+            for table_name in tables
+        },
+        "foreign_keys": {
+            table_name: {
+                (
+                    tuple(foreign_key["constrained_columns"]),
+                    str(foreign_key["referred_table"]),
+                    tuple(foreign_key["referred_columns"]),
+                ): _normalize_ondelete(foreign_key)
+                for foreign_key in inspector.get_foreign_keys(table_name)
+            }
+            for table_name in ("estimate_job_inputs", "estimate_job_input_catalog_refs")
+        },
+    }
+
+
+async def _load_schema() -> dict[str, Any]:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        connection = await session.connection()
+        return await connection.run_sync(_inspect_schema)
+
+
+async def _assert_commit_fails(
+    session: AsyncSession,
+    obj: object,
+    expected_substring: str | tuple[str, ...],
+) -> None:
+    session.add(obj)
+    expected_substrings = (
+        [expected_substring] if isinstance(expected_substring, str) else list(expected_substring)
+    )
+
+    try:
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        constraint_name = getattr(getattr(exc, "orig", None), "constraint_name", None)
+        if constraint_name in expected_substrings:
+            return
+
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert any(substring.lower() in message for substring in expected_substrings)
+    else:
+        pytest.fail(f"Expected database error containing {expected_substrings!r}")
+
+
+async def _assert_append_only_sql_mutation_fails(
+    session: AsyncSession,
+    statement: str,
+    *,
+    operation: str,
+    table_name: str,
+    params: dict[str, object],
+) -> None:
+    try:
+        await session.execute(text(statement), params)
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert f"append-only trigger blocked {operation.lower()} on {table_name}" in message
+    else:
+        pytest.fail(f"Expected append-only mutation failure for {operation} on {table_name}")
+
+
+def _load_migration_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_18_0022_add_estimate_job_input_contract",
+        _MIGRATION_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _run_downgrade_guard(db_session: AsyncSession) -> None:
+    migration = _load_migration_module()
+    connection = await db_session.connection()
+
+    def _run_guard(sync_connection: sa.Connection) -> None:
+        migration_context = MigrationContext.configure(sync_connection)
+        migration.op = Operations(migration_context)
+        migration._assert_estimate_job_input_tables_empty()
+
+    await connection.run_sync(_run_guard)
+
+
+async def _create_estimate_job_input(
+    db_session: AsyncSession,
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+) -> uuid.UUID:
+    estimate_job_id = uuid.uuid4()
+    db_session.add(
+        Job(
+            id=estimate_job_id,
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=None,
+            base_revision_id=seed.drawing_revision_id,
+            parent_job_id=seed.quantity_job_id,
+            job_type=JobType.ESTIMATE.value,
+            status=JobStatus.PENDING.value,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        )
+    )
+    await db_session.flush()
+    db_session.add(
+        EstimateJobInput(
+            estimate_job_id=estimate_job_id,
+            project_id=seed.project_id,
+            source_file_id=seed.file_id,
+            drawing_revision_id=seed.drawing_revision_id,
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            source_job_type=JobType.ESTIMATE.value,
+            quantity_gate="allowed",
+            trusted_totals=True,
+            currency="GBP",
+            pricing_effective_date=date(2026, 5, 18),
+            pricing_mode="explicit",
+            assumptions_json={"waste_factor": "10%"},
+        )
+    )
+    await db_session.flush()
+    return estimate_job_id
+
+
+def _build_estimate_job_input(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    *,
+    estimate_job_id: uuid.UUID,
+    source_job_type: str = JobType.ESTIMATE.value,
+    quantity_takeoff_id: uuid.UUID | None = None,
+    quantity_gate: str = "allowed",
+    trusted_totals: bool = True,
+    currency: str = "GBP",
+    pricing_mode: str = "explicit",
+    assumptions_json: object = cast(object, {"waste_factor": "10%"}),
+) -> EstimateJobInput:
+    return EstimateJobInput(
+        estimate_job_id=estimate_job_id,
+        project_id=seed.project_id,
+        source_file_id=seed.file_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        quantity_takeoff_id=quantity_takeoff_id or seed.quantity_takeoff_id,
+        source_job_type=source_job_type,
+        quantity_gate=quantity_gate,
+        trusted_totals=trusted_totals,
+        currency=currency,
+        pricing_effective_date=date(2026, 5, 18),
+        pricing_mode=pricing_mode,
+        assumptions_json=cast(dict[str, Any], assumptions_json),
+    )
+
+
+def _build_catalog_ref(
+    *,
+    estimate_job_id: uuid.UUID,
+    ref_type: str,
+    selection_key: str,
+    ref_order: int,
+    catalog_id: uuid.UUID,
+    catalog_checksum_sha256: str,
+    selection_context_json: object = cast(object, {"source": "test"}),
+) -> EstimateJobInputCatalogRef:
+    return EstimateJobInputCatalogRef(
+        estimate_job_id=estimate_job_id,
+        ref_type=ref_type,
+        selection_key=selection_key,
+        ref_order=ref_order,
+        rate_catalog_entry_id=catalog_id if ref_type == "rate" else None,
+        material_catalog_entry_id=catalog_id if ref_type == "material" else None,
+        formula_definition_id=catalog_id if ref_type == "formula" else None,
+        catalog_checksum_sha256=catalog_checksum_sha256,
+        selection_context_json=cast(dict[str, Any], selection_context_json),
+    )
+
+
+async def test_estimate_job_input_schema_matches_contract() -> None:
+    schema = await _load_schema()
+    columns = schema["columns"]
+    unique_constraints = schema["unique_constraints"]
+    primary_keys = schema["primary_keys"]
+    check_constraints = schema["check_constraints"]
+    foreign_keys = schema["foreign_keys"]
+
+    assert "estimate" in check_constraints["jobs"]["ck_jobs_job_type_valid"]
+    assert "estimate" in check_constraints["jobs"][
+        "ck_jobs_revision_scoped_base_revision_required"
+    ]
+    assert "estimate" in check_constraints["jobs"][
+        "ck_jobs_revision_scoped_extraction_profile_forbidden"
+    ]
+
+    for required_column in (
+        "estimate_job_id",
+        "project_id",
+        "source_file_id",
+        "drawing_revision_id",
+        "quantity_takeoff_id",
+        "source_job_type",
+        "quantity_gate",
+        "trusted_totals",
+        "currency",
+        "pricing_effective_date",
+        "pricing_mode",
+        "assumptions_json",
+        "created_at",
+    ):
+        assert columns["estimate_job_inputs"][required_column]["nullable"] is False
+    for required_column in (
+        "estimate_job_id",
+        "ref_type",
+        "selection_key",
+        "ref_order",
+        "catalog_checksum_sha256",
+        "selection_context_json",
+        "created_at",
+    ):
+        assert columns["estimate_job_input_catalog_refs"][required_column]["nullable"] is False
+
+    assert ("estimate_job_id", "project_id", "drawing_revision_id") in unique_constraints[
+        "estimate_job_inputs"
+    ]
+    assert primary_keys["estimate_job_input_catalog_refs"] == (
+        "estimate_job_id",
+        "ref_type",
+        "selection_key",
+    )
+    assert ("estimate_job_id", "ref_order") in unique_constraints[
+        "estimate_job_input_catalog_refs"
+    ]
+
+    for constraint_name in (
+        "ck_estimate_job_inputs_source_job_type_estimate",
+        "ck_estimate_job_inputs_quantity_gate_allowed",
+        "ck_estimate_job_inputs_trusted_totals_true",
+        "ck_estimate_job_inputs_currency_gbp",
+        "ck_estimate_job_inputs_pricing_mode_valid",
+        "ck_estimate_job_inputs_assumptions_json_object",
+    ):
+        assert constraint_name in check_constraints["estimate_job_inputs"]
+    for constraint_name in (
+        "ck_estimate_job_input_catalog_refs_selection_key_nonblank",
+        "ck_estimate_job_input_catalog_refs_ref_order_nonnegative",
+        "ck_estimate_job_input_catalog_refs_ref_type_valid",
+        "ck_estimate_job_input_catalog_refs_typed_catalog_ref_match",
+        "ck_estimate_job_input_catalog_refs_checksum_sha256_format",
+        "ck_est_job_input_catalog_refs_context_json_object",
+    ):
+        assert constraint_name in check_constraints["estimate_job_input_catalog_refs"]
+
+    assert (
+        (
+            "estimate_job_id",
+            "project_id",
+            "source_file_id",
+            "drawing_revision_id",
+            "source_job_type",
+        ),
+        "jobs",
+        ("id", "project_id", "file_id", "base_revision_id", "job_type"),
+    ) in foreign_keys["estimate_job_inputs"]
+    assert (
+        (
+            "quantity_takeoff_id",
+            "project_id",
+            "drawing_revision_id",
+            "quantity_gate",
+            "trusted_totals",
+        ),
+        "quantity_takeoffs",
+        ("id", "project_id", "drawing_revision_id", "quantity_gate", "trusted_totals"),
+    ) in foreign_keys["estimate_job_inputs"]
+    for constrained_column, referred_table in (
+        ("rate_catalog_entry_id", "rate_catalog_entries"),
+        ("material_catalog_entry_id", "material_catalog_entries"),
+        ("formula_definition_id", "formula_definitions"),
+    ):
+        assert ((constrained_column,), referred_table, ("id",)) in foreign_keys[
+            "estimate_job_input_catalog_refs"
+        ]
+
+
+async def test_estimate_job_input_persists_lineage_catalog_refs_and_worker_boundary(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    rate, material, formula = await snapshot_item_persistence._create_catalog_rows(
+        db_session,
+        seed.project_id,
+    )
+    estimate_job_id = await _create_estimate_job_input(db_session, seed)
+    db_session.add_all(
+        [
+            _build_catalog_ref(
+                estimate_job_id=estimate_job_id,
+                ref_type="rate",
+                selection_key="labour:installer",
+                ref_order=0,
+                catalog_id=rate.id,
+                catalog_checksum_sha256=rate.checksum_sha256,
+            ),
+            _build_catalog_ref(
+                estimate_job_id=estimate_job_id,
+                ref_type="material",
+                selection_key="cable:standard",
+                ref_order=1,
+                catalog_id=material.id,
+                catalog_checksum_sha256=material.checksum_sha256,
+            ),
+            _build_catalog_ref(
+                estimate_job_id=estimate_job_id,
+                ref_type="formula",
+                selection_key="waste-factor:v1",
+                ref_order=2,
+                catalog_id=formula.id,
+                catalog_checksum_sha256=formula.checksum_sha256,
+            ),
+        ]
+    )
+
+    await db_session.commit()
+
+    persisted_input = await db_session.get(EstimateJobInput, estimate_job_id)
+    assert persisted_input is not None
+    assert persisted_input.project_id == seed.project_id
+    assert persisted_input.source_file_id == seed.file_id
+    assert persisted_input.drawing_revision_id == seed.drawing_revision_id
+    assert persisted_input.quantity_takeoff_id == seed.quantity_takeoff_id
+    assert persisted_input.source_job_type == JobType.ESTIMATE.value
+    assert persisted_input.quantity_gate == "allowed"
+    assert persisted_input.trusted_totals is True
+    assert persisted_input.currency == "GBP"
+    assert persisted_input.pricing_effective_date == date(2026, 5, 18)
+    assert persisted_input.pricing_mode == "explicit"
+    assert persisted_input.assumptions_json == {"waste_factor": "10%"}
+
+    refs = (
+        await db_session.execute(
+            select(EstimateJobInputCatalogRef)
+            .where(EstimateJobInputCatalogRef.estimate_job_id == estimate_job_id)
+            .order_by(EstimateJobInputCatalogRef.ref_order.asc())
+        )
+    ).scalars().all()
+    assert [(ref.ref_type, ref.selection_key, ref.ref_order) for ref in refs] == [
+        ("rate", "labour:installer", 0),
+        ("material", "cable:standard", 1),
+        ("formula", "waste-factor:v1", 2),
+    ]
+
+    assert worker_module.is_recoverable_enqueue_job_type(JobType.ESTIMATE) is False
+    assert worker_module.get_job_enqueue_publisher(JobType.ESTIMATE) is None
+
+
+async def test_estimate_job_contract_rejects_ambiguous_job_inputs(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+
+    await _assert_commit_fails(
+        db_session,
+        Job(
+            id=uuid.uuid4(),
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            job_type=JobType.ESTIMATE.value,
+            status=JobStatus.PENDING.value,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        ),
+        "ck_jobs_revision_scoped_base_revision_required",
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        Job(
+            id=uuid.uuid4(),
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=seed.extraction_profile_id,
+            base_revision_id=seed.drawing_revision_id,
+            job_type=JobType.ESTIMATE.value,
+            status=JobStatus.PENDING.value,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        ),
+        "ck_jobs_revision_scoped_extraction_profile_forbidden",
+    )
+
+    reprocess_job_id = uuid.uuid4()
+    db_session.add(
+        Job(
+            id=reprocess_job_id,
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=seed.extraction_profile_id,
+            base_revision_id=seed.drawing_revision_id,
+            job_type=JobType.REPROCESS.value,
+            status=JobStatus.SUCCEEDED.value,
+            enqueue_status="published",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        )
+    )
+    await db_session.commit()
+
+    for kwargs, expected_substring in (
+        (
+            {"source_job_type": JobType.REPROCESS.value},
+            "ck_estimate_job_inputs_source_job_type_estimate",
+        ),
+        ({"quantity_gate": "review_gated"}, "ck_estimate_job_inputs_quantity_gate_allowed"),
+        ({"trusted_totals": False}, "ck_estimate_job_inputs_trusted_totals_true"),
+        ({"currency": "USD"}, "ck_estimate_job_inputs_currency_gbp"),
+        ({"pricing_mode": "retry_timestamp"}, "ck_estimate_job_inputs_pricing_mode_valid"),
+        ({"assumptions_json": []}, "ck_estimate_job_inputs_assumptions_json_object"),
+    ):
+        await _assert_commit_fails(
+            db_session,
+            _build_estimate_job_input(seed, estimate_job_id=reprocess_job_id, **kwargs),
+            expected_substring,
+        )
+
+
+async def test_estimate_catalog_refs_reject_ambiguous_or_nondeterministic_inputs(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    rate, _, _ = await snapshot_item_persistence._create_catalog_rows(db_session, seed.project_id)
+    rate_id = rate.id
+    rate_checksum = rate.checksum_sha256
+    estimate_job_id = await _create_estimate_job_input(db_session, seed)
+    await db_session.commit()
+
+    for ref, expected_substring in (
+        (
+            _build_catalog_ref(
+                estimate_job_id=estimate_job_id,
+                ref_type="rate",
+                selection_key="   ",
+                ref_order=0,
+                catalog_id=rate_id,
+                catalog_checksum_sha256=rate_checksum,
+            ),
+            "ck_estimate_job_input_catalog_refs_selection_key_nonblank",
+        ),
+        (
+            EstimateJobInputCatalogRef(
+                estimate_job_id=estimate_job_id,
+                ref_type="rate",
+                selection_key="labour:installer",
+                ref_order=0,
+                rate_catalog_entry_id=rate_id,
+                material_catalog_entry_id=rate_id,
+                formula_definition_id=None,
+                catalog_checksum_sha256=rate_checksum,
+                selection_context_json={"source": "test"},
+            ),
+            "ck_estimate_job_input_catalog_refs_typed_catalog_ref_match",
+        ),
+        (
+            _build_catalog_ref(
+                estimate_job_id=estimate_job_id,
+                ref_type="rate",
+                selection_key="labour:installer",
+                ref_order=0,
+                catalog_id=rate_id,
+                catalog_checksum_sha256="A" * 64,
+            ),
+            "ck_estimate_job_input_catalog_refs_checksum_sha256_format",
+        ),
+        (
+            _build_catalog_ref(
+                estimate_job_id=estimate_job_id,
+                ref_type="rate",
+                selection_key="labour:installer",
+                ref_order=0,
+                catalog_id=rate_id,
+                catalog_checksum_sha256=rate_checksum,
+                selection_context_json=[],
+            ),
+            "ck_est_job_input_catalog_refs_context_json_object",
+        ),
+    ):
+        await _assert_commit_fails(db_session, ref, expected_substring)
+
+    db_session.add(
+        _build_catalog_ref(
+            estimate_job_id=estimate_job_id,
+            ref_type="rate",
+            selection_key="labour:installer",
+            ref_order=0,
+            catalog_id=rate_id,
+            catalog_checksum_sha256=rate_checksum,
+        )
+    )
+    await db_session.commit()
+
+    await _assert_commit_fails(
+        db_session,
+        _build_catalog_ref(
+            estimate_job_id=estimate_job_id,
+            ref_type="rate",
+            selection_key="labour:installer",
+            ref_order=1,
+            catalog_id=rate_id,
+            catalog_checksum_sha256=rate_checksum,
+        ),
+        "uq_estimate_job_input_catalog_refs_job_ref_type_selection_key",
+    )
+    await _assert_commit_fails(
+        db_session,
+        _build_catalog_ref(
+            estimate_job_id=estimate_job_id,
+            ref_type="rate",
+            selection_key="labour:second",
+            ref_order=0,
+            catalog_id=rate_id,
+            catalog_checksum_sha256=rate_checksum,
+        ),
+        "uq_estimate_job_input_catalog_refs_estimate_job_id_ref_order",
+    )
+
+
+async def test_estimate_job_inputs_are_append_only_and_downgrade_guarded(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    await _run_downgrade_guard(db_session)
+
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    rate, _, _ = await snapshot_item_persistence._create_catalog_rows(db_session, seed.project_id)
+    estimate_job_id = await _create_estimate_job_input(db_session, seed)
+    db_session.add(
+        _build_catalog_ref(
+            estimate_job_id=estimate_job_id,
+            ref_type="rate",
+            selection_key="labour:installer",
+            ref_order=0,
+            catalog_id=rate.id,
+            catalog_checksum_sha256=rate.checksum_sha256,
+        )
+    )
+    await db_session.commit()
+
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        "UPDATE estimate_job_inputs SET currency = 'USD' WHERE estimate_job_id = :job_id",
+        operation="UPDATE",
+        table_name="estimate_job_inputs",
+        params={"job_id": estimate_job_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        "DELETE FROM estimate_job_input_catalog_refs WHERE estimate_job_id = :job_id",
+        operation="DELETE",
+        table_name="estimate_job_input_catalog_refs",
+        params={"job_id": estimate_job_id},
+    )
+
+    with pytest.raises(RuntimeError, match="estimate_job_input_catalog_refs contains 1 row"):
+        await _run_downgrade_guard(db_session)

--- a/tests/test_estimation_catalog_persistence.py
+++ b/tests/test_estimation_catalog_persistence.py
@@ -28,6 +28,7 @@ pytestmark = [pytest.mark.asyncio, requires_database]
 
 CatalogBuilder = Callable[..., Any]
 CATALOG_TABLES: tuple[str, ...] = (
+    "estimate_job_input_catalog_refs",
     "estimate_items",
     "estimate_snapshot_entries",
     "formula_definition_supersessions",
@@ -56,6 +57,7 @@ async def _cleanup_catalog_tables() -> None:
             await session.execute(
                 text(
                     "TRUNCATE TABLE "
+                    "estimate_job_input_catalog_refs, "
                     "estimate_items, "
                     "estimate_snapshot_entries, "
                     "formula_definition_supersessions, "
@@ -712,12 +714,14 @@ async def test_catalog_tables_reject_append_only_mutations(
     await _assert_append_only_sql_mutation_fails(
         db_session,
         (
-            f'TRUNCATE TABLE "estimate_items", "estimate_snapshot_entries", '
+            'TRUNCATE TABLE "estimate_job_input_catalog_refs", '
+            f'"estimate_items", "estimate_snapshot_entries", '
             f'"{table_name}", "{supersession_table_name}"'
         ),
         table_name=table_name,
         operation="TRUNCATE",
         expected_substring=(
+            "append-only trigger blocked TRUNCATE on estimate_job_input_catalog_refs",
             "append-only trigger blocked TRUNCATE on estimate_items",
             "append-only trigger blocked TRUNCATE on estimate_snapshot_entries",
             f"append-only trigger blocked TRUNCATE on {table_name}",

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -601,6 +601,7 @@ async def _create_quantity_takeoff_job(
     base_revision_id: uuid.UUID,
     parent_job_id: uuid.UUID,
     status: str,
+    job_type: str = JobType.QUANTITY_TAKEOFF.value,
     attempts: int = 0,
     max_attempts: int = 3,
 ) -> Job:
@@ -615,7 +616,7 @@ async def _create_quantity_takeoff_job(
         extraction_profile_id=None,
         base_revision_id=base_revision_id,
         parent_job_id=parent_job_id,
-        job_type=JobType.QUANTITY_TAKEOFF.value,
+        job_type=job_type,
         status=status,
         attempts=attempts,
         max_attempts=max_attempts,
@@ -3145,6 +3146,79 @@ class TestJobs:
         assert retried.extraction_profile_id is None
         assert retried.base_revision_id == original.base_revision_id
         assert retried.parent_job_id == original.parent_job_id
+
+    async def test_retry_job_noops_for_unrecoverable_estimate_job(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should no-op for failed estimate jobs without enqueue recovery."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
+            retried_job_ids.append(str(job_id))
+            return True
+
+        monkeypatch.setattr(
+            jobs_api,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        ingest_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(ingest_job.id)
+        base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+        assert base_revision is not None
+
+        estimate_job = await _create_quantity_takeoff_job(
+            project_id=uuid.UUID(project["id"]),
+            file_id=uuid.UUID(uploaded["id"]),
+            base_revision_id=base_revision.id,
+            parent_job_id=ingest_job.id,
+            job_type=JobType.ESTIMATE.value,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+        )
+        await _update_job(
+            estimate_job.id,
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message="estimate worker unavailable",
+            enqueue_status="pending",
+            enqueue_attempts=2,
+        )
+
+        response = await async_client.post(f"/v1/jobs/{estimate_job.id}/retry")
+
+        assert response.status_code == 202
+        assert retried_job_ids == []
+        unchanged = await _get_job(estimate_job.id)
+        assert unchanged.status == "failed"
+        assert unchanged.attempts == estimate_job.attempts
+        assert unchanged.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert unchanged.error_message == "estimate worker unavailable"
+        assert unchanged.enqueue_status == "pending"
+        assert unchanged.enqueue_attempts == 2
+        assert unchanged.job_type == JobType.ESTIMATE.value
+        assert unchanged.extraction_profile_id is None
+        assert unchanged.base_revision_id == base_revision.id
+        assert unchanged.parent_job_id == ingest_job.id
 
     @pytest.mark.parametrize("status", ["pending", "running"])
     async def test_recover_incomplete_ingest_jobs_requeues_quantity_takeoff_jobs(


### PR DESCRIPTION
Closes #200

## Summary
- add the immutable estimate job input contract with typed catalog refs, job-type constraints, and append-only migrations
- keep estimate jobs out of recovery/publish flows until a real publisher exists, including retry no-op protection for unrecoverable job types
- extend DB-backed regression coverage and repair missing quantity gate constraints on upgraded local schemas

## Test plan
- [x] uv run ruff check app tests alembic
- [x] uv run mypy app tests alembic/versions/2026_05_18_0023_repair_quantity_gate_contract.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest