### PR TITLE
feat(estimation): implement estimate engine service (#201)

### DIFF
--- a/app/estimating/engine/__init__.py
+++ b/app/estimating/engine/__init__.py
@@ -1,0 +1,38 @@
+"""Estimate engine contracts and helpers."""
+
+from .contracts import (
+    EstimateCurrency,
+    EstimateEngineInput,
+    EstimateEngineOutput,
+    EstimateLineSpec,
+    EstimateLineType,
+    EstimateSnapshotEntrySpec,
+    EstimateSnapshotEntryType,
+    JSONValue,
+    deterministic_estimate_version_id,
+    deterministic_item_id,
+    deterministic_snapshot_entry_id,
+)
+from .errors import EstimateEngineError, EstimateEngineErrorCode
+from .formula_adapter import (
+    formula_definition_from_json,
+    formula_definition_from_selected_formula,
+)
+
+__all__ = [
+    "EstimateCurrency",
+    "EstimateEngineError",
+    "EstimateEngineErrorCode",
+    "EstimateEngineInput",
+    "EstimateEngineOutput",
+    "EstimateLineSpec",
+    "EstimateLineType",
+    "EstimateSnapshotEntrySpec",
+    "EstimateSnapshotEntryType",
+    "JSONValue",
+    "deterministic_estimate_version_id",
+    "deterministic_item_id",
+    "deterministic_snapshot_entry_id",
+    "formula_definition_from_json",
+    "formula_definition_from_selected_formula",
+]

--- a/app/estimating/engine/contracts.py
+++ b/app/estimating/engine/contracts.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from app.estimating.formulas import (
+    FormulaDefinition,
+    FormulaInputDefinition,
+    FormulaNode,
+    RoundingSpec,
+    ValueContract,
+)
+
+type JSONScalar = None | bool | int | float | str
+type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
+type EstimateCurrency = Literal["GBP"]
+type EstimateQuantityGate = Literal["allowed", "provisional", "review_gated", "blocked"]
+type EstimateSnapshotEntryType = Literal[
+    "quantity_input",
+    "rate",
+    "material",
+    "formula",
+    "assumption",
+]
+type EstimateLineType = Literal["rate", "material", "formula", "assumption", "adjustment"]
+
+
+def _validate_non_empty(name: str, value: str) -> None:
+    if not value:
+        raise ValueError(f"{name} must be a non-empty string")
+
+
+def deterministic_estimate_version_id(estimate_job_id: UUID) -> UUID:
+    return uuid5(NAMESPACE_URL, f"draupnir:estimate:{estimate_job_id}:version")
+
+
+def deterministic_snapshot_entry_id(estimate_job_id: UUID, entry_key: str) -> UUID:
+    _validate_non_empty("entry_key", entry_key)
+    return uuid5(NAMESPACE_URL, f"draupnir:estimate:{estimate_job_id}:snapshot:{entry_key}")
+
+
+def deterministic_item_id(estimate_job_id: UUID, line_key: str) -> UUID:
+    _validate_non_empty("line_key", line_key)
+    return uuid5(NAMESPACE_URL, f"draupnir:estimate:{estimate_job_id}:item:{line_key}")
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateSnapshotEntrySpec:
+    id: UUID
+    entry_type: EstimateSnapshotEntryType
+    entry_key: str
+    entry_label: str
+    sort_order: int
+    source_payload: dict[str, JSONValue] = field(default_factory=dict)
+    source_rate_id: UUID | None = None
+    source_material_id: UUID | None = None
+    source_formula_id: UUID | None = None
+    source_quantity_takeoff_id: UUID | None = None
+    source_quantity_item_id: UUID | None = None
+    source_checksum_sha256: str | None = None
+    quantity_value: Decimal | None = None
+    unit: str | None = None
+    currency: EstimateCurrency | None = None
+    effective_date: date | None = None
+    unit_amount: Decimal | None = None
+    formula_definition: FormulaDefinition | None = None
+    rounding: RoundingSpec | None = None
+    money_amount: Decimal | None = None
+
+    def as_model_kwargs(
+        self,
+        *,
+        estimate_version_id: UUID,
+        project_id: UUID,
+        drawing_revision_id: UUID,
+    ) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "id": self.id,
+            "estimate_version_id": estimate_version_id,
+            "project_id": project_id,
+            "drawing_revision_id": drawing_revision_id,
+            "entry_type": self.entry_type,
+            "entry_key": self.entry_key,
+            "entry_label": self.entry_label,
+            "sort_order": self.sort_order,
+            "currency": self.currency,
+            "quantity_value": self.quantity_value,
+            "unit": self.unit,
+            "effective_date": self.effective_date,
+            "unit_amount": self.unit_amount,
+            "source_payload_json": _snapshot_source_payload_json(self),
+            "source_rate_id": self.source_rate_id,
+            "source_material_id": self.source_material_id,
+            "source_formula_id": self.source_formula_id,
+            "source_quantity_takeoff_id": self.source_quantity_takeoff_id,
+            "source_quantity_item_id": self.source_quantity_item_id,
+            "source_checksum_sha256": self.source_checksum_sha256,
+        }
+        rounding_json = _rounding_json(self.rounding)
+        if rounding_json is not None:
+            payload["rounding_json"] = rounding_json
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateLineSpec:
+    id: UUID
+    line_number: int
+    line_key: str
+    line_type: EstimateLineType
+    description: str
+    currency: EstimateCurrency
+    subtotal_amount: Decimal
+    tax_amount: Decimal
+    total_amount: Decimal
+    quantity_snapshot_entry_id: UUID | None = None
+    rate_snapshot_entry_id: UUID | None = None
+    material_snapshot_entry_id: UUID | None = None
+    formula_snapshot_entry_id: UUID | None = None
+    assumption_snapshot_entry_id: UUID | None = None
+    quantity_value: Decimal | None = None
+    quantity_unit: str | None = None
+    unit_rate_amount: Decimal | None = None
+    effective_date: date | None = None
+    rounding: RoundingSpec | None = None
+    details: dict[str, JSONValue] = field(default_factory=dict)
+
+    def as_model_kwargs(
+        self,
+        *,
+        estimate_version_id: UUID,
+        project_id: UUID,
+        drawing_revision_id: UUID,
+    ) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "id": self.id,
+            "estimate_version_id": estimate_version_id,
+            "project_id": project_id,
+            "drawing_revision_id": drawing_revision_id,
+            "line_type": self.line_type,
+            "line_number": self.line_number,
+            "line_key": self.line_key,
+            "description": self.description,
+            "currency": self.currency,
+            "quantity_value": self.quantity_value,
+            "quantity_unit": self.quantity_unit,
+            "unit_rate_amount": self.unit_rate_amount,
+            "effective_date": self.effective_date,
+            "subtotal_amount": self.subtotal_amount,
+            "tax_amount": self.tax_amount,
+            "total_amount": self.total_amount,
+            "quantity_snapshot_entry_id": self.quantity_snapshot_entry_id,
+            "rate_snapshot_entry_id": self.rate_snapshot_entry_id,
+            "material_snapshot_entry_id": self.material_snapshot_entry_id,
+            "formula_snapshot_entry_id": self.formula_snapshot_entry_id,
+            "assumption_snapshot_entry_id": self.assumption_snapshot_entry_id,
+        }
+        rounding_json = _rounding_json(self.rounding)
+        if rounding_json is not None:
+            payload["rounding_json"] = rounding_json
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateVersionHeader:
+    estimate_version_id: UUID
+    estimate_job_id: UUID
+    project_id: UUID
+    file_id: UUID
+    drawing_revision_id: UUID
+    quantity_takeoff_id: UUID
+    source_job_id: UUID
+    currency: EstimateCurrency
+    subtotal_amount: Decimal
+    tax_amount: Decimal
+    total_amount: Decimal
+    quantity_gate: EstimateQuantityGate = "allowed"
+    trusted_totals: bool = True
+
+    def as_model_kwargs(self) -> dict[str, object]:
+        return {
+            "id": self.estimate_version_id,
+            "project_id": self.project_id,
+            "source_file_id": self.file_id,
+            "drawing_revision_id": self.drawing_revision_id,
+            "quantity_takeoff_id": self.quantity_takeoff_id,
+            "source_job_id": self.source_job_id,
+            "quantity_gate": self.quantity_gate,
+            "trusted_totals": self.trusted_totals,
+            "currency": self.currency,
+            "subtotal_amount": self.subtotal_amount,
+            "tax_amount": self.tax_amount,
+            "total_amount": self.total_amount,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateQuantityEntryInput:
+    entry_key: str
+    entry_label: str
+    sort_order: int
+    source_quantity_item_id: UUID
+    source_checksum_sha256: str
+    quantity_value: Decimal
+    unit: str
+    source_quantity_takeoff_id: UUID | None = None
+    source_payload: dict[str, JSONValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateRateEntryInput:
+    entry_key: str
+    entry_label: str
+    sort_order: int
+    source_rate_id: UUID
+    source_checksum_sha256: str
+    unit: str
+    effective_date: date
+    unit_amount: Decimal
+    source_payload: dict[str, JSONValue] = field(default_factory=dict)
+    currency: EstimateCurrency = "GBP"
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateMaterialEntryInput:
+    entry_key: str
+    entry_label: str
+    sort_order: int
+    source_material_id: UUID
+    source_checksum_sha256: str
+    unit: str
+    effective_date: date
+    unit_amount: Decimal
+    source_payload: dict[str, JSONValue] = field(default_factory=dict)
+    currency: EstimateCurrency = "GBP"
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateFormulaEntryInput:
+    entry_key: str
+    entry_label: str
+    sort_order: int
+    source_formula_id: UUID
+    source_checksum_sha256: str
+    definition: FormulaDefinition
+    source_payload: dict[str, JSONValue] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateAssumptionEntryInput:
+    entry_key: str
+    entry_label: str
+    sort_order: int
+    source_checksum_sha256: str
+    amount: Decimal
+    source_payload: dict[str, JSONValue] = field(default_factory=dict)
+    currency: EstimateCurrency = "GBP"
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateLineInputSpec:
+    line_key: str
+    line_type: EstimateLineType
+    description: str
+    quantity_entry_key: str | None = None
+    rate_entry_key: str | None = None
+    material_entry_key: str | None = None
+    formula_entry_key: str | None = None
+    assumption_entry_key: str | None = None
+    formula_inputs: dict[str, str] = field(default_factory=dict)
+    adjustment_amount: Decimal | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateEngineInput:
+    estimate_job_id: UUID
+    project_id: UUID
+    drawing_revision_id: UUID
+    quantity_takeoff_id: UUID
+    file_id: UUID | None = None
+    source_job_id: UUID | None = None
+    currency: EstimateCurrency = "GBP"
+    quantity_gate: EstimateQuantityGate | None = None
+    trusted_totals: bool = False
+    tax_rate: Decimal = Decimal("0")
+    quantity_entries: tuple[EstimateQuantityEntryInput, ...] = ()
+    rate_entries: tuple[EstimateRateEntryInput, ...] = ()
+    material_entries: tuple[EstimateMaterialEntryInput, ...] = ()
+    formula_entries: tuple[EstimateFormulaEntryInput, ...] = ()
+    assumption_entries: tuple[EstimateAssumptionEntryInput, ...] = ()
+    line_inputs: tuple[EstimateLineInputSpec, ...] = ()
+    snapshot_entries: tuple[EstimateSnapshotEntrySpec, ...] = ()
+    line_specs: tuple[EstimateLineSpec, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateEngineOutput:
+    estimate_version_id: UUID
+    currency: EstimateCurrency
+    snapshot_entries: tuple[EstimateSnapshotEntrySpec, ...]
+    line_items: tuple[EstimateLineSpec, ...]
+    header: EstimateVersionHeader | None = None
+    project_id: UUID | None = None
+    file_id: UUID | None = None
+    drawing_revision_id: UUID | None = None
+    quantity_takeoff_id: UUID | None = None
+    source_job_id: UUID | None = None
+    subtotal_amount: Decimal = Decimal("0")
+    tax_amount: Decimal = Decimal("0")
+    total_amount: Decimal = Decimal("0")
+
+    def estimate_version_model_kwargs(self) -> dict[str, object]:
+        header = _required_header(self.header)
+        return header.as_model_kwargs()
+
+    def snapshot_entry_model_kwargs(self) -> tuple[dict[str, object], ...]:
+        header = _required_header(self.header)
+        return tuple(
+            entry.as_model_kwargs(
+                estimate_version_id=header.estimate_version_id,
+                project_id=header.project_id,
+                drawing_revision_id=header.drawing_revision_id,
+            )
+            for entry in self.snapshot_entries
+        )
+
+    def line_item_model_kwargs(self) -> tuple[dict[str, object], ...]:
+        header = _required_header(self.header)
+        return tuple(
+            line.as_model_kwargs(
+                estimate_version_id=header.estimate_version_id,
+                project_id=header.project_id,
+                drawing_revision_id=header.drawing_revision_id,
+            )
+            for line in self.line_items
+        )
+
+
+def _required_header(header: EstimateVersionHeader | None) -> EstimateVersionHeader:
+    if header is None:
+        raise ValueError("estimate output header is required for ORM payload generation")
+    return header
+
+
+def _snapshot_source_payload_json(snapshot: EstimateSnapshotEntrySpec) -> dict[str, JSONValue]:
+    payload = dict(snapshot.source_payload)
+    if snapshot.formula_definition is not None:
+        payload["formula_definition"] = _formula_definition_json(snapshot.formula_definition)
+    if snapshot.money_amount is not None:
+        payload["money_amount"] = _decimal_text(snapshot.money_amount)
+    return payload
+
+
+def _formula_definition_json(definition: FormulaDefinition) -> dict[str, JSONValue]:
+    return {
+        "formula_id": definition.formula_id,
+        "name": definition.name,
+        "version": definition.version,
+        "checksum": definition.checksum,
+        "output_key": definition.output_key,
+        "output_contract": _value_contract_json(definition.output_contract),
+        "declared_inputs": [_formula_input_definition_json(item) for item in definition.declared_inputs],
+        "expression": _formula_node_json(definition.expression),
+        "rounding": _rounding_json(definition.rounding),
+    }
+
+
+def _formula_input_definition_json(definition: FormulaInputDefinition) -> dict[str, JSONValue]:
+    return {
+        "name": definition.name,
+        "contract": _value_contract_json(definition.contract),
+    }
+
+
+def _formula_node_json(node: FormulaNode) -> dict[str, JSONValue]:
+    return {
+        "kind": node.kind,
+        "value": node.value,
+        "name": node.name,
+        "args": [_formula_node_json(arg) for arg in node.args],
+        "rounding": _rounding_json(node.rounding),
+    }
+
+
+def _value_contract_json(contract: ValueContract) -> dict[str, JSONValue]:
+    return {
+        "kind": contract.kind,
+        "currency": contract.currency,
+        "unit": contract.unit,
+        "per_unit": contract.per_unit,
+    }
+
+
+def _rounding_json(rounding: RoundingSpec | None) -> dict[str, JSONValue] | None:
+    if rounding is None:
+        return None
+    return {"scale": rounding.scale, "mode": rounding.mode}
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"

--- a/app/estimating/engine/contracts.py
+++ b/app/estimating/engine/contracts.py
@@ -362,7 +362,9 @@ def _formula_definition_json(definition: FormulaDefinition) -> dict[str, JSONVal
         "checksum": definition.checksum,
         "output_key": definition.output_key,
         "output_contract": _value_contract_json(definition.output_contract),
-        "declared_inputs": [_formula_input_definition_json(item) for item in definition.declared_inputs],
+        "declared_inputs": [
+            _formula_input_definition_json(item) for item in definition.declared_inputs
+        ],
         "expression": _formula_node_json(definition.expression),
         "rounding": _rounding_json(definition.rounding),
     }

--- a/app/estimating/engine/errors.py
+++ b/app/estimating/engine/errors.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, NoReturn
+
+type EstimateEngineErrorCode = Literal[
+    "INPUT_INVALID",
+    "UNSUPPORTED_FORMULA_JSON",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class EstimateEngineError(ValueError):
+    code: EstimateEngineErrorCode
+    reason: str
+    message: str
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def raise_input_invalid(reason: str, message: str) -> NoReturn:
+    raise EstimateEngineError(code="INPUT_INVALID", reason=reason, message=message)
+
+
+def raise_unsupported_formula_json(reason: str, message: str) -> NoReturn:
+    raise EstimateEngineError(code="UNSUPPORTED_FORMULA_JSON", reason=reason, message=message)

--- a/app/estimating/engine/formula_adapter.py
+++ b/app/estimating/engine/formula_adapter.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+from app.estimating.catalog.selection import SelectedFormula
+from app.estimating.formulas import (
+    FormulaDefinition,
+    FormulaInputDefinition,
+    FormulaNode,
+    RoundingSpec,
+    ValueContract,
+)
+
+from .errors import raise_unsupported_formula_json
+
+_CONTRACT_KEYS = frozenset({"kind", "currency", "unit", "per_unit"})
+_INPUT_KEYS = frozenset({"name", "contract"})
+_NODE_KEYS = frozenset({"kind", "value", "name", "args", "rounding"})
+_ROUNDING_KEYS = frozenset({"scale", "mode"})
+_GBP_ONLY_KINDS = frozenset({"money", "rate"})
+
+
+def formula_definition_from_selected_formula(selected: SelectedFormula) -> FormulaDefinition:
+    return formula_definition_from_json(
+        formula_id=selected.formula_id,
+        name=selected.name,
+        version=selected.version,
+        checksum=selected.checksum_sha256,
+        output_key=selected.output_key,
+        output_contract_json=selected.output_contract,
+        declared_inputs_json=selected.declared_inputs,
+        expression_json=selected.expression,
+        rounding_json=selected.rounding,
+    )
+
+
+def formula_definition_from_json(
+    *,
+    formula_id: str,
+    name: str,
+    version: int,
+    checksum: str,
+    output_key: str,
+    output_contract_json: Mapping[str, object],
+    declared_inputs_json: Sequence[Mapping[str, object]],
+    expression_json: Mapping[str, object],
+    rounding_json: Mapping[str, object] | None = None,
+) -> FormulaDefinition:
+    return FormulaDefinition(
+        formula_id=formula_id,
+        name=name,
+        version=version,
+        checksum=checksum,
+        output_key=output_key,
+        output_contract=_value_contract_from_json(output_contract_json, path="output_contract"),
+        declared_inputs=tuple(
+            _input_definition_from_json(item, path=f"declared_inputs[{index}]")
+            for index, item in enumerate(declared_inputs_json)
+        ),
+        expression=_formula_node_from_json(expression_json, path="expression"),
+        rounding=_rounding_from_json(rounding_json, path="rounding"),
+    )
+
+
+def _value_contract_from_json(payload: Mapping[str, object], *, path: str) -> ValueContract:
+    _reject_legacy_shape(payload, path=path, legacy_key="type", reason="legacy_contract_shape")
+    _reject_unknown_keys(payload, allowed_keys=_CONTRACT_KEYS, path=path, reason="contract_unknown_keys")
+
+    kind = _require_str(payload.get("kind"), path=f"{path}.kind", reason="contract_kind_invalid")
+    currency = _optional_str(payload.get("currency"), path=f"{path}.currency", reason="contract_currency_invalid")
+    unit = _optional_str(payload.get("unit"), path=f"{path}.unit", reason="contract_unit_invalid")
+    per_unit = _optional_str(payload.get("per_unit"), path=f"{path}.per_unit", reason="contract_per_unit_invalid")
+
+    if kind in _GBP_ONLY_KINDS and currency != "GBP":
+        raise_unsupported_formula_json(
+            "unsupported_currency",
+            f"{path}.currency must be 'GBP' for {kind} contracts.",
+        )
+
+    return ValueContract(kind=cast(Any, kind), currency=currency, unit=unit, per_unit=per_unit)
+
+
+def _input_definition_from_json(payload: Mapping[str, object], *, path: str) -> FormulaInputDefinition:
+    _reject_legacy_shape(payload, path=path, legacy_key="key", reason="legacy_input_shape")
+    _reject_unknown_keys(payload, allowed_keys=_INPUT_KEYS, path=path, reason="input_unknown_keys")
+
+    name = _require_str(payload.get("name"), path=f"{path}.name", reason="input_name_invalid")
+    contract_payload = _require_mapping(
+        payload.get("contract"),
+        path=f"{path}.contract",
+        reason="input_contract_invalid",
+    )
+    return FormulaInputDefinition(
+        name=name,
+        contract=_value_contract_from_json(contract_payload, path=f"{path}.contract"),
+    )
+
+
+def _formula_node_from_json(payload: Mapping[str, object], *, path: str) -> FormulaNode:
+    _reject_legacy_shape(payload, path=path, legacy_key="op", reason="legacy_node_shape")
+    _reject_unknown_keys(payload, allowed_keys=_NODE_KEYS, path=path, reason="node_unknown_keys")
+
+    kind = _require_str(payload.get("kind"), path=f"{path}.kind", reason="node_kind_invalid")
+    value = _optional_str(payload.get("value"), path=f"{path}.value", reason="node_value_invalid")
+    name = _optional_str(payload.get("name"), path=f"{path}.name", reason="node_name_invalid")
+    args_payload = payload.get("args", ())
+    args: tuple[FormulaNode, ...]
+    if args_payload is None:
+        args = ()
+    else:
+        items = _require_sequence(args_payload, path=f"{path}.args", reason="node_args_invalid")
+        args = tuple(
+            _formula_node_from_json(
+                _require_mapping(item, path=f"{path}.args[{index}]", reason="node_arg_invalid"),
+                path=f"{path}.args[{index}]",
+            )
+            for index, item in enumerate(items)
+        )
+
+    return FormulaNode(
+        kind=cast(Any, kind),
+        value=value,
+        name=name,
+        args=args,
+        rounding=_rounding_from_json(payload.get("rounding"), path=f"{path}.rounding"),
+    )
+
+
+def _rounding_from_json(
+    payload: Mapping[str, object] | None | object,
+    *,
+    path: str,
+) -> RoundingSpec | None:
+    if payload is None:
+        return None
+    mapping = _require_mapping(payload, path=path, reason="rounding_invalid")
+    _reject_unknown_keys(mapping, allowed_keys=_ROUNDING_KEYS, path=path, reason="rounding_unknown_keys")
+
+    scale = mapping.get("scale")
+    if not isinstance(scale, int) or isinstance(scale, bool):
+        raise_unsupported_formula_json("rounding_scale_invalid", f"{path}.scale must be an integer.")
+
+    mode = _require_str(mapping.get("mode"), path=f"{path}.mode", reason="rounding_mode_invalid")
+    return RoundingSpec(scale=scale, mode=cast(Any, mode))
+
+
+def _require_mapping(value: object, *, path: str, reason: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise_unsupported_formula_json(reason, f"{path} must be an object.")
+    return cast(Mapping[str, object], value)
+
+
+def _require_sequence(value: object, *, path: str, reason: str) -> Sequence[object]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise_unsupported_formula_json(reason, f"{path} must be an array.")
+    return cast(Sequence[object], value)
+
+
+def _require_str(value: object, *, path: str, reason: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise_unsupported_formula_json(reason, f"{path} must be a non-empty string.")
+    return value
+
+
+def _optional_str(value: object, *, path: str, reason: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise_unsupported_formula_json(reason, f"{path} must be a non-empty string when provided.")
+    return value
+
+
+def _reject_legacy_shape(
+    payload: Mapping[str, object],
+    *,
+    path: str,
+    legacy_key: str,
+    reason: str,
+) -> None:
+    if legacy_key in payload and "kind" not in payload:
+        raise_unsupported_formula_json(reason, f"{path} uses unsupported legacy '{legacy_key}' JSON.")
+
+
+def _reject_unknown_keys(
+    payload: Mapping[str, object],
+    *,
+    allowed_keys: frozenset[str],
+    path: str,
+    reason: str,
+) -> None:
+    unknown_keys = sorted(key for key in payload if key not in allowed_keys)
+    if unknown_keys:
+        joined = ", ".join(unknown_keys)
+        raise_unsupported_formula_json(reason, f"{path} contains unsupported keys: {joined}.")

--- a/app/estimating/engine/formula_adapter.py
+++ b/app/estimating/engine/formula_adapter.py
@@ -65,12 +65,25 @@ def formula_definition_from_json(
 
 def _value_contract_from_json(payload: Mapping[str, object], *, path: str) -> ValueContract:
     _reject_legacy_shape(payload, path=path, legacy_key="type", reason="legacy_contract_shape")
-    _reject_unknown_keys(payload, allowed_keys=_CONTRACT_KEYS, path=path, reason="contract_unknown_keys")
+    _reject_unknown_keys(
+        payload,
+        allowed_keys=_CONTRACT_KEYS,
+        path=path,
+        reason="contract_unknown_keys",
+    )
 
     kind = _require_str(payload.get("kind"), path=f"{path}.kind", reason="contract_kind_invalid")
-    currency = _optional_str(payload.get("currency"), path=f"{path}.currency", reason="contract_currency_invalid")
+    currency = _optional_str(
+        payload.get("currency"),
+        path=f"{path}.currency",
+        reason="contract_currency_invalid",
+    )
     unit = _optional_str(payload.get("unit"), path=f"{path}.unit", reason="contract_unit_invalid")
-    per_unit = _optional_str(payload.get("per_unit"), path=f"{path}.per_unit", reason="contract_per_unit_invalid")
+    per_unit = _optional_str(
+        payload.get("per_unit"),
+        path=f"{path}.per_unit",
+        reason="contract_per_unit_invalid",
+    )
 
     if kind in _GBP_ONLY_KINDS and currency != "GBP":
         raise_unsupported_formula_json(
@@ -81,7 +94,9 @@ def _value_contract_from_json(payload: Mapping[str, object], *, path: str) -> Va
     return ValueContract(kind=cast(Any, kind), currency=currency, unit=unit, per_unit=per_unit)
 
 
-def _input_definition_from_json(payload: Mapping[str, object], *, path: str) -> FormulaInputDefinition:
+def _input_definition_from_json(
+    payload: Mapping[str, object], *, path: str
+) -> FormulaInputDefinition:
     _reject_legacy_shape(payload, path=path, legacy_key="key", reason="legacy_input_shape")
     _reject_unknown_keys(payload, allowed_keys=_INPUT_KEYS, path=path, reason="input_unknown_keys")
 
@@ -135,11 +150,19 @@ def _rounding_from_json(
     if payload is None:
         return None
     mapping = _require_mapping(payload, path=path, reason="rounding_invalid")
-    _reject_unknown_keys(mapping, allowed_keys=_ROUNDING_KEYS, path=path, reason="rounding_unknown_keys")
+    _reject_unknown_keys(
+        mapping,
+        allowed_keys=_ROUNDING_KEYS,
+        path=path,
+        reason="rounding_unknown_keys",
+    )
 
     scale = mapping.get("scale")
     if not isinstance(scale, int) or isinstance(scale, bool):
-        raise_unsupported_formula_json("rounding_scale_invalid", f"{path}.scale must be an integer.")
+        raise_unsupported_formula_json(
+            "rounding_scale_invalid",
+            f"{path}.scale must be an integer.",
+        )
 
     mode = _require_str(mapping.get("mode"), path=f"{path}.mode", reason="rounding_mode_invalid")
     return RoundingSpec(scale=scale, mode=cast(Any, mode))
@@ -179,7 +202,10 @@ def _reject_legacy_shape(
     reason: str,
 ) -> None:
     if legacy_key in payload and "kind" not in payload:
-        raise_unsupported_formula_json(reason, f"{path} uses unsupported legacy '{legacy_key}' JSON.")
+        raise_unsupported_formula_json(
+            reason,
+            f"{path} uses unsupported legacy '{legacy_key}' JSON.",
+        )
 
 
 def _reject_unknown_keys(

--- a/app/estimating/engine/service.py
+++ b/app/estimating/engine/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Literal
 from uuid import UUID
 
@@ -25,7 +25,12 @@ from app.estimating.engine.contracts import (
     deterministic_snapshot_entry_id,
 )
 from app.estimating.engine.errors import raise_input_invalid
-from app.estimating.formulas import FormulaValue, RoundingSpec, ValueContract, evaluate_formula
+from app.estimating.formulas import (
+    FormulaValue,
+    RoundingSpec,
+    ValueContract,
+    evaluate_formula,
+)
 
 type _SnapshotValueType = Literal["quantity_input", "rate", "material", "assumption"]
 
@@ -100,7 +105,9 @@ def compose_estimate(engine_input: EstimateEngineInput) -> EstimateEngineOutput:
             value_type="assumption",
         )
 
-    ordered_snapshot_entries = tuple(sorted(snapshot_entries, key=lambda entry: (entry.sort_order, entry.entry_key)))
+    ordered_snapshot_entries = tuple(
+        sorted(snapshot_entries, key=lambda entry: (entry.sort_order, entry.entry_key))
+    )
 
     line_keys: set[str] = set()
     line_items: list[EstimateLineSpec] = []
@@ -163,7 +170,10 @@ def _validate_engine_input(engine_input: EstimateEngineInput) -> None:
             message="estimate input must include file_id and source_job_id lineage fields",
         )
     if engine_input.currency != "GBP":
-        raise_input_invalid(reason="unsupported_currency", message="estimate engine supports GBP only")
+        raise_input_invalid(
+            reason="unsupported_currency",
+            message="estimate engine supports GBP only",
+        )
     if engine_input.quantity_gate != "allowed":
         raise_input_invalid(
             reason="quantity_gate_not_allowed",
@@ -177,7 +187,10 @@ def _validate_engine_input(engine_input: EstimateEngineInput) -> None:
     if engine_input.tax_rate < 0:
         raise_input_invalid(reason="negative_tax_rate", message="tax_rate must be nonnegative")
     if not engine_input.line_inputs:
-        raise_input_invalid(reason="missing_line_items", message="estimate input requires line_inputs")
+        raise_input_invalid(
+            reason="missing_line_items",
+            message="estimate input requires line_inputs",
+        )
 
 
 def _build_quantity_snapshot(
@@ -188,14 +201,20 @@ def _build_quantity_snapshot(
     _validate_non_empty_text("entry_label", quantity_entry.entry_label)
     _validate_non_empty_text("unit", quantity_entry.unit)
     _validate_checksum(quantity_entry.source_checksum_sha256)
-    if quantity_entry.source_quantity_takeoff_id is not None and quantity_entry.source_quantity_takeoff_id != engine_input.quantity_takeoff_id:
+    if (
+        quantity_entry.source_quantity_takeoff_id is not None
+        and quantity_entry.source_quantity_takeoff_id != engine_input.quantity_takeoff_id
+    ):
         raise_input_invalid(
             reason="quantity_takeoff_mismatch",
             message="quantity entry lineage must match estimate input quantity_takeoff_id",
         )
     quantity_value = _quantity_decimal(quantity_entry.quantity_value)
     if quantity_value < 0:
-        raise_input_invalid(reason="negative_quantity", message="quantity values must be nonnegative")
+        raise_input_invalid(
+            reason="negative_quantity",
+            message="quantity values must be nonnegative",
+        )
     return EstimateSnapshotEntrySpec(
         id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, quantity_entry.entry_key),
         entry_type="quantity_input",
@@ -215,7 +234,14 @@ def _build_rate_snapshot(
     engine_input: EstimateEngineInput,
     rate_entry: EstimateRateEntryInput,
 ) -> EstimateSnapshotEntrySpec:
-    _validate_money_rate_entry(rate_entry.entry_key, rate_entry.entry_label, rate_entry.source_checksum_sha256, rate_entry.unit, rate_entry.currency, rate_entry.unit_amount)
+    _validate_money_rate_entry(
+        rate_entry.entry_key,
+        rate_entry.entry_label,
+        rate_entry.source_checksum_sha256,
+        rate_entry.unit,
+        rate_entry.currency,
+        rate_entry.unit_amount,
+    )
     return EstimateSnapshotEntrySpec(
         id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, rate_entry.entry_key),
         entry_type="rate",
@@ -267,7 +293,10 @@ def _build_formula_snapshot(
     _validate_entry_key(formula_entry.entry_key)
     _validate_non_empty_text("entry_label", formula_entry.entry_label)
     _validate_checksum(formula_entry.source_checksum_sha256)
-    if formula_entry.definition.output_contract.kind != "money" or formula_entry.definition.output_contract.currency != "GBP":
+    if (
+        formula_entry.definition.output_contract.kind != "money"
+        or formula_entry.definition.output_contract.currency != "GBP"
+    ):
         raise_input_invalid(
             reason="unsupported_formula_output",
             message="formula entries must resolve to GBP money outputs",
@@ -299,11 +328,20 @@ def _build_assumption_snapshot(
     _validate_non_empty_text("entry_label", assumption_entry.entry_label)
     _validate_checksum(assumption_entry.source_checksum_sha256)
     if assumption_entry.currency != "GBP":
-        raise_input_invalid(reason="unsupported_currency", message="estimate engine supports GBP only")
+        raise_input_invalid(
+            reason="unsupported_currency",
+            message="estimate engine supports GBP only",
+        )
     if assumption_entry.amount < 0:
-        raise_input_invalid(reason="negative_money", message="assumption amounts must be nonnegative")
+        raise_input_invalid(
+            reason="negative_money",
+            message="assumption amounts must be nonnegative",
+        )
     return EstimateSnapshotEntrySpec(
-        id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, assumption_entry.entry_key),
+        id=deterministic_snapshot_entry_id(
+            engine_input.estimate_job_id,
+            assumption_entry.entry_key,
+        ),
         entry_type="assumption",
         entry_key=assumption_entry.entry_key,
         entry_label=assumption_entry.entry_label,
@@ -326,8 +364,16 @@ def _build_line_item(
     _validate_non_empty_text("description", line_input.description)
 
     if line_input.line_type == "rate":
-        quantity_value = _resolve_snapshot_value(snapshot_values, line_input.quantity_entry_key, expected_type="quantity_input")
-        rate_value = _resolve_snapshot_value(snapshot_values, line_input.rate_entry_key, expected_type="rate")
+        quantity_value = _resolve_snapshot_value(
+            snapshot_values,
+            line_input.quantity_entry_key,
+            expected_type="quantity_input",
+        )
+        rate_value = _resolve_snapshot_value(
+            snapshot_values,
+            line_input.rate_entry_key,
+            expected_type="rate",
+        )
         _validate_rate_unit_match(quantity_value, rate_value)
         subtotal_amount = _money(rate_value.amount * quantity_value.amount)
         return _finalize_line_item(
@@ -344,8 +390,16 @@ def _build_line_item(
         )
 
     if line_input.line_type == "material":
-        quantity_value = _resolve_snapshot_value(snapshot_values, line_input.quantity_entry_key, expected_type="quantity_input")
-        material_value = _resolve_snapshot_value(snapshot_values, line_input.material_entry_key, expected_type="material")
+        quantity_value = _resolve_snapshot_value(
+            snapshot_values,
+            line_input.quantity_entry_key,
+            expected_type="quantity_input",
+        )
+        material_value = _resolve_snapshot_value(
+            snapshot_values,
+            line_input.material_entry_key,
+            expected_type="material",
+        )
         _validate_rate_unit_match(quantity_value, material_value)
         subtotal_amount = _money(material_value.amount * quantity_value.amount)
         return _finalize_line_item(
@@ -362,7 +416,11 @@ def _build_line_item(
         )
 
     if line_input.line_type == "assumption":
-        assumption_value = _resolve_snapshot_value(snapshot_values, line_input.assumption_entry_key, expected_type="assumption")
+        assumption_value = _resolve_snapshot_value(
+            snapshot_values,
+            line_input.assumption_entry_key,
+            expected_type="assumption",
+        )
         subtotal_amount = _money(assumption_value.amount)
         return _finalize_line_item(
             engine_input=engine_input,
@@ -411,7 +469,11 @@ def _build_line_item(
             formula_entries=formula_entries,
         )
 
-    raise_input_invalid(reason="unsupported_line_type", message=f"unsupported line type: {line_input.line_type}")
+    raise_input_invalid(
+        reason="unsupported_line_type",
+        message=f"unsupported line type: {line_input.line_type}",
+    )
+    raise AssertionError("unreachable")
 
 
 def _build_formula_line_item(
@@ -425,7 +487,10 @@ def _build_formula_line_item(
     formula_entry_key = _required_key("formula_entry_key", line_input.formula_entry_key)
     formula_entry = formula_entries.get(formula_entry_key)
     if formula_entry is None:
-        raise_input_invalid(reason="line_reference_missing", message="formula line references unknown formula entry")
+        raise_input_invalid(
+            reason="line_reference_missing",
+            message="formula line references unknown formula entry",
+        )
     resolved_formula_entry = formula_entry
 
     formula_inputs: dict[str, FormulaValue] = {}
@@ -441,10 +506,16 @@ def _build_formula_line_item(
             )
         snapshot_value = snapshot_values.get(snapshot_key)
         if snapshot_value is None:
-            raise_input_invalid(reason="line_reference_missing", message="formula line references unknown snapshot entry")
+            raise_input_invalid(
+                reason="line_reference_missing",
+                message="formula line references unknown snapshot entry",
+            )
         resolved_snapshot_value = snapshot_value
         if not _contracts_match(resolved_snapshot_value.contract, declared_input.contract):
-            raise_input_invalid(reason="unit_mismatch", message="formula input contract does not match bound snapshot")
+            raise_input_invalid(
+                reason="unit_mismatch",
+                message="formula input contract does not match bound snapshot",
+            )
         formula_inputs[declared_input.name] = FormulaValue(
             amount=resolved_snapshot_value.amount,
             contract=resolved_snapshot_value.contract,
@@ -454,16 +525,25 @@ def _build_formula_line_item(
             quantity_snapshot = resolved_snapshot_value
 
     formula_result = evaluate_formula(resolved_formula_entry.definition, formula_inputs)
-    if formula_result.value.contract.kind != "money" or formula_result.value.contract.currency != "GBP":
-        raise_input_invalid(reason="unsupported_formula_output", message="formula lines must resolve to GBP money outputs")
+    if (
+        formula_result.value.contract.kind != "money"
+        or formula_result.value.contract.currency != "GBP"
+    ):
+        raise_input_invalid(
+            reason="unsupported_formula_output",
+            message="formula lines must resolve to GBP money outputs",
+        )
 
     pre_round_amount = formula_result.value.amount
     evaluated_amount = _apply_formula_rounding(formula_result.value.amount, formula_result.rounding)
     if evaluated_amount < 0:
-        raise_input_invalid(reason="negative_money", message="formula lines must resolve to nonnegative money")
+        raise_input_invalid(
+            reason="negative_money",
+            message="formula lines must resolve to nonnegative money",
+        )
 
     subtotal_amount = _money(evaluated_amount)
-    bound_input_keys_json: list[JSONValue] = [key for key in bound_keys]
+    bound_input_keys_json: list[JSONValue] = list(bound_keys)
     details: dict[str, JSONValue] = {
         "formula_id": resolved_formula_entry.definition.formula_id,
         "formula_version": resolved_formula_entry.definition.version,
@@ -483,8 +563,13 @@ def _build_formula_line_item(
         line_input=line_input,
         line_number=line_number,
         subtotal_amount=subtotal_amount,
-        quantity_snapshot_entry_id=quantity_snapshot.snapshot.id if quantity_snapshot is not None else None,
-        formula_snapshot_entry_id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, resolved_formula_entry.entry_key),
+        quantity_snapshot_entry_id=(
+            quantity_snapshot.snapshot.id if quantity_snapshot is not None else None
+        ),
+        formula_snapshot_entry_id=deterministic_snapshot_entry_id(
+            engine_input.estimate_job_id,
+            resolved_formula_entry.entry_key,
+        ),
         quantity_value=quantity_snapshot.amount if quantity_snapshot is not None else None,
         quantity_unit=quantity_snapshot.snapshot.unit if quantity_snapshot is not None else None,
         rounding=formula_result.rounding,
@@ -539,7 +624,10 @@ def _finalize_line_item(
 
 def _register_snapshot(snapshot_keys: set[str], snapshot: EstimateSnapshotEntrySpec) -> None:
     if snapshot.entry_key in snapshot_keys:
-        raise_input_invalid(reason="duplicate_snapshot_entry_key", message="snapshot entry keys must be unique")
+        raise_input_invalid(
+            reason="duplicate_snapshot_entry_key",
+            message="snapshot entry keys must be unique",
+        )
     snapshot_keys.add(snapshot.entry_key)
 
 
@@ -558,16 +646,25 @@ def _resolve_snapshot_value(
     key = _required_key("entry_key", entry_key)
     snapshot_value = snapshot_values.get(key)
     if snapshot_value is None:
-        raise_input_invalid(reason="line_reference_missing", message="line references unknown snapshot entry")
+        raise_input_invalid(
+            reason="line_reference_missing",
+            message="line references unknown snapshot entry",
+        )
     resolved_snapshot_value = snapshot_value
     if resolved_snapshot_value.value_type != expected_type:
-        raise_input_invalid(reason="line_reference_type_mismatch", message="line references incompatible snapshot entry type")
+        raise_input_invalid(
+            reason="line_reference_type_mismatch",
+            message="line references incompatible snapshot entry type",
+        )
     return resolved_snapshot_value
 
 
 def _validate_rate_unit_match(quantity_value: _SnapshotValue, rate_value: _SnapshotValue) -> None:
     if rate_value.contract.per_unit != quantity_value.contract.unit:
-        raise_input_invalid(reason="unit_mismatch", message="estimate engine does not support unit conversion")
+        raise_input_invalid(
+            reason="unit_mismatch",
+            message="estimate engine does not support unit conversion",
+        )
 
 
 def _apply_formula_rounding(amount: Decimal, rounding_spec: RoundingSpec | None) -> Decimal:
@@ -598,7 +695,10 @@ def _validate_money_rate_entry(
     _validate_checksum(source_checksum_sha256)
     _validate_non_empty_text("unit", unit)
     if currency != "GBP":
-        raise_input_invalid(reason="unsupported_currency", message="estimate engine supports GBP only")
+        raise_input_invalid(
+            reason="unsupported_currency",
+            message="estimate engine supports GBP only",
+        )
     if unit_amount < 0:
         raise_input_invalid(reason="negative_money", message="unit amounts must be nonnegative")
     if unit_amount.quantize(_CATALOG_QUANTUM) != unit_amount:
@@ -610,7 +710,10 @@ def _validate_money_rate_entry(
 
 def _validate_checksum(checksum: str) -> None:
     if not _CHECKSUM_PATTERN.fullmatch(checksum):
-        raise_input_invalid(reason="invalid_checksum", message="source checksums must be lowercase sha256 hex")
+        raise_input_invalid(
+            reason="invalid_checksum",
+            message="source checksums must be lowercase sha256 hex",
+        )
 
 
 def _validate_entry_key(entry_key: str) -> None:
@@ -643,9 +746,14 @@ def _required_uuid(name: str, value: UUID | None) -> UUID:
     return value
 
 
-def _required_quantity_gate(value: str | None) -> Literal["allowed", "provisional", "review_gated", "blocked"]:
+def _required_quantity_gate(
+    value: str | None,
+) -> Literal["allowed", "provisional", "review_gated", "blocked"]:
     if value is None:
-        raise_input_invalid(reason="quantity_gate_not_allowed", message="quantity_gate is required")
+        raise_input_invalid(
+            reason="quantity_gate_not_allowed",
+            message="quantity_gate is required",
+        )
     return value  # type: ignore[return-value]
 
 
@@ -671,7 +779,13 @@ def _resolve_adjustment_anchor(
                 reason="line_reference_missing",
                 message="adjustment line references unknown formula entry",
             )
-        return deterministic_snapshot_entry_id(engine_input.estimate_job_id, formula_entry.entry_key), None
+        return (
+            deterministic_snapshot_entry_id(
+                engine_input.estimate_job_id,
+                formula_entry.entry_key,
+            ),
+            None,
+        )
 
     assumption_value = _resolve_snapshot_value(
         snapshot_values,

--- a/app/estimating/engine/service.py
+++ b/app/estimating/engine/service.py
@@ -1,0 +1,688 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Literal
+from uuid import UUID
+
+from app.estimating.engine.contracts import (
+    EstimateAssumptionEntryInput,
+    EstimateEngineInput,
+    EstimateEngineOutput,
+    EstimateFormulaEntryInput,
+    EstimateLineInputSpec,
+    EstimateLineSpec,
+    EstimateMaterialEntryInput,
+    EstimateQuantityEntryInput,
+    EstimateRateEntryInput,
+    EstimateSnapshotEntrySpec,
+    EstimateVersionHeader,
+    JSONValue,
+    deterministic_estimate_version_id,
+    deterministic_item_id,
+    deterministic_snapshot_entry_id,
+)
+from app.estimating.engine.errors import raise_input_invalid
+from app.estimating.formulas import FormulaValue, RoundingSpec, ValueContract, evaluate_formula
+
+type _SnapshotValueType = Literal["quantity_input", "rate", "material", "assumption"]
+
+_MONEY_QUANTUM = Decimal("0.01")
+_CATALOG_QUANTUM = Decimal("0.000001")
+_CHECKSUM_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True, slots=True)
+class _SnapshotValue:
+    snapshot: EstimateSnapshotEntrySpec
+    amount: Decimal
+    contract: ValueContract
+    value_type: _SnapshotValueType
+
+
+def compose_estimate(engine_input: EstimateEngineInput) -> EstimateEngineOutput:
+    _validate_engine_input(engine_input)
+
+    snapshot_entries: list[EstimateSnapshotEntrySpec] = []
+    snapshot_keys: set[str] = set()
+    snapshot_values: dict[str, _SnapshotValue] = {}
+    formula_entries: dict[str, EstimateFormulaEntryInput] = {}
+
+    for quantity_entry in engine_input.quantity_entries:
+        snapshot = _build_quantity_snapshot(engine_input, quantity_entry)
+        snapshot_entries.append(snapshot)
+        _register_snapshot(snapshot_keys, snapshot)
+        snapshot_values[quantity_entry.entry_key] = _SnapshotValue(
+            snapshot=snapshot,
+            amount=snapshot.quantity_value or Decimal("0"),
+            contract=ValueContract(kind="quantity", unit=snapshot.unit),
+            value_type="quantity_input",
+        )
+
+    for rate_entry in engine_input.rate_entries:
+        snapshot = _build_rate_snapshot(engine_input, rate_entry)
+        snapshot_entries.append(snapshot)
+        _register_snapshot(snapshot_keys, snapshot)
+        snapshot_values[rate_entry.entry_key] = _SnapshotValue(
+            snapshot=snapshot,
+            amount=snapshot.unit_amount or Decimal("0"),
+            contract=ValueContract(kind="rate", currency=snapshot.currency, per_unit=snapshot.unit),
+            value_type="rate",
+        )
+
+    for material_entry in engine_input.material_entries:
+        snapshot = _build_material_snapshot(engine_input, material_entry)
+        snapshot_entries.append(snapshot)
+        _register_snapshot(snapshot_keys, snapshot)
+        snapshot_values[material_entry.entry_key] = _SnapshotValue(
+            snapshot=snapshot,
+            amount=snapshot.unit_amount or Decimal("0"),
+            contract=ValueContract(kind="rate", currency=snapshot.currency, per_unit=snapshot.unit),
+            value_type="material",
+        )
+
+    for formula_entry in engine_input.formula_entries:
+        snapshot = _build_formula_snapshot(engine_input, formula_entry)
+        snapshot_entries.append(snapshot)
+        _register_snapshot(snapshot_keys, snapshot)
+        formula_entries[formula_entry.entry_key] = formula_entry
+
+    for assumption_entry in engine_input.assumption_entries:
+        snapshot = _build_assumption_snapshot(engine_input, assumption_entry)
+        snapshot_entries.append(snapshot)
+        _register_snapshot(snapshot_keys, snapshot)
+        snapshot_values[assumption_entry.entry_key] = _SnapshotValue(
+            snapshot=snapshot,
+            amount=snapshot.money_amount or Decimal("0"),
+            contract=ValueContract(kind="money", currency=snapshot.currency),
+            value_type="assumption",
+        )
+
+    ordered_snapshot_entries = tuple(sorted(snapshot_entries, key=lambda entry: (entry.sort_order, entry.entry_key)))
+
+    line_keys: set[str] = set()
+    line_items: list[EstimateLineSpec] = []
+    subtotal_amount = Decimal("0")
+    tax_amount = Decimal("0")
+    total_amount = Decimal("0")
+
+    for index, line_input in enumerate(engine_input.line_inputs, start=1):
+        _register_line_key(line_keys, line_input.line_key)
+        line_item = _build_line_item(
+            engine_input=engine_input,
+            line_input=line_input,
+            line_number=index,
+            snapshot_values=snapshot_values,
+            formula_entries=formula_entries,
+        )
+        line_items.append(line_item)
+        subtotal_amount += line_item.subtotal_amount
+        tax_amount += line_item.tax_amount
+        total_amount += line_item.total_amount
+
+    version_id = deterministic_estimate_version_id(engine_input.estimate_job_id)
+    header = EstimateVersionHeader(
+        estimate_version_id=version_id,
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=_required_uuid("file_id", engine_input.file_id),
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=_required_uuid("source_job_id", engine_input.source_job_id),
+        currency=engine_input.currency,
+        quantity_gate=_required_quantity_gate(engine_input.quantity_gate),
+        trusted_totals=engine_input.trusted_totals,
+        subtotal_amount=subtotal_amount,
+        tax_amount=tax_amount,
+        total_amount=total_amount,
+    )
+
+    return EstimateEngineOutput(
+        estimate_version_id=version_id,
+        currency=engine_input.currency,
+        snapshot_entries=ordered_snapshot_entries,
+        line_items=tuple(line_items),
+        header=header,
+        project_id=engine_input.project_id,
+        file_id=header.file_id,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=header.source_job_id,
+        subtotal_amount=subtotal_amount,
+        tax_amount=tax_amount,
+        total_amount=total_amount,
+    )
+
+
+def _validate_engine_input(engine_input: EstimateEngineInput) -> None:
+    if engine_input.file_id is None or engine_input.source_job_id is None:
+        raise_input_invalid(
+            reason="missing_lineage",
+            message="estimate input must include file_id and source_job_id lineage fields",
+        )
+    if engine_input.currency != "GBP":
+        raise_input_invalid(reason="unsupported_currency", message="estimate engine supports GBP only")
+    if engine_input.quantity_gate != "allowed":
+        raise_input_invalid(
+            reason="quantity_gate_not_allowed",
+            message="estimate input requires quantity_gate='allowed'",
+        )
+    if not engine_input.trusted_totals:
+        raise_input_invalid(
+            reason="untrusted_totals",
+            message="estimate input requires trusted_totals=True",
+        )
+    if engine_input.tax_rate < 0:
+        raise_input_invalid(reason="negative_tax_rate", message="tax_rate must be nonnegative")
+    if not engine_input.line_inputs:
+        raise_input_invalid(reason="missing_line_items", message="estimate input requires line_inputs")
+
+
+def _build_quantity_snapshot(
+    engine_input: EstimateEngineInput,
+    quantity_entry: EstimateQuantityEntryInput,
+) -> EstimateSnapshotEntrySpec:
+    _validate_entry_key(quantity_entry.entry_key)
+    _validate_non_empty_text("entry_label", quantity_entry.entry_label)
+    _validate_non_empty_text("unit", quantity_entry.unit)
+    _validate_checksum(quantity_entry.source_checksum_sha256)
+    if quantity_entry.source_quantity_takeoff_id is not None and quantity_entry.source_quantity_takeoff_id != engine_input.quantity_takeoff_id:
+        raise_input_invalid(
+            reason="quantity_takeoff_mismatch",
+            message="quantity entry lineage must match estimate input quantity_takeoff_id",
+        )
+    quantity_value = _quantity_decimal(quantity_entry.quantity_value)
+    if quantity_value < 0:
+        raise_input_invalid(reason="negative_quantity", message="quantity values must be nonnegative")
+    return EstimateSnapshotEntrySpec(
+        id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, quantity_entry.entry_key),
+        entry_type="quantity_input",
+        entry_key=quantity_entry.entry_key,
+        entry_label=quantity_entry.entry_label,
+        sort_order=quantity_entry.sort_order,
+        source_payload=quantity_entry.source_payload,
+        source_quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_quantity_item_id=quantity_entry.source_quantity_item_id,
+        source_checksum_sha256=None,
+        quantity_value=quantity_value,
+        unit=quantity_entry.unit,
+    )
+
+
+def _build_rate_snapshot(
+    engine_input: EstimateEngineInput,
+    rate_entry: EstimateRateEntryInput,
+) -> EstimateSnapshotEntrySpec:
+    _validate_money_rate_entry(rate_entry.entry_key, rate_entry.entry_label, rate_entry.source_checksum_sha256, rate_entry.unit, rate_entry.currency, rate_entry.unit_amount)
+    return EstimateSnapshotEntrySpec(
+        id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, rate_entry.entry_key),
+        entry_type="rate",
+        entry_key=rate_entry.entry_key,
+        entry_label=rate_entry.entry_label,
+        sort_order=rate_entry.sort_order,
+        source_payload=rate_entry.source_payload,
+        source_rate_id=rate_entry.source_rate_id,
+        source_checksum_sha256=rate_entry.source_checksum_sha256,
+        unit=rate_entry.unit,
+        currency=rate_entry.currency,
+        effective_date=rate_entry.effective_date,
+        unit_amount=rate_entry.unit_amount,
+    )
+
+
+def _build_material_snapshot(
+    engine_input: EstimateEngineInput,
+    material_entry: EstimateMaterialEntryInput,
+) -> EstimateSnapshotEntrySpec:
+    _validate_money_rate_entry(
+        material_entry.entry_key,
+        material_entry.entry_label,
+        material_entry.source_checksum_sha256,
+        material_entry.unit,
+        material_entry.currency,
+        material_entry.unit_amount,
+    )
+    return EstimateSnapshotEntrySpec(
+        id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, material_entry.entry_key),
+        entry_type="material",
+        entry_key=material_entry.entry_key,
+        entry_label=material_entry.entry_label,
+        sort_order=material_entry.sort_order,
+        source_payload=material_entry.source_payload,
+        source_material_id=material_entry.source_material_id,
+        source_checksum_sha256=material_entry.source_checksum_sha256,
+        unit=material_entry.unit,
+        currency=material_entry.currency,
+        effective_date=material_entry.effective_date,
+        unit_amount=material_entry.unit_amount,
+    )
+
+
+def _build_formula_snapshot(
+    engine_input: EstimateEngineInput,
+    formula_entry: EstimateFormulaEntryInput,
+) -> EstimateSnapshotEntrySpec:
+    _validate_entry_key(formula_entry.entry_key)
+    _validate_non_empty_text("entry_label", formula_entry.entry_label)
+    _validate_checksum(formula_entry.source_checksum_sha256)
+    if formula_entry.definition.output_contract.kind != "money" or formula_entry.definition.output_contract.currency != "GBP":
+        raise_input_invalid(
+            reason="unsupported_formula_output",
+            message="formula entries must resolve to GBP money outputs",
+        )
+    if formula_entry.source_checksum_sha256 != formula_entry.definition.checksum:
+        raise_input_invalid(
+            reason="formula_checksum_mismatch",
+            message="formula entry checksum must match definition checksum",
+        )
+    return EstimateSnapshotEntrySpec(
+        id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, formula_entry.entry_key),
+        entry_type="formula",
+        entry_key=formula_entry.entry_key,
+        entry_label=formula_entry.entry_label,
+        sort_order=formula_entry.sort_order,
+        source_payload=formula_entry.source_payload,
+        source_formula_id=formula_entry.source_formula_id,
+        source_checksum_sha256=formula_entry.source_checksum_sha256,
+        formula_definition=formula_entry.definition,
+        rounding=formula_entry.definition.rounding,
+    )
+
+
+def _build_assumption_snapshot(
+    engine_input: EstimateEngineInput,
+    assumption_entry: EstimateAssumptionEntryInput,
+) -> EstimateSnapshotEntrySpec:
+    _validate_entry_key(assumption_entry.entry_key)
+    _validate_non_empty_text("entry_label", assumption_entry.entry_label)
+    _validate_checksum(assumption_entry.source_checksum_sha256)
+    if assumption_entry.currency != "GBP":
+        raise_input_invalid(reason="unsupported_currency", message="estimate engine supports GBP only")
+    if assumption_entry.amount < 0:
+        raise_input_invalid(reason="negative_money", message="assumption amounts must be nonnegative")
+    return EstimateSnapshotEntrySpec(
+        id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, assumption_entry.entry_key),
+        entry_type="assumption",
+        entry_key=assumption_entry.entry_key,
+        entry_label=assumption_entry.entry_label,
+        sort_order=assumption_entry.sort_order,
+        source_payload=assumption_entry.source_payload,
+        source_checksum_sha256=None,
+        money_amount=assumption_entry.amount,
+    )
+
+
+def _build_line_item(
+    *,
+    engine_input: EstimateEngineInput,
+    line_input: EstimateLineInputSpec,
+    line_number: int,
+    snapshot_values: dict[str, _SnapshotValue],
+    formula_entries: dict[str, EstimateFormulaEntryInput],
+) -> EstimateLineSpec:
+    _validate_entry_key(line_input.line_key)
+    _validate_non_empty_text("description", line_input.description)
+
+    if line_input.line_type == "rate":
+        quantity_value = _resolve_snapshot_value(snapshot_values, line_input.quantity_entry_key, expected_type="quantity_input")
+        rate_value = _resolve_snapshot_value(snapshot_values, line_input.rate_entry_key, expected_type="rate")
+        _validate_rate_unit_match(quantity_value, rate_value)
+        subtotal_amount = _money(rate_value.amount * quantity_value.amount)
+        return _finalize_line_item(
+            engine_input=engine_input,
+            line_input=line_input,
+            line_number=line_number,
+            subtotal_amount=subtotal_amount,
+            quantity_snapshot_entry_id=quantity_value.snapshot.id,
+            rate_snapshot_entry_id=rate_value.snapshot.id,
+            quantity_value=quantity_value.amount,
+            quantity_unit=quantity_value.snapshot.unit,
+            unit_rate_amount=rate_value.amount,
+            effective_date=rate_value.snapshot.effective_date,
+        )
+
+    if line_input.line_type == "material":
+        quantity_value = _resolve_snapshot_value(snapshot_values, line_input.quantity_entry_key, expected_type="quantity_input")
+        material_value = _resolve_snapshot_value(snapshot_values, line_input.material_entry_key, expected_type="material")
+        _validate_rate_unit_match(quantity_value, material_value)
+        subtotal_amount = _money(material_value.amount * quantity_value.amount)
+        return _finalize_line_item(
+            engine_input=engine_input,
+            line_input=line_input,
+            line_number=line_number,
+            subtotal_amount=subtotal_amount,
+            quantity_snapshot_entry_id=quantity_value.snapshot.id,
+            material_snapshot_entry_id=material_value.snapshot.id,
+            quantity_value=quantity_value.amount,
+            quantity_unit=quantity_value.snapshot.unit,
+            unit_rate_amount=material_value.amount,
+            effective_date=material_value.snapshot.effective_date,
+        )
+
+    if line_input.line_type == "assumption":
+        assumption_value = _resolve_snapshot_value(snapshot_values, line_input.assumption_entry_key, expected_type="assumption")
+        subtotal_amount = _money(assumption_value.amount)
+        return _finalize_line_item(
+            engine_input=engine_input,
+            line_input=line_input,
+            line_number=line_number,
+            subtotal_amount=subtotal_amount,
+            assumption_snapshot_entry_id=assumption_value.snapshot.id,
+            details={"amount": _decimal_text(assumption_value.amount)},
+        )
+
+    if line_input.line_type == "adjustment":
+        adjustment_amount = line_input.adjustment_amount
+        if adjustment_amount is None:
+            raise_input_invalid(
+                reason="missing_adjustment_amount",
+                message="adjustment lines require adjustment_amount",
+            )
+        if adjustment_amount < 0:
+            raise_input_invalid(
+                reason="negative_adjustment",
+                message="adjustment lines must be nonnegative explicit amounts",
+            )
+        formula_snapshot_entry_id, assumption_snapshot_entry_id = _resolve_adjustment_anchor(
+            engine_input=engine_input,
+            line_input=line_input,
+            snapshot_values=snapshot_values,
+            formula_entries=formula_entries,
+        )
+        subtotal_amount = _money(adjustment_amount)
+        return _finalize_line_item(
+            engine_input=engine_input,
+            line_input=line_input,
+            line_number=line_number,
+            subtotal_amount=subtotal_amount,
+            formula_snapshot_entry_id=formula_snapshot_entry_id,
+            assumption_snapshot_entry_id=assumption_snapshot_entry_id,
+            details={"adjustment_amount": _decimal_text(adjustment_amount)},
+        )
+
+    if line_input.line_type == "formula":
+        return _build_formula_line_item(
+            engine_input=engine_input,
+            line_input=line_input,
+            line_number=line_number,
+            snapshot_values=snapshot_values,
+            formula_entries=formula_entries,
+        )
+
+    raise_input_invalid(reason="unsupported_line_type", message=f"unsupported line type: {line_input.line_type}")
+
+
+def _build_formula_line_item(
+    *,
+    engine_input: EstimateEngineInput,
+    line_input: EstimateLineInputSpec,
+    line_number: int,
+    snapshot_values: dict[str, _SnapshotValue],
+    formula_entries: dict[str, EstimateFormulaEntryInput],
+) -> EstimateLineSpec:
+    formula_entry_key = _required_key("formula_entry_key", line_input.formula_entry_key)
+    formula_entry = formula_entries.get(formula_entry_key)
+    if formula_entry is None:
+        raise_input_invalid(reason="line_reference_missing", message="formula line references unknown formula entry")
+    resolved_formula_entry = formula_entry
+
+    formula_inputs: dict[str, FormulaValue] = {}
+    bound_keys: list[str] = []
+    quantity_snapshot: _SnapshotValue | None = None
+
+    for declared_input in resolved_formula_entry.definition.declared_inputs:
+        snapshot_key = line_input.formula_inputs.get(declared_input.name)
+        if snapshot_key is None:
+            raise_input_invalid(
+                reason="missing_formula_input",
+                message=f"formula line missing binding for input '{declared_input.name}'",
+            )
+        snapshot_value = snapshot_values.get(snapshot_key)
+        if snapshot_value is None:
+            raise_input_invalid(reason="line_reference_missing", message="formula line references unknown snapshot entry")
+        resolved_snapshot_value = snapshot_value
+        if not _contracts_match(resolved_snapshot_value.contract, declared_input.contract):
+            raise_input_invalid(reason="unit_mismatch", message="formula input contract does not match bound snapshot")
+        formula_inputs[declared_input.name] = FormulaValue(
+            amount=resolved_snapshot_value.amount,
+            contract=resolved_snapshot_value.contract,
+        )
+        bound_keys.append(snapshot_key)
+        if resolved_snapshot_value.value_type == "quantity_input" and quantity_snapshot is None:
+            quantity_snapshot = resolved_snapshot_value
+
+    formula_result = evaluate_formula(resolved_formula_entry.definition, formula_inputs)
+    if formula_result.value.contract.kind != "money" or formula_result.value.contract.currency != "GBP":
+        raise_input_invalid(reason="unsupported_formula_output", message="formula lines must resolve to GBP money outputs")
+
+    pre_round_amount = formula_result.value.amount
+    evaluated_amount = _apply_formula_rounding(formula_result.value.amount, formula_result.rounding)
+    if evaluated_amount < 0:
+        raise_input_invalid(reason="negative_money", message="formula lines must resolve to nonnegative money")
+
+    subtotal_amount = _money(evaluated_amount)
+    bound_input_keys_json: list[JSONValue] = [key for key in bound_keys]
+    details: dict[str, JSONValue] = {
+        "formula_id": resolved_formula_entry.definition.formula_id,
+        "formula_version": resolved_formula_entry.definition.version,
+        "formula_checksum": resolved_formula_entry.definition.checksum,
+        "bound_input_keys": bound_input_keys_json,
+        "pre_round_amount": _decimal_text(pre_round_amount),
+        "evaluated_amount": _decimal_text(evaluated_amount),
+    }
+    if formula_result.rounding is not None:
+        details["applied_rounding"] = {
+            "scale": formula_result.rounding.scale,
+            "mode": formula_result.rounding.mode,
+        }
+
+    return _finalize_line_item(
+        engine_input=engine_input,
+        line_input=line_input,
+        line_number=line_number,
+        subtotal_amount=subtotal_amount,
+        quantity_snapshot_entry_id=quantity_snapshot.snapshot.id if quantity_snapshot is not None else None,
+        formula_snapshot_entry_id=deterministic_snapshot_entry_id(engine_input.estimate_job_id, resolved_formula_entry.entry_key),
+        quantity_value=quantity_snapshot.amount if quantity_snapshot is not None else None,
+        quantity_unit=quantity_snapshot.snapshot.unit if quantity_snapshot is not None else None,
+        rounding=formula_result.rounding,
+        details=details,
+    )
+
+
+def _finalize_line_item(
+    *,
+    engine_input: EstimateEngineInput,
+    line_input: EstimateLineInputSpec,
+    line_number: int,
+    subtotal_amount: Decimal,
+    quantity_snapshot_entry_id: UUID | None = None,
+    rate_snapshot_entry_id: UUID | None = None,
+    material_snapshot_entry_id: UUID | None = None,
+    formula_snapshot_entry_id: UUID | None = None,
+    assumption_snapshot_entry_id: UUID | None = None,
+    quantity_value: Decimal | None = None,
+    quantity_unit: str | None = None,
+    unit_rate_amount: Decimal | None = None,
+    effective_date: date | None = None,
+    rounding: RoundingSpec | None = None,
+    details: dict[str, JSONValue] | None = None,
+) -> EstimateLineSpec:
+    tax_amount = _money(subtotal_amount * engine_input.tax_rate)
+    total_amount = subtotal_amount + tax_amount
+    normalized_details: dict[str, JSONValue] = details or {}
+    return EstimateLineSpec(
+        id=deterministic_item_id(engine_input.estimate_job_id, line_input.line_key),
+        line_number=line_number,
+        line_key=line_input.line_key,
+        line_type=line_input.line_type,
+        description=line_input.description,
+        currency=engine_input.currency,
+        subtotal_amount=subtotal_amount,
+        tax_amount=tax_amount,
+        total_amount=total_amount,
+        quantity_snapshot_entry_id=quantity_snapshot_entry_id,
+        rate_snapshot_entry_id=rate_snapshot_entry_id,
+        material_snapshot_entry_id=material_snapshot_entry_id,
+        formula_snapshot_entry_id=formula_snapshot_entry_id,
+        assumption_snapshot_entry_id=assumption_snapshot_entry_id,
+        quantity_value=quantity_value,
+        quantity_unit=quantity_unit,
+        unit_rate_amount=unit_rate_amount,
+        effective_date=effective_date,
+        rounding=rounding,
+        details=normalized_details,
+    )
+
+
+def _register_snapshot(snapshot_keys: set[str], snapshot: EstimateSnapshotEntrySpec) -> None:
+    if snapshot.entry_key in snapshot_keys:
+        raise_input_invalid(reason="duplicate_snapshot_entry_key", message="snapshot entry keys must be unique")
+    snapshot_keys.add(snapshot.entry_key)
+
+
+def _register_line_key(line_keys: set[str], line_key: str) -> None:
+    if line_key in line_keys:
+        raise_input_invalid(reason="duplicate_line_key", message="line keys must be unique")
+    line_keys.add(line_key)
+
+
+def _resolve_snapshot_value(
+    snapshot_values: dict[str, _SnapshotValue],
+    entry_key: str | None,
+    *,
+    expected_type: _SnapshotValueType,
+) -> _SnapshotValue:
+    key = _required_key("entry_key", entry_key)
+    snapshot_value = snapshot_values.get(key)
+    if snapshot_value is None:
+        raise_input_invalid(reason="line_reference_missing", message="line references unknown snapshot entry")
+    resolved_snapshot_value = snapshot_value
+    if resolved_snapshot_value.value_type != expected_type:
+        raise_input_invalid(reason="line_reference_type_mismatch", message="line references incompatible snapshot entry type")
+    return resolved_snapshot_value
+
+
+def _validate_rate_unit_match(quantity_value: _SnapshotValue, rate_value: _SnapshotValue) -> None:
+    if rate_value.contract.per_unit != quantity_value.contract.unit:
+        raise_input_invalid(reason="unit_mismatch", message="estimate engine does not support unit conversion")
+
+
+def _apply_formula_rounding(amount: Decimal, rounding_spec: RoundingSpec | None) -> Decimal:
+    if rounding_spec is None:
+        return amount
+    quantum = Decimal(1).scaleb(-rounding_spec.scale)
+    return amount.quantize(quantum, rounding=rounding_spec.mode)
+
+
+def _money(value: Decimal) -> Decimal:
+    return value.quantize(_MONEY_QUANTUM, rounding=ROUND_HALF_UP)
+
+
+def _quantity_decimal(value: Decimal) -> Decimal:
+    return value.quantize(_CATALOG_QUANTUM)
+
+
+def _validate_money_rate_entry(
+    entry_key: str,
+    entry_label: str,
+    source_checksum_sha256: str,
+    unit: str,
+    currency: str,
+    unit_amount: Decimal,
+) -> None:
+    _validate_entry_key(entry_key)
+    _validate_non_empty_text("entry_label", entry_label)
+    _validate_checksum(source_checksum_sha256)
+    _validate_non_empty_text("unit", unit)
+    if currency != "GBP":
+        raise_input_invalid(reason="unsupported_currency", message="estimate engine supports GBP only")
+    if unit_amount < 0:
+        raise_input_invalid(reason="negative_money", message="unit amounts must be nonnegative")
+    if unit_amount.quantize(_CATALOG_QUANTUM) != unit_amount:
+        raise_input_invalid(
+            reason="invalid_rate_scale",
+            message="catalog unit amounts must use scale 6 or less",
+        )
+
+
+def _validate_checksum(checksum: str) -> None:
+    if not _CHECKSUM_PATTERN.fullmatch(checksum):
+        raise_input_invalid(reason="invalid_checksum", message="source checksums must be lowercase sha256 hex")
+
+
+def _validate_entry_key(entry_key: str) -> None:
+    _validate_non_empty_text("entry_key", entry_key)
+
+
+def _validate_non_empty_text(name: str, value: str) -> None:
+    if not value:
+        raise_input_invalid(reason="input_invalid", message=f"{name} must be a non-empty string")
+
+
+def _contracts_match(actual: ValueContract, expected: ValueContract) -> bool:
+    return (
+        actual.kind == expected.kind
+        and actual.currency == expected.currency
+        and actual.unit == expected.unit
+        and actual.per_unit == expected.per_unit
+    )
+
+
+def _required_key(name: str, value: str | None) -> str:
+    if value is None or not value:
+        raise_input_invalid(reason="missing_reference", message=f"{name} is required")
+    return value
+
+
+def _required_uuid(name: str, value: UUID | None) -> UUID:
+    if value is None:
+        raise_input_invalid(reason="missing_lineage", message=f"{name} is required")
+    return value
+
+
+def _required_quantity_gate(value: str | None) -> Literal["allowed", "provisional", "review_gated", "blocked"]:
+    if value is None:
+        raise_input_invalid(reason="quantity_gate_not_allowed", message="quantity_gate is required")
+    return value  # type: ignore[return-value]
+
+
+def _resolve_adjustment_anchor(
+    *,
+    engine_input: EstimateEngineInput,
+    line_input: EstimateLineInputSpec,
+    snapshot_values: dict[str, _SnapshotValue],
+    formula_entries: dict[str, EstimateFormulaEntryInput],
+) -> tuple[UUID | None, UUID | None]:
+    has_formula_anchor = bool(line_input.formula_entry_key)
+    has_assumption_anchor = bool(line_input.assumption_entry_key)
+    if has_formula_anchor == has_assumption_anchor:
+        raise_input_invalid(
+            reason="invalid_adjustment_anchor",
+            message="adjustment lines require exactly one formula or assumption anchor",
+        )
+
+    if line_input.formula_entry_key is not None:
+        formula_entry = formula_entries.get(line_input.formula_entry_key)
+        if formula_entry is None:
+            raise_input_invalid(
+                reason="line_reference_missing",
+                message="adjustment line references unknown formula entry",
+            )
+        return deterministic_snapshot_entry_id(engine_input.estimate_job_id, formula_entry.entry_key), None
+
+    assumption_value = _resolve_snapshot_value(
+        snapshot_values,
+        line_input.assumption_entry_key,
+        expected_type="assumption",
+    )
+    return None, assumption_value.snapshot.id
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"

--- a/tests/test_estimate_engine_contracts.py
+++ b/tests/test_estimate_engine_contracts.py
@@ -102,8 +102,9 @@ def test_engine_contracts_expose_deterministic_ids_and_frozen_specs() -> None:
 
     assert engine_input.currency == "GBP"
     assert engine_output.line_items[0].id == item_id
+    field_name = "description"
     with pytest.raises(FrozenInstanceError):
-        line.description = "mutated"
+        setattr(line, field_name, "mutated")
 
 
 def test_formula_definition_from_json_maps_dataclass_equivalent_json() -> None:
@@ -197,9 +198,24 @@ def test_formula_definition_from_selected_formula_uses_selected_formula_payloads
 @pytest.mark.parametrize(
     ("declared_inputs_json", "expression_json", "output_contract_json", "reason"),
     [
-        ([{"key": "quantity", "type": "decimal"}], {"kind": "literal", "value": "1"}, {"kind": "money", "currency": "GBP"}, "legacy_input_shape"),
-        ([{"name": "base", "contract": {"kind": "scalar"}}], {"op": "literal", "value": "1"}, {"kind": "money", "currency": "GBP"}, "legacy_node_shape"),
-        ([{"name": "base", "contract": {"kind": "scalar"}}], {"kind": "literal", "value": "1"}, {"kind": "money", "currency": "USD"}, "unsupported_currency"),
+        (
+            [{"key": "quantity", "type": "decimal"}],
+            {"kind": "literal", "value": "1"},
+            {"kind": "money", "currency": "GBP"},
+            "legacy_input_shape",
+        ),
+        (
+            [{"name": "base", "contract": {"kind": "scalar"}}],
+            {"op": "literal", "value": "1"},
+            {"kind": "money", "currency": "GBP"},
+            "legacy_node_shape",
+        ),
+        (
+            [{"name": "base", "contract": {"kind": "scalar"}}],
+            {"kind": "literal", "value": "1"},
+            {"kind": "money", "currency": "USD"},
+            "unsupported_currency",
+        ),
     ],
 )
 def test_formula_definition_from_json_rejects_legacy_and_unsupported_shapes(

--- a/tests/test_estimate_engine_contracts.py
+++ b/tests/test_estimate_engine_contracts.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import date
+from decimal import Decimal
+from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
+
+import pytest
+
+from app.estimating.catalog.selection import SelectedFormula
+from app.estimating.engine import (
+    EstimateEngineError,
+    EstimateEngineInput,
+    EstimateEngineOutput,
+    EstimateLineSpec,
+    EstimateSnapshotEntrySpec,
+    deterministic_estimate_version_id,
+    deterministic_item_id,
+    deterministic_snapshot_entry_id,
+    formula_definition_from_json,
+    formula_definition_from_selected_formula,
+)
+from app.estimating.formulas import (
+    FormulaDefinition,
+    FormulaInputDefinition,
+    FormulaNode,
+    RoundingSpec,
+    ValueContract,
+)
+
+SCALAR = ValueContract(kind="scalar")
+MONEY_GBP = ValueContract(kind="money", currency="GBP")
+QUANTITY_M = ValueContract(kind="quantity", unit="m")
+RATE_GBP_PER_M = ValueContract(kind="rate", currency="GBP", per_unit="m")
+
+
+def test_engine_contracts_expose_deterministic_ids_and_frozen_specs() -> None:
+    estimate_job_id = UUID("11111111-1111-1111-1111-111111111111")
+    snapshot_id = deterministic_snapshot_entry_id(estimate_job_id, "rate:installer")
+    item_id = deterministic_item_id(estimate_job_id, "line:1:rate")
+    version_id = deterministic_estimate_version_id(estimate_job_id)
+
+    assert version_id == uuid5(
+        NAMESPACE_URL,
+        "draupnir:estimate:11111111-1111-1111-1111-111111111111:version",
+    )
+    assert snapshot_id == uuid5(
+        NAMESPACE_URL,
+        "draupnir:estimate:11111111-1111-1111-1111-111111111111:snapshot:rate:installer",
+    )
+    assert item_id == uuid5(
+        NAMESPACE_URL,
+        "draupnir:estimate:11111111-1111-1111-1111-111111111111:item:line:1:rate",
+    )
+
+    snapshot = EstimateSnapshotEntrySpec(
+        id=snapshot_id,
+        entry_type="rate",
+        entry_key="rate:installer",
+        entry_label="Installer labour",
+        sort_order=1,
+        source_payload={"rate_key": "labour:installer"},
+        source_rate_id=uuid4(),
+        source_checksum_sha256="a" * 64,
+        unit="m",
+        currency="GBP",
+        effective_date=date(2026, 1, 1),
+        unit_amount=Decimal("12.345678"),
+        rounding=RoundingSpec(scale=2, mode="ROUND_HALF_UP"),
+    )
+    line = EstimateLineSpec(
+        id=item_id,
+        line_number=1,
+        line_key="line:1:rate",
+        line_type="rate",
+        description="Installer labour",
+        currency="GBP",
+        subtotal_amount=Decimal("10.00"),
+        tax_amount=Decimal("2.00"),
+        total_amount=Decimal("12.00"),
+        quantity_snapshot_entry_id=uuid4(),
+        rate_snapshot_entry_id=snapshot.id,
+        quantity_value=Decimal("5.0"),
+        quantity_unit="m",
+        unit_rate_amount=Decimal("12.345678"),
+        effective_date=date(2026, 1, 1),
+    )
+    engine_input = EstimateEngineInput(
+        estimate_job_id=estimate_job_id,
+        project_id=uuid4(),
+        drawing_revision_id=uuid4(),
+        quantity_takeoff_id=uuid4(),
+        snapshot_entries=(snapshot,),
+        line_specs=(line,),
+    )
+    engine_output = EstimateEngineOutput(
+        estimate_version_id=version_id,
+        currency="GBP",
+        snapshot_entries=(snapshot,),
+        line_items=(line,),
+    )
+
+    assert engine_input.currency == "GBP"
+    assert engine_output.line_items[0].id == item_id
+    with pytest.raises(FrozenInstanceError):
+        line.description = "mutated"
+
+
+def test_formula_definition_from_json_maps_dataclass_equivalent_json() -> None:
+    definition = formula_definition_from_json(
+        formula_id="formula.paint_total",
+        name="Paint total",
+        version=1,
+        checksum="c" * 64,
+        output_key="estimate.paint_total",
+        output_contract_json={"kind": "money", "currency": "GBP"},
+        declared_inputs_json=[
+            {"name": "rate", "contract": {"kind": "rate", "currency": "GBP", "per_unit": "m"}},
+            {"name": "quantity", "contract": {"kind": "quantity", "unit": "m"}},
+        ],
+        expression_json={
+            "kind": "round",
+            "args": [
+                {
+                    "kind": "multiply",
+                    "args": [
+                        {"kind": "input", "name": "rate"},
+                        {"kind": "input", "name": "quantity"},
+                    ],
+                }
+            ],
+            "rounding": {"scale": 2, "mode": "ROUND_HALF_UP"},
+        },
+        rounding_json={"scale": 2, "mode": "ROUND_HALF_UP"},
+    )
+
+    assert definition == FormulaDefinition(
+        formula_id="formula.paint_total",
+        name="Paint total",
+        version=1,
+        checksum="c" * 64,
+        output_key="estimate.paint_total",
+        output_contract=MONEY_GBP,
+        declared_inputs=(
+            FormulaInputDefinition(name="rate", contract=RATE_GBP_PER_M),
+            FormulaInputDefinition(name="quantity", contract=QUANTITY_M),
+        ),
+        expression=FormulaNode(
+            kind="round",
+            args=(
+                FormulaNode(
+                    kind="multiply",
+                    args=(
+                        FormulaNode(kind="input", name="rate"),
+                        FormulaNode(kind="input", name="quantity"),
+                    ),
+                ),
+            ),
+            rounding=RoundingSpec(scale=2, mode="ROUND_HALF_UP"),
+        ),
+        rounding=RoundingSpec(scale=2, mode="ROUND_HALF_UP"),
+    )
+
+
+def test_formula_definition_from_selected_formula_uses_selected_formula_payloads() -> None:
+    selected = SelectedFormula(
+        definition_id=uuid4(),
+        scope_type="project",
+        project_id=uuid4(),
+        formula_id="formula.selected",
+        version=2,
+        name="Selected formula",
+        dsl_version="1.0",
+        output_key="estimate.selected",
+        output_contract={"kind": "scalar"},
+        declared_inputs=[{"name": "base", "contract": {"kind": "scalar"}}],
+        checksum_sha256="d" * 64,
+        expression={"kind": "input", "name": "base"},
+        rounding=None,
+    )
+
+    definition = formula_definition_from_selected_formula(selected)
+
+    assert definition == FormulaDefinition(
+        formula_id="formula.selected",
+        name="Selected formula",
+        version=2,
+        checksum="d" * 64,
+        output_key="estimate.selected",
+        output_contract=SCALAR,
+        declared_inputs=(FormulaInputDefinition(name="base", contract=SCALAR),),
+        expression=FormulaNode(kind="input", name="base"),
+        rounding=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("declared_inputs_json", "expression_json", "output_contract_json", "reason"),
+    [
+        ([{"key": "quantity", "type": "decimal"}], {"kind": "literal", "value": "1"}, {"kind": "money", "currency": "GBP"}, "legacy_input_shape"),
+        ([{"name": "base", "contract": {"kind": "scalar"}}], {"op": "literal", "value": "1"}, {"kind": "money", "currency": "GBP"}, "legacy_node_shape"),
+        ([{"name": "base", "contract": {"kind": "scalar"}}], {"kind": "literal", "value": "1"}, {"kind": "money", "currency": "USD"}, "unsupported_currency"),
+    ],
+)
+def test_formula_definition_from_json_rejects_legacy_and_unsupported_shapes(
+    declared_inputs_json: list[dict[str, str | dict[str, str]]],
+    expression_json: dict[str, object],
+    output_contract_json: dict[str, str],
+    reason: str,
+) -> None:
+    with pytest.raises(EstimateEngineError) as exc_info:
+        formula_definition_from_json(
+            formula_id="formula.invalid",
+            name="Invalid formula",
+            version=1,
+            checksum="e" * 64,
+            output_key="estimate.invalid",
+            output_contract_json=output_contract_json,
+            declared_inputs_json=declared_inputs_json,
+            expression_json=expression_json,
+        )
+
+    assert exc_info.value.code == "UNSUPPORTED_FORMULA_JSON"
+    assert exc_info.value.reason == reason

--- a/tests/test_estimate_engine_persistence_payloads.py
+++ b/tests/test_estimate_engine_persistence_payloads.py
@@ -297,7 +297,10 @@ async def test_engine_output_persists_and_replays_with_orm_payloads(
 ) -> None:
     seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
     estimate_job_id = await _create_estimate_job(db_session, seed)
-    installer_rate, formula_rate, material, formula = await _create_catalog_rows(db_session, seed.project_id)
+    installer_rate, formula_rate, material, formula = await _create_catalog_rows(
+        db_session,
+        seed.project_id,
+    )
     engine_input = _build_engine_input(
         seed,
         estimate_job_id=estimate_job_id,
@@ -315,7 +318,9 @@ async def test_engine_output_persists_and_replays_with_orm_payloads(
     assert result.line_item_model_kwargs() == replay.line_item_model_kwargs()
 
     estimate_version = EstimateVersion(**result.estimate_version_model_kwargs())
-    snapshot_entries = [EstimateSnapshotEntry(**payload) for payload in result.snapshot_entry_model_kwargs()]
+    snapshot_entries = [
+        EstimateSnapshotEntry(**payload) for payload in result.snapshot_entry_model_kwargs()
+    ]
     line_items = [EstimateItem(**payload) for payload in result.line_item_model_kwargs()]
 
     db_session.add(estimate_version)
@@ -343,9 +348,15 @@ async def test_engine_output_persists_and_replays_with_orm_payloads(
     assert len(persisted_snapshots) == 7
     assert len(persisted_items) == 5
 
-    quantity_snapshot = next(entry for entry in persisted_snapshots if entry.entry_key == "quantity:labour")
-    formula_snapshot = next(entry for entry in persisted_snapshots if entry.entry_key == "formula:rounded_markup")
-    assumption_snapshot = next(entry for entry in persisted_snapshots if entry.entry_key == "assumption:mobilisation")
+    quantity_snapshot = next(
+        entry for entry in persisted_snapshots if entry.entry_key == "quantity:labour"
+    )
+    formula_snapshot = next(
+        entry for entry in persisted_snapshots if entry.entry_key == "formula:rounded_markup"
+    )
+    assumption_snapshot = next(
+        entry for entry in persisted_snapshots if entry.entry_key == "assumption:mobilisation"
+    )
     formula_item = next(item for item in persisted_items if item.line_key == "line:formula")
     adjustment_item = next(item for item in persisted_items if item.line_key == "line:adjustment")
 
@@ -358,8 +369,19 @@ async def test_engine_output_persists_and_replays_with_orm_payloads(
         "output_key": "estimate.rounded_markup",
         "output_contract": {"kind": "money", "currency": "GBP", "unit": None, "per_unit": None},
         "declared_inputs": [
-            {"name": "rate", "contract": {"kind": "rate", "currency": "GBP", "unit": None, "per_unit": "m"}},
-            {"name": "quantity", "contract": {"kind": "quantity", "currency": None, "unit": "m", "per_unit": None}},
+            {
+                "name": "rate",
+                "contract": {"kind": "rate", "currency": "GBP", "unit": None, "per_unit": "m"},
+            },
+            {
+                "name": "quantity",
+                "contract": {
+                    "kind": "quantity",
+                    "currency": None,
+                    "unit": "m",
+                    "per_unit": None,
+                },
+            },
         ],
         "expression": {
             "kind": "multiply",
@@ -461,7 +483,9 @@ async def test_engine_output_replays_rate_lines_from_persisted_quantity_scale(
     replay = compose_estimate(_engine_input(Decimal("0.290000")))
 
     estimate_version = EstimateVersion(**result.estimate_version_model_kwargs())
-    snapshot_entries = [EstimateSnapshotEntry(**payload) for payload in result.snapshot_entry_model_kwargs()]
+    snapshot_entries = [
+        EstimateSnapshotEntry(**payload) for payload in result.snapshot_entry_model_kwargs()
+    ]
     line_items = [EstimateItem(**payload) for payload in result.line_item_model_kwargs()]
 
     db_session.add(estimate_version)
@@ -474,7 +498,9 @@ async def test_engine_output_replays_rate_lines_from_persisted_quantity_scale(
     persisted_snapshot = await db_session.scalar(
         select(EstimateSnapshotEntry).where(EstimateSnapshotEntry.entry_key == "quantity:labour")
     )
-    persisted_item = await db_session.scalar(select(EstimateItem).where(EstimateItem.line_key == "line:replay"))
+    persisted_item = await db_session.scalar(
+        select(EstimateItem).where(EstimateItem.line_key == "line:replay")
+    )
 
     assert persisted_snapshot is not None
     assert persisted_item is not None

--- a/tests/test_estimate_engine_persistence_payloads.py
+++ b/tests/test_estimate_engine_persistence_payloads.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import date
+from decimal import Decimal
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+from app.estimating.engine import formula_definition_from_json
+from app.estimating.engine.contracts import (
+    EstimateAssumptionEntryInput,
+    EstimateEngineInput,
+    EstimateFormulaEntryInput,
+    EstimateLineInputSpec,
+    EstimateMaterialEntryInput,
+    EstimateQuantityEntryInput,
+    EstimateRateEntryInput,
+)
+from app.estimating.engine.service import compose_estimate
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
+from app.models.estimation_catalog import EstimationFormula, EstimationMaterial, EstimationRate
+from app.models.job import Job, JobStatus, JobType
+from tests import test_quantity_takeoff_persistence as quantity_takeoff_persistence
+from tests.conftest import requires_database
+
+pytest_plugins = ("tests.test_quantity_takeoff_persistence",)
+pytestmark = [pytest.mark.asyncio, requires_database]
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_projects: None) -> AsyncGenerator[AsyncSession, None]:
+    _ = cleanup_projects
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+async def _create_estimate_job(
+    db_session: AsyncSession,
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+) -> uuid.UUID:
+    estimate_job_id = uuid.uuid4()
+    db_session.add(
+        Job(
+            id=estimate_job_id,
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=None,
+            base_revision_id=seed.drawing_revision_id,
+            parent_job_id=seed.quantity_job_id,
+            job_type=JobType.ESTIMATE.value,
+            status=JobStatus.SUCCEEDED.value,
+            enqueue_status="published",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        )
+    )
+    await db_session.commit()
+    return estimate_job_id
+
+
+async def _create_catalog_rows(
+    db_session: AsyncSession,
+    project_id: uuid.UUID,
+) -> tuple[EstimationRate, EstimationRate, EstimationMaterial, EstimationFormula]:
+    installer_rate = EstimationRate(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        rate_key="labour:installer",
+        source="test",
+        metadata_json={"source": "test"},
+        name="Installer labour",
+        item_type="linear_length",
+        per_unit="m",
+        currency="GBP",
+        amount=Decimal("12.345678"),
+        effective_from=date(2026, 1, 1),
+        checksum_sha256="c" * 64,
+    )
+    formula_rate = EstimationRate(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        rate_key="labour:formula",
+        source="test",
+        metadata_json={"source": "test"},
+        name="Formula rate",
+        item_type="linear_length",
+        per_unit="m",
+        currency="GBP",
+        amount=Decimal("0.496000"),
+        effective_from=date(2026, 1, 1),
+        checksum_sha256="d" * 64,
+    )
+    material = EstimationMaterial(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        material_key="paint:standard",
+        source="test",
+        metadata_json={"source": "test"},
+        name="Paint",
+        unit="m",
+        currency="GBP",
+        unit_cost=Decimal("3.210000"),
+        effective_from=date(2026, 1, 1),
+        checksum_sha256="1" * 64,
+    )
+    formula = EstimationFormula(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=project_id,
+        formula_id="formula.rounded_markup",
+        version=1,
+        name="Rounded markup",
+        dsl_version="0.1",
+        output_key="estimate.rounded_markup",
+        output_contract_json={"kind": "money", "currency": "GBP"},
+        declared_inputs_json=[
+            {"name": "rate", "contract": {"kind": "rate", "currency": "GBP", "per_unit": "m"}},
+            {"name": "quantity", "contract": {"kind": "quantity", "unit": "m"}},
+        ],
+        expression_json={
+            "kind": "multiply",
+            "args": [
+                {"kind": "input", "name": "rate"},
+                {"kind": "input", "name": "quantity"},
+            ],
+        },
+        rounding_json={"scale": 1, "mode": "ROUND_HALF_UP"},
+        checksum_sha256="f" * 64,
+    )
+    db_session.add_all([installer_rate, formula_rate, material, formula])
+    await db_session.commit()
+    return installer_rate, formula_rate, material, formula
+
+
+def _build_engine_input(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    *,
+    estimate_job_id: uuid.UUID,
+    installer_rate: EstimationRate,
+    formula_rate: EstimationRate,
+    material: EstimationMaterial,
+    formula: EstimationFormula,
+) -> EstimateEngineInput:
+    formula_definition = formula_definition_from_json(
+        formula_id=formula.formula_id,
+        name=formula.name,
+        version=formula.version,
+        checksum=formula.checksum_sha256,
+        output_key=formula.output_key,
+        output_contract_json=formula.output_contract_json,
+        declared_inputs_json=formula.declared_inputs_json,
+        expression_json=formula.expression_json,
+        rounding_json=formula.rounding_json,
+    )
+    return EstimateEngineInput(
+        estimate_job_id=estimate_job_id,
+        project_id=seed.project_id,
+        file_id=seed.file_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        quantity_takeoff_id=seed.quantity_takeoff_id,
+        source_job_id=estimate_job_id,
+        quantity_gate="allowed",
+        trusted_totals=True,
+        tax_rate=Decimal("0.20"),
+        quantity_entries=(
+            EstimateQuantityEntryInput(
+                entry_key="quantity:labour",
+                entry_label="Labour quantity",
+                sort_order=1,
+                source_quantity_item_id=seed.quantity_item_id,
+                source_checksum_sha256="a" * 64,
+                quantity_value=Decimal("2.5"),
+                unit="m",
+                source_quantity_takeoff_id=seed.quantity_takeoff_id,
+                source_payload={"source": "takeoff"},
+            ),
+            EstimateQuantityEntryInput(
+                entry_key="quantity:material",
+                entry_label="Material quantity",
+                sort_order=2,
+                source_quantity_item_id=seed.quantity_item_id,
+                source_checksum_sha256="b" * 64,
+                quantity_value=Decimal("1.25"),
+                unit="m",
+                source_quantity_takeoff_id=seed.quantity_takeoff_id,
+            ),
+        ),
+        rate_entries=(
+            EstimateRateEntryInput(
+                entry_key="rate:installer",
+                entry_label="Installer labour",
+                sort_order=3,
+                source_rate_id=installer_rate.id,
+                source_checksum_sha256=installer_rate.checksum_sha256,
+                unit=installer_rate.per_unit,
+                effective_date=installer_rate.effective_from,
+                unit_amount=installer_rate.amount,
+            ),
+            EstimateRateEntryInput(
+                entry_key="rate:formula",
+                entry_label="Formula rate",
+                sort_order=4,
+                source_rate_id=formula_rate.id,
+                source_checksum_sha256=formula_rate.checksum_sha256,
+                unit=formula_rate.per_unit,
+                effective_date=formula_rate.effective_from,
+                unit_amount=formula_rate.amount,
+            ),
+        ),
+        material_entries=(
+            EstimateMaterialEntryInput(
+                entry_key="material:paint",
+                entry_label="Paint",
+                sort_order=5,
+                source_material_id=material.id,
+                source_checksum_sha256=material.checksum_sha256,
+                unit=material.unit,
+                effective_date=material.effective_from,
+                unit_amount=material.unit_cost,
+            ),
+        ),
+        formula_entries=(
+            EstimateFormulaEntryInput(
+                entry_key="formula:rounded_markup",
+                entry_label="Rounded markup",
+                sort_order=6,
+                source_formula_id=formula.id,
+                source_checksum_sha256=formula.checksum_sha256,
+                definition=formula_definition,
+            ),
+        ),
+        assumption_entries=(
+            EstimateAssumptionEntryInput(
+                entry_key="assumption:mobilisation",
+                entry_label="Mobilisation",
+                sort_order=7,
+                source_checksum_sha256="2" * 64,
+                amount=Decimal("5.555"),
+            ),
+        ),
+        line_inputs=(
+            EstimateLineInputSpec(
+                line_key="line:labour",
+                line_type="rate",
+                description="Installer labour",
+                quantity_entry_key="quantity:labour",
+                rate_entry_key="rate:installer",
+            ),
+            EstimateLineInputSpec(
+                line_key="line:material",
+                line_type="material",
+                description="Paint",
+                quantity_entry_key="quantity:material",
+                material_entry_key="material:paint",
+            ),
+            EstimateLineInputSpec(
+                line_key="line:formula",
+                line_type="formula",
+                description="Rounded markup",
+                formula_entry_key="formula:rounded_markup",
+                formula_inputs={"rate": "rate:formula", "quantity": "quantity:labour"},
+            ),
+            EstimateLineInputSpec(
+                line_key="line:assumption",
+                line_type="assumption",
+                description="Mobilisation",
+                assumption_entry_key="assumption:mobilisation",
+            ),
+            EstimateLineInputSpec(
+                line_key="line:adjustment",
+                line_type="adjustment",
+                description="Access uplift",
+                assumption_entry_key="assumption:mobilisation",
+                adjustment_amount=Decimal("2.225"),
+            ),
+        ),
+    )
+
+
+async def test_engine_output_persists_and_replays_with_orm_payloads(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    estimate_job_id = await _create_estimate_job(db_session, seed)
+    installer_rate, formula_rate, material, formula = await _create_catalog_rows(db_session, seed.project_id)
+    engine_input = _build_engine_input(
+        seed,
+        estimate_job_id=estimate_job_id,
+        installer_rate=installer_rate,
+        formula_rate=formula_rate,
+        material=material,
+        formula=formula,
+    )
+
+    result = compose_estimate(engine_input)
+    replay = compose_estimate(engine_input)
+
+    assert result.estimate_version_model_kwargs() == replay.estimate_version_model_kwargs()
+    assert result.snapshot_entry_model_kwargs() == replay.snapshot_entry_model_kwargs()
+    assert result.line_item_model_kwargs() == replay.line_item_model_kwargs()
+
+    estimate_version = EstimateVersion(**result.estimate_version_model_kwargs())
+    snapshot_entries = [EstimateSnapshotEntry(**payload) for payload in result.snapshot_entry_model_kwargs()]
+    line_items = [EstimateItem(**payload) for payload in result.line_item_model_kwargs()]
+
+    db_session.add(estimate_version)
+    await db_session.commit()
+    db_session.add_all(snapshot_entries)
+    await db_session.commit()
+    db_session.add_all(line_items)
+    await db_session.commit()
+
+    persisted_snapshots = list(
+        await db_session.scalars(
+            select(EstimateSnapshotEntry)
+            .where(EstimateSnapshotEntry.estimate_version_id == result.estimate_version_id)
+            .order_by(EstimateSnapshotEntry.sort_order)
+        )
+    )
+    persisted_items = list(
+        await db_session.scalars(
+            select(EstimateItem)
+            .where(EstimateItem.estimate_version_id == result.estimate_version_id)
+            .order_by(EstimateItem.line_number)
+        )
+    )
+
+    assert len(persisted_snapshots) == 7
+    assert len(persisted_items) == 5
+
+    quantity_snapshot = next(entry for entry in persisted_snapshots if entry.entry_key == "quantity:labour")
+    formula_snapshot = next(entry for entry in persisted_snapshots if entry.entry_key == "formula:rounded_markup")
+    assumption_snapshot = next(entry for entry in persisted_snapshots if entry.entry_key == "assumption:mobilisation")
+    formula_item = next(item for item in persisted_items if item.line_key == "line:formula")
+    adjustment_item = next(item for item in persisted_items if item.line_key == "line:adjustment")
+
+    assert quantity_snapshot.source_checksum_sha256 is None
+    assert formula_snapshot.source_payload_json["formula_definition"] == {
+        "formula_id": "formula.rounded_markup",
+        "name": "Rounded markup",
+        "version": 1,
+        "checksum": "f" * 64,
+        "output_key": "estimate.rounded_markup",
+        "output_contract": {"kind": "money", "currency": "GBP", "unit": None, "per_unit": None},
+        "declared_inputs": [
+            {"name": "rate", "contract": {"kind": "rate", "currency": "GBP", "unit": None, "per_unit": "m"}},
+            {"name": "quantity", "contract": {"kind": "quantity", "currency": None, "unit": "m", "per_unit": None}},
+        ],
+        "expression": {
+            "kind": "multiply",
+            "value": None,
+            "name": None,
+            "args": [
+                {"kind": "input", "value": None, "name": "rate", "args": [], "rounding": None},
+                {"kind": "input", "value": None, "name": "quantity", "args": [], "rounding": None},
+            ],
+            "rounding": None,
+        },
+        "rounding": {"scale": 1, "mode": "ROUND_HALF_UP"},
+    }
+    assert assumption_snapshot.currency is None
+    assert assumption_snapshot.source_checksum_sha256 is None
+    assert assumption_snapshot.source_payload_json == {"money_amount": "5.555"}
+    assert formula_item.formula_snapshot_entry_id == formula_snapshot.id
+    assert formula_item.quantity_snapshot_entry_id == quantity_snapshot.id
+    assert formula_item.quantity_value == Decimal("2.500000")
+    assert formula_item.quantity_unit == "m"
+    assert formula_item.rate_snapshot_entry_id is None
+    assert formula_item.material_snapshot_entry_id is None
+    assert formula_item.assumption_snapshot_entry_id is None
+    assert adjustment_item.formula_snapshot_entry_id is None
+    assert adjustment_item.assumption_snapshot_entry_id == assumption_snapshot.id
+
+
+async def test_engine_output_replays_rate_lines_from_persisted_quantity_scale(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    estimate_job_id = await _create_estimate_job(db_session, seed)
+    replay_rate = EstimationRate(
+        id=uuid.uuid4(),
+        scope_type="project",
+        project_id=seed.project_id,
+        rate_key="labour:replay",
+        source="test",
+        metadata_json={"source": "test"},
+        name="Replay labour",
+        item_type="linear_length",
+        per_unit="m",
+        currency="GBP",
+        amount=Decimal("0.500000"),
+        effective_from=date(2026, 1, 1),
+        checksum_sha256="e" * 64,
+    )
+    db_session.add(replay_rate)
+    await db_session.commit()
+
+    def _engine_input(quantity_value: Decimal) -> EstimateEngineInput:
+        return EstimateEngineInput(
+            estimate_job_id=estimate_job_id,
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            drawing_revision_id=seed.drawing_revision_id,
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            source_job_id=estimate_job_id,
+            quantity_gate="allowed",
+            trusted_totals=True,
+            tax_rate=Decimal("0"),
+            quantity_entries=(
+                EstimateQuantityEntryInput(
+                    entry_key="quantity:labour",
+                    entry_label="Labour quantity",
+                    sort_order=1,
+                    source_quantity_item_id=seed.quantity_item_id,
+                    source_checksum_sha256="a" * 64,
+                    quantity_value=quantity_value,
+                    unit="m",
+                    source_quantity_takeoff_id=seed.quantity_takeoff_id,
+                ),
+            ),
+            rate_entries=(
+                EstimateRateEntryInput(
+                    entry_key="rate:replay",
+                    entry_label="Replay labour",
+                    sort_order=2,
+                    source_rate_id=replay_rate.id,
+                    source_checksum_sha256=replay_rate.checksum_sha256,
+                    unit=replay_rate.per_unit,
+                    effective_date=replay_rate.effective_from,
+                    unit_amount=replay_rate.amount,
+                ),
+            ),
+            line_inputs=(
+                EstimateLineInputSpec(
+                    line_key="line:replay",
+                    line_type="rate",
+                    description="Replay labour",
+                    quantity_entry_key="quantity:labour",
+                    rate_entry_key="rate:replay",
+                ),
+            ),
+        )
+
+    result = compose_estimate(_engine_input(Decimal("0.29")))
+    replay = compose_estimate(_engine_input(Decimal("0.290000")))
+
+    estimate_version = EstimateVersion(**result.estimate_version_model_kwargs())
+    snapshot_entries = [EstimateSnapshotEntry(**payload) for payload in result.snapshot_entry_model_kwargs()]
+    line_items = [EstimateItem(**payload) for payload in result.line_item_model_kwargs()]
+
+    db_session.add(estimate_version)
+    await db_session.commit()
+    db_session.add_all(snapshot_entries)
+    await db_session.commit()
+    db_session.add_all(line_items)
+    await db_session.commit()
+
+    persisted_snapshot = await db_session.scalar(
+        select(EstimateSnapshotEntry).where(EstimateSnapshotEntry.entry_key == "quantity:labour")
+    )
+    persisted_item = await db_session.scalar(select(EstimateItem).where(EstimateItem.line_key == "line:replay"))
+
+    assert persisted_snapshot is not None
+    assert persisted_item is not None
+    assert persisted_snapshot.quantity_value == Decimal("0.290000")
+    assert persisted_item.quantity_value == Decimal("0.290000")
+    assert persisted_item.subtotal_amount == Decimal("0.15")
+    assert result.snapshot_entry_model_kwargs() == replay.snapshot_entry_model_kwargs()
+    assert result.line_item_model_kwargs() == replay.line_item_model_kwargs()

--- a/tests/test_estimate_engine_service.py
+++ b/tests/test_estimate_engine_service.py
@@ -197,7 +197,9 @@ def test_compose_estimate_builds_deterministic_payloads_and_totals() -> None:
 
     result = compose_estimate(engine_input)
 
-    assert result.estimate_version_id == deterministic_estimate_version_id(engine_input.estimate_job_id)
+    assert result.estimate_version_id == deterministic_estimate_version_id(
+        engine_input.estimate_job_id
+    )
     assert result.header is not None
     assert result.header.file_id == engine_input.file_id
     assert result.header.source_job_id == engine_input.source_job_id
@@ -274,10 +276,14 @@ def test_compose_estimate_builds_deterministic_payloads_and_totals() -> None:
         payload for payload in snapshot_payloads if payload["entry_key"] == "formula:rounded_markup"
     )
     assumption_snapshot_payload = next(
-        payload for payload in snapshot_payloads if payload["entry_key"] == "assumption:mobilisation"
+        payload
+        for payload in snapshot_payloads
+        if payload["entry_key"] == "assumption:mobilisation"
     )
     formula_line_payload = next(
-        payload for payload in result.line_item_model_kwargs() if payload["line_key"] == "line:formula"
+        payload
+        for payload in result.line_item_model_kwargs()
+        if payload["line_key"] == "line:formula"
     )
 
     assert result.estimate_version_model_kwargs()["quantity_gate"] == "allowed"
@@ -290,8 +296,19 @@ def test_compose_estimate_builds_deterministic_payloads_and_totals() -> None:
             "output_key": "estimate.rounded_markup",
             "output_contract": {"kind": "money", "currency": "GBP", "unit": None, "per_unit": None},
             "declared_inputs": [
-                {"name": "rate", "contract": {"kind": "rate", "currency": "GBP", "unit": None, "per_unit": "m"}},
-                {"name": "quantity", "contract": {"kind": "quantity", "currency": None, "unit": "m", "per_unit": None}},
+                {
+                    "name": "rate",
+                    "contract": {"kind": "rate", "currency": "GBP", "unit": None, "per_unit": "m"},
+                },
+                {
+                    "name": "quantity",
+                    "contract": {
+                        "kind": "quantity",
+                        "currency": None,
+                        "unit": "m",
+                        "per_unit": None,
+                    },
+                },
             ],
             "expression": {
                 "kind": "multiply",
@@ -299,7 +316,13 @@ def test_compose_estimate_builds_deterministic_payloads_and_totals() -> None:
                 "name": None,
                 "args": [
                     {"kind": "input", "value": None, "name": "rate", "args": [], "rounding": None},
-                    {"kind": "input", "value": None, "name": "quantity", "args": [], "rounding": None},
+                    {
+                        "kind": "input",
+                        "value": None,
+                        "name": "quantity",
+                        "args": [],
+                        "rounding": None,
+                    },
                 ],
                 "rounding": None,
             },

--- a/tests/test_estimate_engine_service.py
+++ b/tests/test_estimate_engine_service.py
@@ -1,0 +1,592 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.estimating.engine.contracts import (
+    EstimateAssumptionEntryInput,
+    EstimateEngineInput,
+    EstimateFormulaEntryInput,
+    EstimateLineInputSpec,
+    EstimateMaterialEntryInput,
+    EstimateQuantityEntryInput,
+    EstimateRateEntryInput,
+    deterministic_estimate_version_id,
+    deterministic_item_id,
+    deterministic_snapshot_entry_id,
+)
+from app.estimating.engine.errors import EstimateEngineError
+from app.estimating.engine.service import compose_estimate
+from app.estimating.formulas import (
+    FormulaDefinition,
+    FormulaInputDefinition,
+    FormulaNode,
+    RoundingSpec,
+    ValueContract,
+)
+
+QUANTITY_M = ValueContract(kind="quantity", unit="m")
+RATE_GBP_PER_M = ValueContract(kind="rate", currency="GBP", per_unit="m")
+MONEY_GBP = ValueContract(kind="money", currency="GBP")
+
+
+def _formula_definition() -> FormulaDefinition:
+    return FormulaDefinition(
+        formula_id="formula.rounded_markup",
+        name="Rounded markup",
+        version=1,
+        checksum="f" * 64,
+        output_key="estimate.rounded_markup",
+        output_contract=MONEY_GBP,
+        declared_inputs=(
+            FormulaInputDefinition(name="rate", contract=RATE_GBP_PER_M),
+            FormulaInputDefinition(name="quantity", contract=QUANTITY_M),
+        ),
+        expression=FormulaNode(
+            kind="multiply",
+            args=(
+                FormulaNode(kind="input", name="rate"),
+                FormulaNode(kind="input", name="quantity"),
+            ),
+        ),
+        rounding=RoundingSpec(scale=1, mode="ROUND_HALF_UP"),
+    )
+
+
+def _valid_engine_input(*, quantity_gate: str = "allowed") -> EstimateEngineInput:
+    estimate_job_id = UUID("11111111-1111-1111-1111-111111111111")
+    project_id = UUID("22222222-2222-2222-2222-222222222222")
+    file_id = UUID("33333333-3333-3333-3333-333333333333")
+    drawing_revision_id = UUID("44444444-4444-4444-4444-444444444444")
+    quantity_takeoff_id = UUID("55555555-5555-5555-5555-555555555555")
+    source_job_id = UUID("66666666-6666-6666-6666-666666666666")
+    formula_definition = _formula_definition()
+    return EstimateEngineInput(
+        estimate_job_id=estimate_job_id,
+        project_id=project_id,
+        file_id=file_id,
+        drawing_revision_id=drawing_revision_id,
+        quantity_takeoff_id=quantity_takeoff_id,
+        source_job_id=source_job_id,
+        quantity_gate=quantity_gate,  # type: ignore[arg-type]
+        trusted_totals=True,
+        tax_rate=Decimal("0.20"),
+        quantity_entries=(
+            EstimateQuantityEntryInput(
+                entry_key="quantity:labour",
+                entry_label="Labour quantity",
+                sort_order=1,
+                source_quantity_item_id=uuid4(),
+                source_checksum_sha256="a" * 64,
+                quantity_value=Decimal("2.5"),
+                unit="m",
+                source_quantity_takeoff_id=quantity_takeoff_id,
+                source_payload={"source": "takeoff"},
+            ),
+            EstimateQuantityEntryInput(
+                entry_key="quantity:material",
+                entry_label="Material quantity",
+                sort_order=2,
+                source_quantity_item_id=uuid4(),
+                source_checksum_sha256="b" * 64,
+                quantity_value=Decimal("1.25"),
+                unit="m",
+                source_quantity_takeoff_id=quantity_takeoff_id,
+            ),
+        ),
+        rate_entries=(
+            EstimateRateEntryInput(
+                entry_key="rate:installer",
+                entry_label="Installer labour",
+                sort_order=3,
+                source_rate_id=uuid4(),
+                source_checksum_sha256="c" * 64,
+                unit="m",
+                effective_date=date(2026, 1, 1),
+                unit_amount=Decimal("12.345678"),
+            ),
+            EstimateRateEntryInput(
+                entry_key="rate:formula",
+                entry_label="Formula rate",
+                sort_order=4,
+                source_rate_id=uuid4(),
+                source_checksum_sha256="d" * 64,
+                unit="m",
+                effective_date=date(2026, 1, 1),
+                unit_amount=Decimal("0.496000"),
+            ),
+        ),
+        material_entries=(
+            EstimateMaterialEntryInput(
+                entry_key="material:paint",
+                entry_label="Paint",
+                sort_order=5,
+                source_material_id=uuid4(),
+                source_checksum_sha256="1" * 64,
+                unit="m",
+                effective_date=date(2026, 1, 1),
+                unit_amount=Decimal("3.210000"),
+            ),
+        ),
+        formula_entries=(
+            EstimateFormulaEntryInput(
+                entry_key="formula:rounded_markup",
+                entry_label="Rounded markup",
+                sort_order=6,
+                source_formula_id=uuid4(),
+                source_checksum_sha256=formula_definition.checksum,
+                definition=formula_definition,
+            ),
+        ),
+        assumption_entries=(
+            EstimateAssumptionEntryInput(
+                entry_key="assumption:mobilisation",
+                entry_label="Mobilisation",
+                sort_order=7,
+                source_checksum_sha256="2" * 64,
+                amount=Decimal("5.555"),
+            ),
+        ),
+        line_inputs=(
+            EstimateLineInputSpec(
+                line_key="line:labour",
+                line_type="rate",
+                description="Installer labour",
+                quantity_entry_key="quantity:labour",
+                rate_entry_key="rate:installer",
+            ),
+            EstimateLineInputSpec(
+                line_key="line:material",
+                line_type="material",
+                description="Paint",
+                quantity_entry_key="quantity:material",
+                material_entry_key="material:paint",
+            ),
+            EstimateLineInputSpec(
+                line_key="line:formula",
+                line_type="formula",
+                description="Rounded markup",
+                formula_entry_key="formula:rounded_markup",
+                formula_inputs={
+                    "rate": "rate:formula",
+                    "quantity": "quantity:labour",
+                },
+            ),
+            EstimateLineInputSpec(
+                line_key="line:assumption",
+                line_type="assumption",
+                description="Mobilisation",
+                assumption_entry_key="assumption:mobilisation",
+            ),
+            EstimateLineInputSpec(
+                line_key="line:adjustment",
+                line_type="adjustment",
+                description="Access uplift",
+                assumption_entry_key="assumption:mobilisation",
+                adjustment_amount=Decimal("2.225"),
+            ),
+        ),
+    )
+
+
+def test_compose_estimate_builds_deterministic_payloads_and_totals() -> None:
+    engine_input = _valid_engine_input()
+
+    result = compose_estimate(engine_input)
+
+    assert result.estimate_version_id == deterministic_estimate_version_id(engine_input.estimate_job_id)
+    assert result.header is not None
+    assert result.header.file_id == engine_input.file_id
+    assert result.header.source_job_id == engine_input.source_job_id
+    assert result.project_id == engine_input.project_id
+    assert result.quantity_takeoff_id == engine_input.quantity_takeoff_id
+    assert [entry.entry_key for entry in result.snapshot_entries] == [
+        "quantity:labour",
+        "quantity:material",
+        "rate:installer",
+        "rate:formula",
+        "material:paint",
+        "formula:rounded_markup",
+        "assumption:mobilisation",
+    ]
+    assert result.snapshot_entries[0].id == deterministic_snapshot_entry_id(
+        engine_input.estimate_job_id,
+        "quantity:labour",
+    )
+    assert result.snapshot_entries[0].source_checksum_sha256 is None
+    assert result.snapshot_entries[-1].source_checksum_sha256 is None
+    assert result.snapshot_entries[-1].currency is None
+
+    labour_line, material_line, formula_line, assumption_line, adjustment_line = result.line_items
+    assert labour_line.id == deterministic_item_id(engine_input.estimate_job_id, "line:labour")
+    assert labour_line.subtotal_amount == Decimal("30.86")
+    assert labour_line.tax_amount == Decimal("6.17")
+    assert labour_line.total_amount == Decimal("37.03")
+
+    assert material_line.subtotal_amount == Decimal("4.01")
+    assert material_line.tax_amount == Decimal("0.80")
+    assert material_line.total_amount == Decimal("4.81")
+
+    assert formula_line.subtotal_amount == Decimal("1.20")
+    assert formula_line.tax_amount == Decimal("0.24")
+    assert formula_line.total_amount == Decimal("1.44")
+    assert formula_line.formula_snapshot_entry_id == deterministic_snapshot_entry_id(
+        engine_input.estimate_job_id,
+        "formula:rounded_markup",
+    )
+    assert formula_line.quantity_snapshot_entry_id == deterministic_snapshot_entry_id(
+        engine_input.estimate_job_id,
+        "quantity:labour",
+    )
+    assert formula_line.quantity_value == Decimal("2.5")
+    assert formula_line.quantity_unit == "m"
+    assert formula_line.rate_snapshot_entry_id is None
+    assert formula_line.material_snapshot_entry_id is None
+    assert formula_line.assumption_snapshot_entry_id is None
+    assert formula_line.details["pre_round_amount"] == "1.24"
+    assert formula_line.details["evaluated_amount"] == "1.2"
+    assert formula_line.details["applied_rounding"] == {"scale": 1, "mode": "ROUND_HALF_UP"}
+
+    assert assumption_line.subtotal_amount == Decimal("5.56")
+    assert assumption_line.total_amount == Decimal("6.67")
+    assert adjustment_line.subtotal_amount == Decimal("2.23")
+    assert adjustment_line.total_amount == Decimal("2.68")
+    assert adjustment_line.formula_snapshot_entry_id is None
+    assert adjustment_line.assumption_snapshot_entry_id == deterministic_snapshot_entry_id(
+        engine_input.estimate_job_id,
+        "assumption:mobilisation",
+    )
+
+    assert result.subtotal_amount == Decimal("43.86")
+    assert result.tax_amount == Decimal("8.77")
+    assert result.total_amount == Decimal("52.63")
+    assert result.header.subtotal_amount == result.subtotal_amount
+    assert result.header.tax_amount == result.tax_amount
+    assert result.header.total_amount == result.total_amount
+    assert result.header.quantity_gate == "allowed"
+    assert result.header.trusted_totals is True
+
+    snapshot_payloads = result.snapshot_entry_model_kwargs()
+    formula_snapshot_payload = next(
+        payload for payload in snapshot_payloads if payload["entry_key"] == "formula:rounded_markup"
+    )
+    assumption_snapshot_payload = next(
+        payload for payload in snapshot_payloads if payload["entry_key"] == "assumption:mobilisation"
+    )
+    formula_line_payload = next(
+        payload for payload in result.line_item_model_kwargs() if payload["line_key"] == "line:formula"
+    )
+
+    assert result.estimate_version_model_kwargs()["quantity_gate"] == "allowed"
+    assert formula_snapshot_payload["source_payload_json"] == {
+        "formula_definition": {
+            "formula_id": "formula.rounded_markup",
+            "name": "Rounded markup",
+            "version": 1,
+            "checksum": "f" * 64,
+            "output_key": "estimate.rounded_markup",
+            "output_contract": {"kind": "money", "currency": "GBP", "unit": None, "per_unit": None},
+            "declared_inputs": [
+                {"name": "rate", "contract": {"kind": "rate", "currency": "GBP", "unit": None, "per_unit": "m"}},
+                {"name": "quantity", "contract": {"kind": "quantity", "currency": None, "unit": "m", "per_unit": None}},
+            ],
+            "expression": {
+                "kind": "multiply",
+                "value": None,
+                "name": None,
+                "args": [
+                    {"kind": "input", "value": None, "name": "rate", "args": [], "rounding": None},
+                    {"kind": "input", "value": None, "name": "quantity", "args": [], "rounding": None},
+                ],
+                "rounding": None,
+            },
+            "rounding": {"scale": 1, "mode": "ROUND_HALF_UP"},
+        }
+    }
+    assert assumption_snapshot_payload["currency"] is None
+    assert assumption_snapshot_payload["source_payload_json"] == {"money_amount": "5.555"}
+    assert formula_line_payload["quantity_snapshot_entry_id"] == deterministic_snapshot_entry_id(
+        engine_input.estimate_job_id,
+        "quantity:labour",
+    )
+    assert formula_line_payload["quantity_value"] == Decimal("2.5")
+    assert formula_line_payload["quantity_unit"] == "m"
+    assert formula_line_payload["rate_snapshot_entry_id"] is None
+    assert formula_line_payload["material_snapshot_entry_id"] is None
+    assert formula_line_payload["assumption_snapshot_entry_id"] is None
+
+
+def test_compose_estimate_replays_rate_lines_from_persisted_quantity_scale() -> None:
+    estimate_job_id = UUID("77777777-7777-7777-7777-777777777777")
+    project_id = UUID("88888888-8888-8888-8888-888888888888")
+    file_id = UUID("99999999-9999-9999-9999-999999999999")
+    drawing_revision_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    quantity_takeoff_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    source_job_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    quantity_item_id = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+    rate_id = UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+
+    def _engine_input(quantity_value: Decimal) -> EstimateEngineInput:
+        return EstimateEngineInput(
+            estimate_job_id=estimate_job_id,
+            project_id=project_id,
+            file_id=file_id,
+            drawing_revision_id=drawing_revision_id,
+            quantity_takeoff_id=quantity_takeoff_id,
+            source_job_id=source_job_id,
+            quantity_gate="allowed",
+            trusted_totals=True,
+            tax_rate=Decimal("0"),
+            quantity_entries=(
+                EstimateQuantityEntryInput(
+                    entry_key="quantity:labour",
+                    entry_label="Labour quantity",
+                    sort_order=1,
+                    source_quantity_item_id=quantity_item_id,
+                    source_checksum_sha256="a" * 64,
+                    quantity_value=quantity_value,
+                    unit="m",
+                    source_quantity_takeoff_id=quantity_takeoff_id,
+                ),
+            ),
+            rate_entries=(
+                EstimateRateEntryInput(
+                    entry_key="rate:installer",
+                    entry_label="Installer labour",
+                    sort_order=2,
+                    source_rate_id=rate_id,
+                    source_checksum_sha256="c" * 64,
+                    unit="m",
+                    effective_date=date(2026, 1, 1),
+                    unit_amount=Decimal("0.500000"),
+                ),
+            ),
+            line_inputs=(
+                EstimateLineInputSpec(
+                    line_key="line:labour",
+                    line_type="rate",
+                    description="Installer labour",
+                    quantity_entry_key="quantity:labour",
+                    rate_entry_key="rate:installer",
+                ),
+            ),
+        )
+
+    result = compose_estimate(_engine_input(Decimal("0.29")))
+    replay = compose_estimate(_engine_input(Decimal("0.290000")))
+
+    assert result.snapshot_entries[0].quantity_value == Decimal("0.290000")
+    assert result.line_items[0].subtotal_amount == Decimal("0.15")
+    assert replay.line_items[0].subtotal_amount == Decimal("0.15")
+    assert result.snapshot_entry_model_kwargs() == replay.snapshot_entry_model_kwargs()
+    assert result.line_item_model_kwargs() == replay.line_item_model_kwargs()
+
+
+@pytest.mark.parametrize("quantity_gate", ["provisional", "review_gated", "blocked"])
+def test_compose_estimate_rejects_non_allowed_takeoffs(quantity_gate: str) -> None:
+    engine_input = _valid_engine_input(quantity_gate=quantity_gate)
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(engine_input)
+
+    assert exc_info.value.code == "INPUT_INVALID"
+    assert exc_info.value.reason == "quantity_gate_not_allowed"
+
+
+def test_compose_estimate_rejects_missing_lineage_and_untrusted_totals() -> None:
+    engine_input = _valid_engine_input()
+    broken_input = EstimateEngineInput(
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=None,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=engine_input.source_job_id,
+        quantity_gate=engine_input.quantity_gate,
+        trusted_totals=False,
+        tax_rate=engine_input.tax_rate,
+        quantity_entries=engine_input.quantity_entries,
+        rate_entries=engine_input.rate_entries,
+        material_entries=engine_input.material_entries,
+        formula_entries=engine_input.formula_entries,
+        assumption_entries=engine_input.assumption_entries,
+        line_inputs=engine_input.line_inputs,
+    )
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(broken_input)
+
+    assert exc_info.value.reason == "missing_lineage"
+
+
+def test_compose_estimate_rejects_invalid_checksum() -> None:
+    engine_input = _valid_engine_input()
+    broken_input = EstimateEngineInput(
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=engine_input.file_id,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=engine_input.source_job_id,
+        quantity_gate=engine_input.quantity_gate,
+        trusted_totals=engine_input.trusted_totals,
+        tax_rate=engine_input.tax_rate,
+        quantity_entries=engine_input.quantity_entries,
+        rate_entries=(
+            EstimateRateEntryInput(
+                entry_key="rate:installer",
+                entry_label="Installer labour",
+                sort_order=3,
+                source_rate_id=uuid4(),
+                source_checksum_sha256="NOT-A-CHECKSUM",
+                unit="ft",
+                effective_date=date(2026, 1, 1),
+                unit_amount=Decimal("12.345678"),
+            ),
+        ),
+        material_entries=(),
+        formula_entries=(),
+        assumption_entries=(),
+        line_inputs=(
+            EstimateLineInputSpec(
+                line_key="line:labour",
+                line_type="rate",
+                description="Installer labour",
+                quantity_entry_key="quantity:labour",
+                rate_entry_key="rate:installer",
+            ),
+        ),
+    )
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(broken_input)
+
+    assert exc_info.value.reason == "invalid_checksum"
+
+
+def test_compose_estimate_rejects_unit_mismatch_without_conversion() -> None:
+    engine_input = _valid_engine_input()
+    broken_input = EstimateEngineInput(
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=engine_input.file_id,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=engine_input.source_job_id,
+        quantity_gate=engine_input.quantity_gate,
+        trusted_totals=engine_input.trusted_totals,
+        tax_rate=engine_input.tax_rate,
+        quantity_entries=engine_input.quantity_entries,
+        rate_entries=(
+            EstimateRateEntryInput(
+                entry_key="rate:installer",
+                entry_label="Installer labour",
+                sort_order=3,
+                source_rate_id=uuid4(),
+                source_checksum_sha256="c" * 64,
+                unit="ft",
+                effective_date=date(2026, 1, 1),
+                unit_amount=Decimal("12.345678"),
+            ),
+        ),
+        material_entries=(),
+        formula_entries=(),
+        assumption_entries=(),
+        line_inputs=(
+            EstimateLineInputSpec(
+                line_key="line:labour",
+                line_type="rate",
+                description="Installer labour",
+                quantity_entry_key="quantity:labour",
+                rate_entry_key="rate:installer",
+            ),
+        ),
+    )
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(broken_input)
+
+    assert exc_info.value.reason == "unit_mismatch"
+
+
+def test_compose_estimate_rejects_negative_adjustment_lines() -> None:
+    engine_input = _valid_engine_input()
+    broken_input = EstimateEngineInput(
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=engine_input.file_id,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=engine_input.source_job_id,
+        quantity_gate=engine_input.quantity_gate,
+        trusted_totals=engine_input.trusted_totals,
+        tax_rate=engine_input.tax_rate,
+        quantity_entries=engine_input.quantity_entries,
+        rate_entries=engine_input.rate_entries,
+        material_entries=engine_input.material_entries,
+        formula_entries=engine_input.formula_entries,
+        assumption_entries=engine_input.assumption_entries,
+        line_inputs=(
+            EstimateLineInputSpec(
+                line_key="line:adjustment",
+                line_type="adjustment",
+                description="Discount",
+                adjustment_amount=Decimal("-0.01"),
+            ),
+        ),
+    )
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(broken_input)
+
+    assert exc_info.value.reason == "negative_adjustment"
+
+
+@pytest.mark.parametrize(
+    "line_input",
+    [
+        EstimateLineInputSpec(
+            line_key="line:adjustment",
+            line_type="adjustment",
+            description="Access uplift",
+            adjustment_amount=Decimal("2.225"),
+        ),
+        EstimateLineInputSpec(
+            line_key="line:adjustment",
+            line_type="adjustment",
+            description="Access uplift",
+            formula_entry_key="formula:rounded_markup",
+            assumption_entry_key="assumption:mobilisation",
+            adjustment_amount=Decimal("2.225"),
+        ),
+    ],
+)
+def test_compose_estimate_rejects_adjustments_without_exactly_one_anchor(
+    line_input: EstimateLineInputSpec,
+) -> None:
+    engine_input = _valid_engine_input()
+    broken_input = EstimateEngineInput(
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=engine_input.file_id,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=engine_input.source_job_id,
+        quantity_gate=engine_input.quantity_gate,
+        trusted_totals=engine_input.trusted_totals,
+        tax_rate=engine_input.tax_rate,
+        quantity_entries=engine_input.quantity_entries,
+        rate_entries=engine_input.rate_entries,
+        material_entries=engine_input.material_entries,
+        formula_entries=engine_input.formula_entries,
+        assumption_entries=engine_input.assumption_entries,
+        line_inputs=(*engine_input.line_inputs[:-1], line_input),
+    )
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(broken_input)
+
+    assert exc_info.value.reason == "invalid_adjustment_anchor"


### PR DESCRIPTION
Closes #201

## Summary
- add a pure estimate engine that composes deterministic estimate headers, snapshot entries, and line items from trusted quantity takeoffs and selected catalog inputs
- adapt selected formula JSON into the Formula DSL, enforce GBP-only exact unit compatibility, and generate stable UUIDv5 identifiers for replayable payloads
- add service, persistence-payload, and replay tests to prove ORM compatibility and deterministic persisted totals

## Test plan
- [x] uv run mypy app/estimating/engine
- [x] uv build
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_formula_dsl.py tests/test_estimation_catalog_selection.py tests/test_estimation_catalog_resolver.py tests/test_estimate_engine_contracts.py tests/test_estimate_engine_service.py tests/test_estimate_engine_persistence_payloads.py