### PR TITLE
feat(jobs): implement estimate worker finalization

### DIFF
--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1,14 +1,17 @@
 """Celery worker application and persisted job handlers."""
 
 import asyncio
+import hashlib
 import heapq
 import inspect
 import json
+import math
 import uuid
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 from uuid import UUID
 
@@ -21,6 +24,21 @@ from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
+from app.estimating.catalog import CatalogFormulaRef, CatalogMaterialRef, CatalogRateRef
+from app.estimating.catalog.resolver import resolve_formula, resolve_material, resolve_rate
+from app.estimating.catalog.selection import CatalogSelectionError
+from app.estimating.engine import formula_definition_from_selected_formula
+from app.estimating.engine.contracts import (
+    EstimateEngineInput,
+    EstimateEngineOutput,
+    EstimateFormulaEntryInput,
+    EstimateLineInputSpec,
+    EstimateMaterialEntryInput,
+    EstimateQuantityEntryInput,
+    EstimateRateEntryInput,
+)
+from app.estimating.engine.errors import EstimateEngineError
+from app.estimating.engine.service import compose_estimate
 from app.estimating.quantities.contracts import (
     GateStatus,
     QuantityEngineResult,
@@ -34,6 +52,8 @@ from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
+from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
@@ -58,8 +78,9 @@ _RECOVERABLE_ENQUEUE_JOB_TYPES = (
     JobType.INGEST.value,
     JobType.REPROCESS.value,
     JobType.QUANTITY_TAKEOFF.value,
+    JobType.ESTIMATE.value,
 )
-_KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER = frozenset({JobType.ESTIMATE.value})
+_KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER: frozenset[str] = frozenset()
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _ENQUEUE_STATUS_PENDING = "pending"
 _ENQUEUE_STATUS_PUBLISHING = "publishing"
@@ -73,7 +94,9 @@ _ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
 _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
 _PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
 _FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to finalize quantity takeoff job"
+_FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE = "Failed to finalize estimate job"
 _PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Quantity takeoff job failed unexpectedly."
+_PROCESS_ESTIMATE_JOB_ERROR_MESSAGE = "Estimate job failed unexpectedly."
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
 _DEBUG_OVERLAY_ARTIFACT_KIND = "debug_overlay"
@@ -93,6 +116,8 @@ _QUANTITY_TAKEOFF_VALIDATION_REPORT_MISSING_ERROR_MESSAGE = (
 _QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE = (
     "Quantity takeoff base revision is missing normalized entities."
 )
+_ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE = "Estimate job input mapping is invalid."
+_ESTIMATE_WORKER_MAPPING_VERSION = "estimate-line-v1"
 _QUANTITY_CONFLICT_SUMMARY_LIMIT = 5
 _QUANTITY_CONFLICT_ENTITY_ID_LIMIT = 10
 _QUANTITY_CONFLICT_DETAIL_ITEM_LIMIT = 10
@@ -140,6 +165,7 @@ def get_job_enqueue_publisher(job_type: JobType | str) -> Callable[[UUID], None]
         JobType.INGEST.value: enqueue_ingest_job,
         JobType.REPROCESS.value: enqueue_ingest_job,
         JobType.QUANTITY_TAKEOFF.value: enqueue_quantity_takeoff_job,
+        JobType.ESTIMATE.value: enqueue_estimate_job,
     }
     return registry.get(normalized_job_type)
 
@@ -196,6 +222,18 @@ class _QuantityTakeoffJobError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
+class _EstimateJobInputError(Exception):
+    """Raised for deterministic estimate input mapping failures."""
+
+    error_code: ErrorCode
+    message: str
+    details: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
 class _JobAttemptLease:
     """Persisted ownership token for a claimed job attempt."""
 
@@ -229,6 +267,42 @@ class _QuantityTakeoffExecutionInput:
     quantity_gate: str
     gate: RevisionGateMetadata
     entities: list[RevisionEntityInput]
+
+
+@dataclass(frozen=True, slots=True)
+class _EstimateWorkerQuantityEntry:
+    """Deduped quantity entry dependency for estimate worker assembly."""
+
+    entry_key: str
+    quantity_item_id: UUID
+
+
+@dataclass(frozen=True, slots=True)
+class _EstimateWorkerLineInput:
+    """Normalized worker line assembled from one explicit catalog ref."""
+
+    line_key: str
+    line_type: str
+    description: str
+    ref_type: str
+    selection_key: str
+    catalog_entry_key: str
+    ref_order: int
+    catalog_checksum_sha256: str
+    rate_catalog_entry_id: UUID | None
+    material_catalog_entry_id: UUID | None
+    formula_definition_id: UUID | None
+    quantity_entry_key: str | None
+    quantity_item_id: UUID | None
+    formula_inputs: dict[str, Any] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _EstimateWorkerAssemblyInput:
+    """Estimate worker-ready line and quantity-entry inputs."""
+
+    lines: list[_EstimateWorkerLineInput]
+    quantity_entries: list[_EstimateWorkerQuantityEntry]
 
 
 @dataclass(frozen=True, slots=True)
@@ -568,6 +642,18 @@ async def _get_existing_quantity_takeoff(
     """Load an existing committed quantity takeoff for a job."""
     result = await session.execute(
         select(QuantityTakeoff).where(QuantityTakeoff.source_job_id == source_job_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_existing_estimate_version(
+    session: AsyncSession,
+    *,
+    source_job_id: UUID,
+) -> EstimateVersion | None:
+    """Load an existing committed estimate version for a job."""
+    result = await session.execute(
+        select(EstimateVersion).where(EstimateVersion.source_job_id == source_job_id)
     )
     return result.scalar_one_or_none()
 
@@ -942,6 +1028,827 @@ def _json_array(value: Any) -> list[Any]:
         return deepcopy(list(value))
 
     return []
+
+
+def _build_estimate_job_input_error(
+    reason: str,
+    *,
+    ref_index: int | None = None,
+    ref_type: str | None = None,
+    selection_key: str | None = None,
+    line_key: str | None = None,
+    extra_details: dict[str, Any] | None = None,
+) -> _EstimateJobInputError:
+    """Build a sanitized deterministic estimate input mapping error."""
+    details: dict[str, Any] = {"reason": reason}
+    if ref_index is not None:
+        details["ref_index"] = ref_index
+    if ref_type is not None:
+        details["ref_type"] = ref_type
+    if selection_key is not None:
+        details["selection_key"] = selection_key
+    if line_key is not None:
+        details["line_key"] = line_key
+    if extra_details:
+        details.update(extra_details)
+    return _EstimateJobInputError(
+        error_code=ErrorCode.INPUT_INVALID,
+        message=_ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE,
+        details=details,
+    )
+
+
+def _estimate_mapping_uuid(
+    value: Any,
+    *,
+    reason: str,
+    ref_index: int,
+    ref_type: str,
+    selection_key: str,
+    line_key: str,
+    field_name: str,
+) -> UUID:
+    """Parse one required UUID field from estimate mapping context."""
+    normalized = _string_ref(value)
+    if normalized is None:
+        raise _build_estimate_job_input_error(
+            reason,
+            ref_index=ref_index,
+            ref_type=ref_type,
+            selection_key=selection_key,
+            line_key=line_key,
+            extra_details={"field": field_name},
+        )
+    try:
+        return UUID(normalized)
+    except ValueError as exc:
+        raise _build_estimate_job_input_error(
+            reason,
+            ref_index=ref_index,
+            ref_type=ref_type,
+            selection_key=selection_key,
+            line_key=line_key,
+            extra_details={"field": field_name},
+        ) from exc
+
+
+def _build_estimate_worker_mapping_v1(
+    catalog_refs: Sequence[Any],
+) -> _EstimateWorkerAssemblyInput:
+    """Assemble deterministic estimate worker mapping inputs from catalog refs."""
+    pending_lines: list[_EstimateWorkerLineInput] = []
+    quantity_entries_by_key: dict[str, _EstimateWorkerQuantityEntry] = {}
+    seen_line_keys: set[str] = set()
+
+    for ref_index, catalog_ref in enumerate(catalog_refs):
+        ref_type = _string_ref(getattr(catalog_ref, "ref_type", None))
+        selection_key = _string_ref(getattr(catalog_ref, "selection_key", None))
+        context = _json_object(getattr(catalog_ref, "selection_context_json", None))
+
+        if context.get("worker_mapping_version") != _ESTIMATE_WORKER_MAPPING_VERSION:
+            raise _build_estimate_job_input_error(
+                "missing_worker_mapping_version",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                extra_details={
+                    "expected_worker_mapping_version": _ESTIMATE_WORKER_MAPPING_VERSION,
+                },
+            )
+
+        line_key = _string_ref(context.get("line_key"))
+        line_type = _string_ref(context.get("line_type"))
+        description = _string_ref(context.get("description"))
+        if (
+            line_key is None
+            or line_type is None
+            or description is None
+            or ref_type is None
+            or selection_key is None
+        ):
+            raise _build_estimate_job_input_error(
+                "missing_required_mapping_field",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+            )
+
+        if line_type != ref_type:
+            raise _build_estimate_job_input_error(
+                "mismatched_line_ref_type",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+                extra_details={"line_type": line_type},
+            )
+
+        raw_ref_order = getattr(catalog_ref, "ref_order", None)
+        if isinstance(raw_ref_order, bool) or not isinstance(raw_ref_order, int):
+            raise _build_estimate_job_input_error(
+                "invalid_ref_order",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+            )
+
+        if line_key in seen_line_keys:
+            raise _build_estimate_job_input_error(
+                "duplicate_line_key",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+            )
+        seen_line_keys.add(line_key)
+
+        quantity_entry_key = _string_ref(context.get("quantity_entry_key"))
+        catalog_checksum_sha256 = _hash_ref(getattr(catalog_ref, "catalog_checksum_sha256", None))
+        if catalog_checksum_sha256 is None:
+            raise _build_estimate_job_input_error(
+                "invalid_catalog_checksum",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+            )
+        catalog_entry_key = _first_string_ref(
+            context.get("catalog_entry_key"),
+            f"{ref_type}:{selection_key}",
+        )
+        assert catalog_entry_key is not None
+        rate_catalog_entry_id: UUID | None = None
+        material_catalog_entry_id: UUID | None = None
+        formula_definition_id: UUID | None = None
+        quantity_item_id: UUID | None = None
+        formula_inputs: dict[str, Any] | None = None
+
+        if ref_type in {"rate", "material"}:
+            quantity_item_id = _estimate_mapping_uuid(
+                context.get("quantity_item_id"),
+                reason="missing_quantity_item_id",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+                field_name="quantity_item_id",
+            )
+            if quantity_entry_key is None:
+                quantity_entry_key = f"quantity:{quantity_item_id}"
+            existing_quantity_entry = quantity_entries_by_key.get(quantity_entry_key)
+            if existing_quantity_entry is None:
+                quantity_entries_by_key[quantity_entry_key] = _EstimateWorkerQuantityEntry(
+                    entry_key=quantity_entry_key,
+                    quantity_item_id=quantity_item_id,
+                )
+            elif existing_quantity_entry.quantity_item_id != quantity_item_id:
+                raise _build_estimate_job_input_error(
+                    "mismatched_quantity_entry",
+                    ref_index=ref_index,
+                    ref_type=ref_type,
+                    selection_key=selection_key,
+                    line_key=line_key,
+                    extra_details={"quantity_entry_key": quantity_entry_key},
+                )
+            if ref_type == "rate":
+                rate_catalog_entry_id = _estimate_mapping_uuid(
+                    getattr(catalog_ref, "rate_catalog_entry_id", None),
+                    reason="missing_catalog_entry_id",
+                    ref_index=ref_index,
+                    ref_type=ref_type,
+                    selection_key=selection_key,
+                    line_key=line_key,
+                    field_name="rate_catalog_entry_id",
+                )
+            else:
+                material_catalog_entry_id = _estimate_mapping_uuid(
+                    getattr(catalog_ref, "material_catalog_entry_id", None),
+                    reason="missing_catalog_entry_id",
+                    ref_index=ref_index,
+                    ref_type=ref_type,
+                    selection_key=selection_key,
+                    line_key=line_key,
+                    field_name="material_catalog_entry_id",
+                )
+        elif ref_type == "formula":
+            if not isinstance(context.get("formula_inputs"), dict):
+                raise _build_estimate_job_input_error(
+                    "missing_formula_inputs",
+                    ref_index=ref_index,
+                    ref_type=ref_type,
+                    selection_key=selection_key,
+                    line_key=line_key,
+                )
+            formula_inputs = _json_object(context.get("formula_inputs"))
+            formula_definition_id = _estimate_mapping_uuid(
+                getattr(catalog_ref, "formula_definition_id", None),
+                reason="missing_catalog_entry_id",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+                field_name="formula_definition_id",
+            )
+        else:
+            raise _build_estimate_job_input_error(
+                "unsupported_ref_type",
+                ref_index=ref_index,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                line_key=line_key,
+            )
+
+        pending_lines.append(
+            _EstimateWorkerLineInput(
+                line_key=line_key,
+                line_type=line_type,
+                description=description,
+                ref_type=ref_type,
+                selection_key=selection_key,
+                catalog_entry_key=catalog_entry_key,
+                ref_order=raw_ref_order,
+                catalog_checksum_sha256=catalog_checksum_sha256,
+                rate_catalog_entry_id=rate_catalog_entry_id,
+                material_catalog_entry_id=material_catalog_entry_id,
+                formula_definition_id=formula_definition_id,
+                quantity_entry_key=quantity_entry_key,
+                quantity_item_id=quantity_item_id,
+                formula_inputs=formula_inputs,
+            )
+        )
+
+    lines = sorted(
+        pending_lines,
+        key=lambda line: (line.ref_order, line.ref_type, line.selection_key),
+    )
+    quantity_entries: list[_EstimateWorkerQuantityEntry] = []
+    emitted_quantity_entry_keys: set[str] = set()
+    for line in lines:
+        if line.quantity_entry_key is None or line.quantity_entry_key in emitted_quantity_entry_keys:
+            continue
+        quantity_entries.append(quantity_entries_by_key[line.quantity_entry_key])
+        emitted_quantity_entry_keys.add(line.quantity_entry_key)
+
+    return _EstimateWorkerAssemblyInput(lines=lines, quantity_entries=quantity_entries)
+
+
+def _estimate_input_checksum(payload: dict[str, Any]) -> str:
+    """Build a deterministic checksum for worker-synthesized estimate inputs."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _estimate_decimal(
+    value: Any,
+    *,
+    reason: str,
+    extra_details: dict[str, Any] | None = None,
+) -> Decimal:
+    """Parse one persisted estimate numeric input as a finite Decimal."""
+    if isinstance(value, bool):
+        raise _build_estimate_job_input_error(reason, extra_details=extra_details)
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise _build_estimate_job_input_error(reason, extra_details=extra_details) from exc
+    if not decimal_value.is_finite():
+        raise _build_estimate_job_input_error(reason, extra_details=extra_details)
+    return decimal_value
+
+
+def _estimate_tax_rate(assumptions_json: dict[str, Any]) -> Decimal:
+    """Load the persisted estimate tax rate with a default of zero."""
+    raw_tax_rate = assumptions_json.get("tax_rate", 0)
+    tax_rate = _estimate_decimal(
+        raw_tax_rate,
+        reason="invalid_tax_rate",
+        extra_details={"field": "tax_rate"},
+    )
+    if tax_rate < 0:
+        raise _build_estimate_job_input_error(
+            "invalid_tax_rate",
+            extra_details={"field": "tax_rate"},
+        )
+    return tax_rate
+
+
+def _estimate_formula_binding_tokens(
+    raw_bindings: dict[str, Any],
+    *,
+    line: _EstimateWorkerLineInput,
+    declared_input_names: tuple[str, ...],
+) -> dict[str, str]:
+    """Normalize persisted formula-binding payloads into declared-input tokens."""
+    bindings_payload = raw_bindings.get("bindings")
+    if isinstance(bindings_payload, dict):
+        if not all(
+            isinstance(key, str)
+            and key
+            and isinstance(value, str)
+            and value
+            for key, value in bindings_payload.items()
+        ):
+            raise _build_estimate_job_input_error(
+                "invalid_formula_input_binding",
+                ref_type=line.ref_type,
+                selection_key=line.selection_key,
+                line_key=line.line_key,
+            )
+        return cast(dict[str, str], dict(bindings_payload))
+
+    if raw_bindings and all(
+        isinstance(key, str) and key and isinstance(value, str) and value
+        for key, value in raw_bindings.items()
+    ):
+        return cast(dict[str, str], dict(raw_bindings))
+
+    operand_line_keys = raw_bindings.get("operand_line_keys")
+    if isinstance(operand_line_keys, list) and len(operand_line_keys) == len(declared_input_names):
+        if not all(isinstance(value, str) and value for value in operand_line_keys):
+            raise _build_estimate_job_input_error(
+                "invalid_formula_input_binding",
+                ref_type=line.ref_type,
+                selection_key=line.selection_key,
+                line_key=line.line_key,
+            )
+        return dict(zip(declared_input_names, operand_line_keys, strict=True))
+
+    raise _build_estimate_job_input_error(
+        "invalid_formula_input_binding",
+        ref_type=line.ref_type,
+        selection_key=line.selection_key,
+        line_key=line.line_key,
+    )
+
+
+def _resolve_formula_binding_snapshot_key(
+    token: str,
+    *,
+    line: _EstimateWorkerLineInput,
+    contract_kind: str,
+    lines_by_key: dict[str, _EstimateWorkerLineInput],
+    quantity_entry_keys: set[str],
+    rate_entry_keys: set[str],
+    material_entry_keys: set[str],
+) -> str:
+    """Resolve one persisted formula-binding token into an engine snapshot entry key."""
+    if contract_kind == "quantity" and token in quantity_entry_keys:
+        return token
+    if contract_kind == "rate" and token in rate_entry_keys | material_entry_keys:
+        return token
+
+    bound_line = lines_by_key.get(token)
+    if bound_line is None:
+        raise _build_estimate_job_input_error(
+            "invalid_formula_input_binding",
+            ref_type=line.ref_type,
+            selection_key=line.selection_key,
+            line_key=line.line_key,
+            extra_details={"binding": token, "contract_kind": contract_kind},
+        )
+
+    if contract_kind == "quantity" and bound_line.quantity_entry_key is not None:
+        return bound_line.quantity_entry_key
+    if contract_kind == "rate":
+        if bound_line.rate_catalog_entry_id is not None:
+            return bound_line.catalog_entry_key
+        if bound_line.material_catalog_entry_id is not None:
+            return bound_line.catalog_entry_key
+
+    raise _build_estimate_job_input_error(
+        "invalid_formula_input_binding",
+        ref_type=line.ref_type,
+        selection_key=line.selection_key,
+        line_key=line.line_key,
+        extra_details={"binding": token, "contract_kind": contract_kind},
+    )
+
+
+async def _build_estimate_engine_input(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> EstimateEngineInput:
+    """Load deterministic engine inputs for a claimed persisted estimate job."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
+        if job.job_type != JobType.ESTIMATE.value:
+            raise ValueError(f"Unsupported estimate job type '{job.job_type}'")
+        if job.base_revision_id is None:
+            raise _RevisionConflictError(
+                message="Estimate job is missing its finalized base revision.",
+                details={
+                    "base_revision_id": None,
+                    "current_revision_id": None,
+                },
+            )
+
+        estimate_input = await session.get(EstimateJobInput, job.id)
+        if estimate_input is None:
+            raise _build_estimate_job_input_error("missing_estimate_job_input")
+        if (
+            estimate_input.project_id != job.project_id
+            or estimate_input.source_file_id != job.file_id
+            or estimate_input.drawing_revision_id != job.base_revision_id
+        ):
+            raise _build_estimate_job_input_error(
+                "estimate_input_lineage_mismatch",
+                extra_details={
+                    "drawing_revision_id": str(estimate_input.drawing_revision_id),
+                    "base_revision_id": str(job.base_revision_id),
+                },
+            )
+
+        quantity_takeoff = await session.get(QuantityTakeoff, estimate_input.quantity_takeoff_id)
+        if quantity_takeoff is None:
+            raise _build_estimate_job_input_error(
+                "missing_quantity_takeoff",
+                extra_details={"quantity_takeoff_id": str(estimate_input.quantity_takeoff_id)},
+            )
+        if (
+            quantity_takeoff.project_id != job.project_id
+            or quantity_takeoff.source_file_id != job.file_id
+            or quantity_takeoff.drawing_revision_id != job.base_revision_id
+            or quantity_takeoff.id != estimate_input.quantity_takeoff_id
+            or quantity_takeoff.quantity_gate != estimate_input.quantity_gate
+            or quantity_takeoff.trusted_totals is not estimate_input.trusted_totals
+            or quantity_takeoff.source_job_type != estimate_input.source_job_type
+        ):
+            raise _build_estimate_job_input_error(
+                "quantity_takeoff_lineage_mismatch",
+                extra_details={
+                    "quantity_takeoff_id": str(quantity_takeoff.id),
+                    "drawing_revision_id": str(quantity_takeoff.drawing_revision_id),
+                },
+            )
+
+        catalog_refs_result = await session.execute(
+            select(EstimateJobInputCatalogRef)
+            .where(EstimateJobInputCatalogRef.estimate_job_id == job.id)
+            .order_by(
+                EstimateJobInputCatalogRef.ref_order.asc(),
+                EstimateJobInputCatalogRef.ref_type.asc(),
+                EstimateJobInputCatalogRef.selection_key.asc(),
+            )
+        )
+        catalog_refs = list(catalog_refs_result.scalars().all())
+        assembly = _build_estimate_worker_mapping_v1(catalog_refs)
+
+        quantity_items_result = await session.execute(
+            select(QuantityItem)
+            .where(QuantityItem.quantity_takeoff_id == quantity_takeoff.id)
+            .order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc())
+        )
+        quantity_items = list(quantity_items_result.scalars().all())
+        quantity_items_by_id = {item.id: item for item in quantity_items}
+
+        next_snapshot_sort_order = 1
+
+        def _next_snapshot_sort_order() -> int:
+            nonlocal next_snapshot_sort_order
+            sort_order = next_snapshot_sort_order
+            next_snapshot_sort_order += 1
+            return sort_order
+
+        quantity_entries: list[EstimateQuantityEntryInput] = []
+        for quantity_dependency in assembly.quantity_entries:
+            quantity_item = quantity_items_by_id.get(quantity_dependency.quantity_item_id)
+            if quantity_item is None:
+                raise _build_estimate_job_input_error(
+                    "missing_quantity_item",
+                    extra_details={
+                        "quantity_item_id": str(quantity_dependency.quantity_item_id),
+                        "quantity_entry_key": quantity_dependency.entry_key,
+                    },
+                )
+            if quantity_item.item_kind in {
+                QuantityItemKind.EXCLUSION.value,
+                QuantityItemKind.CONFLICT.value,
+            }:
+                raise _build_estimate_job_input_error(
+                    "invalid_quantity_item_kind",
+                    extra_details={
+                        "quantity_item_id": str(quantity_item.id),
+                        "item_kind": quantity_item.item_kind,
+                    },
+                )
+            if quantity_item.quantity_gate != "allowed":
+                raise _build_estimate_job_input_error(
+                    "quantity_item_gate_not_allowed",
+                    extra_details={
+                        "quantity_item_id": str(quantity_item.id),
+                        "quantity_gate": quantity_item.quantity_gate,
+                    },
+                )
+            if quantity_item.value is None or not math.isfinite(quantity_item.value):
+                raise _build_estimate_job_input_error(
+                    "invalid_quantity_value",
+                    extra_details={"quantity_item_id": str(quantity_item.id)},
+                )
+
+            quantity_payload = {
+                "quantity_takeoff_id": str(quantity_takeoff.id),
+                "quantity_item_id": str(quantity_item.id),
+                "item_kind": quantity_item.item_kind,
+                "quantity_type": quantity_item.quantity_type,
+                "value": quantity_item.value,
+                "unit": quantity_item.unit,
+                "review_state": quantity_item.review_state,
+                "validation_status": quantity_item.validation_status,
+                "quantity_gate": quantity_item.quantity_gate,
+                "source_entity_id": quantity_item.source_entity_id,
+                "excluded_source_entity_ids_json": deepcopy(
+                    quantity_item.excluded_source_entity_ids_json
+                ),
+            }
+            quantity_entries.append(
+                EstimateQuantityEntryInput(
+                    entry_key=quantity_dependency.entry_key,
+                    entry_label=quantity_item.quantity_type,
+                    sort_order=_next_snapshot_sort_order(),
+                    source_quantity_item_id=quantity_item.id,
+                    source_checksum_sha256=_estimate_input_checksum(quantity_payload),
+                    quantity_value=Decimal(str(quantity_item.value)),
+                    unit=quantity_item.unit,
+                    source_quantity_takeoff_id=quantity_takeoff.id,
+                    source_payload=quantity_payload,
+                )
+            )
+
+        lines_by_key = {line.line_key: line for line in assembly.lines}
+        quantity_entry_keys = {entry.entry_key for entry in quantity_entries}
+        rate_entry_keys = {
+            line.catalog_entry_key for line in assembly.lines if line.rate_catalog_entry_id is not None
+        }
+        material_entry_keys = {
+            line.catalog_entry_key
+            for line in assembly.lines
+            if line.material_catalog_entry_id is not None
+        }
+        rate_entries: list[EstimateRateEntryInput] = []
+        material_entries: list[EstimateMaterialEntryInput] = []
+        formula_entries: list[EstimateFormulaEntryInput] = []
+        line_inputs: list[EstimateLineInputSpec] = []
+        emitted_catalog_entry_sources: dict[str, tuple[str, UUID, str]] = {}
+
+        def _register_catalog_entry_source(
+            *,
+            line: _EstimateWorkerLineInput,
+            source_id: UUID,
+            source_checksum_sha256: str,
+        ) -> bool:
+            candidate = (line.ref_type, source_id, source_checksum_sha256)
+            existing = emitted_catalog_entry_sources.get(line.catalog_entry_key)
+            if existing is None:
+                emitted_catalog_entry_sources[line.catalog_entry_key] = candidate
+                return True
+            if existing != candidate:
+                existing_ref_type, existing_source_id, existing_checksum = existing
+                raise _build_estimate_job_input_error(
+                    "colliding_catalog_entry_key",
+                    ref_type=line.ref_type,
+                    selection_key=line.selection_key,
+                    line_key=line.line_key,
+                    extra_details={
+                        "catalog_entry_key": line.catalog_entry_key,
+                        "existing_ref_type": existing_ref_type,
+                        "existing_source_id": str(existing_source_id),
+                        "existing_checksum_sha256": existing_checksum,
+                    },
+                )
+            return False
+
+        for line in assembly.lines:
+            if line.ref_type == "rate":
+                assert line.rate_catalog_entry_id is not None
+                try:
+                    matched_rate = await resolve_rate(
+                        session,
+                        ref=CatalogRateRef(
+                            id=line.rate_catalog_entry_id,
+                            checksum_sha256=line.catalog_checksum_sha256,
+                        ),
+                    )
+                except CatalogSelectionError as exc:
+                    raise _build_estimate_job_input_error(
+                        "catalog_ref_unresolved",
+                        ref_type=line.ref_type,
+                        selection_key=line.selection_key,
+                        line_key=line.line_key,
+                        extra_details={
+                            "conflict_count": len(exc.conflicting_candidate_ids),
+                        },
+                    ) from exc
+
+                if _register_catalog_entry_source(
+                    line=line,
+                    source_id=matched_rate.id,
+                    source_checksum_sha256=matched_rate.checksum_sha256,
+                ):
+                    rate_entries.append(
+                        EstimateRateEntryInput(
+                            entry_key=line.catalog_entry_key,
+                            entry_label=line.description,
+                            sort_order=_next_snapshot_sort_order(),
+                            source_rate_id=matched_rate.id,
+                            source_checksum_sha256=matched_rate.checksum_sha256,
+                            unit=matched_rate.unit,
+                            effective_date=matched_rate.effective_start,
+                            unit_amount=matched_rate.value,
+                            source_payload={
+                                "selection_key": line.selection_key,
+                                "rate_key": matched_rate.rate_key,
+                                "item_type": matched_rate.item_type,
+                                "metadata": deepcopy(matched_rate.metadata or {}),
+                            },
+                            currency=cast(Any, matched_rate.currency),
+                        )
+                    )
+
+                line_inputs.append(
+                    EstimateLineInputSpec(
+                        line_key=line.line_key,
+                        line_type=cast(Any, line.line_type),
+                        description=line.description,
+                        quantity_entry_key=line.quantity_entry_key,
+                        rate_entry_key=line.catalog_entry_key,
+                    )
+                )
+                continue
+
+            if line.ref_type == "material":
+                assert line.material_catalog_entry_id is not None
+                try:
+                    matched_material = await resolve_material(
+                        session,
+                        ref=CatalogMaterialRef(
+                            id=line.material_catalog_entry_id,
+                            checksum_sha256=line.catalog_checksum_sha256,
+                        ),
+                    )
+                except CatalogSelectionError as exc:
+                    raise _build_estimate_job_input_error(
+                        "catalog_ref_unresolved",
+                        ref_type=line.ref_type,
+                        selection_key=line.selection_key,
+                        line_key=line.line_key,
+                        extra_details={
+                            "conflict_count": len(exc.conflicting_candidate_ids),
+                        },
+                    ) from exc
+
+                if _register_catalog_entry_source(
+                    line=line,
+                    source_id=matched_material.id,
+                    source_checksum_sha256=matched_material.checksum_sha256,
+                ):
+                    material_entries.append(
+                        EstimateMaterialEntryInput(
+                            entry_key=line.catalog_entry_key,
+                            entry_label=line.description,
+                            sort_order=_next_snapshot_sort_order(),
+                            source_material_id=matched_material.id,
+                            source_checksum_sha256=matched_material.checksum_sha256,
+                            unit=matched_material.unit,
+                            effective_date=matched_material.effective_start,
+                            unit_amount=matched_material.value,
+                            source_payload={
+                                "selection_key": line.selection_key,
+                                "material_key": matched_material.material_key,
+                                "metadata": deepcopy(matched_material.metadata or {}),
+                            },
+                            currency=cast(Any, matched_material.currency),
+                        )
+                    )
+
+                line_inputs.append(
+                    EstimateLineInputSpec(
+                        line_key=line.line_key,
+                        line_type=cast(Any, line.line_type),
+                        description=line.description,
+                        quantity_entry_key=line.quantity_entry_key,
+                        material_entry_key=line.catalog_entry_key,
+                    )
+                )
+                continue
+
+            assert line.formula_definition_id is not None
+            try:
+                selected_formula = await resolve_formula(
+                    session,
+                    ref=CatalogFormulaRef(
+                        id=line.formula_definition_id,
+                        checksum_sha256=line.catalog_checksum_sha256,
+                    ),
+                )
+            except CatalogSelectionError as exc:
+                raise _build_estimate_job_input_error(
+                    "catalog_ref_unresolved",
+                    ref_type=line.ref_type,
+                    selection_key=line.selection_key,
+                    line_key=line.line_key,
+                    extra_details={
+                        "conflict_count": len(exc.conflicting_candidate_ids),
+                    },
+                ) from exc
+
+            try:
+                formula_definition = formula_definition_from_selected_formula(selected_formula)
+            except Exception as exc:
+                raise _build_estimate_job_input_error(
+                    "invalid_formula_definition",
+                    ref_type=line.ref_type,
+                    selection_key=line.selection_key,
+                    line_key=line.line_key,
+                ) from exc
+            if _register_catalog_entry_source(
+                line=line,
+                source_id=selected_formula.definition_id,
+                source_checksum_sha256=selected_formula.checksum_sha256,
+            ):
+                formula_entries.append(
+                    EstimateFormulaEntryInput(
+                        entry_key=line.catalog_entry_key,
+                        entry_label=line.description,
+                        sort_order=_next_snapshot_sort_order(),
+                        source_formula_id=selected_formula.definition_id,
+                        source_checksum_sha256=selected_formula.checksum_sha256,
+                        definition=formula_definition,
+                        source_payload={
+                            "selection_key": line.selection_key,
+                            "formula_id": selected_formula.formula_id,
+                            "formula_version": selected_formula.version,
+                        },
+                    )
+                )
+
+            raw_formula_inputs = line.formula_inputs or {}
+            declared_input_names = tuple(
+                declared_input.name for declared_input in formula_definition.declared_inputs
+            )
+            binding_tokens = _estimate_formula_binding_tokens(
+                raw_formula_inputs,
+                line=line,
+                declared_input_names=declared_input_names,
+            )
+            for declared_input_name in declared_input_names:
+                if declared_input_name not in binding_tokens:
+                    raise _build_estimate_job_input_error(
+                        "missing_formula_input_binding",
+                        ref_type=line.ref_type,
+                        selection_key=line.selection_key,
+                        line_key=line.line_key,
+                        extra_details={"input": declared_input_name},
+                    )
+            resolved_formula_inputs = {
+                declared_input.name: _resolve_formula_binding_snapshot_key(
+                    binding_tokens[declared_input.name],
+                    line=line,
+                    contract_kind=declared_input.contract.kind,
+                    lines_by_key=lines_by_key,
+                    quantity_entry_keys=quantity_entry_keys,
+                    rate_entry_keys=rate_entry_keys,
+                    material_entry_keys=material_entry_keys,
+                )
+                for declared_input in formula_definition.declared_inputs
+            }
+            line_inputs.append(
+                EstimateLineInputSpec(
+                    line_key=line.line_key,
+                    line_type=cast(Any, line.line_type),
+                    description=line.description,
+                    formula_entry_key=line.catalog_entry_key,
+                    formula_inputs=resolved_formula_inputs,
+                )
+            )
+
+        return EstimateEngineInput(
+            estimate_job_id=job.id,
+            project_id=job.project_id,
+            file_id=job.file_id,
+            source_job_id=job.id,
+            drawing_revision_id=estimate_input.drawing_revision_id,
+            quantity_takeoff_id=quantity_takeoff.id,
+            currency=cast(Any, estimate_input.currency),
+            quantity_gate=cast(Any, estimate_input.quantity_gate),
+            trusted_totals=estimate_input.trusted_totals,
+            tax_rate=_estimate_tax_rate(estimate_input.assumptions_json),
+            quantity_entries=tuple(quantity_entries),
+            rate_entries=tuple(rate_entries),
+            material_entries=tuple(material_entries),
+            formula_entries=tuple(formula_entries),
+            line_inputs=tuple(line_inputs),
+        )
 
 
 def _float_value(value: Any) -> float | None:
@@ -2480,6 +3387,129 @@ async def _finalize_quantity_takeoff_job(
     return True
 
 
+async def _finalize_estimate_job(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    output: EstimateEngineOutput,
+) -> bool:
+    """Atomically publish estimate rows and terminal job success."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    estimate_version_kwargs = output.estimate_version_model_kwargs()
+    snapshot_entry_kwargs = list(output.snapshot_entry_model_kwargs())
+    line_item_kwargs = list(output.line_item_model_kwargs())
+
+    async with session_maker() as session:
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "estimate_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            logger.info(
+                "estimate_job_completion_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
+            await session.commit()
+            logger.info("estimate_job_cancelled", job_id=str(job_id))
+            return False
+
+        if job.status != "running":
+            logger.info(
+                "estimate_job_completion_skipped_non_running_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if (
+            locked_source.project.deleted_at is not None
+            or locked_source.source_file is None
+            or locked_source.source_file.deleted_at is not None
+        ):
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            logger.info("estimate_job_cancelled_inactive_source", job_id=str(job_id))
+            return False
+
+        output_revision_id = cast(UUID | None, estimate_version_kwargs.get("drawing_revision_id"))
+        if job.base_revision_id != output_revision_id:
+            raise _RevisionConflictError(
+                message="Estimate base revision changed before finalization.",
+                details={
+                    "base_revision_id": (
+                        str(job.base_revision_id) if job.base_revision_id is not None else None
+                    ),
+                    "drawing_revision_id": str(output_revision_id) if output_revision_id else None,
+                },
+            )
+
+        existing_version = await _get_existing_estimate_version(session, source_job_id=job.id)
+        if existing_version is not None:
+            logger.info(
+                "estimate_job_completion_skipped_existing_version",
+                job_id=str(job_id),
+                estimate_version_id=str(existing_version.id),
+            )
+            return False
+
+        estimate_version = EstimateVersion(**estimate_version_kwargs)
+        snapshot_entries = [EstimateSnapshotEntry(**kwargs) for kwargs in snapshot_entry_kwargs]
+        line_items = [EstimateItem(**kwargs) for kwargs in line_item_kwargs]
+
+        session.add(estimate_version)
+        await session.flush()
+        session.add_all(snapshot_entries)
+        session.add_all(line_items)
+
+        job.status = "succeeded"
+        job.finished_at = _utcnow()
+        job.error_code = None
+        job.error_message = None
+        _clear_job_attempt_lease(job)
+        await emit_job_event(
+            job.id,
+            level="info",
+            message="Job succeeded",
+            data_json={
+                "status": "succeeded",
+                "attempts": job.attempts,
+                "estimate_version_id": str(estimate_version.id),
+                "snapshot_entry_count": len(snapshot_entries),
+                "line_item_count": len(line_items),
+            },
+            session=session,
+        )
+        await session.commit()
+
+    return True
+
+
 async def emit_job_event(
     job_id: UUID,
     *,
@@ -3275,6 +4305,130 @@ async def _begin_or_resume_quantity_takeoff_job(job_id: UUID) -> _JobAttemptLeas
     return None
 
 
+async def _begin_or_resume_estimate_job(job_id: UUID) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted estimate job under a row lock."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    now = _utcnow()
+
+    async with session_maker() as session:
+        bootstrap = await _get_job_lock_bootstrap(session, job_id)
+        if bootstrap is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        project = await _get_project(session, bootstrap.project_id, for_update=True)
+        if project is None:
+            raise LookupError(
+                f"Project with identifier '{bootstrap.project_id}' for job '{job_id}' not found"
+            )
+
+        job = await _get_job_for_update_with_metadata(
+            session,
+            job_id,
+            expected_project_id=bootstrap.project_id,
+            expected_file_id=bootstrap.file_id,
+        )
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+
+        if job.job_type != JobType.ESTIMATE.value:
+            logger.info(
+                "estimate_job_unsupported_type_skipped",
+                job_id=str(job_id),
+                job_type=job.job_type,
+                status=job.status,
+            )
+            return None
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "estimate_job_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return None
+
+        if project.deleted_at is not None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info("estimate_job_cancelled_inactive_source", job_id=str(job_id))
+            return None
+
+        source_file = await _get_source_file(
+            session,
+            project_id=job.project_id,
+            file_id=job.file_id,
+            for_update=True,
+        )
+        if source_file is None or source_file.deleted_at is not None:
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+            )
+            logger.info("estimate_job_cancelled_inactive_source", job_id=str(job_id))
+            return None
+
+        if not job.cancel_requested:
+            if job.status == "running":
+                if _is_stale_running_job(job, now=now):
+                    lease = _claim_job_attempt_lease(job, now=now, increment_attempt=True)
+                    await emit_job_event(
+                        job.id,
+                        level="info",
+                        message="Job started",
+                        data_json={
+                            "status": "running",
+                            "attempts": job.attempts,
+                            "reclaimed": True,
+                        },
+                        session=session,
+                    )
+                    await session.commit()
+                    logger.warning(
+                        "estimate_job_reclaimed_stale_running_status",
+                        job_id=str(job_id),
+                        status=job.status,
+                    )
+                    return lease
+
+                logger.info(
+                    "estimate_job_duplicate_delivery_skipped_running_attempt",
+                    job_id=str(job_id),
+                    status=job.status,
+                )
+                return None
+
+            lease = _claim_job_attempt_lease(job, now=now, increment_attempt=True)
+            await emit_job_event(
+                job.id,
+                level="info",
+                message="Job started",
+                data_json={"status": "running", "attempts": job.attempts, "reclaimed": False},
+                session=session,
+            )
+            await session.commit()
+            return lease
+
+        _finalize_job_cancelled(job)
+        await emit_job_event(
+            job.id,
+            level="warning",
+            message="Job cancelled",
+            data_json={"status": "cancelled"},
+            session=session,
+        )
+        await session.commit()
+
+    logger.info("estimate_job_cancelled", job_id=str(job_id))
+    return None
+
+
 async def process_ingest_job(job_id: UUID) -> None:
     """Load a persisted ingest job, run ingestion, and persist state transitions."""
     session_maker = get_session_maker()
@@ -3416,7 +4570,7 @@ async def process_ingest_job(job_id: UUID) -> None:
 
 
 async def recover_incomplete_ingest_jobs() -> list[UUID]:
-    """Requeue incomplete persisted ingest/reprocess/quantity jobs on worker startup."""
+    """Requeue incomplete persisted ingest/reprocess/quantity/estimate jobs on worker startup."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -3486,7 +4640,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
 
 
 def recover_incomplete_ingest_jobs_on_worker_start(**_: object) -> None:
-    """Requeue incomplete ingest/reprocess/quantity jobs when a worker starts."""
+    """Requeue incomplete ingest/reprocess/quantity/estimate jobs when a worker starts."""
     try:
         recovered_job_ids = asyncio.run(recover_incomplete_ingest_jobs())
     except Exception as exc:
@@ -3687,3 +4841,155 @@ def run_quantity_takeoff_job(job_id: str) -> None:
 def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
     """Publish a persisted quantity takeoff job to Celery."""
     run_quantity_takeoff_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)
+
+
+async def process_estimate_job(job_id: UUID) -> None:
+    """Load a persisted estimate job and assemble deterministic engine inputs."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    lease = await _begin_or_resume_estimate_job(job_id)
+    if lease is None:
+        return
+
+    try:
+        engine_input = await _build_estimate_engine_input(job_id, attempt_token=lease.token)
+        estimate_output = compose_estimate(engine_input)
+    except _StaleJobAttemptError:
+        logger.info("estimate_job_stale_attempt_skipped", job_id=str(job_id))
+        return
+    except _RevisionConflictError as exc:
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=ErrorCode.REVISION_CONFLICT,
+            attempt_token=lease.token,
+            error_details=exc.details,
+        )
+        logger.warning(
+            "estimate_job_revision_conflict",
+            job_id=str(job_id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            **exc.details,
+        )
+        return
+    except _EstimateJobInputError as exc:
+        failure_details = exc.details
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=exc.error_code,
+            attempt_token=lease.token,
+            error_details=failure_details,
+        )
+        logger.warning(
+            "estimate_job_input_failed",
+            job_id=str(job_id),
+            error_code=exc.error_code.value,
+            **(failure_details or {}),
+        )
+        return
+    except EstimateEngineError as exc:
+        failure_details = {"reason": exc.reason}
+        await _mark_job_failed(
+            job_id,
+            error_message=_ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE,
+            error_code=ErrorCode.INPUT_INVALID,
+            attempt_token=lease.token,
+            error_details=failure_details,
+        )
+        logger.warning(
+            "estimate_job_input_failed",
+            job_id=str(job_id),
+            error_code=ErrorCode.INPUT_INVALID.value,
+            **failure_details,
+        )
+        return
+    except asyncio.CancelledError:
+        await _mark_job_cancelled(job_id, attempt_token=lease.token)
+        logger.info("estimate_job_cancelled_during_execution", job_id=str(job_id))
+        raise
+    except Exception:
+        await _mark_job_failed(
+            job_id,
+            error_message=_PROCESS_ESTIMATE_JOB_ERROR_MESSAGE,
+            attempt_token=lease.token,
+        )
+        logger.error(
+            "estimate_job_failed",
+            job_id=str(job_id),
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message=_PROCESS_ESTIMATE_JOB_ERROR_MESSAGE,
+            exc_info=True,
+        )
+        raise
+
+    logger.info(
+        "estimate_job_composed_pending_finalization",
+        job_id=str(job_id),
+        quantity_entry_count=len(engine_input.quantity_entries),
+        rate_entry_count=len(engine_input.rate_entries),
+        material_entry_count=len(engine_input.material_entries),
+        formula_entry_count=len(engine_input.formula_entries),
+        line_count=len(engine_input.line_inputs),
+    )
+
+    try:
+        finalized = await _finalize_estimate_job(
+            job_id,
+            attempt_token=lease.token,
+            output=estimate_output,
+        )
+    except asyncio.CancelledError:
+        await _mark_job_cancelled(job_id, attempt_token=lease.token)
+        logger.info("estimate_job_cancelled_during_finalization", job_id=str(job_id))
+        raise
+    except _RevisionConflictError as exc:
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=ErrorCode.REVISION_CONFLICT,
+            attempt_token=lease.token,
+            error_details=exc.details,
+        )
+        logger.warning(
+            "estimate_job_revision_conflict",
+            job_id=str(job_id),
+            error_code=ErrorCode.REVISION_CONFLICT.value,
+            **exc.details,
+        )
+        return
+    except Exception:
+        await _mark_job_failed(
+            job_id,
+            error_message=_FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE,
+            attempt_token=lease.token,
+        )
+        logger.error(
+            "estimate_job_finalization_failed",
+            job_id=str(job_id),
+            error_code=ErrorCode.INTERNAL_ERROR.value,
+            error_message=_FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE,
+            exc_info=True,
+        )
+        raise
+
+    if finalized:
+        logger.info("estimate_job_succeeded", job_id=str(job_id))
+
+
+@celery_app.task(
+    name="app.jobs.worker.run_estimate_job",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def run_estimate_job(job_id: str) -> None:
+    """Celery task wrapper for persisted estimate jobs."""
+    asyncio.run(process_estimate_job(UUID(job_id)))
+
+
+def enqueue_estimate_job(job_id: UUID) -> None:
+    """Publish a persisted estimate job to Celery."""
+    run_estimate_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -386,6 +386,7 @@ class _JobProgressEventBridge:
             finally:
                 self._queue.task_done()
 
+
 celery_app = Celery(
     "draupnir",
     broker=settings.broker_url,
@@ -520,9 +521,7 @@ async def _get_job_lock_bootstrap(
     job_id: UUID,
 ) -> _JobLockBootstrap | None:
     """Load job metadata without taking locks."""
-    result = await session.execute(
-        select(Job.project_id, Job.file_id).where(Job.id == job_id)
-    )
+    result = await session.execute(select(Job.project_id, Job.file_id).where(Job.id == job_id))
     row = result.one_or_none()
     if row is None:
         return None
@@ -554,11 +553,7 @@ async def _get_job_for_update_with_metadata(
     expected_file_id: UUID | None = None,
 ) -> Job | None:
     """Load and lock a persisted job row, revalidating stable metadata."""
-    result = await session.execute(
-        select(Job)
-        .where(Job.id == job_id)
-        .with_for_update(of=Job)
-    )
+    result = await session.execute(select(Job).where(Job.id == job_id).with_for_update(of=Job))
     job = result.scalar_one_or_none()
     if job is None:
         return None
@@ -578,10 +573,7 @@ async def _get_source_file(
     for_update: bool = False,
 ) -> File | None:
     """Load a source file row, optionally under a row lock."""
-    statement = select(File).where(
-        (File.project_id == project_id)
-        & (File.id == file_id)
-    )
+    statement = select(File).where((File.project_id == project_id) & (File.id == file_id))
     if for_update:
         statement = statement.with_for_update(of=File)
 
@@ -919,8 +911,7 @@ def _build_persisted_validation_report_json(
                 "code": "validation_report_persisted",
                 "status": "passed",
                 "message": (
-                    "Persisted validation report columns are attached to the "
-                    "canonical payload."
+                    "Persisted validation report columns are attached to the canonical payload."
                 ),
             }
         )
@@ -1286,7 +1277,10 @@ def _build_estimate_worker_mapping_v1(
     quantity_entries: list[_EstimateWorkerQuantityEntry] = []
     emitted_quantity_entry_keys: set[str] = set()
     for line in lines:
-        if line.quantity_entry_key is None or line.quantity_entry_key in emitted_quantity_entry_keys:
+        if (
+            line.quantity_entry_key is None
+            or line.quantity_entry_key in emitted_quantity_entry_keys
+        ):
             continue
         quantity_entries.append(quantity_entries_by_key[line.quantity_entry_key])
         emitted_quantity_entry_keys.add(line.quantity_entry_key)
@@ -1344,10 +1338,7 @@ def _estimate_formula_binding_tokens(
     bindings_payload = raw_bindings.get("bindings")
     if isinstance(bindings_payload, dict):
         if not all(
-            isinstance(key, str)
-            and key
-            and isinstance(value, str)
-            and value
+            isinstance(key, str) and key and isinstance(value, str) and value
             for key, value in bindings_payload.items()
         ):
             raise _build_estimate_job_input_error(
@@ -1588,7 +1579,9 @@ async def _build_estimate_engine_input(
         lines_by_key = {line.line_key: line for line in assembly.lines}
         quantity_entry_keys = {entry.entry_key for entry in quantity_entries}
         rate_entry_keys = {
-            line.catalog_entry_key for line in assembly.lines if line.rate_catalog_entry_id is not None
+            line.catalog_entry_key
+            for line in assembly.lines
+            if line.rate_catalog_entry_id is not None
         }
         material_entry_keys = {
             line.catalog_entry_key
@@ -1925,9 +1918,7 @@ def _entity_provenance_json(entity_payload_json: dict[str, Any]) -> dict[str, An
         else entity_payload_json.get("extraction_path")
     )
     notes_value = (
-        provenance.get("notes")
-        if "notes" in provenance
-        else entity_payload_json.get("notes")
+        provenance.get("notes") if "notes" in provenance else entity_payload_json.get("notes")
     )
     adapter_json = provenance.get("adapter")
     if isinstance(adapter_json, dict):
@@ -2908,9 +2899,7 @@ def _quantity_gate_details(
 def _manifest_entity_count(manifest: RevisionEntityManifest) -> int | None:
     """Return the expected entity count when recorded on the manifest."""
     raw_count = (
-        manifest.counts_json.get("entities")
-        if isinstance(manifest.counts_json, dict)
-        else None
+        manifest.counts_json.get("entities") if isinstance(manifest.counts_json, dict) else None
     )
     return raw_count if isinstance(raw_count, int) else None
 
@@ -3047,9 +3036,7 @@ def _build_quantity_conflict_summaries(conflicts: Sequence[Any]) -> list[dict[st
         summaries.append(
             {
                 "dedup_key": _bounded_conflict_text(getattr(conflict, "dedup_key", None)),
-                "entity_ids": _bounded_conflict_entity_ids(
-                    getattr(conflict, "entity_ids", ())
-                ),
+                "entity_ids": _bounded_conflict_entity_ids(getattr(conflict, "entity_ids", ())),
                 "reason": _bounded_conflict_text(getattr(conflict, "reason", None)),
                 "details": _bounded_conflict_json(getattr(conflict, "details", None)),
             }

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -1473,7 +1473,8 @@ async def _build_estimate_engine_input(
             or quantity_takeoff.id != estimate_input.quantity_takeoff_id
             or quantity_takeoff.quantity_gate != estimate_input.quantity_gate
             or quantity_takeoff.trusted_totals is not estimate_input.trusted_totals
-            or quantity_takeoff.source_job_type != estimate_input.source_job_type
+            or quantity_takeoff.source_job_type != JobType.QUANTITY_TAKEOFF.value
+            or estimate_input.source_job_type != JobType.ESTIMATE.value
         ):
             raise _build_estimate_job_input_error(
                 "quantity_takeoff_lineage_mismatch",

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -3473,6 +3473,7 @@ async def _finalize_estimate_job(
         session.add(estimate_version)
         await session.flush()
         session.add_all(snapshot_entries)
+        await session.flush()
         session.add_all(line_items)
 
         job.status = "succeeded"

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -854,6 +854,49 @@ Estimate snapshots:
   `is_successor`, or backfilled successor-pointer fields to identify the chosen
   snapshot, catalog row, formula, or estimate version.
 
+### Worker Mapping Contract For Estimate Finalization
+
+- Estimate finalization remains worker-only. The worker that owns finalization is
+  the only writer allowed to map staged selection results into committed
+  estimate-version rows, and it must do so atomically with terminal success.
+- The worker must persist `selection_context_json` with
+  `worker_mapping_version = "estimate-line-v1"` for each finalized estimate
+  line.
+- Explicit refs are required. MVP estimate finalization must not auto-select or
+  infer missing refs inside the worker mapping step.
+- The referenced quantity takeoff must remain trusted estimation input at
+  finalization time: `trusted_totals = true` and `quantity_gate = allowed` are
+  required.
+- Invalid mapping, missing required refs, or nontrusted/non-eligible quantity
+  takeoff input must fail closed as `INPUT_INVALID` and produce no committed
+  estimate output.
+
+`selection_context_json` mapping version `estimate-line-v1` must record:
+
+- `worker_mapping_version` - exactly `"estimate-line-v1"`
+- `line_key` - stable finalized line key
+- `line_type` - finalized line kind for the mapped ref
+- `description` - finalized human-readable line description
+- `quantity_item_id` - required for rate and material refs; the pinned source
+  quantity item for that line
+- `quantity_entry_key` - optional quantity snapshot entry key used by the
+  finalized line; if absent the worker derives `quantity:<quantity_item_id>`
+- `catalog_entry_key` - optional key for the resolved frozen catalog entry used
+  by the finalized line; when absent the worker derives `<ref_type>:<selection_key>`
+- `formula_inputs` - required for formula refs; structured declared input
+  bindings to snapshot entry keys used for the finalized formula evaluation
+
+Worker mapping cardinality and ordering rules:
+
+- One explicit ref produces exactly one finalized estimate line.
+- Finalized line order is deterministic: sort by `ref_order`, then by
+  `ref_type`, then by `selection_key`.
+- When one estimate request mixes quantity-backed and catalog-backed refs,
+  quantity-backed entries must be deduplicated and sorted before catalog-backed
+  entries are mapped into finalized lines.
+- Invalid bindings must fail closed. The worker must not drop a bad binding,
+  reorder around it, or publish a partial finalized estimate version.
+
 Catalog scope and mutation rules:
 
 - Catalog data may exist at a global scope and at a project override scope.

--- a/tests/test_estimate_job_input_contract.py
+++ b/tests/test_estimate_job_input_contract.py
@@ -309,12 +309,11 @@ async def test_estimate_job_input_schema_matches_contract() -> None:
     foreign_keys = schema["foreign_keys"]
 
     assert "estimate" in check_constraints["jobs"]["ck_jobs_job_type_valid"]
-    assert "estimate" in check_constraints["jobs"][
-        "ck_jobs_revision_scoped_base_revision_required"
-    ]
-    assert "estimate" in check_constraints["jobs"][
-        "ck_jobs_revision_scoped_extraction_profile_forbidden"
-    ]
+    assert "estimate" in check_constraints["jobs"]["ck_jobs_revision_scoped_base_revision_required"]
+    assert (
+        "estimate"
+        in check_constraints["jobs"]["ck_jobs_revision_scoped_extraction_profile_forbidden"]
+    )
 
     for required_column in (
         "estimate_job_id",
@@ -351,9 +350,7 @@ async def test_estimate_job_input_schema_matches_contract() -> None:
         "ref_type",
         "selection_key",
     )
-    assert ("estimate_job_id", "ref_order") in unique_constraints[
-        "estimate_job_input_catalog_refs"
-    ]
+    assert ("estimate_job_id", "ref_order") in unique_constraints["estimate_job_input_catalog_refs"]
 
     for constraint_name in (
         "ck_estimate_job_inputs_source_job_type_estimate",
@@ -462,20 +459,25 @@ async def test_estimate_job_input_persists_lineage_catalog_refs_and_worker_bound
     assert persisted_input.assumptions_json == {"waste_factor": "10%"}
 
     refs = (
-        await db_session.execute(
-            select(EstimateJobInputCatalogRef)
-            .where(EstimateJobInputCatalogRef.estimate_job_id == estimate_job_id)
-            .order_by(EstimateJobInputCatalogRef.ref_order.asc())
+        (
+            await db_session.execute(
+                select(EstimateJobInputCatalogRef)
+                .where(EstimateJobInputCatalogRef.estimate_job_id == estimate_job_id)
+                .order_by(EstimateJobInputCatalogRef.ref_order.asc())
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert [(ref.ref_type, ref.selection_key, ref.ref_order) for ref in refs] == [
         ("rate", "labour:installer", 0),
         ("material", "cable:standard", 1),
         ("formula", "waste-factor:v1", 2),
     ]
 
-    assert worker_module.is_recoverable_enqueue_job_type(JobType.ESTIMATE) is False
-    assert worker_module.get_job_enqueue_publisher(JobType.ESTIMATE) is None
+    publisher = worker_module.get_job_enqueue_publisher(JobType.ESTIMATE)
+    assert worker_module.is_recoverable_enqueue_job_type(JobType.ESTIMATE) is True
+    assert publisher is not None
 
 
 async def test_estimate_job_contract_rejects_ambiguous_job_inputs(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -855,7 +855,7 @@ async def _persist_estimate_job_input(
                     output_contract_json={"kind": "money", "currency": "GBP"},
                     declared_inputs_json=[],
                     expression_json={"kind": "constant", "value": "1"},
-                    rounding_json=None,
+                    rounding_json={},
                     checksum_sha256=checksum,
                 )
             )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -773,7 +773,7 @@ async def _persist_estimate_job_input(
         source_file_id=estimate_job.file_id,
         drawing_revision_id=quantity_takeoff.drawing_revision_id,
         quantity_takeoff_id=quantity_takeoff.id,
-        source_job_type=quantity_takeoff.source_job_type,
+        source_job_type="estimate",
         quantity_gate=quantity_takeoff.quantity_gate,
         trusted_totals=quantity_takeoff.trusted_totals,
         currency="GBP",

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -174,6 +174,22 @@ def _quantity_length_total(values_by_type: dict[str, float]) -> float:
     return length_values[0]
 
 
+def _select_eligible_aggregate_quantity_item(quantity_items: list[QuantityItem]) -> QuantityItem:
+    """Return one deterministic aggregate quantity item eligible for estimate mapping."""
+    eligible_items = sorted(
+        (
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate"
+            and item.value is not None
+            and item.quantity_gate in {"allowed", "allowed_provisional"}
+        ),
+        key=lambda item: (item.quantity_type, str(item.id)),
+    )
+    assert eligible_items, "expected at least one eligible aggregate quantity item"
+    return eligible_items[0]
+
+
 def _quantity_takeoff_semantic_payload(
     takeoff: QuantityTakeoff,
     items: list[QuantityItem],
@@ -762,7 +778,7 @@ async def _persist_estimate_job_input(
         trusted_totals=quantity_takeoff.trusted_totals,
         currency="GBP",
         pricing_effective_date=date(2026, 1, 2),
-        pricing_mode="explicit_refs",
+        pricing_mode="explicit",
         assumptions_json=deepcopy(assumptions_json),
     )
 
@@ -4032,11 +4048,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4213,11 +4225,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4307,11 +4315,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4419,11 +4423,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4513,11 +4513,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4608,11 +4604,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4713,11 +4705,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4808,11 +4796,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -4895,11 +4879,7 @@ class TestJobs:
             quantity_items,
             estimate_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=estimate_job,
@@ -5001,11 +4981,7 @@ class TestJobs:
             quantity_items,
             engine_invalid_job,
         ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
-        quantity_item = next(
-            item
-            for item in quantity_items
-            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
-        )
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
 
         await _persist_estimate_job_input(
             estimate_job=engine_invalid_job,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -26,6 +26,8 @@ import app.api.v1.jobs as jobs_api
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
+from app.estimating.engine.errors import EstimateEngineError
+from app.estimating.engine.service import compose_estimate as real_compose_estimate
 from app.ingestion.contracts import (
     AdapterFailureKind,
     CancellationHandle,
@@ -37,8 +39,6 @@ from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest
 from app.ingestion.runner import (
     run_ingestion as real_run_ingestion,
 )
-from app.estimating.engine.service import compose_estimate as real_compose_estimate
-from app.estimating.engine.errors import EstimateEngineError
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
@@ -244,7 +244,9 @@ def _estimate_catalog_ref_stub(
         ref_type=ref_type,
         selection_key=selection_key,
         ref_order=ref_order,
-        rate_catalog_entry_id=rate_catalog_entry_id or (uuid.uuid4() if ref_type == "rate" else None),
+        rate_catalog_entry_id=(
+            rate_catalog_entry_id or (uuid.uuid4() if ref_type == "rate" else None)
+        ),
         material_catalog_entry_id=(
             material_catalog_entry_id or (uuid.uuid4() if ref_type == "material" else None)
         ),
@@ -636,12 +638,16 @@ async def _get_quantity_takeoffs_for_job(job_id: uuid.UUID) -> list[QuantityTake
 
     async with session_maker() as session:
         takeoffs = (
-            await session.execute(
-                select(QuantityTakeoff)
-                .where(QuantityTakeoff.source_job_id == job_id)
-                .order_by(QuantityTakeoff.created_at.asc(), QuantityTakeoff.id.asc())
+            (
+                await session.execute(
+                    select(QuantityTakeoff)
+                    .where(QuantityTakeoff.source_job_id == job_id)
+                    .order_by(QuantityTakeoff.created_at.asc(), QuantityTakeoff.id.asc())
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     return list(takeoffs)
 
@@ -653,12 +659,16 @@ async def _get_quantity_items_for_takeoff(quantity_takeoff_id: uuid.UUID) -> lis
 
     async with session_maker() as session:
         items = (
-            await session.execute(
-                select(QuantityItem)
-                .where(QuantityItem.quantity_takeoff_id == quantity_takeoff_id)
-                .order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc())
+            (
+                await session.execute(
+                    select(QuantityItem)
+                    .where(QuantityItem.quantity_takeoff_id == quantity_takeoff_id)
+                    .order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc())
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     return list(items)
 
@@ -670,12 +680,16 @@ async def _get_estimate_versions_for_job(job_id: uuid.UUID) -> list[EstimateVers
 
     async with session_maker() as session:
         versions = (
-            await session.execute(
-                select(EstimateVersion)
-                .where(EstimateVersion.source_job_id == job_id)
-                .order_by(EstimateVersion.created_at.asc(), EstimateVersion.id.asc())
+            (
+                await session.execute(
+                    select(EstimateVersion)
+                    .where(EstimateVersion.source_job_id == job_id)
+                    .order_by(EstimateVersion.created_at.asc(), EstimateVersion.id.asc())
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     return list(versions)
 
@@ -689,12 +703,18 @@ async def _get_estimate_snapshot_entries_for_version(
 
     async with session_maker() as session:
         entries = (
-            await session.execute(
-                select(EstimateSnapshotEntry)
-                .where(EstimateSnapshotEntry.estimate_version_id == estimate_version_id)
-                .order_by(EstimateSnapshotEntry.created_at.asc(), EstimateSnapshotEntry.id.asc())
+            (
+                await session.execute(
+                    select(EstimateSnapshotEntry)
+                    .where(EstimateSnapshotEntry.estimate_version_id == estimate_version_id)
+                    .order_by(
+                        EstimateSnapshotEntry.created_at.asc(), EstimateSnapshotEntry.id.asc()
+                    )
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     return list(entries)
 
@@ -706,12 +726,16 @@ async def _get_estimate_items_for_version(estimate_version_id: uuid.UUID) -> lis
 
     async with session_maker() as session:
         items = (
-            await session.execute(
-                select(EstimateItem)
-                .where(EstimateItem.estimate_version_id == estimate_version_id)
-                .order_by(EstimateItem.created_at.asc(), EstimateItem.id.asc())
+            (
+                await session.execute(
+                    select(EstimateItem)
+                    .where(EstimateItem.estimate_version_id == estimate_version_id)
+                    .order_by(EstimateItem.created_at.asc(), EstimateItem.id.asc())
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     return list(items)
 
@@ -758,7 +782,9 @@ async def _persist_estimate_job_input(
                 ref_payload.get("formula_definition_id"),
             ),
             catalog_checksum_sha256=cast(str, ref_payload["catalog_checksum_sha256"]),
-            selection_context_json=deepcopy(cast(dict[str, Any], ref_payload["selection_context_json"])),
+            selection_context_json=deepcopy(
+                cast(dict[str, Any], ref_payload["selection_context_json"])
+            ),
         )
         for ref_payload in catalog_refs
     ]
@@ -772,7 +798,16 @@ async def _persist_estimate_job_input(
 async def _create_ready_estimate_execution_job(
     async_client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[dict[str, Any], dict[str, Any], Job, DrawingRevision, Job, QuantityTakeoff, list[QuantityItem], Job]:
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    Job,
+    DrawingRevision,
+    Job,
+    QuantityTakeoff,
+    list[QuantityItem],
+    Job,
+]:
     """Create a pending estimate job with a finalized trusted allowed quantity takeoff."""
 
     async def _run_quantity_ready_ingestion(
@@ -786,9 +821,13 @@ async def _create_ready_estimate_execution_job(
         )
 
     monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
-    project, uploaded, ingest_job, base_revision, quantity_job = await _create_ready_quantity_takeoff_job(
-        async_client
-    )
+    (
+        project,
+        uploaded,
+        ingest_job,
+        base_revision,
+        quantity_job,
+    ) = await _create_ready_quantity_takeoff_job(async_client)
     await worker_module.process_quantity_takeoff_job(quantity_job.id)
     takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
     assert len(takeoffs) == 1
@@ -1057,12 +1096,16 @@ async def _get_generated_artifacts_for_job(job_id: uuid.UUID) -> list[GeneratedA
 
     async with session_maker() as session:
         artifacts = (
-            await session.execute(
-                select(GeneratedArtifact)
-                .where(GeneratedArtifact.job_id == job_id)
-                .order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc())
+            (
+                await session.execute(
+                    select(GeneratedArtifact)
+                    .where(GeneratedArtifact.job_id == job_id)
+                    .order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc())
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     return list(artifacts)
 
@@ -2181,9 +2224,7 @@ class TestJobs:
             persisted_job.status = "running"
             persisted_job.attempts = 1
             persisted_job.started_at = (
-                datetime.now(UTC)
-                - worker_module._RUNNING_JOB_STALE_AFTER
-                - timedelta(seconds=1)
+                datetime.now(UTC) - worker_module._RUNNING_JOB_STALE_AFTER - timedelta(seconds=1)
             )
             persisted_job.attempt_token = old_attempt_token
             persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -2225,9 +2266,7 @@ class TestJobs:
             persisted_job.status = "running"
             persisted_job.attempts = 1
             persisted_job.started_at = (
-                datetime.now(UTC)
-                - worker_module._RUNNING_JOB_STALE_AFTER
-                - timedelta(seconds=1)
+                datetime.now(UTC) - worker_module._RUNNING_JOB_STALE_AFTER - timedelta(seconds=1)
             )
             persisted_job.attempt_token = old_attempt_token
             persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -2665,9 +2704,7 @@ class TestJobs:
             persisted_job.status = "running"
             persisted_job.attempts = 1
             persisted_job.started_at = (
-                datetime.now(UTC)
-                - worker_module._RUNNING_JOB_STALE_AFTER
-                - timedelta(seconds=1)
+                datetime.now(UTC) - worker_module._RUNNING_JOB_STALE_AFTER - timedelta(seconds=1)
             )
             persisted_job.attempt_token = old_attempt_token
             persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -2725,9 +2762,7 @@ class TestJobs:
             persisted_job.status = "running"
             persisted_job.attempts = 1
             persisted_job.started_at = (
-                datetime.now(UTC)
-                - worker_module._RUNNING_JOB_STALE_AFTER
-                - timedelta(seconds=1)
+                datetime.now(UTC) - worker_module._RUNNING_JOB_STALE_AFTER - timedelta(seconds=1)
             )
             persisted_job.attempt_token = stale_attempt_token
             persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -3468,7 +3503,7 @@ class TestJobs:
     def test_build_estimate_worker_mapping_v1_maps_rate_material_and_formula_refs(
         self,
     ) -> None:
-        """Estimate mapping helper should derive defaults, sort lines, and dedup quantity entries."""
+        """Estimate mapping helper should derive defaults, sort lines, and dedup entries."""
         _ = self
         shared_quantity_item_id = uuid.uuid4()
         catalog_refs = [
@@ -3727,9 +3762,7 @@ class TestJobs:
         )
         monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_ingest_recovery_enqueue)
 
-        project, uploaded, ingest_job, base_revision, estimate_job = await _create_ready_estimate_job(
-            async_client
-        )
+        _, _, _, _, estimate_job = await _create_ready_estimate_job(async_client)
         await _update_job(
             estimate_job.id,
             status=status,
@@ -3845,9 +3878,7 @@ class TestJobs:
             persisted_job.status = "running"
             persisted_job.attempts = 1
             persisted_job.started_at = (
-                datetime.now(UTC)
-                - worker_module._RUNNING_JOB_STALE_AFTER
-                - timedelta(seconds=1)
+                datetime.now(UTC) - worker_module._RUNNING_JOB_STALE_AFTER - timedelta(seconds=1)
             )
             persisted_job.attempt_token = old_attempt_token
             persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -3958,9 +3989,7 @@ class TestJobs:
 
         worker_module.enqueue_estimate_job(job_id)
 
-        assert published == [
-            {"args": (str(job_id),), "task_id": str(job_id), "retry": False}
-        ]
+        assert published == [{"args": (str(job_id),), "task_id": str(job_id), "retry": False}]
 
     def test_run_estimate_job_dispatches_persisted_processor(
         self,
@@ -3988,7 +4017,7 @@ class TestJobs:
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Estimate worker should deterministically compose engine input before persistence lands."""
+        """Estimate worker should compose engine input before persistence lands."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
@@ -4032,9 +4061,7 @@ class TestJobs:
                     "ref_type": "formula",
                     "selection_key": "waste-10",
                     "ref_order": 30,
-                    "formula_definition_id": uuid.UUID(
-                        "00000000-0000-0000-0000-000000000202"
-                    ),
+                    "formula_definition_id": uuid.UUID("00000000-0000-0000-0000-000000000202"),
                     "catalog_checksum_sha256": "2" * 64,
                     "selection_context_json": {
                         "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
@@ -4048,9 +4075,7 @@ class TestJobs:
                     "ref_type": "material",
                     "selection_key": "paint-gallon",
                     "ref_order": 20,
-                    "material_catalog_entry_id": uuid.UUID(
-                        "00000000-0000-0000-0000-000000000203"
-                    ),
+                    "material_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000203"),
                     "catalog_checksum_sha256": "3" * 64,
                     "selection_context_json": {
                         "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
@@ -4065,7 +4090,10 @@ class TestJobs:
 
         fake_formula_definition = types.SimpleNamespace(
             declared_inputs=(
-                types.SimpleNamespace(name="rate_input", contract=types.SimpleNamespace(kind="rate")),
+                types.SimpleNamespace(
+                    name="rate_input",
+                    contract=types.SimpleNamespace(kind="rate"),
+                ),
             ),
         )
         captured_engine_inputs: list[Any] = []
@@ -4639,9 +4667,7 @@ class TestJobs:
             assert persisted_job is not None
             persisted_job.status = "running"
             persisted_job.started_at = (
-                datetime.now(UTC)
-                - worker_module._RUNNING_JOB_STALE_AFTER
-                - timedelta(seconds=1)
+                datetime.now(UTC) - worker_module._RUNNING_JOB_STALE_AFTER - timedelta(seconds=1)
             )
             persisted_job.attempt_token = stale_lease.token
             persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
@@ -5232,9 +5258,13 @@ class TestJobs:
             "expected_validation_status",
         )
         monkeypatch.setattr(worker_module, "run_ingestion", real_run_ingestion)
-        project, uploaded, _, base_revision, quantity_job = (
-            await _create_real_dxf_quantity_takeoff_job(async_client, fixture_filename)
-        )
+        (
+            project,
+            uploaded,
+            _,
+            base_revision,
+            quantity_job,
+        ) = await _create_real_dxf_quantity_takeoff_job(async_client, fixture_filename)
 
         await worker_module.process_quantity_takeoff_job(quantity_job.id)
 
@@ -5260,9 +5290,7 @@ class TestJobs:
         assert all(item.item_kind != "exclusion" for item in items)
 
         aggregate_values = _quantity_item_values_by_type(items, item_kind="aggregate")
-        assert aggregate_values["count:entity_count"] == pytest.approx(
-            float(expected_line_count)
-        )
+        assert aggregate_values["count:entity_count"] == pytest.approx(float(expected_line_count))
         assert aggregate_values["count:line_count"] == pytest.approx(float(expected_line_count))
         assert _quantity_length_total(aggregate_values) == pytest.approx(expected_total_length)
 
@@ -5359,9 +5387,13 @@ class TestJobs:
         _ = enqueued_job_ids
         fixture_filename = "dxf/simple-line.dxf"
         monkeypatch.setattr(worker_module, "run_ingestion", real_run_ingestion)
-        project, uploaded, ingest_job, base_revision, first_job = (
-            await _create_real_dxf_quantity_takeoff_job(async_client, fixture_filename)
-        )
+        (
+            project,
+            uploaded,
+            ingest_job,
+            base_revision,
+            first_job,
+        ) = await _create_real_dxf_quantity_takeoff_job(async_client, fixture_filename)
         second_job = await _create_quantity_takeoff_job(
             project_id=uuid.UUID(project["id"]),
             file_id=uuid.UUID(uploaded["id"]),
@@ -5440,9 +5472,7 @@ class TestJobs:
 
         items = await _get_quantity_items_for_takeoff(takeoffs[0].id)
         aggregate_values = _quantity_item_values_by_type(items, item_kind="aggregate")
-        assert aggregate_values["count:entity_count"] == pytest.approx(
-            float(expected_line_count)
-        )
+        assert aggregate_values["count:entity_count"] == pytest.approx(float(expected_line_count))
         assert aggregate_values["count:line_count"] == pytest.approx(float(expected_line_count))
         assert _quantity_length_total(aggregate_values) == pytest.approx(expected_total_length)
 
@@ -5504,8 +5534,7 @@ class TestJobs:
         assert updated_job.status == "failed"
         assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
         assert (
-            updated_job.error_message
-            == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
+            updated_job.error_message == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
         )
         assert takeoffs == []
 
@@ -5566,8 +5595,7 @@ class TestJobs:
         assert updated_job.attempts == 1
         assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
         assert (
-            updated_job.error_message
-            == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
+            updated_job.error_message == worker_module._QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE
         )
         assert takeoffs == []
 
@@ -5656,8 +5684,7 @@ class TestJobs:
         assert event_payload["status"] == "failed"
         assert event_payload["error_code"] == ErrorCode.INPUT_INVALID.value
         assert (
-            event_payload["error_message"]
-            == worker_module._QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE
+            event_payload["error_message"] == worker_module._QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE
         )
         assert event_payload["details"]["conflict_count"] == 2
         conflict_summaries = event_payload["details"]["conflicts"]
@@ -5786,10 +5813,7 @@ class TestJobs:
         updated_job = await _get_job(quantity_job.id)
         takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
         assert updated_job.status == "failed"
-        assert (
-            updated_job.error_code
-            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
-        )
+        assert updated_job.error_code == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
         assert (
             updated_job.error_message
             == worker_module._QUANTITY_TAKEOFF_MATERIALIZATION_MISSING_ERROR_MESSAGE
@@ -5800,10 +5824,7 @@ class TestJobs:
         assert response.status_code == 200
         event_payload = response.json()["items"][-1]["data_json"]
         assert event_payload["status"] == "failed"
-        assert (
-            event_payload["error_code"]
-            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
-        )
+        assert event_payload["error_code"] == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
         assert event_payload["details"]["drawing_revision_id"] == str(base_revision.id)
 
     async def test_process_quantity_takeoff_job_fails_materialization_mismatch_without_rows(
@@ -5842,19 +5863,13 @@ class TestJobs:
         updated_job = await _get_job(quantity_job.id)
         takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
         assert updated_job.status == "failed"
-        assert (
-            updated_job.error_code
-            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
-        )
+        assert updated_job.error_code == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
         assert takeoffs == []
 
         response = await async_client.get(f"/v1/jobs/{quantity_job.id}/events")
         assert response.status_code == 200
         event_payload = response.json()["items"][-1]["data_json"]
-        assert (
-            event_payload["error_code"]
-            == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
-        )
+        assert event_payload["error_code"] == ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED.value
         assert event_payload["details"] == {
             "drawing_revision_id": str(base_revision.id),
             "expected_entities": 1,
@@ -6286,8 +6301,7 @@ class TestJobs:
         assert unchanged.status == "failed"
         assert unchanged.error_code == ErrorCode.REVISION_CONFLICT.value
         assert (
-            unchanged.error_message
-            == "Reprocess base revision became stale before finalization."
+            unchanged.error_message == "Reprocess base revision became stale before finalization."
         )
 
     async def test_retry_job_is_terminal_no_op_for_cancelled_job(
@@ -6479,9 +6493,7 @@ class TestJobs:
                 .with_for_update(of=Project)
             )
 
-            delete_task = asyncio.create_task(
-                async_client.delete(f"/v1/projects/{project['id']}")
-            )
+            delete_task = asyncio.create_task(async_client.delete(f"/v1/projects/{project['id']}"))
             with pytest.raises(TimeoutError):
                 await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
 
@@ -6650,9 +6662,7 @@ class TestJobs:
                 .with_for_update(of=Project)
             )
 
-            delete_task = asyncio.create_task(
-                async_client.delete(f"/v1/projects/{project['id']}")
-            )
+            delete_task = asyncio.create_task(async_client.delete(f"/v1/projects/{project['id']}"))
             with pytest.raises(TimeoutError):
                 await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
 
@@ -6701,9 +6711,7 @@ class TestJobs:
                 .with_for_update(of=Project)
             )
 
-            delete_task = asyncio.create_task(
-                async_client.delete(f"/v1/projects/{project['id']}")
-            )
+            delete_task = asyncio.create_task(async_client.delete(f"/v1/projects/{project['id']}"))
             with pytest.raises(TimeoutError):
                 await asyncio.wait_for(asyncio.shield(delete_task), timeout=0.2)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -9,7 +9,8 @@ from collections.abc import Callable
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
@@ -36,7 +37,11 @@ from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest
 from app.ingestion.runner import (
     run_ingestion as real_run_ingestion,
 )
+from app.estimating.engine.service import compose_estimate as real_compose_estimate
+from app.estimating.engine.errors import EstimateEngineError
 from app.models.drawing_revision import DrawingRevision
+from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
@@ -198,6 +203,70 @@ def _quantity_takeoff_semantic_payload(
             key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
         ),
     }
+
+
+def _estimate_catalog_ref_stub(
+    *,
+    ref_type: str,
+    selection_key: str,
+    line_key: str,
+    ref_order: int,
+    worker_mapping_version: str | None = worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+    description: str | None = None,
+    quantity_entry_key: str | None = None,
+    catalog_entry_key: str | None = None,
+    quantity_item_id: uuid.UUID | None = None,
+    formula_inputs: dict[str, Any] | None = None,
+    mapped_line_type: str | None = None,
+    rate_catalog_entry_id: uuid.UUID | None = None,
+    material_catalog_entry_id: uuid.UUID | None = None,
+    formula_definition_id: uuid.UUID | None = None,
+    catalog_checksum_sha256: str = "a" * 64,
+) -> types.SimpleNamespace:
+    """Build a lightweight estimate catalog-ref stub for worker mapping tests."""
+    selection_context_json: dict[str, Any] = {
+        "line_key": line_key,
+        "line_type": mapped_line_type or ref_type,
+        "description": description or f"{ref_type} {selection_key}",
+    }
+    if worker_mapping_version is not None:
+        selection_context_json["worker_mapping_version"] = worker_mapping_version
+    if quantity_entry_key is not None:
+        selection_context_json["quantity_entry_key"] = quantity_entry_key
+    if catalog_entry_key is not None:
+        selection_context_json["catalog_entry_key"] = catalog_entry_key
+    if quantity_item_id is not None:
+        selection_context_json["quantity_item_id"] = str(quantity_item_id)
+    if formula_inputs is not None:
+        selection_context_json["formula_inputs"] = deepcopy(formula_inputs)
+
+    return types.SimpleNamespace(
+        ref_type=ref_type,
+        selection_key=selection_key,
+        ref_order=ref_order,
+        rate_catalog_entry_id=rate_catalog_entry_id or (uuid.uuid4() if ref_type == "rate" else None),
+        material_catalog_entry_id=(
+            material_catalog_entry_id or (uuid.uuid4() if ref_type == "material" else None)
+        ),
+        formula_definition_id=(
+            formula_definition_id or (uuid.uuid4() if ref_type == "formula" else None)
+        ),
+        catalog_checksum_sha256=catalog_checksum_sha256,
+        selection_context_json=selection_context_json,
+    )
+
+
+def _assert_estimate_mapping_invalid(
+    exc_info: pytest.ExceptionInfo[worker_module._EstimateJobInputError],
+    *,
+    reason: str,
+) -> None:
+    """Assert deterministic sanitized estimate mapping failures."""
+    error = exc_info.value
+    assert error.error_code == ErrorCode.INPUT_INVALID
+    assert error.message == worker_module._ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE
+    assert error.details is not None
+    assert error.details["reason"] == reason
 
 
 class _AdapterModule(types.ModuleType):
@@ -594,6 +663,159 @@ async def _get_quantity_items_for_takeoff(quantity_takeoff_id: uuid.UUID) -> lis
     return list(items)
 
 
+async def _get_estimate_versions_for_job(job_id: uuid.UUID) -> list[EstimateVersion]:
+    """Load persisted estimate versions for an estimate source job."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        versions = (
+            await session.execute(
+                select(EstimateVersion)
+                .where(EstimateVersion.source_job_id == job_id)
+                .order_by(EstimateVersion.created_at.asc(), EstimateVersion.id.asc())
+            )
+        ).scalars().all()
+
+    return list(versions)
+
+
+async def _get_estimate_snapshot_entries_for_version(
+    estimate_version_id: uuid.UUID,
+) -> list[EstimateSnapshotEntry]:
+    """Load persisted estimate snapshot entries for one version."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        entries = (
+            await session.execute(
+                select(EstimateSnapshotEntry)
+                .where(EstimateSnapshotEntry.estimate_version_id == estimate_version_id)
+                .order_by(EstimateSnapshotEntry.created_at.asc(), EstimateSnapshotEntry.id.asc())
+            )
+        ).scalars().all()
+
+    return list(entries)
+
+
+async def _get_estimate_items_for_version(estimate_version_id: uuid.UUID) -> list[EstimateItem]:
+    """Load persisted estimate line items for one version."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        items = (
+            await session.execute(
+                select(EstimateItem)
+                .where(EstimateItem.estimate_version_id == estimate_version_id)
+                .order_by(EstimateItem.created_at.asc(), EstimateItem.id.asc())
+            )
+        ).scalars().all()
+
+    return list(items)
+
+
+async def _persist_estimate_job_input(
+    *,
+    estimate_job: Job,
+    quantity_takeoff: QuantityTakeoff,
+    assumptions_json: dict[str, Any],
+    catalog_refs: list[dict[str, Any]],
+) -> None:
+    """Persist one estimate input row and its explicit catalog refs."""
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    estimate_input = EstimateJobInput(
+        estimate_job_id=estimate_job.id,
+        project_id=estimate_job.project_id,
+        source_file_id=estimate_job.file_id,
+        drawing_revision_id=quantity_takeoff.drawing_revision_id,
+        quantity_takeoff_id=quantity_takeoff.id,
+        source_job_type=quantity_takeoff.source_job_type,
+        quantity_gate=quantity_takeoff.quantity_gate,
+        trusted_totals=quantity_takeoff.trusted_totals,
+        currency="GBP",
+        pricing_effective_date=date(2026, 1, 2),
+        pricing_mode="explicit_refs",
+        assumptions_json=deepcopy(assumptions_json),
+    )
+
+    ref_rows = [
+        EstimateJobInputCatalogRef(
+            estimate_job_id=estimate_job.id,
+            ref_type=cast(str, ref_payload["ref_type"]),
+            selection_key=cast(str, ref_payload["selection_key"]),
+            ref_order=cast(int, ref_payload["ref_order"]),
+            rate_catalog_entry_id=cast(uuid.UUID | None, ref_payload.get("rate_catalog_entry_id")),
+            material_catalog_entry_id=cast(
+                uuid.UUID | None,
+                ref_payload.get("material_catalog_entry_id"),
+            ),
+            formula_definition_id=cast(
+                uuid.UUID | None,
+                ref_payload.get("formula_definition_id"),
+            ),
+            catalog_checksum_sha256=cast(str, ref_payload["catalog_checksum_sha256"]),
+            selection_context_json=deepcopy(cast(dict[str, Any], ref_payload["selection_context_json"])),
+        )
+        for ref_payload in catalog_refs
+    ]
+
+    async with session_maker() as session:
+        session.add(estimate_input)
+        session.add_all(ref_rows)
+        await session.commit()
+
+
+async def _create_ready_estimate_execution_job(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, Any], dict[str, Any], Job, DrawingRevision, Job, QuantityTakeoff, list[QuantityItem], Job]:
+    """Create a pending estimate job with a finalized trusted allowed quantity takeoff."""
+
+    async def _run_quantity_ready_ingestion(
+        request: IngestionRunRequest,
+    ) -> IngestFinalizationPayload:
+        return _build_fake_quantity_ingest_payload(
+            request,
+            review_state="approved",
+            validation_status="valid",
+            quantity_gate="allowed",
+        )
+
+    monkeypatch.setattr(worker_module, "run_ingestion", _run_quantity_ready_ingestion)
+    project, uploaded, ingest_job, base_revision, quantity_job = await _create_ready_quantity_takeoff_job(
+        async_client
+    )
+    await worker_module.process_quantity_takeoff_job(quantity_job.id)
+    takeoffs = await _get_quantity_takeoffs_for_job(quantity_job.id)
+    assert len(takeoffs) == 1
+    quantity_takeoff = takeoffs[0]
+    quantity_items = await _get_quantity_items_for_takeoff(quantity_takeoff.id)
+
+    estimate_job = await _create_quantity_takeoff_job(
+        project_id=uuid.UUID(project["id"]),
+        file_id=uuid.UUID(uploaded["id"]),
+        base_revision_id=base_revision.id,
+        parent_job_id=quantity_job.id,
+        job_type=JobType.ESTIMATE.value,
+        status="pending",
+    )
+
+    return (
+        project,
+        uploaded,
+        ingest_job,
+        base_revision,
+        quantity_job,
+        quantity_takeoff,
+        quantity_items,
+        estimate_job,
+    )
+
+
 async def _create_quantity_takeoff_job(
     *,
     project_id: uuid.UUID,
@@ -650,6 +872,29 @@ async def _create_ready_quantity_takeoff_job(
     )
 
     return project, uploaded, ingest_job, base_revision, quantity_job
+
+
+async def _create_ready_estimate_job(
+    async_client: httpx.AsyncClient,
+) -> tuple[dict[str, Any], dict[str, Any], Job, DrawingRevision, Job]:
+    """Create a project/file/revision and pending estimate job for worker tests."""
+    project = await _create_project(async_client)
+    uploaded = await _upload_file(async_client, project["id"])
+    ingest_job = await _get_job_for_file(str(uploaded["id"]))
+    await worker_module.process_ingest_job(ingest_job.id)
+    base_revision = await _get_latest_revision_for_file(uuid.UUID(uploaded["id"]))
+    assert base_revision is not None
+
+    estimate_job = await _create_quantity_takeoff_job(
+        project_id=uuid.UUID(project["id"]),
+        file_id=uuid.UUID(uploaded["id"]),
+        base_revision_id=base_revision.id,
+        parent_job_id=ingest_job.id,
+        job_type=JobType.ESTIMATE.value,
+        status="pending",
+    )
+
+    return project, uploaded, ingest_job, base_revision, estimate_job
 
 
 async def _create_real_dxf_quantity_takeoff_job(
@@ -3147,14 +3392,14 @@ class TestJobs:
         assert retried.base_revision_id == original.base_revision_id
         assert retried.parent_job_id == original.parent_job_id
 
-    async def test_retry_job_noops_for_unrecoverable_estimate_job(
+    async def test_retry_job_requeues_failed_estimate_job(
         self,
         async_client: httpx.AsyncClient,
         cleanup_projects: None,
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Retry should no-op for failed estimate jobs without enqueue recovery."""
+        """Retry should route failed estimate jobs back through durable enqueue recovery."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
@@ -3207,18 +3452,155 @@ class TestJobs:
         response = await async_client.post(f"/v1/jobs/{estimate_job.id}/retry")
 
         assert response.status_code == 202
-        assert retried_job_ids == []
-        unchanged = await _get_job(estimate_job.id)
-        assert unchanged.status == "failed"
-        assert unchanged.attempts == estimate_job.attempts
-        assert unchanged.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert unchanged.error_message == "estimate worker unavailable"
-        assert unchanged.enqueue_status == "pending"
-        assert unchanged.enqueue_attempts == 2
-        assert unchanged.job_type == JobType.ESTIMATE.value
-        assert unchanged.extraction_profile_id is None
-        assert unchanged.base_revision_id == base_revision.id
-        assert unchanged.parent_job_id == ingest_job.id
+        assert retried_job_ids == [str(estimate_job.id)]
+        retried = await _get_job(estimate_job.id)
+        assert retried.status == "pending"
+        assert retried.attempts == estimate_job.attempts
+        assert retried.error_code is None
+        assert retried.error_message is None
+        assert retried.enqueue_status == "pending"
+        assert retried.enqueue_attempts == 0
+        assert retried.job_type == JobType.ESTIMATE.value
+        assert retried.extraction_profile_id is None
+        assert retried.base_revision_id == base_revision.id
+        assert retried.parent_job_id == ingest_job.id
+
+    def test_build_estimate_worker_mapping_v1_maps_rate_material_and_formula_refs(
+        self,
+    ) -> None:
+        """Estimate mapping helper should derive defaults, sort lines, and dedup quantity entries."""
+        _ = self
+        shared_quantity_item_id = uuid.uuid4()
+        catalog_refs = [
+            _estimate_catalog_ref_stub(
+                ref_type="rate",
+                selection_key="paint-labor",
+                line_key="line-rate",
+                ref_order=20,
+                description="Paint labor",
+                quantity_item_id=shared_quantity_item_id,
+            ),
+            _estimate_catalog_ref_stub(
+                ref_type="formula",
+                selection_key="waste-10",
+                line_key="line-formula",
+                ref_order=30,
+                description="Waste allowance",
+                formula_inputs={
+                    "operand_line_keys": ["line-rate", "line-material"],
+                    "expression": "subtotal * 1.10",
+                },
+            ),
+            _estimate_catalog_ref_stub(
+                ref_type="material",
+                selection_key="paint-gallon",
+                line_key="line-material",
+                ref_order=20,
+                description="Paint gallon",
+                quantity_item_id=shared_quantity_item_id,
+            ),
+        ]
+
+        assembly = worker_module._build_estimate_worker_mapping_v1(catalog_refs)
+
+        assert [line.line_key for line in assembly.lines] == [
+            "line-material",
+            "line-rate",
+            "line-formula",
+        ]
+        assert [line.ref_type for line in assembly.lines] == ["material", "rate", "formula"]
+        assert [line.line_type for line in assembly.lines] == ["material", "rate", "formula"]
+        assert [line.description for line in assembly.lines] == [
+            "Paint gallon",
+            "Paint labor",
+            "Waste allowance",
+        ]
+        assert [line.ref_order for line in assembly.lines] == [20, 20, 30]
+        assert [line.catalog_entry_key for line in assembly.lines] == [
+            "material:paint-gallon",
+            "rate:paint-labor",
+            "formula:waste-10",
+        ]
+        assert len(assembly.lines) == 3
+        assert assembly.lines[0].quantity_item_id == shared_quantity_item_id
+        assert assembly.lines[1].quantity_item_id == shared_quantity_item_id
+        assert assembly.lines[2].quantity_item_id is None
+        assert assembly.lines[0].quantity_entry_key == f"quantity:{shared_quantity_item_id}"
+        assert assembly.lines[1].quantity_entry_key == f"quantity:{shared_quantity_item_id}"
+        assert assembly.lines[2].formula_inputs == {
+            "operand_line_keys": ["line-rate", "line-material"],
+            "expression": "subtotal * 1.10",
+        }
+        assert [entry.entry_key for entry in assembly.quantity_entries] == [
+            f"quantity:{shared_quantity_item_id}"
+        ]
+        assert assembly.quantity_entries[0].quantity_item_id == shared_quantity_item_id
+
+    @pytest.mark.parametrize(
+        ("catalog_refs", "reason"),
+        [
+            pytest.param(
+                [
+                    _estimate_catalog_ref_stub(
+                        ref_type="rate",
+                        selection_key="missing-version",
+                        line_key="line-rate",
+                        ref_order=10,
+                        worker_mapping_version=None,
+                        quantity_item_id=uuid.UUID("00000000-0000-0000-0000-000000000101"),
+                    )
+                ],
+                "missing_worker_mapping_version",
+                id="missing-version",
+            ),
+            pytest.param(
+                [
+                    _estimate_catalog_ref_stub(
+                        ref_type="rate",
+                        selection_key="first",
+                        line_key="line-duplicate",
+                        ref_order=10,
+                        quantity_item_id=uuid.UUID("00000000-0000-0000-0000-000000000102"),
+                    ),
+                    _estimate_catalog_ref_stub(
+                        ref_type="material",
+                        selection_key="duplicate",
+                        line_key="line-duplicate",
+                        ref_order=20,
+                        quantity_item_id=uuid.UUID("00000000-0000-0000-0000-000000000102"),
+                    ),
+                ],
+                "duplicate_line_key",
+                id="duplicate-line-key",
+            ),
+            pytest.param(
+                [
+                    _estimate_catalog_ref_stub(
+                        ref_type="material",
+                        selection_key="mismatched",
+                        line_key="line-mismatched",
+                        ref_order=10,
+                        mapped_line_type="rate",
+                        quantity_item_id=uuid.UUID("00000000-0000-0000-0000-000000000103"),
+                    )
+                ],
+                "mismatched_line_ref_type",
+                id="mismatched-ref-type",
+            ),
+        ],
+    )
+    def test_build_estimate_worker_mapping_v1_rejects_invalid_refs(
+        self,
+        catalog_refs: list[types.SimpleNamespace],
+        reason: str,
+    ) -> None:
+        """Estimate mapping helper should reject invalid contract inputs before output assembly."""
+        _ = self
+
+        with pytest.raises(worker_module._EstimateJobInputError) as exc_info:
+            worker_module._build_estimate_worker_mapping_v1(catalog_refs)
+
+        _assert_estimate_mapping_invalid(exc_info, reason=reason)
 
     @pytest.mark.parametrize("status", ["pending", "running"])
     async def test_recover_incomplete_ingest_jobs_requeues_quantity_takeoff_jobs(
@@ -3314,6 +3696,1351 @@ class TestJobs:
         assert recovered.extraction_profile_id is None
         assert recovered.base_revision_id == original.base_revision_id
         assert recovered.parent_job_id == original.parent_job_id
+
+    @pytest.mark.parametrize("status", ["pending", "running"])
+    async def test_recover_incomplete_ingest_jobs_requeues_estimate_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+        status: str,
+    ) -> None:
+        """Startup recovery should route estimate jobs through the estimate publisher."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        estimate_recovered_job_ids: list[str] = []
+        ingest_recovered_job_ids: list[str] = []
+
+        def _fake_estimate_recovery_enqueue(job_id: uuid.UUID) -> None:
+            estimate_recovered_job_ids.append(str(job_id))
+
+        def _fake_ingest_recovery_enqueue(job_id: uuid.UUID) -> None:
+            ingest_recovered_job_ids.append(str(job_id))
+
+        monkeypatch.setattr(
+            worker_module,
+            "enqueue_estimate_job",
+            _fake_estimate_recovery_enqueue,
+        )
+        monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_ingest_recovery_enqueue)
+
+        project, uploaded, ingest_job, base_revision, estimate_job = await _create_ready_estimate_job(
+            async_client
+        )
+        await _update_job(
+            estimate_job.id,
+            status=status,
+            attempts=1 if status == "running" else 0,
+        )
+
+        if status == "running":
+            await _update_job(
+                estimate_job.id,
+                enqueue_status="published",
+                enqueue_attempts=1,
+            )
+            session_maker = session_module.AsyncSessionLocal
+            assert session_maker is not None
+            async with session_maker() as session:
+                persisted_job = await session.get(Job, estimate_job.id)
+                assert persisted_job is not None
+                persisted_job.started_at = (
+                    datetime.now(UTC)
+                    - worker_module._RUNNING_JOB_STALE_AFTER
+                    - timedelta(seconds=1)
+                )
+                persisted_job.attempt_token = uuid.uuid4()
+                persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+                await session.commit()
+        else:
+            await _update_job(
+                estimate_job.id,
+                enqueue_status="pending",
+                enqueue_attempts=0,
+            )
+
+        original = await _get_job(estimate_job.id)
+
+        requeued = await worker_module.recover_incomplete_ingest_jobs()
+
+        assert requeued == [estimate_job.id]
+        assert estimate_recovered_job_ids == [str(estimate_job.id)]
+        assert ingest_recovered_job_ids == []
+        recovered = await _get_job(estimate_job.id)
+        assert recovered.status == "pending"
+        assert recovered.attempts == original.attempts
+        assert recovered.started_at is None
+        assert recovered.attempt_token is None
+        assert recovered.attempt_lease_expires_at is None
+        assert recovered.enqueue_status == "published"
+        assert recovered.enqueue_attempts == 1
+        assert recovered.project_id == original.project_id
+        assert recovered.file_id == original.file_id
+        assert recovered.job_type == original.job_type
+        assert recovered.extraction_profile_id == original.extraction_profile_id
+        assert recovered.extraction_profile_id is None
+        assert recovered.base_revision_id == original.base_revision_id
+        assert recovered.parent_job_id == original.parent_job_id
+
+    async def test_begin_or_resume_estimate_job_skips_duplicate_running_attempt(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Estimate duplicate delivery should leave a fresh running attempt unchanged."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        _, _, _, _, estimate_job = await _create_ready_estimate_job(async_client)
+        attempt_token = uuid.uuid4()
+        lease_expires_at = datetime.now(UTC) + worker_module._RUNNING_JOB_STALE_AFTER
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, estimate_job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = datetime.now(UTC)
+            persisted_job.attempt_token = attempt_token
+            persisted_job.attempt_lease_expires_at = lease_expires_at
+            await session.commit()
+
+        lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+
+        assert lease is None
+        unchanged = await _get_job(estimate_job.id)
+        assert unchanged.status == "running"
+        assert unchanged.attempts == 1
+        assert unchanged.started_at is not None
+        assert unchanged.finished_at is None
+        assert unchanged.attempt_token == attempt_token
+        assert unchanged.attempt_lease_expires_at == lease_expires_at
+
+    async def test_begin_or_resume_estimate_job_reclaims_stale_running_attempt_with_new_token(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Estimate stale running attempts should be reclaimed with a fresh ownership token."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        _, _, _, _, estimate_job = await _create_ready_estimate_job(async_client)
+        old_attempt_token = uuid.uuid4()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, estimate_job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.attempts = 1
+            persisted_job.started_at = (
+                datetime.now(UTC)
+                - worker_module._RUNNING_JOB_STALE_AFTER
+                - timedelta(seconds=1)
+            )
+            persisted_job.attempt_token = old_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+
+        assert lease is not None
+        assert lease.token != old_attempt_token
+        reclaimed_job = await _get_job(estimate_job.id)
+        assert reclaimed_job.status == "running"
+        assert reclaimed_job.attempts == 2
+        assert reclaimed_job.attempt_token == lease.token
+        assert reclaimed_job.attempt_lease_expires_at == lease.lease_expires_at
+        assert reclaimed_job.attempt_lease_expires_at is not None
+        assert reclaimed_job.attempt_lease_expires_at > datetime.now(UTC)
+
+    async def test_begin_or_resume_estimate_job_cancels_inactive_source(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Estimate begin/resume should cancel when the source project or file is inactive."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project, uploaded, _, _, estimate_job = await _create_ready_estimate_job(async_client)
+        await _mark_source_deleted(
+            uuid.UUID(project["id"]),
+            uuid.UUID(uploaded["id"]),
+            delete_project=False,
+            delete_file=True,
+        )
+
+        lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+
+        assert lease is None
+        cancelled = await _get_job(estimate_job.id)
+        assert cancelled.status == "cancelled"
+        assert cancelled.cancel_requested is True
+        assert cancelled.error_code == ErrorCode.JOB_CANCELLED.value
+        assert cancelled.finished_at is not None
+
+    async def test_begin_or_resume_estimate_job_finalizes_cancel_requested_job_as_cancelled(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Estimate begin/resume should finalize cancel-requested jobs to cancelled."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        _, _, _, _, estimate_job = await _create_ready_estimate_job(async_client)
+        await _update_job(estimate_job.id, status="pending", cancel_requested=True)
+
+        lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+
+        assert lease is None
+        updated = await _get_job(estimate_job.id)
+        assert updated.status == "cancelled"
+        assert updated.cancel_requested is True
+        assert updated.error_code == ErrorCode.JOB_CANCELLED.value
+        assert updated.finished_at is not None
+
+    async def test_begin_or_resume_estimate_job_skips_terminal_status(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Estimate begin/resume should ignore already terminal jobs."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        _, _, _, _, estimate_job = await _create_ready_estimate_job(async_client)
+        await _update_job(estimate_job.id, status="failed", attempts=1, error_message="done")
+        before = await _get_job(estimate_job.id)
+        before_finished_at = before.finished_at
+
+        lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+
+        assert lease is None
+        unchanged = await _get_job(estimate_job.id)
+        assert unchanged.status == "failed"
+        assert unchanged.attempts == 1
+        assert unchanged.error_message == "done"
+        assert unchanged.finished_at == before_finished_at
+
+    def test_enqueue_estimate_job_publishes_persisted_job_to_celery(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate enqueue should publish the persisted job identifier to Celery."""
+        _ = self
+
+        published: list[dict[str, Any]] = []
+
+        def _fake_apply_async(*, args: tuple[str, ...], task_id: str, retry: bool) -> None:
+            published.append({"args": args, "task_id": task_id, "retry": retry})
+
+        job_id = uuid.uuid4()
+        monkeypatch.setattr(worker_module.run_estimate_job, "apply_async", _fake_apply_async)
+
+        worker_module.enqueue_estimate_job(job_id)
+
+        assert published == [
+            {"args": (str(job_id),), "task_id": str(job_id), "retry": False}
+        ]
+
+    def test_run_estimate_job_dispatches_persisted_processor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate Celery wrapper should dispatch to the persisted processor."""
+        _ = self
+
+        processed_job_ids: list[uuid.UUID] = []
+
+        async def _fake_process(job_id: uuid.UUID) -> None:
+            processed_job_ids.append(job_id)
+
+        job_id = uuid.uuid4()
+        monkeypatch.setattr(worker_module, "process_estimate_job", _fake_process)
+
+        worker_module.run_estimate_job(str(job_id))
+
+        assert processed_job_ids == [job_id]
+
+    async def test_process_estimate_job_builds_engine_input_without_publishing_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate worker should deterministically compose engine input before persistence lands."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={"tax_rate": "0.20"},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000201"),
+                    "catalog_checksum_sha256": "1" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                },
+                {
+                    "ref_type": "formula",
+                    "selection_key": "waste-10",
+                    "ref_order": 30,
+                    "formula_definition_id": uuid.UUID(
+                        "00000000-0000-0000-0000-000000000202"
+                    ),
+                    "catalog_checksum_sha256": "2" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-formula",
+                        "line_type": "formula",
+                        "description": "Waste allowance",
+                        "formula_inputs": {"operand_line_keys": ["line-rate"]},
+                    },
+                },
+                {
+                    "ref_type": "material",
+                    "selection_key": "paint-gallon",
+                    "ref_order": 20,
+                    "material_catalog_entry_id": uuid.UUID(
+                        "00000000-0000-0000-0000-000000000203"
+                    ),
+                    "catalog_checksum_sha256": "3" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-material",
+                        "line_type": "material",
+                        "description": "Paint gallon",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                },
+            ],
+        )
+
+        fake_formula_definition = types.SimpleNamespace(
+            declared_inputs=(
+                types.SimpleNamespace(name="rate_input", contract=types.SimpleNamespace(kind="rate")),
+            ),
+        )
+        captured_engine_inputs: list[Any] = []
+        finalized_outputs: list[Any] = []
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000201"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="1" * 64,
+                metadata={"crew": "A"},
+            )
+
+        async def _resolve_material(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000203"),
+                material_key="paint-gallon",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("7.25"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="3" * 64,
+                metadata={"sku": "PAINT"},
+            )
+
+        async def _resolve_formula(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                definition_id=uuid.UUID("00000000-0000-0000-0000-000000000202"),
+                checksum_sha256="2" * 64,
+                formula_id="waste-10",
+                version=1,
+            )
+
+        def _compose_estimate(engine_input: Any) -> Any:
+            captured_engine_inputs.append(engine_input)
+            return types.SimpleNamespace()
+
+        async def _skip_finalize(*args: Any, **kwargs: Any) -> bool:
+            finalized_outputs.append(kwargs["output"])
+            return False
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+        monkeypatch.setattr(worker_module, "resolve_material", _resolve_material)
+        monkeypatch.setattr(worker_module, "resolve_formula", _resolve_formula)
+        monkeypatch.setattr(
+            worker_module,
+            "formula_definition_from_selected_formula",
+            lambda _: fake_formula_definition,
+        )
+        monkeypatch.setattr(worker_module, "compose_estimate", _compose_estimate)
+        monkeypatch.setattr(worker_module, "_finalize_estimate_job", _skip_finalize)
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "running"
+        assert updated_job.attempts == 1
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
+        assert updated_job.finished_at is None
+        assert estimate_versions == []
+        assert len(captured_engine_inputs) == 1
+        assert len(finalized_outputs) == 1
+
+        engine_input = captured_engine_inputs[0]
+        assert engine_input.tax_rate == Decimal("0.20")
+        assert tuple(entry.entry_key for entry in engine_input.quantity_entries) == (
+            f"quantity:{quantity_item.id}",
+        )
+        assert tuple(entry.source_quantity_item_id for entry in engine_input.quantity_entries) == (
+            quantity_item.id,
+        )
+        assert tuple(entry.entry_key for entry in engine_input.rate_entries) == (
+            "rate:paint-labor",
+        )
+        assert tuple(entry.entry_key for entry in engine_input.material_entries) == (
+            "material:paint-gallon",
+        )
+        assert tuple(entry.entry_key for entry in engine_input.formula_entries) == (
+            "formula:waste-10",
+        )
+        assert tuple(line.line_key for line in engine_input.line_inputs) == (
+            "line-material",
+            "line-rate",
+            "line-formula",
+        )
+        assert engine_input.line_inputs[2].formula_inputs == {"rate_input": "rate:paint-labor"}
+
+    async def test_process_estimate_job_persists_expected_output_atomically(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate worker should atomically persist one finalized version and terminal success."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={"tax_rate": "0.20"},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000231"),
+                    "catalog_checksum_sha256": "7" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000231"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="7" * 64,
+                metadata={"crew": "A"},
+            )
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "succeeded"
+        assert updated_job.attempts == 1
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
+        assert updated_job.finished_at is not None
+        assert len(estimate_versions) == 1
+        estimate_version = estimate_versions[0]
+        snapshot_entries = await _get_estimate_snapshot_entries_for_version(estimate_version.id)
+        line_items = await _get_estimate_items_for_version(estimate_version.id)
+        assert snapshot_entries != []
+        assert line_items != []
+        assert sorted(entry.sort_order for entry in snapshot_entries) == [1, 2]
+
+        response = await async_client.get(f"/v1/jobs/{estimate_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload == {
+            "status": "succeeded",
+            "attempts": 1,
+            "estimate_version_id": str(estimate_version.id),
+            "snapshot_entry_count": len(snapshot_entries),
+            "line_item_count": len(line_items),
+        }
+
+    async def test_process_estimate_job_rejects_colliding_catalog_entry_keys(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate input build should fail when explicit catalog keys alias different sources."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor-a",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000241"),
+                    "catalog_checksum_sha256": "d" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate-a",
+                        "line_type": "rate",
+                        "description": "Paint labor A",
+                        "quantity_item_id": str(quantity_item.id),
+                        "catalog_entry_key": "shared:paint-labor",
+                    },
+                },
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor-b",
+                    "ref_order": 30,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000242"),
+                    "catalog_checksum_sha256": "e" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate-b",
+                        "line_type": "rate",
+                        "description": "Paint labor B",
+                        "quantity_item_id": str(quantity_item.id),
+                        "catalog_entry_key": "shared:paint-labor",
+                    },
+                },
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = args
+            catalog_ref = kwargs["ref"]
+            if catalog_ref.id == uuid.UUID("00000000-0000-0000-0000-000000000241"):
+                return types.SimpleNamespace(
+                    id=catalog_ref.id,
+                    rate_key="paint-labor-a",
+                    item_type="labor",
+                    unit=quantity_item.unit,
+                    currency="GBP",
+                    value=Decimal("12.50"),
+                    effective_start=date(2026, 1, 2),
+                    checksum_sha256="d" * 64,
+                    metadata={},
+                )
+            if catalog_ref.id == uuid.UUID("00000000-0000-0000-0000-000000000242"):
+                return types.SimpleNamespace(
+                    id=catalog_ref.id,
+                    rate_key="paint-labor-b",
+                    item_type="labor",
+                    unit=quantity_item.unit,
+                    currency="GBP",
+                    value=Decimal("13.50"),
+                    effective_start=date(2026, 1, 2),
+                    checksum_sha256="e" * 64,
+                    metadata={},
+                )
+            raise AssertionError(f"Unexpected rate ref: {catalog_ref.id}")
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert updated_job.error_message == worker_module._ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE
+        assert estimate_versions == []
+
+        response = await async_client.get(f"/v1/jobs/{estimate_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["details"]["reason"] == "colliding_catalog_entry_key"
+
+    async def test_process_estimate_job_honors_cancel_before_finalization(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate finalization should re-check cancellation before publishing output."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000232"),
+                    "catalog_checksum_sha256": "8" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000232"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="8" * 64,
+                metadata={},
+            )
+
+        original_build_execution_input = worker_module._build_estimate_engine_input
+
+        async def _cancel_after_input_load(
+            job_id: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+        ) -> Any:
+            engine_input = await original_build_execution_input(job_id, attempt_token=attempt_token)
+            await _update_job(job_id, cancel_requested=True)
+            return engine_input
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+        monkeypatch.setattr(
+            worker_module,
+            "_build_estimate_engine_input",
+            _cancel_after_input_load,
+        )
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "cancelled"
+        assert updated_job.attempts == 1
+        assert estimate_versions == []
+
+        response = await async_client.get(f"/v1/jobs/{estimate_job.id}/events")
+        assert response.status_code == 200
+        assert response.json()["items"][-1]["data_json"] == {"status": "cancelled"}
+
+    async def test_finalize_estimate_job_skips_existing_output_without_duplicates(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate finalization should not publish duplicates when output already exists."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000233"),
+                    "catalog_checksum_sha256": "9" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000233"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="9" * 64,
+                metadata={},
+            )
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+
+        await worker_module.process_estimate_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert len(estimate_versions) == 1
+
+        duplicate_attempt_token = uuid.uuid4()
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, estimate_job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.finished_at = None
+            persisted_job.attempt_token = duplicate_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+            await session.commit()
+
+        engine_input = await worker_module._build_estimate_engine_input(
+            estimate_job.id,
+            attempt_token=duplicate_attempt_token,
+        )
+        finalized = await worker_module._finalize_estimate_job(
+            estimate_job.id,
+            attempt_token=duplicate_attempt_token,
+            output=real_compose_estimate(engine_input),
+        )
+
+        assert finalized is False
+        assert len(await _get_estimate_versions_for_job(estimate_job.id)) == 1
+
+    async def test_finalize_estimate_job_skips_stale_attempt_without_output(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate finalization should no-op when a stale attempt loses ownership."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000235"),
+                    "catalog_checksum_sha256": "b" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000235"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="b" * 64,
+                metadata={},
+            )
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+
+        stale_lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+        assert stale_lease is not None
+        engine_input = await worker_module._build_estimate_engine_input(
+            estimate_job.id,
+            attempt_token=stale_lease.token,
+        )
+        estimate_output = real_compose_estimate(engine_input)
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, estimate_job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.started_at = (
+                datetime.now(UTC)
+                - worker_module._RUNNING_JOB_STALE_AFTER
+                - timedelta(seconds=1)
+            )
+            persisted_job.attempt_token = stale_lease.token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        current_lease = await worker_module._begin_or_resume_estimate_job(estimate_job.id)
+        assert current_lease is not None
+        assert current_lease.token != stale_lease.token
+
+        finalized = await worker_module._finalize_estimate_job(
+            estimate_job.id,
+            attempt_token=stale_lease.token,
+            output=estimate_output,
+        )
+
+        assert finalized is False
+        assert await _get_estimate_versions_for_job(estimate_job.id) == []
+        updated_job = await _get_job(estimate_job.id)
+        assert updated_job.status == "running"
+        assert updated_job.attempts == 2
+        assert updated_job.attempt_token == current_lease.token
+        assert updated_job.finished_at is None
+
+    async def test_process_estimate_job_fails_revision_drift_without_output(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate finalization should fail closed when the output revision drifts."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000236"),
+                    "catalog_checksum_sha256": "c" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000236"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="c" * 64,
+                metadata={},
+            )
+
+        mismatched_revision_id = uuid.uuid4()
+
+        class _MismatchedRevisionOutput:
+            def __init__(self, output: Any) -> None:
+                self._output = output
+
+            def estimate_version_model_kwargs(self) -> dict[str, Any]:
+                kwargs = dict(self._output.estimate_version_model_kwargs())
+                kwargs["drawing_revision_id"] = mismatched_revision_id
+                return kwargs
+
+            def snapshot_entry_model_kwargs(self) -> Any:
+                return self._output.snapshot_entry_model_kwargs()
+
+            def line_item_model_kwargs(self) -> Any:
+                return self._output.line_item_model_kwargs()
+
+        def _compose_mismatched_revision(engine_input: Any) -> Any:
+            return _MismatchedRevisionOutput(real_compose_estimate(engine_input))
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+        monkeypatch.setattr(worker_module, "compose_estimate", _compose_mismatched_revision)
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.REVISION_CONFLICT.value
+        assert estimate_versions == []
+
+    async def test_process_estimate_job_rolls_back_outputs_when_insert_fails(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate finalization failures should roll back outputs and terminal success."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000234"),
+                    "catalog_checksum_sha256": "a" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000234"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="a" * 64,
+                metadata={},
+            )
+
+        def _raise_insert_failure(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            raise IntegrityError("insert into estimate_items", {}, RuntimeError("boom"))
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+        monkeypatch.setattr(worker_module, "EstimateItem", _raise_insert_failure)
+
+        with pytest.raises(IntegrityError):
+            await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
+        assert updated_job.error_message == worker_module._FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE
+        assert estimate_versions == []
+
+        response = await async_client.get(f"/v1/jobs/{estimate_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["error_code"] == ErrorCode.INTERNAL_ERROR.value
+
+    async def test_process_estimate_job_fails_invalid_mapping_without_output_rows(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate mapping failures should close the job with INPUT_INVALID before persistence."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000211"),
+                    "catalog_checksum_sha256": "4" * 64,
+                    "selection_context_json": {
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert updated_job.error_message == worker_module._ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE
+        assert estimate_versions == []
+
+        response = await async_client.get(f"/v1/jobs/{estimate_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["error_code"] == ErrorCode.INPUT_INVALID.value
+        assert event_payload["details"]["reason"] == "missing_worker_mapping_version"
+
+    async def test_process_estimate_job_fails_invalid_quantity_or_engine_input_without_outputs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate worker should fail closed on invalid quantity selection and engine rejection."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        exclusion_item = next(item for item in quantity_items if item.item_kind == "exclusion")
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000221"),
+                    "catalog_checksum_sha256": "5" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(exclusion_item.id),
+                    },
+                }
+            ],
+        )
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        invalid_quantity_job = await _get_job(estimate_job.id)
+        assert invalid_quantity_job.status == "failed"
+        assert invalid_quantity_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert await _get_estimate_versions_for_job(estimate_job.id) == []
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            engine_invalid_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = next(
+            item
+            for item in quantity_items
+            if item.item_kind == "aggregate" and item.quantity_type.startswith("length")
+        )
+
+        await _persist_estimate_job_input(
+            estimate_job=engine_invalid_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": "paint-labor",
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000222"),
+                    "catalog_checksum_sha256": "6" * 64,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "line-rate",
+                        "line_type": "rate",
+                        "description": "Paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            return types.SimpleNamespace(
+                id=uuid.UUID("00000000-0000-0000-0000-000000000222"),
+                rate_key="paint-labor",
+                item_type="labor",
+                unit=quantity_item.unit,
+                currency="GBP",
+                value=Decimal("12.50"),
+                effective_start=date(2026, 1, 2),
+                checksum_sha256="6" * 64,
+                metadata={},
+            )
+
+        def _raise_engine_input_invalid(_: Any) -> Any:
+            raise EstimateEngineError(
+                cast(Any, "INPUT_INVALID"),
+                "engine_input_invalid",
+                "engine rejected input",
+            )
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_rate)
+        monkeypatch.setattr(worker_module, "compose_estimate", _raise_engine_input_invalid)
+
+        await worker_module.process_estimate_job(engine_invalid_job.id)
+
+        updated_job = await _get_job(engine_invalid_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(engine_invalid_job.id)
+        assert updated_job.status == "failed"
+        assert updated_job.error_code == ErrorCode.INPUT_INVALID.value
+        assert updated_job.error_message == worker_module._ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE
+        assert estimate_versions == []
+
+        response = await async_client.get(f"/v1/jobs/{engine_invalid_job.id}/events")
+        assert response.status_code == 200
+        event_payload = response.json()["items"][-1]["data_json"]
+        assert event_payload["status"] == "failed"
+        assert event_payload["details"] == {"reason": "engine_input_invalid"}
 
     async def test_process_ingest_job_skips_quantity_takeoff_jobs_without_mutation(
         self,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -35,13 +35,22 @@ from app.ingestion.contracts import (
     ProgressUpdate,
 )
 from app.ingestion.finalization import IngestFinalizationPayload, compute_adapter_result_checksum
-from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest
+from app.ingestion.runner import (
+    IngestionRunnerError,
+    IngestionRunRequest,
+)
 from app.ingestion.runner import (
     run_ingestion as real_run_ingestion,
 )
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
+from app.models.estimation_catalog import (
+    CatalogScopeType,
+    EstimationFormula,
+    EstimationMaterial,
+    EstimationRate,
+)
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
@@ -782,6 +791,75 @@ async def _persist_estimate_job_input(
         assumptions_json=deepcopy(assumptions_json),
     )
 
+    catalog_rows: list[EstimationRate | EstimationMaterial | EstimationFormula] = []
+    for ref_payload in catalog_refs:
+        ref_type = cast(str, ref_payload["ref_type"])
+        selection_key = cast(str, ref_payload["selection_key"])
+        checksum = cast(str, ref_payload["catalog_checksum_sha256"])
+
+        if ref_type == "rate":
+            rate_id = cast(uuid.UUID, ref_payload["rate_catalog_entry_id"])
+            catalog_rows.append(
+                EstimationRate(
+                    id=rate_id,
+                    scope_type=CatalogScopeType.PROJECT,
+                    project_id=estimate_job.project_id,
+                    rate_key=selection_key,
+                    source="tests.test_jobs",
+                    metadata_json={},
+                    name=selection_key,
+                    item_type="labor",
+                    per_unit="meter",
+                    currency="GBP",
+                    amount=Decimal("1.00"),
+                    effective_from=estimate_input.pricing_effective_date,
+                    effective_to=None,
+                    checksum_sha256=checksum,
+                )
+            )
+            continue
+
+        if ref_type == "material":
+            material_id = cast(uuid.UUID, ref_payload["material_catalog_entry_id"])
+            catalog_rows.append(
+                EstimationMaterial(
+                    id=material_id,
+                    scope_type=CatalogScopeType.PROJECT,
+                    project_id=estimate_job.project_id,
+                    material_key=selection_key,
+                    source="tests.test_jobs",
+                    metadata_json={},
+                    name=selection_key,
+                    unit="meter",
+                    currency="GBP",
+                    unit_cost=Decimal("1.00"),
+                    effective_from=estimate_input.pricing_effective_date,
+                    effective_to=None,
+                    checksum_sha256=checksum,
+                )
+            )
+            continue
+
+        if ref_type == "formula":
+            formula_id = cast(uuid.UUID, ref_payload["formula_definition_id"])
+            catalog_rows.append(
+                EstimationFormula(
+                    id=formula_id,
+                    scope_type=CatalogScopeType.PROJECT,
+                    project_id=estimate_job.project_id,
+                    formula_id=selection_key,
+                    version=1,
+                    name=selection_key,
+                    dsl_version="1.0",
+                    output_key=f"formula:{selection_key}",
+                    output_contract_json={"kind": "money", "currency": "GBP"},
+                    declared_inputs_json=[],
+                    expression_json={"kind": "constant", "value": "1"},
+                    rounding_json=None,
+                    checksum_sha256=checksum,
+                )
+            )
+
     ref_rows = [
         EstimateJobInputCatalogRef(
             estimate_job_id=estimate_job.id,
@@ -807,6 +885,8 @@ async def _persist_estimate_job_input(
 
     async with session_maker() as session:
         session.add(estimate_input)
+        session.add_all(catalog_rows)
+        await session.flush()
         session.add_all(ref_rows)
         await session.commit()
 
@@ -4086,7 +4166,7 @@ class TestJobs:
                 {
                     "ref_type": "material",
                     "selection_key": "paint-gallon",
-                    "ref_order": 20,
+                    "ref_order": 10,
                     "material_catalog_entry_id": uuid.UUID("00000000-0000-0000-0000-000000000203"),
                     "catalog_checksum_sha256": "3" * 64,
                     "selection_context_json": {


### PR DESCRIPTION
Closes #202

## Summary
- add durable estimate job dispatch, claim/resume, deterministic input assembly, and atomic worker finalization
- enforce mapping v1, trusted allowed takeoff constraints, duplicate-output guards, and revision/cancellation fencing
- add worker/job tests plus TRD updates covering retries, stale attempts, rollback, and key collision safeguards

## Test plan
- [x] uv run mypy app/jobs/worker.py tests/test_jobs.py
- [x] uv run pytest tests/test_jobs.py tests/test_estimate_engine_service.py tests/test_estimate_engine_persistence_payloads.py tests/test_estimate_job_input_contract.py tests/test_estimate_version_persistence.py tests/test_estimate_snapshot_item_persistence.py

## Notes
- DB-dependent suites skipped in the current environment as expected.