### PR TITLE
feat: add catalog and formula API endpoints (#204)

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -1,5 +1,6 @@
 """API v1 routers."""
 
+from app.api.v1.estimation import estimation_router
 from app.api.v1.files import files_router
 from app.api.v1.health import health_router
 from app.api.v1.jobs import jobs_router
@@ -8,6 +9,7 @@ from app.api.v1.revisions import revisions_router
 from app.api.v1.system import system_router
 
 __all__ = [
+    "estimation_router",
     "files_router",
     "health_router",
     "jobs_router",

--- a/app/api/v1/estimation.py
+++ b/app/api/v1/estimation.py
@@ -1,0 +1,1005 @@
+"""Estimation catalog API endpoints."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Annotated, Any, cast
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.idempotency import (
+    IdempotencyReplay,
+    IdempotencyReservation,
+    build_idempotency_fingerprint,
+    claim_idempotency,
+    get_idempotency_key,
+    mark_idempotency_completed,
+    replay_idempotency,
+)
+from app.api.pagination import decode_cursor_payload, encode_cursor_payload, raise_invalid_cursor
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response, raise_not_found
+from app.db.session import get_db
+from app.estimating.catalog.api_checksums import (
+    formula_checksum_sha256,
+    material_checksum_sha256,
+    rate_checksum_sha256,
+)
+from app.models.estimation_catalog import (
+    EstimationFormula,
+    EstimationFormulaSupersession,
+    EstimationMaterial,
+    EstimationMaterialSupersession,
+    EstimationRate,
+    EstimationRateSupersession,
+)
+from app.models.project import Project
+from app.schemas.estimation_catalog import (
+    CatalogCurrencyCode,
+    CatalogScopeType,
+    EstimationFormulaCreate,
+    EstimationFormulaListResponse,
+    EstimationFormulaRead,
+    EstimationMaterialCreate,
+    EstimationMaterialListResponse,
+    EstimationMaterialRead,
+    EstimationRateCreate,
+    EstimationRateListResponse,
+    EstimationRateRead,
+)
+
+estimation_router = APIRouter()
+
+
+class _TimestampCursor(BaseModel):
+    created_at: datetime
+    id: UUID
+
+
+def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
+    return encode_cursor_payload(
+        {
+            "created_at": created_at.isoformat(),
+            "id": str(row_id),
+        }
+    )
+
+
+def _decode_timestamp_cursor(cursor: str) -> tuple[datetime, UUID]:
+    try:
+        payload = _TimestampCursor.model_validate(decode_cursor_payload(cursor))
+    except Exception as exc:  # pragma: no cover - normalized by helper
+        raise_invalid_cursor(exc)
+    return payload.created_at, payload.id
+
+
+async def _get_active_project_or_404(db: AsyncSession, project_id: UUID) -> Project:
+    project = (
+        await db.execute(
+            select(Project)
+            .where((Project.id == project_id) & (Project.deleted_at.is_(None)))
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if project is None:
+        raise_not_found("Project", str(project_id))
+    assert project is not None
+    return project
+
+
+def _active_project_visibility(entry_project_id: Any) -> Any:
+    return or_(
+        entry_project_id.is_(None),
+        select(Project.id)
+        .where((Project.id == entry_project_id) & (Project.deleted_at.is_(None)))
+        .exists(),
+    )
+
+
+def _catalog_conflict_body(kind: str) -> dict[str, Any]:
+    return create_error_response(
+        code=ErrorCode.DB_CONFLICT,
+        message=f"{kind} conflicts with an existing persisted catalog record.",
+        details=None,
+    )
+
+
+async def _raise_catalog_conflict(
+    db: AsyncSession,
+    reservation: IdempotencyReservation | None,
+    *,
+    kind: str,
+) -> None:
+    error_body = _catalog_conflict_body(kind)
+    if reservation is not None:
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status.HTTP_409_CONFLICT,
+            response_body=error_body,
+        )
+        await db.commit()
+    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error_body)
+
+
+def _raise_input_invalid(message: str) -> None:
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INPUT_INVALID,
+            message=message,
+            details=None,
+        ),
+    )
+
+
+def _serialize_rate(
+    rate: EstimationRate,
+    *,
+    superseded_by_id: UUID | None,
+    supersedes_rate_id: UUID | None,
+) -> EstimationRateRead:
+    return EstimationRateRead(
+        id=rate.id,
+        scope_type=cast(CatalogScopeType, rate.scope_type),
+        project_id=rate.project_id,
+        rate_key=rate.rate_key,
+        source=rate.source,
+        metadata_json=rate.metadata_json,
+        name=rate.name,
+        item_type=rate.item_type,
+        per_unit=rate.per_unit,
+        currency=cast(CatalogCurrencyCode, rate.currency),
+        amount=rate.amount,
+        effective_from=rate.effective_from,
+        effective_to=rate.effective_to,
+        checksum_sha256=rate.checksum_sha256,
+        superseded_by_id=superseded_by_id,
+        supersedes_rate_id=supersedes_rate_id,
+        created_at=rate.created_at,
+    )
+
+
+def _serialize_material(
+    material: EstimationMaterial,
+    *,
+    superseded_by_id: UUID | None,
+    supersedes_material_id: UUID | None,
+) -> EstimationMaterialRead:
+    return EstimationMaterialRead(
+        id=material.id,
+        scope_type=cast(CatalogScopeType, material.scope_type),
+        project_id=material.project_id,
+        material_key=material.material_key,
+        source=material.source,
+        metadata_json=material.metadata_json,
+        name=material.name,
+        unit=material.unit,
+        currency=cast(CatalogCurrencyCode, material.currency),
+        unit_cost=material.unit_cost,
+        effective_from=material.effective_from,
+        effective_to=material.effective_to,
+        checksum_sha256=material.checksum_sha256,
+        superseded_by_id=superseded_by_id,
+        supersedes_material_id=supersedes_material_id,
+        created_at=material.created_at,
+    )
+
+
+def _serialize_formula(
+    formula: EstimationFormula,
+    *,
+    superseded_by_id: UUID | None,
+    supersedes_formula_id: UUID | None,
+) -> EstimationFormulaRead:
+    return EstimationFormulaRead(
+        id=formula.id,
+        scope_type=cast(CatalogScopeType, formula.scope_type),
+        project_id=formula.project_id,
+        formula_id=formula.formula_id,
+        version=formula.version,
+        name=formula.name,
+        dsl_version=formula.dsl_version,
+        output_key=formula.output_key,
+        output_contract_json=formula.output_contract_json,
+        declared_inputs_json=formula.declared_inputs_json,
+        expression_json=formula.expression_json,
+        rounding_json=formula.rounding_json,
+        checksum_sha256=formula.checksum_sha256,
+        superseded_by_id=superseded_by_id,
+        supersedes_formula_id=supersedes_formula_id,
+        created_at=formula.created_at,
+    )
+
+
+def _rate_query() -> tuple[Any, Any]:
+    superseded_link = aliased(EstimationRateSupersession)
+    supersedes_link = aliased(EstimationRateSupersession)
+    statement = (
+        select(
+            EstimationRate,
+            superseded_link.successor_rate_id,
+            supersedes_link.predecessor_rate_id,
+        )
+        .outerjoin(
+            superseded_link,
+            superseded_link.predecessor_rate_id == EstimationRate.id,
+        )
+        .outerjoin(
+            supersedes_link,
+            supersedes_link.successor_rate_id == EstimationRate.id,
+        )
+        .where(_active_project_visibility(EstimationRate.project_id))
+    )
+    return statement, superseded_link.successor_rate_id
+
+
+def _material_query() -> tuple[Any, Any]:
+    superseded_link = aliased(EstimationMaterialSupersession)
+    supersedes_link = aliased(EstimationMaterialSupersession)
+    statement = (
+        select(
+            EstimationMaterial,
+            superseded_link.successor_material_id,
+            supersedes_link.predecessor_material_id,
+        )
+        .outerjoin(
+            superseded_link,
+            superseded_link.predecessor_material_id == EstimationMaterial.id,
+        )
+        .outerjoin(
+            supersedes_link,
+            supersedes_link.successor_material_id == EstimationMaterial.id,
+        )
+        .where(_active_project_visibility(EstimationMaterial.project_id))
+    )
+    return statement, superseded_link.successor_material_id
+
+
+def _formula_query() -> tuple[Any, Any]:
+    superseded_link = aliased(EstimationFormulaSupersession)
+    supersedes_link = aliased(EstimationFormulaSupersession)
+    statement = (
+        select(
+            EstimationFormula,
+            superseded_link.successor_formula_id,
+            supersedes_link.predecessor_formula_id,
+        )
+        .outerjoin(
+            superseded_link,
+            superseded_link.predecessor_formula_id == EstimationFormula.id,
+        )
+        .outerjoin(
+            supersedes_link,
+            supersedes_link.successor_formula_id == EstimationFormula.id,
+        )
+        .where(_active_project_visibility(EstimationFormula.project_id))
+    )
+    return statement, superseded_link.successor_formula_id
+
+
+async def _get_rate_predecessor_or_404(db: AsyncSession, rate_id: UUID) -> EstimationRate:
+    rate = (
+        await db.execute(
+            select(EstimationRate)
+            .where(
+                (EstimationRate.id == rate_id)
+                & _active_project_visibility(EstimationRate.project_id)
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if rate is None:
+        raise_not_found("Rate catalog entry", str(rate_id))
+    assert rate is not None
+    return rate
+
+
+async def _get_material_predecessor_or_404(
+    db: AsyncSession,
+    material_id: UUID,
+) -> EstimationMaterial:
+    material = (
+        await db.execute(
+            select(EstimationMaterial)
+            .where(
+                (EstimationMaterial.id == material_id)
+                & _active_project_visibility(EstimationMaterial.project_id)
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if material is None:
+        raise_not_found("Material catalog entry", str(material_id))
+    assert material is not None
+    return material
+
+
+async def _get_formula_predecessor_or_404(
+    db: AsyncSession,
+    formula_id: UUID,
+) -> EstimationFormula:
+    formula = (
+        await db.execute(
+            select(EstimationFormula)
+            .where(
+                (EstimationFormula.id == formula_id)
+                & _active_project_visibility(EstimationFormula.project_id)
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if formula is None:
+        raise_not_found("Formula definition", str(formula_id))
+    assert formula is not None
+    return formula
+
+
+def _validate_rate_supersession(
+    payload: EstimationRateCreate,
+    predecessor: EstimationRate,
+) -> None:
+    if (
+        predecessor.scope_type != payload.scope_type
+        or predecessor.project_id != payload.project_id
+        or predecessor.rate_key != payload.rate_key
+        or predecessor.item_type != payload.item_type
+        or predecessor.per_unit != payload.per_unit
+        or predecessor.currency != payload.currency
+    ):
+        _raise_input_invalid(
+            "supersedes_rate_id must reference a rate entry with the same "
+            "scope, project, key, item type, unit, and currency.",
+        )
+
+
+def _validate_material_supersession(
+    payload: EstimationMaterialCreate,
+    predecessor: EstimationMaterial,
+) -> None:
+    if (
+        predecessor.scope_type != payload.scope_type
+        or predecessor.project_id != payload.project_id
+        or predecessor.material_key != payload.material_key
+        or predecessor.unit != payload.unit
+        or predecessor.currency != payload.currency
+    ):
+        _raise_input_invalid(
+            "supersedes_material_id must reference a material entry with the "
+            "same scope, project, key, unit, and currency.",
+        )
+
+
+def _validate_formula_supersession(
+    payload: EstimationFormulaCreate,
+    predecessor: EstimationFormula,
+) -> None:
+    if (
+        predecessor.scope_type != payload.scope_type
+        or predecessor.project_id != payload.project_id
+        or predecessor.formula_id != payload.formula_id
+    ):
+        _raise_input_invalid(
+            "supersedes_formula_id must reference a formula definition with "
+            "the same scope, project, and formula_id.",
+        )
+
+
+def _validate_successor_effective_window(
+    predecessor_effective_to: date | None,
+    successor_effective_from: date,
+    *,
+    resource_name: str,
+) -> None:
+    if predecessor_effective_to is None or predecessor_effective_to > successor_effective_from:
+        _raise_input_invalid(
+            f"supersedes_{resource_name}_id must reference an entry whose effective "
+            "window ends on or before the successor effective_from date.",
+        )
+
+
+@estimation_router.post(
+    "/estimation/catalog/rates",
+    response_model=EstimationRateRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_rate(
+    rate_in: EstimationRateCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> EstimationRateRead | Response:
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = build_idempotency_fingerprint(
+            "estimation.rates.create",
+            rate_in.model_dump(mode="json"),
+        )
+        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        if replay is not None:
+            return replay.response
+
+    if rate_in.project_id is not None:
+        await _get_active_project_or_404(db, rate_in.project_id)
+
+    predecessor: EstimationRate | None = None
+    if rate_in.supersedes_rate_id is not None:
+        predecessor = await _get_rate_predecessor_or_404(db, rate_in.supersedes_rate_id)
+        _validate_rate_supersession(rate_in, predecessor)
+        _validate_successor_effective_window(
+            predecessor.effective_to,
+            rate_in.effective_from,
+            resource_name="rate",
+        )
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await claim_idempotency(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path="/estimation/catalog/rates",
+        )
+        if isinstance(claim, IdempotencyReplay):
+            return claim.response
+        reservation = claim
+
+    rate = EstimationRate(
+        scope_type=rate_in.scope_type,
+        project_id=rate_in.project_id,
+        rate_key=rate_in.rate_key,
+        source=rate_in.source,
+        metadata_json=rate_in.metadata_json,
+        name=rate_in.name,
+        item_type=rate_in.item_type,
+        per_unit=rate_in.per_unit,
+        currency=rate_in.currency,
+        amount=rate_in.amount,
+        effective_from=rate_in.effective_from,
+        effective_to=rate_in.effective_to,
+        checksum_sha256=rate_checksum_sha256(
+            scope_type=rate_in.scope_type,
+            project_id=rate_in.project_id,
+            rate_key=rate_in.rate_key,
+            source=rate_in.source,
+            metadata_json=rate_in.metadata_json,
+            name=rate_in.name,
+            item_type=rate_in.item_type,
+            per_unit=rate_in.per_unit,
+            currency=rate_in.currency,
+            amount=rate_in.amount,
+            effective_from=rate_in.effective_from,
+            effective_to=rate_in.effective_to,
+        ),
+    )
+    db.add(rate)
+
+    try:
+        await db.flush()
+        if predecessor is not None:
+            db.add(
+                EstimationRateSupersession(
+                    predecessor_rate_id=predecessor.id,
+                    successor_rate_id=rate.id,
+                )
+            )
+            await db.flush()
+        await db.refresh(rate)
+    except IntegrityError:
+        await db.rollback()
+        await _raise_catalog_conflict(db, reservation, kind="Rate catalog entry")
+
+    body = _serialize_rate(
+        rate,
+        superseded_by_id=None,
+        supersedes_rate_id=rate_in.supersedes_rate_id,
+    )
+    response_body = body.model_dump(mode="json")
+    if reservation is not None:
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status.HTTP_201_CREATED,
+            response_body=response_body,
+        )
+    await db.commit()
+
+    if reservation is not None:
+        return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_body)
+    return body
+
+
+@estimation_router.get(
+    "/estimation/catalog/rates/{rate_id}",
+    response_model=EstimationRateRead,
+)
+async def get_rate(
+    rate_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EstimationRateRead:
+    statement, _ = _rate_query()
+    row = (await db.execute(statement.where(EstimationRate.id == rate_id))).one_or_none()
+    if row is None:
+        raise_not_found("Rate catalog entry", str(rate_id))
+    assert row is not None
+    return _serialize_rate(row[0], superseded_by_id=row[1], supersedes_rate_id=row[2])
+
+
+@estimation_router.get(
+    "/estimation/catalog/rates",
+    response_model=EstimationRateListResponse,
+)
+async def list_rates(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Page size")] = 50,
+    scope_type: Annotated[
+        CatalogScopeType | None,
+        Query(description="Filter by scope type"),
+    ] = None,
+    project_id: Annotated[UUID | None, Query(description="Filter by owning project id")] = None,
+    rate_key: Annotated[str | None, Query(description="Filter by stable rate key")] = None,
+    source: Annotated[str | None, Query(description="Filter by source label")] = None,
+    item_type: Annotated[str | None, Query(description="Filter by rate item type")] = None,
+    per_unit: Annotated[str | None, Query(description="Filter by unit")] = None,
+    currency: Annotated[CatalogCurrencyCode | None, Query(description="Filter by currency")] = None,
+    as_of: Annotated[
+        date | None,
+        Query(description="Filter to entries effective on the given date"),
+    ] = None,
+    include_superseded: Annotated[
+        bool,
+        Query(description="Include superseded entries; default false hides stale entries"),
+    ] = False,
+) -> EstimationRateListResponse:
+    statement, superseded_by_column = _rate_query()
+    if scope_type is not None:
+        statement = statement.where(EstimationRate.scope_type == scope_type)
+    if project_id is not None:
+        statement = statement.where(EstimationRate.project_id == project_id)
+    if rate_key is not None:
+        statement = statement.where(EstimationRate.rate_key == rate_key)
+    if source is not None:
+        statement = statement.where(EstimationRate.source == source)
+    if item_type is not None:
+        statement = statement.where(EstimationRate.item_type == item_type)
+    if per_unit is not None:
+        statement = statement.where(EstimationRate.per_unit == per_unit)
+    if currency is not None:
+        statement = statement.where(EstimationRate.currency == currency)
+    if as_of is not None:
+        statement = statement.where(
+            (EstimationRate.effective_from <= as_of)
+            & (EstimationRate.effective_to.is_(None) | (EstimationRate.effective_to > as_of))
+        )
+    if not include_superseded:
+        statement = statement.where(superseded_by_column.is_(None))
+    if cursor is not None:
+        created_at, row_id = _decode_timestamp_cursor(cursor)
+        statement = statement.where(
+            (EstimationRate.created_at < created_at)
+            | ((EstimationRate.created_at == created_at) & (EstimationRate.id < row_id))
+        )
+
+    rows = (
+        await db.execute(
+            statement.order_by(EstimationRate.created_at.desc(), EstimationRate.id.desc()).limit(
+                limit + 1
+            )
+        )
+    ).all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row[0].created_at, last_row[0].id)
+    return EstimationRateListResponse(
+        items=[
+            _serialize_rate(row[0], superseded_by_id=row[1], supersedes_rate_id=row[2])
+            for row in page
+        ],
+        next_cursor=next_cursor,
+    )
+
+
+@estimation_router.post(
+    "/estimation/catalog/materials",
+    response_model=EstimationMaterialRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_material(
+    material_in: EstimationMaterialCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> EstimationMaterialRead | Response:
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = build_idempotency_fingerprint(
+            "estimation.materials.create",
+            material_in.model_dump(mode="json"),
+        )
+        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        if replay is not None:
+            return replay.response
+
+    if material_in.project_id is not None:
+        await _get_active_project_or_404(db, material_in.project_id)
+
+    predecessor: EstimationMaterial | None = None
+    if material_in.supersedes_material_id is not None:
+        predecessor = await _get_material_predecessor_or_404(db, material_in.supersedes_material_id)
+        _validate_material_supersession(material_in, predecessor)
+        _validate_successor_effective_window(
+            predecessor.effective_to,
+            material_in.effective_from,
+            resource_name="material",
+        )
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await claim_idempotency(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path="/estimation/catalog/materials",
+        )
+        if isinstance(claim, IdempotencyReplay):
+            return claim.response
+        reservation = claim
+
+    material = EstimationMaterial(
+        scope_type=material_in.scope_type,
+        project_id=material_in.project_id,
+        material_key=material_in.material_key,
+        source=material_in.source,
+        metadata_json=material_in.metadata_json,
+        name=material_in.name,
+        unit=material_in.unit,
+        currency=material_in.currency,
+        unit_cost=material_in.unit_cost,
+        effective_from=material_in.effective_from,
+        effective_to=material_in.effective_to,
+        checksum_sha256=material_checksum_sha256(
+            scope_type=material_in.scope_type,
+            project_id=material_in.project_id,
+            material_key=material_in.material_key,
+            source=material_in.source,
+            metadata_json=material_in.metadata_json,
+            name=material_in.name,
+            unit=material_in.unit,
+            currency=material_in.currency,
+            unit_cost=material_in.unit_cost,
+            effective_from=material_in.effective_from,
+            effective_to=material_in.effective_to,
+        ),
+    )
+    db.add(material)
+
+    try:
+        await db.flush()
+        if predecessor is not None:
+            db.add(
+                EstimationMaterialSupersession(
+                    predecessor_material_id=predecessor.id,
+                    successor_material_id=material.id,
+                )
+            )
+            await db.flush()
+        await db.refresh(material)
+    except IntegrityError:
+        await db.rollback()
+        await _raise_catalog_conflict(db, reservation, kind="Material catalog entry")
+
+    body = _serialize_material(
+        material,
+        superseded_by_id=None,
+        supersedes_material_id=material_in.supersedes_material_id,
+    )
+    response_body = body.model_dump(mode="json")
+    if reservation is not None:
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status.HTTP_201_CREATED,
+            response_body=response_body,
+        )
+    await db.commit()
+
+    if reservation is not None:
+        return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_body)
+    return body
+
+
+@estimation_router.get(
+    "/estimation/catalog/materials/{material_id}",
+    response_model=EstimationMaterialRead,
+)
+async def get_material(
+    material_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EstimationMaterialRead:
+    statement, _ = _material_query()
+    row = (await db.execute(statement.where(EstimationMaterial.id == material_id))).one_or_none()
+    if row is None:
+        raise_not_found("Material catalog entry", str(material_id))
+    assert row is not None
+    return _serialize_material(row[0], superseded_by_id=row[1], supersedes_material_id=row[2])
+
+
+@estimation_router.get(
+    "/estimation/catalog/materials",
+    response_model=EstimationMaterialListResponse,
+)
+async def list_materials(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Page size")] = 50,
+    scope_type: Annotated[
+        CatalogScopeType | None,
+        Query(description="Filter by scope type"),
+    ] = None,
+    project_id: Annotated[UUID | None, Query(description="Filter by owning project id")] = None,
+    material_key: Annotated[str | None, Query(description="Filter by stable material key")] = None,
+    source: Annotated[str | None, Query(description="Filter by source label")] = None,
+    unit: Annotated[str | None, Query(description="Filter by unit")] = None,
+    currency: Annotated[CatalogCurrencyCode | None, Query(description="Filter by currency")] = None,
+    as_of: Annotated[
+        date | None,
+        Query(description="Filter to entries effective on the given date"),
+    ] = None,
+    include_superseded: Annotated[
+        bool,
+        Query(description="Include superseded entries; default false hides stale entries"),
+    ] = False,
+) -> EstimationMaterialListResponse:
+    statement, superseded_by_column = _material_query()
+    if scope_type is not None:
+        statement = statement.where(EstimationMaterial.scope_type == scope_type)
+    if project_id is not None:
+        statement = statement.where(EstimationMaterial.project_id == project_id)
+    if material_key is not None:
+        statement = statement.where(EstimationMaterial.material_key == material_key)
+    if source is not None:
+        statement = statement.where(EstimationMaterial.source == source)
+    if unit is not None:
+        statement = statement.where(EstimationMaterial.unit == unit)
+    if currency is not None:
+        statement = statement.where(EstimationMaterial.currency == currency)
+    if as_of is not None:
+        statement = statement.where(
+            (EstimationMaterial.effective_from <= as_of)
+            & (
+                EstimationMaterial.effective_to.is_(None)
+                | (EstimationMaterial.effective_to > as_of)
+            )
+        )
+    if not include_superseded:
+        statement = statement.where(superseded_by_column.is_(None))
+    if cursor is not None:
+        created_at, row_id = _decode_timestamp_cursor(cursor)
+        statement = statement.where(
+            (EstimationMaterial.created_at < created_at)
+            | ((EstimationMaterial.created_at == created_at) & (EstimationMaterial.id < row_id))
+        )
+
+    rows = (
+        await db.execute(
+            statement.order_by(
+                EstimationMaterial.created_at.desc(), EstimationMaterial.id.desc()
+            ).limit(limit + 1)
+        )
+    ).all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row[0].created_at, last_row[0].id)
+    return EstimationMaterialListResponse(
+        items=[
+            _serialize_material(
+                row[0],
+                superseded_by_id=row[1],
+                supersedes_material_id=row[2],
+            )
+            for row in page
+        ],
+        next_cursor=next_cursor,
+    )
+
+
+@estimation_router.post(
+    "/estimation/formulas",
+    response_model=EstimationFormulaRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_formula(
+    formula_in: EstimationFormulaCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> EstimationFormulaRead | Response:
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = build_idempotency_fingerprint(
+            "estimation.formulas.create",
+            formula_in.model_dump(mode="json"),
+        )
+        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        if replay is not None:
+            return replay.response
+
+    if formula_in.project_id is not None:
+        await _get_active_project_or_404(db, formula_in.project_id)
+
+    predecessor: EstimationFormula | None = None
+    if formula_in.supersedes_formula_id is not None:
+        predecessor = await _get_formula_predecessor_or_404(db, formula_in.supersedes_formula_id)
+        _validate_formula_supersession(formula_in, predecessor)
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await claim_idempotency(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path="/estimation/formulas",
+        )
+        if isinstance(claim, IdempotencyReplay):
+            return claim.response
+        reservation = claim
+
+    formula = EstimationFormula(
+        scope_type=formula_in.scope_type,
+        project_id=formula_in.project_id,
+        formula_id=formula_in.formula_id,
+        version=formula_in.version,
+        name=formula_in.name,
+        dsl_version=formula_in.dsl_version,
+        output_key=formula_in.output_key,
+        output_contract_json=formula_in.output_contract_json,
+        declared_inputs_json=formula_in.declared_inputs_json,
+        expression_json=formula_in.expression_json,
+        rounding_json=formula_in.rounding_json,
+        checksum_sha256=formula_checksum_sha256(
+            scope_type=formula_in.scope_type,
+            project_id=formula_in.project_id,
+            formula_id=formula_in.formula_id,
+            version=formula_in.version,
+            name=formula_in.name,
+            dsl_version=formula_in.dsl_version,
+            output_key=formula_in.output_key,
+            output_contract_json=formula_in.output_contract_json,
+            declared_inputs_json=formula_in.declared_inputs_json,
+            expression_json=formula_in.expression_json,
+            rounding_json=formula_in.rounding_json,
+        ),
+    )
+    db.add(formula)
+
+    try:
+        await db.flush()
+        if predecessor is not None:
+            db.add(
+                EstimationFormulaSupersession(
+                    predecessor_formula_id=predecessor.id,
+                    successor_formula_id=formula.id,
+                )
+            )
+            await db.flush()
+        await db.refresh(formula)
+    except IntegrityError:
+        await db.rollback()
+        await _raise_catalog_conflict(db, reservation, kind="Formula definition")
+
+    body = _serialize_formula(
+        formula,
+        superseded_by_id=None,
+        supersedes_formula_id=formula_in.supersedes_formula_id,
+    )
+    response_body = body.model_dump(mode="json")
+    if reservation is not None:
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status.HTTP_201_CREATED,
+            response_body=response_body,
+        )
+    await db.commit()
+
+    if reservation is not None:
+        return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_body)
+    return body
+
+
+@estimation_router.get(
+    "/estimation/formulas/{formula_definition_id}",
+    response_model=EstimationFormulaRead,
+)
+async def get_formula(
+    formula_definition_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EstimationFormulaRead:
+    statement, _ = _formula_query()
+    row = (
+        await db.execute(statement.where(EstimationFormula.id == formula_definition_id))
+    ).one_or_none()
+    if row is None:
+        raise_not_found("Formula definition", str(formula_definition_id))
+    assert row is not None
+    return _serialize_formula(row[0], superseded_by_id=row[1], supersedes_formula_id=row[2])
+
+
+@estimation_router.get(
+    "/estimation/formulas",
+    response_model=EstimationFormulaListResponse,
+)
+async def list_formulas(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
+    limit: Annotated[int, Query(ge=1, le=200, description="Page size")] = 50,
+    scope_type: Annotated[
+        CatalogScopeType | None,
+        Query(description="Filter by scope type"),
+    ] = None,
+    project_id: Annotated[UUID | None, Query(description="Filter by owning project id")] = None,
+    formula_id: Annotated[str | None, Query(description="Filter by stable formula id")] = None,
+    version: Annotated[int | None, Query(ge=1, description="Filter by formula version")] = None,
+    dsl_version: Annotated[str | None, Query(description="Filter by DSL version")] = None,
+    output_key: Annotated[str | None, Query(description="Filter by output key")] = None,
+    include_superseded: Annotated[
+        bool,
+        Query(description="Include superseded entries; default false hides stale entries"),
+    ] = False,
+) -> EstimationFormulaListResponse:
+    statement, superseded_by_column = _formula_query()
+    if scope_type is not None:
+        statement = statement.where(EstimationFormula.scope_type == scope_type)
+    if project_id is not None:
+        statement = statement.where(EstimationFormula.project_id == project_id)
+    if formula_id is not None:
+        statement = statement.where(EstimationFormula.formula_id == formula_id)
+    if version is not None:
+        statement = statement.where(EstimationFormula.version == version)
+    if dsl_version is not None:
+        statement = statement.where(EstimationFormula.dsl_version == dsl_version)
+    if output_key is not None:
+        statement = statement.where(EstimationFormula.output_key == output_key)
+    if not include_superseded:
+        statement = statement.where(superseded_by_column.is_(None))
+    if cursor is not None:
+        created_at, row_id = _decode_timestamp_cursor(cursor)
+        statement = statement.where(
+            (EstimationFormula.created_at < created_at)
+            | ((EstimationFormula.created_at == created_at) & (EstimationFormula.id < row_id))
+        )
+
+    rows = (
+        await db.execute(
+            statement.order_by(
+                EstimationFormula.created_at.desc(), EstimationFormula.id.desc()
+            ).limit(limit + 1)
+        )
+    ).all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row[0].created_at, last_row[0].id)
+    return EstimationFormulaListResponse(
+        items=[
+            _serialize_formula(row[0], superseded_by_id=row[1], supersedes_formula_id=row[2])
+            for row in page
+        ],
+        next_cursor=next_cursor,
+    )

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,5 +1,6 @@
 """Custom exception handlers and error response utilities."""
 
+from collections.abc import Mapping, Sequence
 from http import HTTPStatus
 from typing import Any
 
@@ -26,6 +27,19 @@ class APIErrorResponse(BaseModel):
     error: APIError
 
 
+def _sanitize_error_details(details: Any) -> Any:
+    """Convert arbitrary detail payloads into JSON-serializable values."""
+    if details is None or isinstance(details, (str, int, float, bool)):
+        return details
+    if isinstance(details, BaseException):
+        return str(details)
+    if isinstance(details, Mapping):
+        return {str(key): _sanitize_error_details(value) for key, value in details.items()}
+    if isinstance(details, Sequence) and not isinstance(details, str):
+        return [_sanitize_error_details(value) for value in details]
+    return str(details)
+
+
 def create_error_response(
     code: ErrorCode,
     message: str,
@@ -42,7 +56,11 @@ def create_error_response(
         Dictionary matching the APIErrorResponse schema
     """
     return APIErrorResponse(
-        error=APIError(code=code, message=message, details=details)
+        error=APIError(
+            code=code,
+            message=message,
+            details=_sanitize_error_details(details),
+        )
     ).model_dump(mode="json")
 
 

--- a/app/estimating/catalog/api_checksums.py
+++ b/app/estimating/catalog/api_checksums.py
@@ -1,0 +1,295 @@
+"""Server-derived canonical checksum helpers for estimation catalog APIs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from uuid import UUID
+
+from app.estimating.formulas import (
+    FormulaInputDefinition,
+    FormulaNode,
+    RoundingSpec,
+    ValueContract,
+    validate_formula_definition_json,
+)
+
+_SIX_DECIMAL_PLACES = Decimal("0.000001")
+_ZERO = Decimal("0.000000")
+
+
+def rate_checksum_sha256(
+    *,
+    scope_type: str,
+    project_id: UUID | None,
+    rate_key: str,
+    source: str,
+    metadata_json: Mapping[str, object],
+    name: str,
+    item_type: str,
+    per_unit: str,
+    currency: str,
+    amount: Decimal,
+    effective_from: date,
+    effective_to: date | None,
+) -> str:
+    _validate_scope(scope_type, project_id)
+    _require_non_empty_string(rate_key, field_name="rate_key")
+    _require_non_empty_string(source, field_name="source")
+    _require_mapping(metadata_json, field_name="metadata_json")
+    _require_non_empty_string(name, field_name="name")
+    _require_non_empty_string(item_type, field_name="item_type")
+    _require_non_empty_string(per_unit, field_name="per_unit")
+    _validate_gbp_currency(currency)
+    _validate_positive_money(amount, field_name="amount")
+    _validate_effective_window(effective_from, effective_to)
+    return _checksum(
+        {
+            "scope_type": scope_type,
+            "project_id": project_id,
+            "rate_key": rate_key,
+            "source": source,
+            "metadata_json": dict(metadata_json),
+            "name": name,
+            "item_type": item_type,
+            "per_unit": per_unit,
+            "currency": currency,
+            "amount": amount,
+            "effective_from": effective_from,
+            "effective_to": effective_to,
+        }
+    )
+
+
+def material_checksum_sha256(
+    *,
+    scope_type: str,
+    project_id: UUID | None,
+    material_key: str,
+    source: str,
+    metadata_json: Mapping[str, object],
+    name: str,
+    unit: str,
+    currency: str,
+    unit_cost: Decimal,
+    effective_from: date,
+    effective_to: date | None,
+) -> str:
+    _validate_scope(scope_type, project_id)
+    _require_non_empty_string(material_key, field_name="material_key")
+    _require_non_empty_string(source, field_name="source")
+    _require_mapping(metadata_json, field_name="metadata_json")
+    _require_non_empty_string(name, field_name="name")
+    _require_non_empty_string(unit, field_name="unit")
+    _validate_gbp_currency(currency)
+    _validate_positive_money(unit_cost, field_name="unit_cost")
+    _validate_effective_window(effective_from, effective_to)
+    return _checksum(
+        {
+            "scope_type": scope_type,
+            "project_id": project_id,
+            "material_key": material_key,
+            "source": source,
+            "metadata_json": dict(metadata_json),
+            "name": name,
+            "unit": unit,
+            "currency": currency,
+            "unit_cost": unit_cost,
+            "effective_from": effective_from,
+            "effective_to": effective_to,
+        }
+    )
+
+
+def formula_checksum_sha256(
+    *,
+    scope_type: str,
+    project_id: UUID | None,
+    formula_id: str,
+    version: int,
+    name: str,
+    dsl_version: str,
+    output_key: str,
+    output_contract_json: Mapping[str, object],
+    declared_inputs_json: Sequence[Mapping[str, object]],
+    expression_json: Mapping[str, object],
+    rounding_json: Mapping[str, object] | None = None,
+) -> str:
+    _validate_scope(scope_type, project_id)
+    _require_non_empty_string(formula_id, field_name="formula_id")
+    if type(version) is not int or version < 1:
+        raise ValueError("version must be greater than or equal to one.")
+    _require_non_empty_string(name, field_name="name")
+    _require_non_empty_string(dsl_version, field_name="dsl_version")
+    _require_non_empty_string(output_key, field_name="output_key")
+    _require_mapping(output_contract_json, field_name="output_contract_json")
+    _require_mapping_sequence(declared_inputs_json, field_name="declared_inputs_json")
+    _require_mapping(expression_json, field_name="expression_json")
+    if rounding_json is not None:
+        _require_mapping(rounding_json, field_name="rounding_json")
+
+    definition = validate_formula_definition_json(
+        formula_id=formula_id,
+        name=name,
+        version=version,
+        checksum="pending",
+        output_key=output_key,
+        output_contract_json=output_contract_json,
+        declared_inputs_json=declared_inputs_json,
+        expression_json=expression_json,
+        rounding_json=rounding_json,
+    )
+    return _checksum(
+        {
+            "scope_type": scope_type,
+            "project_id": project_id,
+            "formula_id": definition.formula_id,
+            "version": definition.version,
+            "name": definition.name,
+            "dsl_version": dsl_version,
+            "output_key": definition.output_key,
+            "output_contract_json": _value_contract_json(definition.output_contract),
+            "declared_inputs_json": [
+                _formula_input_definition_json(item) for item in definition.declared_inputs
+            ],
+            "expression_json": _formula_node_json(definition.expression),
+            "rounding_json": _rounding_json(definition.rounding),
+        }
+    )
+
+
+def _checksum(payload: Mapping[str, object]) -> str:
+    canonical = _canonicalize(payload)
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":"), allow_nan=False).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonicalize(value: object) -> object:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        return _decimal_text(value)
+    if isinstance(value, date | datetime):
+        return value.isoformat()
+    if isinstance(value, float):
+        raise ValueError("canonical checksum payloads do not accept float values.")
+    if isinstance(value, Mapping):
+        canonical: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise ValueError("canonical checksum payload object keys must be strings.")
+            canonical[key] = _canonicalize(item)
+        return canonical
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_canonicalize(item) for item in value]
+    raise ValueError(f"Unsupported canonical checksum payload value type: {type(value).__name__}.")
+
+
+def _decimal_text(value: Decimal) -> str:
+    if not value.is_finite():
+        raise ValueError("canonical checksum decimal values must be finite.")
+    try:
+        quantized = value.quantize(_SIX_DECIMAL_PLACES)
+    except InvalidOperation as exc:
+        raise ValueError("canonical checksum decimal values must fit six decimal places.") from exc
+    if quantized == _ZERO:
+        quantized = _ZERO
+    return format(quantized, ".6f")
+
+
+def _validate_scope(scope_type: str, project_id: UUID | None) -> None:
+    if scope_type not in {"global", "project"}:
+        raise ValueError("scope_type must be 'global' or 'project'.")
+    if scope_type == "global" and project_id is not None:
+        raise ValueError("project_id must be null when scope_type is 'global'.")
+    if scope_type == "project" and project_id is None:
+        raise ValueError("project_id is required when scope_type is 'project'.")
+
+
+def _validate_gbp_currency(currency: str) -> None:
+    if currency != "GBP":
+        raise ValueError("currency must be 'GBP'.")
+
+
+def _validate_positive_money(value: Decimal, *, field_name: str) -> None:
+    if not isinstance(value, Decimal):
+        raise ValueError(f"{field_name} must be a Decimal.")
+    if not value.is_finite():
+        raise ValueError(f"{field_name} must be finite.")
+    if value <= Decimal("0"):
+        raise ValueError(f"{field_name} must be greater than zero.")
+    exponent = value.as_tuple().exponent
+    if not isinstance(exponent, int) or exponent < -6:
+        raise ValueError(f"{field_name} must use at most six decimal places.")
+
+
+def _validate_effective_window(effective_from: date, effective_to: date | None) -> None:
+    if not isinstance(effective_from, date):
+        raise ValueError("effective_from must be a date.")
+    if effective_to is not None and not isinstance(effective_to, date):
+        raise ValueError("effective_to must be a date when provided.")
+    if effective_to is not None and effective_to <= effective_from:
+        raise ValueError("effective_to must be greater than effective_from.")
+
+
+def _require_non_empty_string(value: str, *, field_name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} must be a non-empty string.")
+
+
+def _require_mapping(value: Mapping[str, object], *, field_name: str) -> None:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field_name} must be an object.")
+
+
+def _require_mapping_sequence(value: Sequence[Mapping[str, object]], *, field_name: str) -> None:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise ValueError(f"{field_name} must be an array.")
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise ValueError(f"{field_name}[{index}] must be an object.")
+
+
+def _formula_input_definition_json(definition: FormulaInputDefinition) -> dict[str, object]:
+    return {
+        "name": definition.name,
+        "contract": _value_contract_json(definition.contract),
+    }
+
+
+def _formula_node_json(node: FormulaNode) -> dict[str, object]:
+    return {
+        "kind": node.kind,
+        "value": node.value,
+        "name": node.name,
+        "args": [_formula_node_json(arg) for arg in node.args],
+        "rounding": _rounding_json(node.rounding),
+    }
+
+
+def _value_contract_json(contract: ValueContract) -> dict[str, object]:
+    return {
+        "kind": contract.kind,
+        "currency": contract.currency,
+        "unit": contract.unit,
+        "per_unit": contract.per_unit,
+    }
+
+
+def _rounding_json(rounding: RoundingSpec | None) -> dict[str, object] | None:
+    if rounding is None:
+        return None
+    return {"scale": rounding.scale, "mode": rounding.mode}

--- a/app/estimating/formulas/__init__.py
+++ b/app/estimating/formulas/__init__.py
@@ -8,7 +8,11 @@ from .contracts import (
     RoundingSpec,
     ValueContract,
 )
-from .evaluator import evaluate_formula
+from .evaluator import (
+    evaluate_formula,
+    validate_formula_definition,
+    validate_formula_definition_json,
+)
 
 __all__ = [
     "FormulaDefinition",
@@ -20,4 +24,6 @@ __all__ = [
     "RoundingSpec",
     "ValueContract",
     "evaluate_formula",
+    "validate_formula_definition",
+    "validate_formula_definition_json",
 ]

--- a/app/estimating/formulas/evaluator.py
+++ b/app/estimating/formulas/evaluator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from decimal import (
     ROUND_HALF_EVEN,
@@ -101,6 +101,48 @@ def evaluate_formula(
             reason="decimal_invalid",
             message="Invalid decimal operation during formula evaluation.",
         ) from exc
+
+
+def validate_formula_definition(definition: FormulaDefinition) -> FormulaDefinition:
+    with localcontext(_EVALUATION_CONTEXT):
+        _validate_definition(definition)
+    return definition
+
+
+def validate_formula_definition_json(
+    *,
+    formula_id: str,
+    name: str,
+    version: int,
+    checksum: str,
+    output_key: str,
+    output_contract_json: Mapping[str, object],
+    declared_inputs_json: Sequence[Mapping[str, object]],
+    expression_json: Mapping[str, object],
+    rounding_json: Mapping[str, object] | None = None,
+) -> FormulaDefinition:
+    from app.estimating.engine.errors import EstimateEngineError
+    from app.estimating.engine.formula_adapter import formula_definition_from_json
+
+    try:
+        definition = formula_definition_from_json(
+            formula_id=formula_id,
+            name=name,
+            version=version,
+            checksum=checksum,
+            output_key=output_key,
+            output_contract_json=output_contract_json,
+            declared_inputs_json=declared_inputs_json,
+            expression_json=expression_json,
+            rounding_json=rounding_json,
+        )
+    except EstimateEngineError as exc:
+        raise FormulaEvaluationError(
+            code=_INPUT_INVALID,
+            reason=exc.reason,
+            message=exc.message,
+        ) from exc
+    return validate_formula_definition(definition)
 
 
 def _validate_definition(definition: FormulaDefinition) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.api.v1 import (
+    estimation_router,
     files_router,
     health_router,
     jobs_router,
@@ -47,6 +48,7 @@ def create_app() -> FastAPI:
     app.include_router(files_router, prefix=settings.api_prefix)
     app.include_router(jobs_router, prefix=settings.api_prefix)
     app.include_router(revisions_router, prefix=settings.api_prefix)
+    app.include_router(estimation_router, prefix=settings.api_prefix)
 
     logger.info("app_started", version=settings.app_version)
 

--- a/app/schemas/estimation_catalog.py
+++ b/app/schemas/estimation_catalog.py
@@ -1,0 +1,327 @@
+"""Pydantic schemas for versioned estimation catalog endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.estimating.catalog.api_checksums import formula_checksum_sha256
+
+CatalogScopeType = Literal["global", "project"]
+CatalogCurrencyCode = Literal["GBP"]
+
+
+def _require_json_object(value: object, *, field_name: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object.")
+    return value
+
+
+def _reject_json_floats(value: object, *, field_name: str) -> None:
+    if isinstance(value, float):
+        raise ValueError(f"{field_name} must not contain float values.")
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            nested_field_name = f"{field_name}.{key}" if isinstance(key, str) else field_name
+            _reject_json_floats(item, field_name=nested_field_name)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for index, item in enumerate(value):
+            _reject_json_floats(item, field_name=f"{field_name}[{index}]")
+
+
+def _require_json_object_array(value: object, *, field_name: str) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be an array.")
+    result: list[dict[str, object]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{field_name}[{index}] must be an object.")
+        result.append(item)
+    return result
+
+
+def _validate_positive_money(value: Decimal, *, field_name: str) -> Decimal:
+    if not value.is_finite():
+        raise ValueError(f"{field_name} must be finite.")
+    if value <= Decimal("0"):
+        raise ValueError(f"{field_name} must be greater than zero.")
+    exponent = value.as_tuple().exponent
+    if not isinstance(exponent, int) or exponent < -6:
+        raise ValueError(f"{field_name} must use at most six decimal places.")
+    return value
+
+
+def _validate_scope(scope_type: CatalogScopeType, project_id: UUID | None) -> None:
+    if scope_type == "global" and project_id is not None:
+        raise ValueError("project_id must be null when scope_type is 'global'.")
+    if scope_type == "project" and project_id is None:
+        raise ValueError("project_id is required when scope_type is 'project'.")
+
+
+class EstimationRateCreate(BaseModel):
+    """Request payload for creating an immutable rate catalog entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope_type: CatalogScopeType = Field(..., description="Catalog entry scope type")
+    project_id: UUID | None = Field(None, description="Owning project for project-scoped rates")
+    rate_key: str = Field(..., min_length=1, max_length=255, description="Stable rate key")
+    source: str = Field(..., min_length=1, max_length=64, description="Catalog source label")
+    metadata_json: dict[str, object] = Field(
+        default_factory=dict,
+        description="Arbitrary source metadata JSON object",
+    )
+    name: str = Field(..., min_length=1, max_length=255, description="Human-readable rate name")
+    item_type: str = Field(..., min_length=1, max_length=64, description="Rate item type")
+    per_unit: str = Field(..., min_length=1, max_length=64, description="Rate unit")
+    currency: CatalogCurrencyCode = Field(..., description="Three-letter uppercase currency code")
+    amount: Decimal = Field(
+        ...,
+        gt=Decimal("0"),
+        max_digits=18,
+        decimal_places=6,
+        description="Positive rate amount in GBP",
+    )
+    effective_from: date = Field(..., description="Inclusive effective start date")
+    effective_to: date | None = Field(None, description="Exclusive effective end date")
+    supersedes_rate_id: UUID | None = Field(
+        None,
+        description="Optional predecessor rate entry to supersede atomically",
+    )
+
+    @field_validator("metadata_json", mode="before")
+    @classmethod
+    def validate_metadata_json(cls, value: object) -> dict[str, object]:
+        metadata_json = _require_json_object(value, field_name="metadata_json")
+        _reject_json_floats(metadata_json, field_name="metadata_json")
+        return metadata_json
+
+    @field_validator("amount")
+    @classmethod
+    def validate_amount(cls, value: Decimal) -> Decimal:
+        return _validate_positive_money(value, field_name="amount")
+
+    @model_validator(mode="after")
+    def validate_scope_and_window(self) -> EstimationRateCreate:
+        _validate_scope(self.scope_type, self.project_id)
+        if self.effective_to is not None and self.effective_to <= self.effective_from:
+            raise ValueError("effective_to must be greater than effective_from.")
+        return self
+
+
+class EstimationRateRead(BaseModel):
+    """Committed immutable rate catalog entry payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    scope_type: CatalogScopeType
+    project_id: UUID | None
+    rate_key: str
+    source: str
+    metadata_json: dict[str, object]
+    name: str
+    item_type: str
+    per_unit: str
+    currency: CatalogCurrencyCode
+    amount: Decimal
+    effective_from: date
+    effective_to: date | None
+    checksum_sha256: str = Field(..., min_length=64, max_length=64)
+    superseded_by_id: UUID | None = None
+    supersedes_rate_id: UUID | None = None
+    created_at: datetime
+
+
+class EstimationRateListResponse(BaseModel):
+    """Cursor-paginated rate catalog page."""
+
+    items: list[EstimationRateRead]
+    next_cursor: str | None = None
+
+
+class EstimationMaterialCreate(BaseModel):
+    """Request payload for creating an immutable material catalog entry."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope_type: CatalogScopeType = Field(..., description="Catalog entry scope type")
+    project_id: UUID | None = Field(
+        None,
+        description="Owning project for project-scoped materials",
+    )
+    material_key: str = Field(..., min_length=1, max_length=255, description="Stable material key")
+    source: str = Field(..., min_length=1, max_length=64, description="Catalog source label")
+    metadata_json: dict[str, object] = Field(
+        default_factory=dict,
+        description="Arbitrary source metadata JSON object",
+    )
+    name: str = Field(..., min_length=1, max_length=255, description="Human-readable material name")
+    unit: str = Field(..., min_length=1, max_length=64, description="Material unit")
+    currency: CatalogCurrencyCode = Field(..., description="Three-letter uppercase currency code")
+    unit_cost: Decimal = Field(
+        ...,
+        gt=Decimal("0"),
+        max_digits=18,
+        decimal_places=6,
+        description="Positive unit cost in GBP",
+    )
+    effective_from: date = Field(..., description="Inclusive effective start date")
+    effective_to: date | None = Field(None, description="Exclusive effective end date")
+    supersedes_material_id: UUID | None = Field(
+        None,
+        description="Optional predecessor material entry to supersede atomically",
+    )
+
+    @field_validator("metadata_json", mode="before")
+    @classmethod
+    def validate_metadata_json(cls, value: object) -> dict[str, object]:
+        metadata_json = _require_json_object(value, field_name="metadata_json")
+        _reject_json_floats(metadata_json, field_name="metadata_json")
+        return metadata_json
+
+    @field_validator("unit_cost")
+    @classmethod
+    def validate_unit_cost(cls, value: Decimal) -> Decimal:
+        return _validate_positive_money(value, field_name="unit_cost")
+
+    @model_validator(mode="after")
+    def validate_scope_and_window(self) -> EstimationMaterialCreate:
+        _validate_scope(self.scope_type, self.project_id)
+        if self.effective_to is not None and self.effective_to <= self.effective_from:
+            raise ValueError("effective_to must be greater than effective_from.")
+        return self
+
+
+class EstimationMaterialRead(BaseModel):
+    """Committed immutable material catalog entry payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    scope_type: CatalogScopeType
+    project_id: UUID | None
+    material_key: str
+    source: str
+    metadata_json: dict[str, object]
+    name: str
+    unit: str
+    currency: CatalogCurrencyCode
+    unit_cost: Decimal
+    effective_from: date
+    effective_to: date | None
+    checksum_sha256: str = Field(..., min_length=64, max_length=64)
+    superseded_by_id: UUID | None = None
+    supersedes_material_id: UUID | None = None
+    created_at: datetime
+
+
+class EstimationMaterialListResponse(BaseModel):
+    """Cursor-paginated material catalog page."""
+
+    items: list[EstimationMaterialRead]
+    next_cursor: str | None = None
+
+
+class EstimationFormulaCreate(BaseModel):
+    """Request payload for creating an immutable formula definition."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope_type: CatalogScopeType = Field(..., description="Formula scope type")
+    project_id: UUID | None = Field(None, description="Owning project for project-scoped formulas")
+    formula_id: str = Field(..., min_length=1, max_length=255, description="Stable formula id")
+    version: int = Field(..., ge=1, description="Positive formula version")
+    name: str = Field(..., min_length=1, max_length=255, description="Human-readable formula name")
+    dsl_version: str = Field(..., min_length=1, max_length=32, description="Formula DSL version")
+    output_key: str = Field(..., min_length=1, max_length=255, description="Output field key")
+    output_contract_json: dict[str, object] = Field(..., description="Formula output contract JSON")
+    declared_inputs_json: list[dict[str, object]] = Field(
+        ...,
+        description="Formula declared input JSON array",
+    )
+    expression_json: dict[str, object] = Field(..., description="Formula expression JSON object")
+    rounding_json: dict[str, object] | None = Field(
+        None,
+        description="Optional formula-level rounding JSON object",
+    )
+    supersedes_formula_id: UUID | None = Field(
+        None,
+        description="Optional predecessor formula definition to supersede atomically",
+    )
+
+    @field_validator("output_contract_json", mode="before")
+    @classmethod
+    def validate_output_contract_json(cls, value: object) -> dict[str, object]:
+        return _require_json_object(value, field_name="output_contract_json")
+
+    @field_validator("declared_inputs_json", mode="before")
+    @classmethod
+    def validate_declared_inputs_json(cls, value: object) -> list[dict[str, object]]:
+        return _require_json_object_array(value, field_name="declared_inputs_json")
+
+    @field_validator("expression_json", mode="before")
+    @classmethod
+    def validate_expression_json(cls, value: object) -> dict[str, object]:
+        return _require_json_object(value, field_name="expression_json")
+
+    @field_validator("rounding_json", mode="before")
+    @classmethod
+    def validate_rounding_json(cls, value: object) -> dict[str, object] | None:
+        if value is None:
+            return None
+        return _require_json_object(value, field_name="rounding_json")
+
+    @model_validator(mode="after")
+    def validate_scope_and_definition(self) -> EstimationFormulaCreate:
+        _validate_scope(self.scope_type, self.project_id)
+        formula_checksum_sha256(
+            scope_type=self.scope_type,
+            project_id=self.project_id,
+            formula_id=self.formula_id,
+            version=self.version,
+            name=self.name,
+            dsl_version=self.dsl_version,
+            output_key=self.output_key,
+            output_contract_json=self.output_contract_json,
+            declared_inputs_json=self.declared_inputs_json,
+            expression_json=self.expression_json,
+            rounding_json=self.rounding_json,
+        )
+        return self
+
+
+class EstimationFormulaRead(BaseModel):
+    """Committed immutable formula definition payload."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    scope_type: CatalogScopeType
+    project_id: UUID | None
+    formula_id: str
+    version: int
+    name: str
+    dsl_version: str
+    output_key: str
+    output_contract_json: dict[str, Any]
+    declared_inputs_json: list[dict[str, Any]]
+    expression_json: dict[str, Any]
+    rounding_json: dict[str, Any] | None
+    checksum_sha256: str = Field(..., min_length=64, max_length=64)
+    superseded_by_id: UUID | None = None
+    supersedes_formula_id: UUID | None = None
+    created_at: datetime
+
+
+class EstimationFormulaListResponse(BaseModel):
+    """Cursor-paginated formula catalog page."""
+
+    items: list[EstimationFormulaRead]
+    next_cursor: str | None = None

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -920,6 +920,69 @@ Catalog scope and mutation rules:
 - Job progress should be observable through polling first, events later.
 - API-key auth should be easy to add later.
 
+### Estimation Catalog And Formula APIs
+
+MVP estimation API scope here is limited to catalog and formula definition
+management. This section does not define estimate creation, estimate generation,
+or any UI/CLI workflow.
+
+Endpoint families under `/v1`:
+
+- `POST /v1/estimation/catalog/rates`
+- `GET /v1/estimation/catalog/rates`
+- `GET /v1/estimation/catalog/rates/{rate_id}`
+- `POST /v1/estimation/catalog/materials`
+- `GET /v1/estimation/catalog/materials`
+- `GET /v1/estimation/catalog/materials/{material_id}`
+- `POST /v1/estimation/formulas`
+- `GET /v1/estimation/formulas`
+- `GET /v1/estimation/formulas/{formula_definition_id}`
+
+Shared write/read invariants:
+
+- Create endpoints are append-only and immutable. Replacements happen by writing
+  a new row, not by mutating an existing row in place.
+- Write endpoints may accept an optional `Idempotency-Key` header.
+- The server derives and persists checksums; clients must not be the source of
+  truth for stored checksum values.
+- Read responses for rates, materials, and formulas must include the persisted
+  checksum and any supersession metadata.
+- Supersession metadata is optional and must support append-only lineage such as
+  `supersedes_*` and `superseded_by_*` relationships without rewriting history.
+- Missing or soft-deleted project scope must be treated as not found rather than
+  silently falling back to another scope.
+
+List endpoint behavior:
+
+- List endpoints use cursor pagination.
+- `include_superseded` defaults to `false`.
+- Rates and materials support filtering by scope, project, stable key, source,
+  unit, currency, and `as_of`.
+- `as_of` filtering for rates and materials uses half-open effective-date logic:
+  `effective_from <= as_of < effective_to`, with `effective_to` nullable for an
+  open-ended current row.
+- Formula list endpoints support filters for scope, project, formula id,
+  version, DSL version, and output key.
+
+Resource semantics:
+
+- Rate and material create/read/list APIs must expose global rows and
+  project-scoped rows without collapsing them into one mutable current record.
+- Formula create/read/list APIs must expose immutable versioned definitions,
+  including the Formula DSL payload and output contract metadata.
+- Read-by-id endpoints return one immutable resource row by durable id and do
+  not perform estimate execution or preview generation.
+
+Standard error behavior:
+
+- Errors use the standard envelope `{error:{code,message,details}}`.
+- Return `404` when the addressed project is missing or soft-deleted, or when
+  the requested catalog/formula resource does not exist.
+- Return `422` with `INPUT_INVALID` for invalid Formula DSL payloads or invalid
+  request shape.
+- Return `409` with `DB_CONFLICT` for uniqueness conflicts, effective-date
+  overlap conflicts, or invalid supersession/conflict cases.
+
 ## Non-Functional Requirements
 
 - Local development must work through Docker Compose.

--- a/tests/test_estimation_catalog_api.py
+++ b/tests/test_estimation_catalog_api.py
@@ -1,0 +1,803 @@
+"""Database-backed API tests for estimation catalog and formulas endpoints."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+from sqlalchemy import select
+
+import app.db.session as session_module
+from app.estimating.catalog.api_checksums import (
+    formula_checksum_sha256,
+    material_checksum_sha256,
+    rate_checksum_sha256,
+)
+from app.models.project import Project
+from tests.conftest import requires_database
+
+
+def test_rate_checksum_is_deterministic_for_json_key_order_and_changes_with_content() -> None:
+    # Arrange
+    project_id = str(uuid4())
+    payload = _valid_rate_payload(project_id=project_id)
+
+    # Act
+    checksum_a = rate_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        rate_key=payload["rate_key"],
+        source=payload["source"],
+        metadata_json={"a": 1, "b": 2},
+        name=payload["name"],
+        item_type=payload["item_type"],
+        per_unit=payload["per_unit"],
+        currency=payload["currency"],
+        amount=Decimal(payload["amount"]),
+        effective_from=date.fromisoformat(payload["effective_from"]),
+        effective_to=None,
+    )
+    checksum_b = rate_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        rate_key=payload["rate_key"],
+        source=payload["source"],
+        metadata_json={"b": 2, "a": 1},
+        name=payload["name"],
+        item_type=payload["item_type"],
+        per_unit=payload["per_unit"],
+        currency=payload["currency"],
+        amount=Decimal(payload["amount"]),
+        effective_from=date.fromisoformat(payload["effective_from"]),
+        effective_to=None,
+    )
+    checksum_changed = rate_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        rate_key=payload["rate_key"],
+        source=payload["source"],
+        metadata_json={"a": 1, "b": 2},
+        name=payload["name"],
+        item_type=payload["item_type"],
+        per_unit=payload["per_unit"],
+        currency=payload["currency"],
+        amount=Decimal("12.600000"),
+        effective_from=date.fromisoformat(payload["effective_from"]),
+        effective_to=None,
+    )
+
+    # Assert
+    assert checksum_a == checksum_b
+    assert checksum_a != checksum_changed
+
+
+def test_material_checksum_is_deterministic_for_json_key_order_and_changes_with_content() -> None:
+    # Arrange
+    project_id = str(uuid4())
+    payload = _valid_material_payload(project_id=project_id)
+
+    # Act
+    checksum_a = material_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        material_key=payload["material_key"],
+        source=payload["source"],
+        metadata_json={"first": "x", "second": "y"},
+        name=payload["name"],
+        unit=payload["unit"],
+        currency=payload["currency"],
+        unit_cost=Decimal(payload["unit_cost"]),
+        effective_from=date.fromisoformat(payload["effective_from"]),
+        effective_to=None,
+    )
+    checksum_b = material_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        material_key=payload["material_key"],
+        source=payload["source"],
+        metadata_json={"second": "y", "first": "x"},
+        name=payload["name"],
+        unit=payload["unit"],
+        currency=payload["currency"],
+        unit_cost=Decimal(payload["unit_cost"]),
+        effective_from=date.fromisoformat(payload["effective_from"]),
+        effective_to=None,
+    )
+    checksum_changed = material_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        material_key=payload["material_key"],
+        source=payload["source"],
+        metadata_json={"first": "x", "second": "y"},
+        name="PVC conduit 25mm",
+        unit=payload["unit"],
+        currency=payload["currency"],
+        unit_cost=Decimal(payload["unit_cost"]),
+        effective_from=date.fromisoformat(payload["effective_from"]),
+        effective_to=None,
+    )
+
+    # Assert
+    assert checksum_a == checksum_b
+    assert checksum_a != checksum_changed
+
+
+def test_formula_checksum_is_deterministic_for_json_key_order_and_changes_with_content() -> None:
+    # Arrange
+    project_id = str(uuid4())
+    payload = _valid_formula_payload(project_id=project_id)
+    declared_inputs_a = [
+        {
+            "name": "rate",
+            "contract": {"kind": "rate", "currency": "GBP", "per_unit": "m"},
+        },
+        {"name": "quantity", "contract": {"kind": "quantity", "unit": "m"}},
+    ]
+    declared_inputs_b = [
+        {
+            "contract": {"per_unit": "m", "currency": "GBP", "kind": "rate"},
+            "name": "rate",
+        },
+        {"contract": {"unit": "m", "kind": "quantity"}, "name": "quantity"},
+    ]
+
+    # Act
+    checksum_a = formula_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        formula_id=payload["formula_id"],
+        version=payload["version"],
+        name=payload["name"],
+        dsl_version=payload["dsl_version"],
+        output_key=payload["output_key"],
+        output_contract_json={"kind": "money", "currency": "GBP"},
+        declared_inputs_json=declared_inputs_a,
+        expression_json=payload["expression_json"],
+        rounding_json=payload["rounding_json"],
+    )
+    checksum_b = formula_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        formula_id=payload["formula_id"],
+        version=payload["version"],
+        name=payload["name"],
+        dsl_version=payload["dsl_version"],
+        output_key=payload["output_key"],
+        output_contract_json={"currency": "GBP", "kind": "money"},
+        declared_inputs_json=declared_inputs_b,
+        expression_json=payload["expression_json"],
+        rounding_json={"mode": "ROUND_HALF_UP", "scale": 2},
+    )
+    checksum_changed = formula_checksum_sha256(
+        scope_type=payload["scope_type"],
+        project_id=UUID(payload["project_id"]),
+        formula_id=payload["formula_id"],
+        version=2,
+        name=payload["name"],
+        dsl_version=payload["dsl_version"],
+        output_key=payload["output_key"],
+        output_contract_json={"kind": "money", "currency": "GBP"},
+        declared_inputs_json=declared_inputs_a,
+        expression_json=payload["expression_json"],
+        rounding_json=payload["rounding_json"],
+    )
+
+    # Assert
+    assert checksum_a == checksum_b
+    assert checksum_a != checksum_changed
+
+
+def _missing_uuid() -> str:
+    return "00000000-0000-0000-0000-000000000000"
+
+
+def _assert_checksum_sha256(value: Any) -> None:
+    assert isinstance(value, str)
+    assert re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+async def _create_project(async_client: httpx.AsyncClient, name: str) -> str:
+    response = await async_client.post("/v1/projects", json={"name": name})
+    assert response.status_code == 201
+    project = response.json()
+    return str(project["id"])
+
+
+async def _mark_project_deleted(project_id: str) -> None:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        project = (
+            await session.execute(select(Project).where(Project.id == UUID(project_id)))
+        ).scalar_one()
+        project.deleted_at = project.updated_at
+        await session.commit()
+
+
+def _valid_rate_payload(*, project_id: str) -> dict[str, Any]:
+    return {
+        "scope_type": "project",
+        "project_id": project_id,
+        "rate_key": "labour:installer",
+        "source": "manual",
+        "metadata_json": {"region": "uk-south"},
+        "name": "Installer labour",
+        "item_type": "labour",
+        "per_unit": "m",
+        "currency": "GBP",
+        "amount": "12.500000",
+        "effective_from": "2026-01-01",
+        "effective_to": None,
+    }
+
+
+def _valid_material_payload(*, project_id: str) -> dict[str, Any]:
+    return {
+        "scope_type": "project",
+        "project_id": project_id,
+        "material_key": "conduit:pvc-20mm",
+        "source": "manual",
+        "metadata_json": {"grade": "standard"},
+        "name": "PVC conduit 20mm",
+        "unit": "m",
+        "currency": "GBP",
+        "unit_cost": "3.250000",
+        "effective_from": "2026-01-01",
+        "effective_to": None,
+    }
+
+
+def _valid_formula_payload(*, project_id: str) -> dict[str, Any]:
+    return {
+        "scope_type": "project",
+        "project_id": project_id,
+        "formula_id": "line-total",
+        "version": 1,
+        "name": "Line total",
+        "dsl_version": "1.0",
+        "output_key": "line_total",
+        "output_contract_json": {"kind": "money", "currency": "GBP"},
+        "declared_inputs_json": [
+            {
+                "name": "rate",
+                "contract": {"kind": "rate", "currency": "GBP", "per_unit": "m"},
+            },
+            {"name": "quantity", "contract": {"kind": "quantity", "unit": "m"}},
+        ],
+        "expression_json": {
+            "kind": "multiply",
+            "args": [
+                {"kind": "input", "name": "rate"},
+                {"kind": "input", "name": "quantity"},
+            ],
+        },
+        "rounding_json": {"scale": 2, "mode": "ROUND_HALF_UP"},
+    }
+
+
+@requires_database
+class TestEstimationCatalogApiHappyPath:
+    async def test_rates_create_read_list(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        project_id = await _create_project(async_client, name="Rate Project")
+        payload = _valid_rate_payload(project_id=project_id)
+
+        # Act
+        create_response = await async_client.post("/v1/estimation/catalog/rates", json=payload)
+
+        # Assert
+        assert create_response.status_code == 201
+        created = create_response.json()
+        assert created["scope_type"] == "project"
+        assert created["project_id"] == project_id
+        assert created["rate_key"] == payload["rate_key"]
+        assert created["item_type"] == payload["item_type"]
+        assert created["per_unit"] == payload["per_unit"]
+        assert created["currency"] == payload["currency"]
+        assert created["amount"] == payload["amount"]
+        _assert_checksum_sha256(created["checksum_sha256"])
+
+        rate_id = created["id"]
+        read_response = await async_client.get(f"/v1/estimation/catalog/rates/{rate_id}")
+        assert read_response.status_code == 200
+        read_rate = read_response.json()
+        assert read_rate["id"] == rate_id
+        assert read_rate["checksum_sha256"] == created["checksum_sha256"]
+
+        list_response = await async_client.get("/v1/estimation/catalog/rates")
+        assert list_response.status_code == 200
+        items = list_response.json()["items"]
+        assert any(item["id"] == rate_id for item in items)
+
+    async def test_materials_create_read_list(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        project_id = await _create_project(async_client, name="Material Project")
+        payload = _valid_material_payload(project_id=project_id)
+
+        # Act
+        create_response = await async_client.post("/v1/estimation/catalog/materials", json=payload)
+
+        # Assert
+        assert create_response.status_code == 201
+        created = create_response.json()
+        assert created["scope_type"] == "project"
+        assert created["project_id"] == project_id
+        assert created["material_key"] == payload["material_key"]
+        assert created["unit"] == payload["unit"]
+        assert created["currency"] == payload["currency"]
+        assert created["unit_cost"] == payload["unit_cost"]
+        _assert_checksum_sha256(created["checksum_sha256"])
+
+        material_id = created["id"]
+        read_response = await async_client.get(f"/v1/estimation/catalog/materials/{material_id}")
+        assert read_response.status_code == 200
+        read_material = read_response.json()
+        assert read_material["id"] == material_id
+        assert read_material["checksum_sha256"] == created["checksum_sha256"]
+
+        list_response = await async_client.get("/v1/estimation/catalog/materials")
+        assert list_response.status_code == 200
+        items = list_response.json()["items"]
+        assert any(item["id"] == material_id for item in items)
+
+    async def test_formulas_create_read_list(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        # Arrange
+        project_id = await _create_project(async_client, name="Formula Project")
+        payload = _valid_formula_payload(project_id=project_id)
+
+        # Act
+        create_response = await async_client.post("/v1/estimation/formulas", json=payload)
+
+        # Assert
+        assert create_response.status_code == 201
+        created = create_response.json()
+        assert created["scope_type"] == "project"
+        assert created["project_id"] == project_id
+        assert created["formula_id"] == payload["formula_id"]
+        assert created["version"] == payload["version"]
+        assert created["dsl_version"] == payload["dsl_version"]
+        assert created["output_key"] == payload["output_key"]
+        _assert_checksum_sha256(created["checksum_sha256"])
+
+        formula_definition_id = created["id"]
+        read_response = await async_client.get(f"/v1/estimation/formulas/{formula_definition_id}")
+        assert read_response.status_code == 200
+        read_formula = read_response.json()
+        assert read_formula["id"] == formula_definition_id
+        assert read_formula["checksum_sha256"] == created["checksum_sha256"]
+
+        list_response = await async_client.get("/v1/estimation/formulas")
+        assert list_response.status_code == 200
+        items = list_response.json()["items"]
+        assert any(item["id"] == formula_definition_id for item in items)
+
+
+@requires_database
+class TestEstimationCatalogApiErrorPaths:
+    async def test_create_rate_rejects_malformed_scope_project_combination(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        payload = _valid_rate_payload(project_id=str(uuid4()))
+        payload["scope_type"] = "global"
+
+        response = await async_client.post("/v1/estimation/catalog/rates", json=payload)
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    async def test_create_rate_rejects_metadata_json_float_with_validation_envelope(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Rate Float Metadata Project")
+        payload = _valid_rate_payload(project_id=project_id)
+        payload["metadata_json"] = {"multiplier": 1.25}
+
+        response = await async_client.post("/v1/estimation/catalog/rates", json=payload)
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    async def test_create_rate_returns_not_found_for_missing_project(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        payload = _valid_rate_payload(project_id=_missing_uuid())
+
+        response = await async_client.post("/v1/estimation/catalog/rates", json=payload)
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_create_material_returns_not_found_for_soft_deleted_project(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Deleted Project")
+        await _mark_project_deleted(project_id)
+        payload = _valid_material_payload(project_id=project_id)
+
+        response = await async_client.post("/v1/estimation/catalog/materials", json=payload)
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_create_material_rejects_metadata_json_float_with_validation_envelope(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Material Float Metadata Project")
+        payload = _valid_material_payload(project_id=project_id)
+        payload["metadata_json"] = {"density": 2.5}
+
+        response = await async_client.post("/v1/estimation/catalog/materials", json=payload)
+
+        assert response.status_code == 422
+        assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    async def test_get_rate_returns_not_found_for_missing_resource(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.get(f"/v1/estimation/catalog/rates/{_missing_uuid()}")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_get_material_returns_not_found_for_missing_resource(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.get(f"/v1/estimation/catalog/materials/{_missing_uuid()}")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_get_formula_returns_not_found_for_missing_resource(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        response = await async_client.get(f"/v1/estimation/formulas/{_missing_uuid()}")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    async def test_create_formula_rejects_legacy_invalid_dsl_before_persistence(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Formula Validation Project")
+        payload = _valid_formula_payload(project_id=project_id)
+        payload["declared_inputs_json"] = [
+            {
+                "key": "rate",
+                "contract": {"kind": "rate", "currency": "GBP", "per_unit": "m"},
+            },
+            {"name": "quantity", "contract": {"kind": "quantity", "unit": "m"}},
+        ]
+        payload["expression_json"] = {
+            "op": "multiply",
+            "args": [
+                {"kind": "input", "name": "rate"},
+                {"kind": "input", "name": "quantity"},
+            ],
+        }
+
+        create_response = await async_client.post("/v1/estimation/formulas", json=payload)
+
+        assert create_response.status_code == 422
+        assert create_response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+        list_response = await async_client.get("/v1/estimation/formulas")
+        assert list_response.status_code == 200
+        assert list_response.json()["items"] == []
+
+
+@requires_database
+class TestEstimationCatalogApiRateIdempotency:
+    async def test_create_rate_replays_same_response_for_same_idempotency_key_and_payload(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Idempotency Replay Project")
+        payload = _valid_rate_payload(project_id=project_id)
+        headers = {"Idempotency-Key": "rate-create-replay-key"}
+
+        first_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+            headers=headers,
+        )
+        second_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+            headers=headers,
+        )
+
+        assert first_response.status_code == 201
+        assert second_response.status_code == 201
+        first_body = first_response.json()
+        second_body = second_response.json()
+        assert first_body["id"] == second_body["id"]
+        assert first_body["checksum_sha256"] == second_body["checksum_sha256"]
+        assert first_body == second_body
+
+    async def test_create_rate_returns_conflict_for_same_idempotency_key_and_different_payload(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Idempotency Conflict Project")
+        payload = _valid_rate_payload(project_id=project_id)
+        conflicting_payload = _valid_rate_payload(project_id=project_id)
+        conflicting_payload["name"] = "Installer labour changed"
+        headers = {"Idempotency-Key": "rate-create-conflict-key"}
+
+        first_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+            headers=headers,
+        )
+        conflict_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=conflicting_payload,
+            headers=headers,
+        )
+
+        assert first_response.status_code == 201
+        assert conflict_response.status_code == 409
+        body = conflict_response.json()
+        assert "error" in body
+        assert isinstance(body["error"].get("code"), str)
+        assert body["error"]["code"]
+
+
+@requires_database
+class TestEstimationCatalogApiSupersessionAndAsOf:
+    async def test_rate_superseded_entry_hidden_by_default_and_included_when_requested(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Rate Supersession Project")
+
+        predecessor_payload = _valid_rate_payload(project_id=project_id)
+        predecessor_payload["effective_to"] = "2026-03-01"
+        predecessor_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=predecessor_payload,
+        )
+        assert predecessor_response.status_code == 201
+        predecessor_id = predecessor_response.json()["id"]
+
+        successor_payload = _valid_rate_payload(project_id=project_id)
+        successor_payload["name"] = "Installer labour v2"
+        successor_payload["amount"] = "13.500000"
+        successor_payload["effective_from"] = "2026-03-01"
+        successor_payload["supersedes_rate_id"] = predecessor_id
+        successor_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=successor_payload,
+        )
+        assert successor_response.status_code == 201
+        successor_id = successor_response.json()["id"]
+
+        default_list_response = await async_client.get(
+            "/v1/estimation/catalog/rates",
+            params={"project_id": project_id, "rate_key": predecessor_payload["rate_key"]},
+        )
+        assert default_list_response.status_code == 200
+        default_ids = {item["id"] for item in default_list_response.json()["items"]}
+        assert successor_id in default_ids
+        assert predecessor_id not in default_ids
+
+        include_superseded_response = await async_client.get(
+            "/v1/estimation/catalog/rates",
+            params={
+                "project_id": project_id,
+                "rate_key": predecessor_payload["rate_key"],
+                "include_superseded": "true",
+            },
+        )
+        assert include_superseded_response.status_code == 200
+        include_superseded_ids = {
+            item["id"] for item in include_superseded_response.json()["items"]
+        }
+        assert predecessor_id in include_superseded_ids
+        assert successor_id in include_superseded_ids
+
+    async def test_rate_list_as_of_filters_by_effective_window(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Rate As-Of Project")
+
+        january_rate_payload = _valid_rate_payload(project_id=project_id)
+        january_rate_payload["rate_key"] = "labour:jan"
+        january_rate_payload["effective_from"] = "2026-01-01"
+        january_rate_payload["effective_to"] = "2026-02-01"
+        january_rate_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=january_rate_payload,
+        )
+        assert january_rate_response.status_code == 201
+        january_rate_id = january_rate_response.json()["id"]
+
+        march_rate_payload = _valid_rate_payload(project_id=project_id)
+        march_rate_payload["rate_key"] = "labour:mar"
+        march_rate_payload["name"] = "March installer labour"
+        march_rate_payload["effective_from"] = "2026-03-01"
+        march_rate_payload["effective_to"] = None
+        march_rate_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=march_rate_payload,
+        )
+        assert march_rate_response.status_code == 201
+        march_rate_id = march_rate_response.json()["id"]
+
+        as_of_response = await async_client.get(
+            "/v1/estimation/catalog/rates",
+            params={"project_id": project_id, "as_of": "2026-01-15"},
+        )
+        assert as_of_response.status_code == 200
+        as_of_ids = {item["id"] for item in as_of_response.json()["items"]}
+        assert january_rate_id in as_of_ids
+        assert march_rate_id not in as_of_ids
+
+    async def test_material_list_as_of_filters_by_effective_window(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Material As-Of Project")
+
+        january_material_payload = _valid_material_payload(project_id=project_id)
+        january_material_payload["material_key"] = "material:jan"
+        january_material_payload["effective_from"] = "2026-01-01"
+        january_material_payload["effective_to"] = "2026-02-01"
+        january_material_response = await async_client.post(
+            "/v1/estimation/catalog/materials",
+            json=january_material_payload,
+        )
+        assert january_material_response.status_code == 201
+        january_material_id = january_material_response.json()["id"]
+
+        march_material_payload = _valid_material_payload(project_id=project_id)
+        march_material_payload["material_key"] = "material:mar"
+        march_material_payload["name"] = "March PVC conduit"
+        march_material_payload["effective_from"] = "2026-03-01"
+        march_material_payload["effective_to"] = None
+        march_material_response = await async_client.post(
+            "/v1/estimation/catalog/materials",
+            json=march_material_payload,
+        )
+        assert march_material_response.status_code == 201
+        march_material_id = march_material_response.json()["id"]
+
+        as_of_response = await async_client.get(
+            "/v1/estimation/catalog/materials",
+            params={"project_id": project_id, "as_of": "2026-01-15"},
+        )
+        assert as_of_response.status_code == 200
+        as_of_ids = {item["id"] for item in as_of_response.json()["items"]}
+        assert january_material_id in as_of_ids
+        assert march_material_id not in as_of_ids
+
+
+@requires_database
+class TestEstimationCatalogApiConflicts:
+    async def test_create_formula_duplicate_payload_returns_db_conflict(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Formula Conflict Project")
+        payload = _valid_formula_payload(project_id=project_id)
+
+        first_response = await async_client.post("/v1/estimation/formulas", json=payload)
+        conflict_response = await async_client.post("/v1/estimation/formulas", json=payload)
+
+        assert first_response.status_code == 201
+        assert conflict_response.status_code == 409
+        assert conflict_response.json()["error"]["code"] == "DB_CONFLICT"
+
+    async def test_create_rate_duplicate_payload_returns_db_conflict(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Rate Conflict Project")
+        payload = _valid_rate_payload(project_id=project_id)
+
+        first_response = await async_client.post("/v1/estimation/catalog/rates", json=payload)
+        conflict_response = await async_client.post("/v1/estimation/catalog/rates", json=payload)
+
+        assert first_response.status_code == 201
+        assert conflict_response.status_code == 409
+        assert conflict_response.json()["error"]["code"] == "DB_CONFLICT"


### PR DESCRIPTION
Closes #204

## Summary
- add create/read/list APIs for versioned estimation rates, materials, and formulas
- enforce append-only writes with server-derived checksums, idempotency, supersession metadata, and sanitized error envelopes
- add DB-backed API coverage and document the new `/v1/estimation/catalog/*` and `/v1/estimation/formulas` surface

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv run pytest tests/test_formula_dsl.py tests/test_estimation_catalog_resolver.py tests/test_estimation_catalog_persistence.py tests/test_estimation_catalog_api.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_estimation_catalog_api.py