### PR TITLE
chore: add adaptive pre-push CI parity gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # =============================================================================
 # Draupnir — Pre-commit Hooks
 # =============================================================================
-# Install:  uv sync --extra db --extra jobs --extra dev --extra test && uv run pre-commit install
+# Install:  uv sync --extra db --extra jobs --extra dev --extra test && make hooks
 # Run all:  uv run pre-commit run --all-files
 # =============================================================================
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   make test        — Run pytest
 #   make format      — Run ruff formatter on app/ and tests/
 #   make check       — Run lint + typecheck + test
-#   make hooks       — Install pre-commit hooks via uv
+#   make hooks       — Install pre-commit + adaptive pre-push hooks
 #   make up          — Start Docker Compose stack
 #   make down        — Stop Docker Compose stack
 #   make logs        — Follow Docker Compose logs
@@ -22,6 +22,8 @@
 # =============================================================================
 
 UV_SYNC_ARGS = --extra db --extra jobs --extra dev --extra test
+PRE_PUSH_HOOK = .git/hooks/pre-push
+PRE_PUSH_HOOK_VERSION = v1
 
 .PHONY: sync lint typecheck test format check hooks up down logs ps shell-api shell-worker migrate
 
@@ -44,6 +46,9 @@ check: lint typecheck test
 
 hooks:
 	uv run pre-commit install
+	@mkdir -p "$(dir $(PRE_PUSH_HOOK))"
+	@printf '%s\n' '#!/bin/sh' '# draupnir pre-push ci-parity $(PRE_PUSH_HOOK_VERSION)' 'exec uv run python scripts/pre_push_check.py "$$@"' > "$(PRE_PUSH_HOOK)"
+	@chmod +x "$(PRE_PUSH_HOOK)"
 
 # ---------------------------------------------------------------------------
 # Docker Compose targets

--- a/scripts/pre_push_check.py
+++ b/scripts/pre_push_check.py
@@ -1,0 +1,312 @@
+"""Adaptive pre-push CI parity gate."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import TextIO
+from urllib.parse import urlparse
+
+ZERO_OID = "0" * 40
+EXAMPLE_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test"
+SENSITIVE_PREFIXES = (
+    "app/api/",
+    "app/models/",
+    "app/db/",
+    "alembic/",
+)
+SENSITIVE_TEST_TOKENS = frozenset({"api", "db", "persistence"})
+SENSITIVE_TEST_CONTENT_MARKERS = frozenset(
+    {
+        "requires_database",
+        "from app.db",
+        "import app.db",
+        "from sqlalchemy",
+        "import sqlalchemy",
+        "asyncsession",
+        "async_sessionmaker",
+    }
+)
+LOCAL_DATABASE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+class CommandError(RuntimeError):
+    """Raised when a git discovery command fails."""
+
+
+@dataclass(frozen=True)
+class RefUpdate:
+    local_ref: str
+    local_sha: str
+    remote_ref: str
+    remote_sha: str
+
+
+QueryRunner = Callable[[Sequence[str]], str]
+ExecRunner = Callable[[Sequence[str]], int]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("remote_name", nargs="?", default="origin")
+    parser.add_argument("remote_url", nargs="?", default="")
+    return parser.parse_args(argv)
+
+
+def parse_ref_updates(lines: Iterable[str]) -> list[RefUpdate]:
+    updates: list[RefUpdate] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 4:
+            raise ValueError(f"invalid pre-push update line: {raw_line!r}")
+        updates.append(RefUpdate(*parts[:4]))
+    return updates
+
+
+def default_query_runner(args: Sequence[str]) -> str:
+    result = subprocess.run(
+        list(args),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "command failed"
+        raise CommandError(f"{' '.join(args)}: {message}")
+    return result.stdout.strip()
+
+
+def default_exec_runner(args: Sequence[str]) -> int:
+    result = subprocess.run(list(args), check=False)
+    return result.returncode
+
+
+def try_query(args: Sequence[str], query_runner: QueryRunner) -> str | None:
+    try:
+        output = query_runner(args)
+    except CommandError:
+        return None
+    return output or None
+
+
+def unique_paths(paths: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for path in paths:
+        normalized = path.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(normalized)
+    return ordered
+
+
+def list_diff_files(left: str, right: str, query_runner: QueryRunner) -> list[str]:
+    output = query_runner(["git", "diff", "--name-only", f"{left}..{right}"])
+    return unique_paths(output.splitlines())
+
+
+def current_head_files(query_runner: QueryRunner) -> list[str]:
+    output = query_runner(["git", "diff", "--name-only", "HEAD"])
+    return unique_paths(output.splitlines())
+
+
+def resolve_merge_base(
+    local_ref: str,
+    local_sha: str,
+    remote_name: str,
+    query_runner: QueryRunner,
+) -> str | None:
+    candidates: list[str] = []
+    if local_ref.startswith("refs/heads/"):
+        upstream = try_query(
+            ["git", "for-each-ref", "--format=%(upstream:short)", local_ref],
+            query_runner,
+        )
+        if upstream:
+            candidates.append(upstream)
+    remote_head = try_query(
+        ["git", "symbolic-ref", "--quiet", "--short", f"refs/remotes/{remote_name}/HEAD"],
+        query_runner,
+    )
+    if remote_head:
+        candidates.append(remote_head)
+    candidates.extend((f"{remote_name}/main", f"{remote_name}/master"))
+    for candidate in unique_paths(candidates):
+        merge_base = try_query(["git", "merge-base", local_sha, candidate], query_runner)
+        if merge_base:
+            return merge_base
+    return None
+
+
+def changed_files_for_update(
+    update: RefUpdate,
+    remote_name: str,
+    query_runner: QueryRunner,
+) -> list[str]:
+    if update.local_sha == ZERO_OID:
+        return []
+    if update.remote_sha != ZERO_OID:
+        return list_diff_files(update.remote_sha, update.local_sha, query_runner)
+    merge_base = resolve_merge_base(
+        local_ref=update.local_ref,
+        local_sha=update.local_sha,
+        remote_name=remote_name,
+        query_runner=query_runner,
+    )
+    if merge_base is not None:
+        return list_diff_files(merge_base, update.local_sha, query_runner)
+    output = query_runner(
+        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", update.local_sha]
+    )
+    return unique_paths(output.splitlines())
+
+
+def determine_changed_files(
+    updates: Sequence[RefUpdate],
+    remote_name: str,
+    query_runner: QueryRunner,
+) -> list[str]:
+    if not updates:
+        return current_head_files(query_runner)
+    paths: list[str] = []
+    for update in updates:
+        paths.extend(changed_files_for_update(update, remote_name, query_runner))
+    return unique_paths(paths)
+
+
+def test_file_uses_database(path: str) -> bool:
+    file_path = Path(path)
+    if not file_path.is_file():
+        return False
+    try:
+        contents = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    lowered = contents.lower()
+    return any(marker in lowered for marker in SENSITIVE_TEST_CONTENT_MARKERS)
+
+
+def is_sensitive_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lstrip("./")
+    if any(normalized.startswith(prefix) for prefix in SENSITIVE_PREFIXES):
+        return True
+    pure_path = PurePosixPath(normalized)
+    if not pure_path.parts or pure_path.parts[0] != "tests":
+        return False
+    test_tokens = set(re.split(r"[^a-z0-9]+", pure_path.stem.lower()))
+    path_tokens = {part.lower() for part in pure_path.parts[1:-1]}
+    if SENSITIVE_TEST_TOKENS & (test_tokens | path_tokens):
+        return True
+    return test_file_uses_database(normalized)
+
+
+def format_database_url_message(sensitive_paths: Sequence[str]) -> str:
+    changed_lines = "\n".join(f"  - {path}" for path in sensitive_paths)
+    return (
+        "pre-push check failed: DB-sensitive changes require DATABASE_URL.\n"
+        "Detected paths:\n"
+        f"{changed_lines}\n"
+        "Set DATABASE_URL and rerun push. Example:\n"
+        f"  export DATABASE_URL={EXAMPLE_DATABASE_URL}\n"
+        "This gate mirrors CI with:\n"
+        "  uv run alembic upgrade head\n"
+        "  uv run pytest"
+    )
+
+
+def validate_database_url(database_url: str) -> str | None:
+    parsed = urlparse(database_url)
+    if not parsed.scheme.startswith("postgresql"):
+        return "DATABASE_URL must use a PostgreSQL URL."
+    if parsed.hostname not in LOCAL_DATABASE_HOSTS:
+        return (
+            "DATABASE_URL must point to a dedicated local test database on "
+            "localhost, 127.0.0.1, or ::1."
+        )
+    database_name = parsed.path.lstrip("/")
+    if not database_name.endswith("_test"):
+        return "DATABASE_URL must use a dedicated test database name ending in '_test'."
+    return None
+
+
+def format_invalid_database_url_message(
+    sensitive_paths: Sequence[str],
+    validation_error: str,
+) -> str:
+    changed_lines = "\n".join(f"  - {path}" for path in sensitive_paths)
+    return (
+        "pre-push check failed: DB-sensitive changes require a dedicated local "
+        "test DATABASE_URL.\n"
+        "Detected paths:\n"
+        f"{changed_lines}\n"
+        f"{validation_error}\n"
+        "Set DATABASE_URL to a local test database and rerun push. Example:\n"
+        f"  export DATABASE_URL={EXAMPLE_DATABASE_URL}"
+    )
+
+
+def run_gate(
+    changed_files: Sequence[str],
+    env: Mapping[str, str],
+    exec_runner: ExecRunner,
+    stderr: TextIO,
+) -> int:
+    sensitive_paths = [path for path in changed_files if is_sensitive_path(path)]
+    if sensitive_paths:
+        database_url = env.get("DATABASE_URL")
+        if not database_url:
+            print(format_database_url_message(sensitive_paths), file=stderr)
+            return 1
+        validation_error = validate_database_url(database_url)
+        if validation_error is not None:
+            print(
+                format_invalid_database_url_message(sensitive_paths, validation_error),
+                file=stderr,
+            )
+            return 1
+        print(
+            "pre-push check: DB-sensitive changes detected; running alembic upgrade head.",
+            file=stderr,
+        )
+        migration_code = exec_runner(["uv", "run", "alembic", "upgrade", "head"])
+        if migration_code != 0:
+            return migration_code
+    else:
+        print("pre-push check: no DB-sensitive changes detected.", file=stderr)
+    return exec_runner(["uv", "run", "pytest"])
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    env: Mapping[str, str] | None = None,
+    query_runner: QueryRunner = default_query_runner,
+    exec_runner: ExecRunner = default_exec_runner,
+    stderr: TextIO | None = None,
+) -> int:
+    args = parse_args(argv)
+    input_stream = sys.stdin if stdin is None else stdin
+    output_stream = sys.stderr if stderr is None else stderr
+    active_env = os.environ if env is None else env
+    try:
+        updates = parse_ref_updates(input_stream)
+        changed_files = determine_changed_files(updates, args.remote_name, query_runner)
+    except (CommandError, ValueError) as error:
+        print(f"pre-push check failed: {error}", file=output_stream)
+        return 1
+    return run_gate(changed_files, active_env, exec_runner, output_stream)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pre_push_check.py
+++ b/tests/test_pre_push_check.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from types import ModuleType
+
+
+def load_pre_push_check_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "pre_push_check.py"
+    spec = importlib.util.spec_from_file_location("pre_push_check", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed to load pre_push_check module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+pre_push_check = load_pre_push_check_module()
+
+
+class QueryStub:
+    def __init__(
+        self,
+        responses: Mapping[tuple[str, ...], str],
+        failures: Sequence[tuple[str, ...]] = (),
+    ) -> None:
+        self._responses = dict(responses)
+        self._failures = set(failures)
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, args: Sequence[str]) -> str:
+        key = tuple(args)
+        self.calls.append(key)
+        if key in self._failures:
+            raise pre_push_check.CommandError(f"failed: {' '.join(args)}")
+        try:
+            return self._responses[key]
+        except KeyError as error:
+            raise AssertionError(f"unexpected query: {key!r}") from error
+
+
+class ExecStub:
+    def __init__(self, exit_codes: Mapping[tuple[str, ...], int] | None = None) -> None:
+        self._exit_codes = {} if exit_codes is None else dict(exit_codes)
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, args: Sequence[str]) -> int:
+        key = tuple(args)
+        self.calls.append(key)
+        return self._exit_codes.get(key, 0)
+
+
+def test_is_sensitive_path_detects_expected_paths() -> None:
+    assert pre_push_check.is_sensitive_path("app/api/v1/revisions.py")
+    assert pre_push_check.is_sensitive_path("app/models/job.py")
+    assert pre_push_check.is_sensitive_path("app/db/session.py")
+    assert pre_push_check.is_sensitive_path("alembic/versions/0001_init.py")
+    assert pre_push_check.is_sensitive_path("tests/api/test_revisions.py")
+    assert pre_push_check.is_sensitive_path("tests/test_files.py")
+    assert pre_push_check.is_sensitive_path("tests/test_revision_api.py")
+    assert pre_push_check.is_sensitive_path("tests/persistence/test_catalog.py")
+    assert not pre_push_check.is_sensitive_path("tests/test_storage.py")
+    assert not pre_push_check.is_sensitive_path("docs/runbook.md")
+
+
+def test_determine_changed_files_uses_merge_base_for_new_branch_push() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "for-each-ref",
+                "--format=%(upstream:short)",
+                "refs/heads/feature/pre-push",
+            ): "",
+            (
+                "git",
+                "symbolic-ref",
+                "--quiet",
+                "--short",
+                "refs/remotes/origin/HEAD",
+            ): "origin/main",
+            ("git", "merge-base", "abc123", "origin/main"): "base123",
+            ("git", "diff", "--name-only", "base123..abc123"): (
+                "app/api/v1/revisions.py\ntests/test_revision_api.py\n"
+            ),
+        },
+    )
+    updates = [
+        pre_push_check.RefUpdate(
+            local_ref="refs/heads/feature/pre-push",
+            local_sha="abc123",
+            remote_ref="refs/heads/feature/pre-push",
+            remote_sha=pre_push_check.ZERO_OID,
+        )
+    ]
+
+    changed_files = pre_push_check.determine_changed_files(updates, "origin", query)
+
+    assert changed_files == [
+        "app/api/v1/revisions.py",
+        "tests/test_revision_api.py",
+    ]
+
+
+def test_main_runs_pytest_only_for_non_sensitive_changes() -> None:
+    query = QueryStub(
+        {
+            ("git", "diff", "--name-only", "def456..abc123"): (
+                "docs/runbook.md\nscripts/pre_push_check.py\n"
+            )
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [("uv", "run", "pytest")]
+    assert "no DB-sensitive changes" in stderr.getvalue()
+
+
+def test_main_requires_database_url_for_sensitive_changes() -> None:
+    query = QueryStub(
+        {
+            ("git", "diff", "--name-only", "def456..abc123"): (
+                "app/db/session.py\ntests/test_storage.py\n"
+            )
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert exec_runner.calls == []
+    error_output = stderr.getvalue()
+    assert "DATABASE_URL" in error_output
+    assert "uv run alembic upgrade head" in error_output
+    assert "app/db/session.py" in error_output
+
+
+def test_main_runs_migration_before_pytest_for_sensitive_changes() -> None:
+    query = QueryStub(
+        {
+            ("git", "diff", "--name-only", "def456..abc123"): (
+                "app/models/job.py\ntests/persistence/test_catalog.py\n"
+            )
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest"),
+    ]
+    assert "running alembic upgrade head" in stderr.getvalue()
+
+
+def test_main_rejects_non_local_or_non_test_database_url() -> None:
+    query = QueryStub({("git", "diff", "--name-only", "def456..abc123"): ("tests/test_files.py\n")})
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": "postgresql+asyncpg://postgres:postgres@db.internal:5432/draupnir"},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert exec_runner.calls == []
+    error_output = stderr.getvalue()
+    assert "dedicated local test DATABASE_URL" in error_output
+    assert "localhost, 127.0.0.1, or ::1" in error_output
+    assert pre_push_check.EXAMPLE_DATABASE_URL in error_output


### PR DESCRIPTION
## Summary
- add a versioned `scripts/pre_push_check.py` gate and install it from `make hooks`
- require a local PostgreSQL `_test` `DATABASE_URL` and run Alembic before pytest for DB-sensitive pushes
- add focused tests covering changed-file detection, DB-sensitive test detection, and database URL validation

## Test plan
- [x] `uv run ruff check scripts tests/test_pre_push_check.py`
- [x] `uv run mypy scripts tests/test_pre_push_check.py`
- [x] `uv build`
- [x] `uv run pytest tests/test_pre_push_check.py`

## Notes
- Non-blocking follow-up: harden SQLAlchemy URL query-param override handling in the database URL validator.