### PR TITLE
feat(api): add estimate create API endpoint

### DIFF
--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -2,8 +2,12 @@
 
 import base64
 import binascii
-from datetime import datetime
-from typing import Annotated
+import importlib
+import pkgutil
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from math import isfinite
+from typing import Annotated, Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -29,6 +33,7 @@ from app.api.pagination import (
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
+from app.jobs import worker as jobs_worker_module
 from app.jobs.worker import enqueue_quantity_takeoff_job as _enqueue_quantity_takeoff_job
 from app.jobs.worker import prepare_job_enqueue_intent, publish_job_enqueue_intent
 from app.models.adapter_run_output import AdapterRunOutput
@@ -38,7 +43,12 @@ from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
 from app.models.project import Project
-from app.models.quantity_takeoff import QuantityGate, QuantityItem, QuantityTakeoff
+from app.models.quantity_takeoff import (
+    QuantityGate,
+    QuantityItem,
+    QuantityItemKind,
+    QuantityTakeoff,
+)
 from app.models.revision_materialization import (
     RevisionBlock,
     RevisionEntity,
@@ -52,6 +62,8 @@ from app.schemas.estimate import (
     EstimateItemRead,
     EstimateSnapshotEntryListResponse,
     EstimateSnapshotEntryRead,
+    EstimateVersionCreateCatalogRef,
+    EstimateVersionCreateRequest,
     EstimateVersionListResponse,
     EstimateVersionRead,
 )
@@ -88,6 +100,7 @@ revisions_router = APIRouter()
 
 _DEFAULT_PAGE_SIZE = 50
 _MAX_PAGE_SIZE = 200
+_APP_MODEL_MODULES_LOADED = False
 
 
 class _DrawingRevisionCursor(BaseModel):
@@ -103,6 +116,18 @@ class _GeneratedArtifactCursor(BaseModel):
 
     created_at: datetime
     id: UUID
+
+
+@dataclass(slots=True)
+class _NormalizedEstimateCatalogRef:
+    ref_type: str
+    selection_id: UUID
+    selection_key: str
+    selection_checksum_sha256: str
+    description: str
+    line_key: str
+    quantity_item_id: UUID | None
+    formula_inputs: dict[str, Any] | None
 
 
 def _encode_cursor(payload: BaseModel) -> str:
@@ -150,6 +175,13 @@ def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
     """Compatibility wrapper kept for test fixture patching."""
 
     _enqueue_quantity_takeoff_job(job_id)
+
+
+def enqueue_estimate_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+
+    publisher = jobs_worker_module.enqueue_estimate_job
+    publisher(job_id)
 
 
 def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
@@ -335,6 +367,7 @@ async def _get_active_revision_manifest_or_409(
     revision = await _get_active_revision(revision_id, db)
     if revision is None:
         raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
 
     manifest = await _get_revision_manifest(revision_id, db)
     if manifest is None:
@@ -367,6 +400,412 @@ def _raise_quantity_takeoff_gate_invalid(report: ValidationReport) -> None:
             },
         ),
     )
+
+
+def _raise_estimate_input_invalid(
+    message: str,
+    *,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Raise the standard estimate input validation error."""
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INPUT_INVALID,
+            message=message,
+            details=details,
+        ),
+    )
+
+
+def _raise_estimate_takeoff_gate_invalid(takeoff: QuantityTakeoff) -> None:
+    """Raise the standard pre-enqueue error for non-runnable estimate inputs."""
+
+    _raise_estimate_input_invalid(
+        "Estimate jobs require a trusted quantity takeoff with an allowed quantity gate.",
+        details={
+            "quantity_gate": takeoff.quantity_gate,
+            "trusted_totals": takeoff.trusted_totals,
+            "review_state": takeoff.review_state,
+            "validation_status": takeoff.validation_status,
+        },
+    )
+
+
+def _normalize_estimate_request_body(payload: EstimateVersionCreateRequest) -> dict[str, Any]:
+    """Return the normalized create-request body used for idempotency fingerprints."""
+
+    return payload.model_dump(mode="json", by_alias=False, exclude_none=False)
+
+
+def _mapped_attribute_keys(model_class: type[Any]) -> set[str]:
+    """Return mapped SQLAlchemy attribute keys for a model class."""
+
+    return {attribute.key for attribute in model_class.__mapper__.attrs}
+
+
+def _build_mapped_instance(model_class: type[Any], values: dict[str, Any]) -> Any:
+    """Instantiate a mapped object while ignoring unknown compatibility fields."""
+
+    instance = model_class()
+    valid_keys = _mapped_attribute_keys(model_class)
+    for key, value in values.items():
+        if key in valid_keys:
+            setattr(instance, key, value)
+    return instance
+
+
+def _first_present_attribute(instance: Any, names: tuple[str, ...]) -> Any:
+    """Return the first present attribute value from a candidate name list."""
+
+    for name in names:
+        if hasattr(instance, name):
+            return getattr(instance, name)
+    return None
+
+
+def _load_app_model_modules() -> None:
+    """Import app model modules so mapped classes are registered."""
+
+    import app.models as models_package
+
+    global _APP_MODEL_MODULES_LOADED
+
+    if not _APP_MODEL_MODULES_LOADED:
+        for module_info in pkgutil.iter_modules(models_package.__path__):
+            importlib.import_module(f"{models_package.__name__}.{module_info.name}")
+        _APP_MODEL_MODULES_LOADED = True
+
+
+def _resolve_estimate_job_model_classes() -> tuple[type[Any], type[Any]]:
+    """Resolve mapped model classes used to persist estimate job inputs."""
+
+    _load_app_model_modules()
+    class_map = {mapper.class_.__name__: mapper.class_ for mapper in Job.registry.mappers}
+    input_model = class_map.get("EstimateJobInput")
+    ref_model = class_map.get("EstimateJobInputCatalogRef")
+    if input_model is None or ref_model is None:
+        raise RuntimeError("Estimate job input models are unavailable")
+    return input_model, ref_model
+
+
+def _resolve_catalog_model(ref_type: str) -> type[Any]:
+    """Resolve the mapped catalog/formula model for a request ref type."""
+
+    _load_app_model_modules()
+    candidates: dict[str, list[type[Any]]] = {"rate": [], "material": [], "formula": []}
+    for mapper in Job.registry.mappers:
+        model_class = mapper.class_
+        name = model_class.__name__.lower()
+        table_name = getattr(model_class, "__tablename__", "").lower()
+        if "estimatejobinput" in name or "quantity" in name:
+            continue
+        if "supersession" in name or "supersession" in table_name:
+            continue
+        if (
+            "catalog" in name
+            or "catalog" in table_name
+            or "formula" in name
+            or "formula" in table_name
+        ):
+            if "rate" in name or "rate" in table_name:
+                candidates["rate"].append(model_class)
+            if "material" in name or "material" in table_name:
+                candidates["material"].append(model_class)
+            if "formula" in name or "formula" in table_name:
+                candidates["formula"].append(model_class)
+
+    matches = candidates.get(ref_type, [])
+    if not matches:
+        raise RuntimeError(f"Catalog model for ref type '{ref_type}' is unavailable")
+
+    def _model_score(model_class: type[Any]) -> tuple[int, int]:
+        name = model_class.__name__.lower()
+        table_name = getattr(model_class, "__tablename__", "").lower()
+        return (
+            int("catalog" in name or "catalog" in table_name),
+            int(ref_type in name or ref_type in table_name),
+        )
+
+    return sorted(matches, key=_model_score, reverse=True)[0]
+
+
+def _resolve_catalog_supersession_model(ref_type: str) -> type[Any]:
+    """Resolve the mapped supersession model for a request ref type."""
+
+    _load_app_model_modules()
+    for mapper in Job.registry.mappers:
+        model_class = mapper.class_
+        name = model_class.__name__.lower()
+        table_name = getattr(model_class, "__tablename__", "").lower()
+        if "supersession" not in name and "supersession" not in table_name:
+            continue
+        if ref_type == "rate" and "rate" in name:
+            return model_class
+        if ref_type == "material" and "material" in name:
+            return model_class
+        if ref_type == "formula" and "formula" in name:
+            return model_class
+    raise RuntimeError(f"Catalog supersession model for ref type '{ref_type}' is unavailable")
+
+
+async def _catalog_selection_is_superseded(
+    ref_type: str,
+    selection_id: UUID,
+    db: AsyncSession,
+) -> bool:
+    """Return whether a catalog selection has been superseded."""
+
+    supersession_model = _resolve_catalog_supersession_model(ref_type)
+    predecessor_field_name = {
+        "rate": "predecessor_rate_id",
+        "material": "predecessor_material_id",
+        "formula": "predecessor_formula_id",
+    }[ref_type]
+    result = await db.execute(
+        select(supersession_model).where(
+            getattr(supersession_model, predecessor_field_name) == selection_id
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+def _resolve_estimate_pricing_contract(
+    request: EstimateVersionCreateRequest,
+    *,
+    job_created_at: datetime | None = None,
+) -> tuple[str, date]:
+    """Resolve the persisted pricing contract for an estimate request."""
+
+    if request.pricing.effective_date is not None:
+        return "explicit", request.pricing.effective_date
+    resolved_at = job_created_at or datetime.now(UTC)
+    return "derived_from_job_created_at_utc", resolved_at.date()
+
+
+def _quantity_item_is_executable(quantity_item: QuantityItem) -> bool:
+    """Return whether a quantity item can back a rate/material estimate ref."""
+
+    if quantity_item.item_kind not in {
+        QuantityItemKind.CONTRIBUTOR.value,
+        QuantityItemKind.AGGREGATE.value,
+    }:
+        return False
+
+    value = quantity_item.value
+    return value is not None and isfinite(value)
+
+
+async def _get_estimate_catalog_selection(
+    ref_type: str,
+    selection_id: UUID,
+    db: AsyncSession,
+) -> Any | None:
+    """Return the selected catalog/formula row for a request ref."""
+
+    model_class = _resolve_catalog_model(ref_type)
+    result = await db.execute(select(model_class).where(model_class.id == selection_id))
+    return result.scalar_one_or_none()
+
+
+async def _resolve_estimate_catalog_refs(
+    revision: DrawingRevision,
+    takeoff: QuantityTakeoff,
+    request_refs: list[EstimateVersionCreateCatalogRef],
+    pricing_effective_date: date,
+    db: AsyncSession,
+) -> list[_NormalizedEstimateCatalogRef]:
+    """Validate request refs and normalize worker mapping inputs."""
+
+    if not request_refs:
+        _raise_estimate_input_invalid(
+            "Estimate jobs require at least one catalog or formula reference.",
+            details={"catalog_refs": []},
+        )
+
+    normalized_refs: list[_NormalizedEstimateCatalogRef] = []
+    seen_line_keys: set[str] = set()
+    for request_ref in request_refs:
+        if request_ref.ref_type not in {"rate", "material", "formula"}:
+            _raise_estimate_input_invalid(
+                "Estimate refs must use supported ref types.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        selection = await _get_estimate_catalog_selection(
+            request_ref.ref_type,
+            request_ref.selection_id,
+            db,
+        )
+        if selection is None:
+            _raise_estimate_input_invalid(
+                "Estimate refs must point to visible catalog selections.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        selection_project_id = getattr(selection, "project_id", None)
+        if selection_project_id not in {None, revision.project_id}:
+            _raise_estimate_input_invalid(
+                "Estimate refs must belong to the same project lineage as the revision.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        if await _catalog_selection_is_superseded(
+            request_ref.ref_type, request_ref.selection_id, db
+        ):
+            _raise_estimate_input_invalid(
+                "Estimate refs must point to current catalog selections.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        if getattr(selection, "deleted_at", None) is not None:
+            _raise_estimate_input_invalid(
+                "Estimate refs must point to visible catalog selections.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        selection_key = _first_present_attribute(
+            selection,
+            (
+                "selection_key",
+                "entry_key",
+                "key",
+                "formula_key",
+                "formula_id",
+                "rate_key",
+                "material_key",
+            ),
+        )
+        if selection_key is not None and str(selection_key) != request_ref.selection_key:
+            _raise_estimate_input_invalid(
+                "Estimate refs must use the current catalog selection key.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "selection_key": request_ref.selection_key,
+                },
+            )
+
+        selection_checksum = _first_present_attribute(
+            selection,
+            ("checksum_sha256", "source_checksum_sha256"),
+        )
+        if (
+            selection_checksum is not None
+            and str(selection_checksum) != request_ref.selection_checksum_sha256
+        ):
+            _raise_estimate_input_invalid(
+                "Estimate refs must use the current catalog selection checksum.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "selection_checksum_sha256": request_ref.selection_checksum_sha256,
+                },
+            )
+
+        selection_currency = _first_present_attribute(selection, ("currency",))
+        if selection_currency is not None and str(selection_currency).upper() != "GBP":
+            _raise_estimate_input_invalid(
+                "Estimate jobs only support GBP pricing inputs.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "currency": str(selection_currency),
+                },
+            )
+
+        effective_from = _first_present_attribute(selection, ("effective_from",))
+        effective_to = _first_present_attribute(selection, ("effective_to",))
+        if effective_from is not None and (
+            pricing_effective_date < effective_from
+            or (effective_to is not None and pricing_effective_date >= effective_to)
+        ):
+            _raise_estimate_input_invalid(
+                "Estimate refs must be effective for the resolved pricing date.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "pricing_effective_date": pricing_effective_date.isoformat(),
+                },
+            )
+
+        if request_ref.ref_type in {"rate", "material"}:
+            if request_ref.quantity_item_id is None:
+                _raise_estimate_input_invalid(
+                    "Rate and material refs require a quantity item.",
+                    details={
+                        "ref_type": request_ref.ref_type,
+                        "selection_id": str(request_ref.selection_id),
+                    },
+                )
+
+            quantity_item_result = await db.execute(
+                select(QuantityItem).where(
+                    (QuantityItem.id == request_ref.quantity_item_id)
+                    & (QuantityItem.quantity_takeoff_id == takeoff.id)
+                    & (QuantityItem.project_id == revision.project_id)
+                    & (QuantityItem.drawing_revision_id == revision.id)
+                    & (QuantityItem.quantity_gate == QuantityGate.ALLOWED.value)
+                )
+            )
+            quantity_item = quantity_item_result.scalar_one_or_none()
+            if quantity_item is None or not _quantity_item_is_executable(quantity_item):
+                _raise_estimate_input_invalid(
+                    "Rate and material refs must target quantity items on the requested takeoff.",
+                    details={
+                        "ref_type": request_ref.ref_type,
+                        "selection_id": str(request_ref.selection_id),
+                        "quantity_item_id": str(request_ref.quantity_item_id),
+                    },
+                )
+
+        if request_ref.ref_type == "formula" and request_ref.formula_inputs is None:
+            _raise_estimate_input_invalid(
+                "Formula refs require formula_inputs.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        line_key = request_ref.line_key or f"{request_ref.ref_type}:{request_ref.selection_key}"
+        if line_key in seen_line_keys:
+            _raise_estimate_input_invalid(
+                "Estimate refs must use unique line keys.",
+                details={"line_key": line_key},
+            )
+        seen_line_keys.add(line_key)
+
+        normalized_refs.append(
+            _NormalizedEstimateCatalogRef(
+                ref_type=request_ref.ref_type,
+                selection_id=request_ref.selection_id,
+                selection_key=request_ref.selection_key,
+                selection_checksum_sha256=request_ref.selection_checksum_sha256,
+                description=request_ref.description,
+                line_key=line_key,
+                quantity_item_id=request_ref.quantity_item_id,
+                formula_inputs=request_ref.formula_inputs,
+            )
+        )
+
+    return normalized_refs
 
 
 async def _get_revision_quantity_takeoff_or_404(
@@ -427,6 +866,65 @@ async def _get_revision_estimate_version_or_404(
 
     assert estimate_version is not None
     return estimate_version
+
+
+def _build_estimate_job_input_payload(
+    estimate_job: Job,
+    revision: DrawingRevision,
+    takeoff: QuantityTakeoff,
+    request: EstimateVersionCreateRequest,
+    normalized_refs: list[_NormalizedEstimateCatalogRef],
+    *,
+    pricing_mode: str,
+    pricing_effective_date: date,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build persistence payloads for estimate job input rows."""
+
+    input_payload = {
+        "estimate_job_id": estimate_job.id,
+        "project_id": revision.project_id,
+        "source_file_id": revision.source_file_id,
+        "drawing_revision_id": revision.id,
+        "quantity_takeoff_id": takeoff.id,
+        "source_job_type": JobType.ESTIMATE.value,
+        "currency": request.pricing.currency,
+        "quantity_gate": takeoff.quantity_gate,
+        "trusted_totals": takeoff.trusted_totals,
+        "pricing_mode": pricing_mode,
+        "pricing_effective_date": pricing_effective_date,
+        "assumptions_json": request.assumptions,
+    }
+
+    ref_payloads: list[dict[str, Any]] = []
+    for ref_order, ref in enumerate(normalized_refs, start=1):
+        line_key = ref.line_key
+        selection_context_json = {
+            "worker_mapping_version": "estimate-line-v1",
+            "line_number": ref_order,
+            "line_key": line_key,
+            "line_type": ref.ref_type,
+            "ref_type": ref.ref_type,
+            "description": ref.description,
+            "catalog_entry_key": f"{ref.ref_type}:{ref.selection_key}",
+            "formula_inputs": ref.formula_inputs,
+        }
+        if ref.quantity_item_id is not None:
+            selection_context_json["quantity_item_id"] = str(ref.quantity_item_id)
+
+        ref_payload = {
+            "estimate_job_id": estimate_job.id,
+            "ref_order": ref_order,
+            "ref_type": ref.ref_type,
+            "selection_key": ref.selection_key,
+            "catalog_checksum_sha256": ref.selection_checksum_sha256,
+            "selection_context_json": selection_context_json,
+            "rate_catalog_entry_id": ref.selection_id if ref.ref_type == "rate" else None,
+            "material_catalog_entry_id": ref.selection_id if ref.ref_type == "material" else None,
+            "formula_definition_id": ref.selection_id if ref.ref_type == "formula" else None,
+        }
+        ref_payloads.append(ref_payload)
+
+    return input_payload, ref_payloads
 
 
 @revisions_router.get("/files/{file_id}/revisions", response_model=DrawingRevisionListResponse)
@@ -996,6 +1494,7 @@ async def get_revision_quantity_takeoff(
     revision = await _get_active_revision(revision_id, db)
     if revision is None:
         raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
 
     takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
     return QuantityTakeoffRead.model_validate(takeoff)
@@ -1117,6 +1616,149 @@ async def list_revision_estimates(
         items=[EstimateVersionRead.model_validate(row) for row in page],
         next_cursor=next_cursor,
     )
+
+
+@revisions_router.post(
+    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_revision_estimate_version(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    request: EstimateVersionCreateRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> Job | Response:
+    """Create a pending estimate job for an active revision quantity takeoff."""
+
+    if request.pricing.currency != "GBP":
+        _raise_estimate_input_invalid(
+            "Estimate jobs only support GBP pricing inputs.",
+            details={"currency": request.pricing.currency},
+        )
+
+    normalized_body = _normalize_estimate_request_body(request)
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = build_idempotency_fingerprint(
+            f"revisions.quantity_takeoffs.estimate_versions:{revision_id}:{takeoff_id}",
+            {
+                "revision_id": str(revision_id),
+                "takeoff_id": str(takeoff_id),
+                "body": normalized_body,
+            },
+        )
+        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        if replay is not None:
+            return replay.response
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
+
+    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
+        _raise_estimate_takeoff_gate_invalid(takeoff)
+
+    pricing_mode, pricing_effective_date = _resolve_estimate_pricing_contract(request)
+    normalized_refs = await _resolve_estimate_catalog_refs(
+        revision,
+        takeoff,
+        request.catalog_refs,
+        pricing_effective_date,
+        db,
+    )
+
+    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
+    if locked_revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert locked_revision is not None
+    revision = locked_revision
+    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
+        _raise_estimate_takeoff_gate_invalid(takeoff)
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await claim_idempotency(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path=f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
+        )
+        if isinstance(claim, IdempotencyReplay):
+            return claim.response
+        reservation = claim
+
+    estimate_job = Job(
+        id=uuid4(),
+        project_id=revision.project_id,
+        file_id=revision.source_file_id,
+        extraction_profile_id=None,
+        base_revision_id=revision.id,
+        parent_job_id=(
+            takeoff.source_job_id
+            if takeoff.project_id == revision.project_id
+            and takeoff.source_file_id == revision.source_file_id
+            else None
+        ),
+        job_type=JobType.ESTIMATE.value,
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        enqueue_status="pending",
+        enqueue_attempts=0,
+        cancel_requested=False,
+        error_code=None,
+        error_message=None,
+        started_at=None,
+        finished_at=None,
+    )
+    db.add(estimate_job)
+    prepare_job_enqueue_intent(estimate_job)
+    await db.flush()
+    await db.refresh(estimate_job)
+
+    estimate_job_input_model, estimate_job_input_ref_model = _resolve_estimate_job_model_classes()
+    input_payload, ref_payloads = _build_estimate_job_input_payload(
+        estimate_job,
+        revision,
+        takeoff,
+        request,
+        normalized_refs,
+        pricing_mode=pricing_mode,
+        pricing_effective_date=pricing_effective_date,
+    )
+    db.add(_build_mapped_instance(estimate_job_input_model, input_payload))
+    for ref_payload in ref_payloads:
+        db.add(_build_mapped_instance(estimate_job_input_ref_model, ref_payload))
+
+    success_body: dict[str, object] | None = None
+    if reservation is not None:
+        success_body = JobRead.model_validate(estimate_job).model_dump(mode="json")
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status.HTTP_202_ACCEPTED,
+            response_body=success_body,
+        )
+
+    await db.commit()
+    await publish_job_enqueue_intent(
+        estimate_job.id,
+        publisher=enqueue_estimate_job,
+        suppress_exceptions=True,
+    )
+
+    if reservation is not None:
+        assert success_body is not None
+        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
+
+    return estimate_job
 
 
 @revisions_router.get(

--- a/app/schemas/estimate.py
+++ b/app/schemas/estimate.py
@@ -7,7 +7,80 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class EstimateVersionCreatePricing(BaseModel):
+    """Pricing selection for a queued estimate job."""
+
+    currency: str = "GBP"
+    effective_date: date | None = Field(
+        default=None,
+        validation_alias=AliasChoices("effective_date", "pricing_date"),
+    )
+
+    @field_validator("currency")
+    @classmethod
+    def _normalize_currency(cls, value: str) -> str:
+        return value.strip().upper()
+
+
+class EstimateVersionCreateCatalogRef(BaseModel):
+    """Catalog/formula selection used to build estimate worker input."""
+
+    ref_type: str = Field(validation_alias=AliasChoices("ref_type", "line_type"))
+    selection_id: UUID = Field(
+        validation_alias=AliasChoices("selection_id", "catalog_entry_id", "ref_id")
+    )
+    selection_key: str = Field(
+        validation_alias=AliasChoices("selection_key", "entry_key", "ref_key")
+    )
+    selection_checksum_sha256: str = Field(
+        validation_alias=AliasChoices(
+            "selection_checksum_sha256",
+            "checksum_sha256",
+            "checksum",
+        )
+    )
+    description: str
+    line_key: str | None = None
+    quantity_item_id: UUID | None = None
+    formula_inputs: dict[str, Any] | None = None
+
+    @field_validator("ref_type")
+    @classmethod
+    def _normalize_ref_type(cls, value: str) -> str:
+        return value.strip().lower()
+
+
+class EstimateVersionCreateRequest(BaseModel):
+    """Create-request payload for estimate job enqueue."""
+
+    pricing: EstimateVersionCreatePricing = Field(default_factory=EstimateVersionCreatePricing)
+    assumptions: dict[str, Any] = Field(default_factory=dict)
+    catalog_refs: list[EstimateVersionCreateCatalogRef] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("catalog_refs", "refs", "line_refs"),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_flat_pricing(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+
+        payload = dict(value)
+        if "pricing" not in payload:
+            pricing: dict[str, Any] = {}
+            if "currency" in payload:
+                pricing["currency"] = payload.pop("currency")
+            if "pricing_date" in payload:
+                pricing["pricing_date"] = payload.pop("pricing_date")
+            if "effective_date" in payload:
+                pricing["effective_date"] = payload.pop("effective_date")
+            if pricing:
+                payload["pricing"] = pricing
+        return payload
 
 
 class EstimateVersionRead(BaseModel):

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -42,6 +42,7 @@ from app.models.quantity_takeoff import (
     QuantityItemKind,
     QuantityTakeoff,
 )
+from app.models.revision_materialization import RevisionEntity
 from tests.conftest import requires_database
 
 
@@ -84,6 +85,19 @@ class _AsyncSessionStub:
 
     async def commit(self) -> None:
         self.commits += 1
+
+
+def _response_error_code(response: Any) -> str:
+    body = response.json()
+    error = body.get("error")
+    if error is None:
+        detail = body.get("detail")
+        if isinstance(detail, dict):
+            error = detail.get("error")
+    assert isinstance(error, dict)
+    code = error.get("code")
+    assert isinstance(code, str)
+    return code
 
 
 @dataclass(slots=True)
@@ -991,7 +1005,7 @@ def test_create_revision_estimate_version_rejects_idempotency_reuse_with_differe
     )
 
     assert conflict_response.status_code == 409
-    assert conflict_response.json()["detail"]["error"]["code"] == "IDEMPOTENCY_CONFLICT"
+    assert _response_error_code(conflict_response) == "IDEMPOTENCY_CONFLICT"
     assert len(session.added) == 4
     assert session.commits == 1
     assert enqueued_job_ids == [UUID(first_body["id"])]
@@ -1051,7 +1065,7 @@ def test_create_revision_estimate_version_rejects_non_gbp(monkeypatch: Any) -> N
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert session.added == []
     assert session.commits == 0
     assert publish_calls == []
@@ -1118,7 +1132,7 @@ def test_create_revision_estimate_version_rejects_non_allowed_quantity_gate_befo
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert session.added == []
     assert session.commits == 0
     assert publish_calls == []
@@ -1179,7 +1193,7 @@ def test_create_revision_estimate_version_rejects_untrusted_takeoff(monkeypatch:
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert session.added == []
     assert session.commits == 0
     assert publish_calls == []
@@ -1261,7 +1275,7 @@ def test_create_revision_estimate_version_rejects_catalog_validation_before_enqu
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert session.added == []
     assert session.commits == 0
     assert publish_calls == []
@@ -1390,7 +1404,7 @@ async def test_create_revision_estimate_version_rejects_stale_or_superseded_rate
         rate_key="labour:install",
         checksum_sha256="a" * 64,
         effective_from=date(2026, 1, 1),
-        effective_to=date(2026, 4, 1) if invalid_ref_mode == "stale" else None,
+        effective_to=(date(2026, 4, 1) if invalid_ref_mode == "stale" else date(2026, 5, 20)),
     )
     formula = _build_formula_definition(
         scope_type="project",
@@ -1410,7 +1424,7 @@ async def test_create_revision_estimate_version_rejects_stale_or_superseded_rate
                 project_id=seed.project_id,
                 rate_key="labour:install",
                 checksum_sha256="c" * 64,
-                effective_from=date(2026, 5, 1),
+                effective_from=date(2026, 5, 21),
             )
             db.add(successor_rate)
             await db.commit()
@@ -1446,7 +1460,7 @@ async def test_create_revision_estimate_version_rejects_stale_or_superseded_rate
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert publish_calls == []
 
     async with session_factory() as db:
@@ -1549,7 +1563,7 @@ async def test_create_revision_estimate_version_rejects_cross_project_project_re
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert publish_calls == []
 
     async with session_factory() as db:
@@ -1611,13 +1625,51 @@ async def test_create_revision_estimate_version_rejects_non_executable_quantity_
         db.add(formula)
         await db.commit()
 
-        quantity_item = await db.get(QuantityItem, seed.quantity_item_id)
-        assert quantity_item is not None
-        quantity_item.item_kind = QuantityItemKind.EXCLUSION.value
-        quantity_item.value = None
-        quantity_item.source_entity_id = "entity-1"
+        revision = await db.get(DrawingRevision, seed.revision_id)
+        assert revision is not None
+
+        revision_entity = RevisionEntity(
+            project_id=seed.project_id,
+            source_file_id=seed.file_id,
+            extraction_profile_id=revision.extraction_profile_id,
+            source_job_id=revision.source_job_id,
+            drawing_revision_id=seed.revision_id,
+            adapter_run_output_id=revision.adapter_run_output_id,
+            canonical_entity_schema_version=revision.canonical_entity_schema_version,
+            sequence_index=0,
+            entity_id="entity-1",
+            entity_type="polygon",
+            entity_schema_version="1.0.0",
+            confidence_score=1.0,
+            confidence_json={},
+            geometry_json={},
+            properties_json={},
+            provenance_json={},
+            canonical_entity_json=None,
+            source_identity="entity-1",
+            source_hash="1" * 64,
+        )
+        db.add(revision_entity)
         await db.commit()
 
+        quantity_item = QuantityItem(
+            quantity_takeoff_id=seed.takeoff_id,
+            project_id=seed.project_id,
+            drawing_revision_id=seed.revision_id,
+            item_kind=QuantityItemKind.EXCLUSION.value,
+            quantity_type="area",
+            value=None,
+            unit="sq_ft",
+            review_state="approved",
+            validation_status="valid",
+            quantity_gate=QuantityGate.ALLOWED.value,
+            source_entity_id="entity-1",
+            excluded_source_entity_ids_json=[],
+        )
+        db.add(quantity_item)
+        await db.commit()
+
+    request_body["catalog_refs"][0]["quantity_item_id"] = str(quantity_item.id)
     request_body["catalog_refs"][0]["selection_id"] = str(rate.id)
     request_body["catalog_refs"][1]["selection_id"] = str(formula.id)
 
@@ -1642,7 +1694,7 @@ async def test_create_revision_estimate_version_rejects_non_executable_quantity_
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert publish_calls == []
 
     async with session_factory() as db:
@@ -2048,7 +2100,7 @@ def test_create_revision_quantity_takeoff_rejects_review_gated_or_blocked(
     response = client.post(f"/v1/revisions/{revision.id}/quantity-takeoffs")
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert _response_error_code(response) == "INPUT_INVALID"
     assert session.added == []
     assert session.commits == 0
     assert publish_calls == []
@@ -2108,7 +2160,7 @@ def test_list_revision_quantity_takeoffs_rejects_invalid_cursor(monkeypatch: Any
     response = client.get(f"/v1/revisions/{revision.id}/quantity-takeoffs?cursor=not-base64")
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INVALID_CURSOR"
+    assert _response_error_code(response) == "INVALID_CURSOR"
 
 
 def test_list_revision_quantity_takeoff_items_rejects_invalid_cursor(
@@ -2136,4 +2188,4 @@ def test_list_revision_quantity_takeoff_items_rejects_invalid_cursor(
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"]["error"]["code"] == "INVALID_CURSOR"
+    assert _response_error_code(response) == "INVALID_CURSOR"

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
 from uuid import UUID, uuid4
@@ -15,6 +16,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import IdempotencyReplay, IdempotencyReservation
@@ -24,6 +26,12 @@ from app.db import session as session_module
 from app.db.session import get_db
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
+from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
+from app.models.estimation_catalog import (
+    EstimationFormula,
+    EstimationRate,
+    EstimationRateSupersession,
+)
 from app.models.extraction_profile import ExtractionProfile
 from app.models.file import File
 from app.models.job import Job, JobType
@@ -84,6 +92,7 @@ class _QuantityLineageSeed:
     file_id: UUID
     revision_id: UUID
     takeoff_id: UUID
+    quantity_item_id: UUID
 
 
 def _build_app(session: _AsyncSessionStub) -> FastAPI:
@@ -111,6 +120,56 @@ def _build_validation_report(*, quantity_gate: str = QuantityGate.ALLOWED.value)
         review_state="approved",
         validation_status="valid",
     )
+
+
+def _build_takeoff(
+    revision: SimpleNamespace,
+    *,
+    takeoff_id: UUID | None = None,
+    quantity_gate: str = QuantityGate.ALLOWED.value,
+    trusted_totals: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=takeoff_id or uuid4(),
+        project_id=revision.project_id,
+        source_file_id=revision.source_file_id,
+        drawing_revision_id=revision.id,
+        source_job_id=uuid4(),
+        source_job_type=JobType.QUANTITY_TAKEOFF.value,
+        review_state="approved",
+        validation_status="valid",
+        quantity_gate=quantity_gate,
+        trusted_totals=trusted_totals,
+    )
+
+
+def _build_estimate_request_body(
+    *, quantity_item_id: UUID, currency: str = "GBP"
+) -> dict[str, Any]:
+    return {
+        "pricing": {"currency": currency},
+        "assumptions": {"crew": "default"},
+        "catalog_refs": [
+            {
+                "ref_type": "rate",
+                "selection_id": str(uuid4()),
+                "selection_key": "labour:install",
+                "selection_checksum_sha256": "a" * 64,
+                "description": "Install labour",
+                "line_key": "line-rate-1",
+                "quantity_item_id": str(quantity_item_id),
+            },
+            {
+                "ref_type": "formula",
+                "selection_id": str(uuid4()),
+                "selection_key": "formula:waste",
+                "selection_checksum_sha256": "b" * 64,
+                "description": "Waste uplift",
+                "line_key": "line-formula-2",
+                "formula_inputs": {"waste_factor": "0.10"},
+            },
+        ],
+    }
 
 
 async def _seed_quantity_lineage() -> _QuantityLineageSeed:
@@ -281,6 +340,7 @@ async def _seed_quantity_lineage() -> _QuantityLineageSeed:
         file_id=file_id,
         revision_id=revision_id,
         takeoff_id=takeoff_id,
+        quantity_item_id=item.id,
     )
 
 
@@ -298,6 +358,55 @@ async def _soft_delete_lineage(seed: _QuantityLineageSeed, *, target: str) -> No
             assert project is not None
             project.deleted_at = datetime.now(UTC)
         await db.commit()
+
+
+def _build_rate_catalog_entry(
+    *,
+    scope_type: str,
+    project_id: UUID | None,
+    rate_key: str,
+    checksum_sha256: str,
+    effective_from: date,
+    effective_to: date | None = None,
+) -> EstimationRate:
+    return EstimationRate(
+        scope_type=scope_type,
+        project_id=project_id,
+        rate_key=rate_key,
+        source="fixture",
+        metadata_json={},
+        name="Install labour",
+        item_type="labour",
+        per_unit="sq_ft",
+        currency="GBP",
+        amount=Decimal("12.340000"),
+        effective_from=effective_from,
+        effective_to=effective_to,
+        checksum_sha256=checksum_sha256,
+    )
+
+
+def _build_formula_definition(
+    *,
+    scope_type: str,
+    project_id: UUID | None,
+    formula_id: str,
+    checksum_sha256: str,
+) -> EstimationFormula:
+    return EstimationFormula(
+        scope_type=scope_type,
+        project_id=project_id,
+        formula_id=formula_id,
+        version=1,
+        name="Waste uplift",
+        dsl_version="1.0.0",
+        output_key="total",
+        output_contract_json={"type": "number"},
+        declared_inputs_json=[{"key": "waste_factor", "type": "number"}],
+        expression_json={"kind": "literal", "value": "1.10"},
+        rounding_json=None,
+        checksum_sha256=checksum_sha256,
+    )
 
 
 def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatch: Any) -> None:
@@ -461,6 +570,1108 @@ def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatc
     assert len(session.added) == 1
 
 
+def test_create_revision_estimate_version_replays_idempotent_response(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision)
+    quantity_item_id = uuid4()
+    request_body = _build_estimate_request_body(quantity_item_id=quantity_item_id)
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    idempotency_state: dict[str, dict[str, Any]] = {}
+    enqueued_job_ids: list[UUID] = []
+
+    class _EstimateJobInputRecord:
+        pass
+
+    class _EstimateJobInputCatalogRefRecord:
+        pass
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_resolve_estimate_catalog_refs(
+        revision_value: Any,
+        takeoff_value: Any,
+        request_refs: Any,
+        pricing_effective_date: date,
+        db: AsyncSession,
+    ) -> list[Any]:
+        _ = (revision_value, takeoff_value, pricing_effective_date, db)
+        return [
+            revisions_module._NormalizedEstimateCatalogRef(
+                ref_type=request_refs[0].ref_type,
+                selection_id=request_refs[0].selection_id,
+                selection_key=request_refs[0].selection_key,
+                selection_checksum_sha256=request_refs[0].selection_checksum_sha256,
+                description=request_refs[0].description,
+                line_key=request_refs[0].line_key,
+                quantity_item_id=request_refs[0].quantity_item_id,
+                formula_inputs=request_refs[0].formula_inputs,
+            ),
+            revisions_module._NormalizedEstimateCatalogRef(
+                ref_type=request_refs[1].ref_type,
+                selection_id=request_refs[1].selection_id,
+                selection_key=request_refs[1].selection_key,
+                selection_checksum_sha256=request_refs[1].selection_checksum_sha256,
+                description=request_refs[1].description,
+                line_key=request_refs[1].line_key,
+                quantity_item_id=request_refs[1].quantity_item_id,
+                formula_inputs=request_refs[1].formula_inputs,
+            ),
+        ]
+
+    async def fake_replay_idempotency(
+        db: AsyncSession,
+        *,
+        key: str,
+        fingerprint: str,
+    ) -> IdempotencyReplay | None:
+        _ = db
+        record = idempotency_state.get(key)
+        if record is None or record["fingerprint"] != fingerprint or not record["completed"]:
+            return None
+        return IdempotencyReplay(
+            response=JSONResponse(
+                status_code=record["status_code"],
+                content=record["response_body"],
+            )
+        )
+
+    async def fake_claim_idempotency(
+        db: AsyncSession,
+        *,
+        key: str,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation:
+        _ = (db, method, path)
+        record = idempotency_state.get(key)
+        if record is None:
+            idempotency_state[key] = {"fingerprint": fingerprint, "completed": False}
+        return IdempotencyReservation(record_id=uuid4())
+
+    async def fake_mark_idempotency_completed(
+        db: AsyncSession,
+        reservation: IdempotencyReservation,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> None:
+        _ = (db, reservation)
+        idempotency_state["estimate-1"].update(
+            completed=True,
+            status_code=status_code,
+            response_body=response_body,
+        )
+
+    def fake_prepare_job_enqueue_intent(job: Any) -> None:
+        _ = job
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = suppress_exceptions
+        assert publisher is revisions_module.enqueue_estimate_job
+        publisher(job_id)
+
+    def fake_enqueue_estimate_job(job_id: UUID) -> None:
+        enqueued_job_ids.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_catalog_refs",
+        fake_resolve_estimate_catalog_refs,
+    )
+    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
+    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
+    monkeypatch.setattr(
+        revisions_module,
+        "mark_idempotency_completed",
+        fake_mark_idempotency_completed,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "prepare_job_enqueue_intent",
+        fake_prepare_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(revisions_module, "enqueue_estimate_job", fake_enqueue_estimate_job)
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_job_model_classes",
+        lambda: (_EstimateJobInputRecord, _EstimateJobInputCatalogRefRecord),
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_build_mapped_instance",
+        lambda _model_class, values: type("StubRecord", (), values.copy())(),
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        headers={"Idempotency-Key": "estimate-1"},
+        json=request_body,
+    )
+
+    assert response.status_code == 202
+    first_body = response.json()
+    assert first_body["job_type"] == "estimate"
+    assert first_body["base_revision_id"] == str(revision.id)
+    assert first_body["parent_job_id"] == str(takeoff.source_job_id)
+    assert len(session.added) == 4
+    estimate_job = session.added[0]
+    estimate_input = session.added[1]
+    assert estimate_input.estimate_job_id == estimate_job.id
+    assert estimate_input.source_job_type == JobType.ESTIMATE.value
+    assert estimate_input.currency == "GBP"
+    assert estimate_input.pricing_mode == "derived_from_job_created_at_utc"
+    assert estimate_input.pricing_effective_date == estimate_job.created_at.date()
+    assert estimate_input.assumptions_json == {"crew": "default"}
+    first_ref = session.added[2]
+    second_ref = session.added[3]
+    assert first_ref.ref_order == 1
+    assert first_ref.estimate_job_id == estimate_job.id
+    assert first_ref.rate_catalog_entry_id == UUID(request_body["catalog_refs"][0]["selection_id"])
+    assert first_ref.catalog_checksum_sha256 == "a" * 64
+    assert first_ref.selection_context_json["worker_mapping_version"] == "estimate-line-v1"
+    assert first_ref.selection_context_json["quantity_item_id"] == str(quantity_item_id)
+    assert second_ref.ref_order == 2
+    assert second_ref.formula_definition_id == UUID(request_body["catalog_refs"][1]["selection_id"])
+    assert second_ref.catalog_checksum_sha256 == "b" * 64
+    assert second_ref.selection_context_json["formula_inputs"] == {"waste_factor": "0.10"}
+    assert enqueued_job_ids == [UUID(first_body["id"])]
+
+    replay_response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        headers={"Idempotency-Key": "estimate-1"},
+        json=request_body,
+    )
+
+    assert replay_response.status_code == 202
+    assert replay_response.json() == first_body
+    assert len(session.added) == 4
+
+
+def test_create_revision_estimate_version_rejects_idempotency_reuse_with_different_payload(
+    monkeypatch: Any,
+) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision)
+    quantity_item_id = uuid4()
+    request_body = _build_estimate_request_body(quantity_item_id=quantity_item_id)
+    conflicting_request_body = _build_estimate_request_body(quantity_item_id=quantity_item_id)
+    conflicting_request_body["assumptions"] = {"crew": "alternate"}
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    idempotency_state: dict[str, dict[str, Any]] = {}
+    enqueued_job_ids: list[UUID] = []
+
+    class _EstimateJobInputRecord:
+        pass
+
+    class _EstimateJobInputCatalogRefRecord:
+        pass
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_resolve_estimate_catalog_refs(
+        revision_value: Any,
+        takeoff_value: Any,
+        request_refs: Any,
+        pricing_effective_date: date,
+        db: AsyncSession,
+    ) -> list[Any]:
+        _ = (revision_value, takeoff_value, pricing_effective_date, db)
+        return [
+            revisions_module._NormalizedEstimateCatalogRef(
+                ref_type=request_refs[0].ref_type,
+                selection_id=request_refs[0].selection_id,
+                selection_key=request_refs[0].selection_key,
+                selection_checksum_sha256=request_refs[0].selection_checksum_sha256,
+                description=request_refs[0].description,
+                line_key=request_refs[0].line_key,
+                quantity_item_id=request_refs[0].quantity_item_id,
+                formula_inputs=request_refs[0].formula_inputs,
+            ),
+            revisions_module._NormalizedEstimateCatalogRef(
+                ref_type=request_refs[1].ref_type,
+                selection_id=request_refs[1].selection_id,
+                selection_key=request_refs[1].selection_key,
+                selection_checksum_sha256=request_refs[1].selection_checksum_sha256,
+                description=request_refs[1].description,
+                line_key=request_refs[1].line_key,
+                quantity_item_id=request_refs[1].quantity_item_id,
+                formula_inputs=request_refs[1].formula_inputs,
+            ),
+        ]
+
+    async def fake_replay_idempotency(
+        db: AsyncSession,
+        *,
+        key: str,
+        fingerprint: str,
+    ) -> IdempotencyReplay | None:
+        _ = db
+        record = idempotency_state.get(key)
+        if record is None:
+            return None
+        if record["fingerprint"] != fingerprint:
+            return IdempotencyReplay(
+                response=JSONResponse(
+                    status_code=409,
+                    content={
+                        "detail": {
+                            "error": {
+                                "code": "IDEMPOTENCY_CONFLICT",
+                                "message": "Idempotency-Key already used with different payload.",
+                                "details": None,
+                            }
+                        }
+                    },
+                )
+            )
+        if not record["completed"]:
+            return None
+        return IdempotencyReplay(
+            response=JSONResponse(
+                status_code=record["status_code"],
+                content=record["response_body"],
+            )
+        )
+
+    async def fake_claim_idempotency(
+        db: AsyncSession,
+        *,
+        key: str,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation:
+        _ = (db, method, path)
+        record = idempotency_state.get(key)
+        if record is None:
+            idempotency_state[key] = {"fingerprint": fingerprint, "completed": False}
+        return IdempotencyReservation(record_id=uuid4())
+
+    async def fake_mark_idempotency_completed(
+        db: AsyncSession,
+        reservation: IdempotencyReservation,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> None:
+        _ = (db, reservation)
+        idempotency_state["estimate-1"].update(
+            completed=True,
+            status_code=status_code,
+            response_body=response_body,
+        )
+
+    def fake_prepare_job_enqueue_intent(job: Any) -> None:
+        _ = job
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = suppress_exceptions
+        assert publisher is revisions_module.enqueue_estimate_job
+        publisher(job_id)
+
+    def fake_enqueue_estimate_job(job_id: UUID) -> None:
+        enqueued_job_ids.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_catalog_refs",
+        fake_resolve_estimate_catalog_refs,
+    )
+    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
+    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
+    monkeypatch.setattr(
+        revisions_module,
+        "mark_idempotency_completed",
+        fake_mark_idempotency_completed,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "prepare_job_enqueue_intent",
+        fake_prepare_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(revisions_module, "enqueue_estimate_job", fake_enqueue_estimate_job)
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_job_model_classes",
+        lambda: (_EstimateJobInputRecord, _EstimateJobInputCatalogRefRecord),
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_build_mapped_instance",
+        lambda _model_class, values: type("StubRecord", (), values.copy())(),
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        headers={"Idempotency-Key": "estimate-1"},
+        json=request_body,
+    )
+
+    assert response.status_code == 202
+    first_body = response.json()
+    assert len(session.added) == 4
+    assert session.commits == 1
+    assert enqueued_job_ids == [UUID(first_body["id"])]
+
+    conflict_response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        headers={"Idempotency-Key": "estimate-1"},
+        json=conflicting_request_body,
+    )
+
+    assert conflict_response.status_code == 409
+    assert conflict_response.json()["detail"]["error"]["code"] == "IDEMPOTENCY_CONFLICT"
+    assert len(session.added) == 4
+    assert session.commits == 1
+    assert enqueued_job_ids == [UUID(first_body["id"])]
+
+
+def test_create_revision_estimate_version_rejects_non_gbp(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision)
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    publish_calls: list[UUID] = []
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        json=_build_estimate_request_body(quantity_item_id=uuid4(), currency="USD"),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert session.added == []
+    assert session.commits == 0
+    assert publish_calls == []
+
+
+def test_create_revision_estimate_version_rejects_non_allowed_quantity_gate_before_enqueue(
+    monkeypatch: Any,
+) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision, quantity_gate=QuantityGate.REVIEW_GATED.value)
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    publish_calls: list[UUID] = []
+    enqueue_calls: list[UUID] = []
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    def fake_enqueue_estimate_job(job_id: UUID) -> None:
+        enqueue_calls.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(revisions_module, "enqueue_estimate_job", fake_enqueue_estimate_job)
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        json=_build_estimate_request_body(quantity_item_id=uuid4()),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert session.added == []
+    assert session.commits == 0
+    assert publish_calls == []
+    assert enqueue_calls == []
+
+
+def test_create_revision_estimate_version_rejects_untrusted_takeoff(monkeypatch: Any) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision, trusted_totals=False)
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    publish_calls: list[UUID] = []
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        json=_build_estimate_request_body(quantity_item_id=uuid4()),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert session.added == []
+    assert session.commits == 0
+    assert publish_calls == []
+
+
+def test_create_revision_estimate_version_rejects_catalog_validation_before_enqueue(
+    monkeypatch: Any,
+) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision)
+    quantity_item_id = uuid4()
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    publish_calls: list[UUID] = []
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_resolve_estimate_catalog_refs(
+        revision_value: Any,
+        takeoff_value: Any,
+        request_refs: Any,
+        pricing_effective_date: date,
+        db: AsyncSession,
+    ) -> list[Any]:
+        _ = (revision_value, takeoff_value, request_refs, pricing_effective_date, db)
+        revisions_module._raise_estimate_input_invalid(
+            "Estimate refs must use the current catalog selection checksum.",
+            details={"selection_checksum_sha256": "mismatch"},
+        )
+        raise AssertionError("unreachable")
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_catalog_refs",
+        fake_resolve_estimate_catalog_refs,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        json=_build_estimate_request_body(quantity_item_id=quantity_item_id),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert session.added == []
+    assert session.commits == 0
+    assert publish_calls == []
+
+
+@pytest.mark.anyio
+@requires_database
+async def test_create_revision_estimate_version_persists_mapped_input_fields_and_allows_global_refs(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    request_body = _build_estimate_request_body(quantity_item_id=seed.quantity_item_id)
+    request_body["pricing"]["effective_date"] = "2026-05-20"
+    publish_calls: list[UUID] = []
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    rate = _build_rate_catalog_entry(
+        scope_type="global",
+        project_id=None,
+        rate_key="labour:install",
+        checksum_sha256="a" * 64,
+        effective_from=date(2026, 1, 1),
+    )
+    formula = _build_formula_definition(
+        scope_type="global",
+        project_id=None,
+        formula_id="formula:waste",
+        checksum_sha256="b" * 64,
+    )
+
+    async with session_factory() as db:
+        db.add(rate)
+        db.add(formula)
+        await db.commit()
+
+    request_body["catalog_refs"][0]["selection_id"] = str(rate.id)
+    request_body["catalog_refs"][1]["selection_id"] = str(formula.id)
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = await async_client.post(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}/estimate-versions",
+        json=request_body,
+    )
+
+    assert response.status_code == 202
+    estimate_job_id = UUID(response.json()["id"])
+    assert publish_calls == [estimate_job_id]
+
+    async with session_factory() as db:
+        estimate_input = await db.get(EstimateJobInput, estimate_job_id)
+        assert estimate_input is not None
+        assert estimate_input.estimate_job_id == estimate_job_id
+        assert estimate_input.project_id == seed.project_id
+        assert estimate_input.source_file_id == seed.file_id
+        assert estimate_input.drawing_revision_id == seed.revision_id
+        assert estimate_input.quantity_takeoff_id == seed.takeoff_id
+        assert estimate_input.source_job_type == JobType.ESTIMATE.value
+        assert estimate_input.currency == "GBP"
+        assert estimate_input.pricing_mode == "explicit"
+        assert estimate_input.pricing_effective_date == date(2026, 5, 20)
+        assert estimate_input.assumptions_json == {"crew": "default"}
+
+        ref_rows = (
+            (
+                await db.execute(
+                    select(EstimateJobInputCatalogRef)
+                    .where(EstimateJobInputCatalogRef.estimate_job_id == estimate_job_id)
+                    .order_by(EstimateJobInputCatalogRef.ref_order.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(ref_rows) == 2
+    assert ref_rows[0].ref_type == "rate"
+    assert ref_rows[0].selection_key == "labour:install"
+    assert ref_rows[0].rate_catalog_entry_id == rate.id
+    assert ref_rows[0].material_catalog_entry_id is None
+    assert ref_rows[0].formula_definition_id is None
+    assert ref_rows[0].catalog_checksum_sha256 == "a" * 64
+    assert ref_rows[0].selection_context_json["line_key"] == "line-rate-1"
+    assert ref_rows[0].selection_context_json["quantity_item_id"] == str(seed.quantity_item_id)
+    assert ref_rows[1].ref_type == "formula"
+    assert ref_rows[1].selection_key == "formula:waste"
+    assert ref_rows[1].rate_catalog_entry_id is None
+    assert ref_rows[1].formula_definition_id == formula.id
+    assert ref_rows[1].catalog_checksum_sha256 == "b" * 64
+    assert ref_rows[1].selection_context_json["formula_inputs"] == {"waste_factor": "0.10"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("invalid_ref_mode", ["stale", "superseded"])
+@requires_database
+async def test_create_revision_estimate_version_rejects_stale_or_superseded_rate_refs_before_insert(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+    invalid_ref_mode: str,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    request_body = _build_estimate_request_body(quantity_item_id=seed.quantity_item_id)
+    request_body["pricing"]["effective_date"] = "2026-05-20"
+    publish_calls: list[UUID] = []
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    rate = _build_rate_catalog_entry(
+        scope_type="project",
+        project_id=seed.project_id,
+        rate_key="labour:install",
+        checksum_sha256="a" * 64,
+        effective_from=date(2026, 1, 1),
+        effective_to=date(2026, 4, 1) if invalid_ref_mode == "stale" else None,
+    )
+    formula = _build_formula_definition(
+        scope_type="project",
+        project_id=seed.project_id,
+        formula_id="formula:waste",
+        checksum_sha256="b" * 64,
+    )
+
+    async with session_factory() as db:
+        db.add(rate)
+        db.add(formula)
+        await db.commit()
+
+        if invalid_ref_mode == "superseded":
+            successor_rate = _build_rate_catalog_entry(
+                scope_type="project",
+                project_id=seed.project_id,
+                rate_key="labour:install",
+                checksum_sha256="c" * 64,
+                effective_from=date(2026, 5, 1),
+            )
+            db.add(successor_rate)
+            await db.commit()
+            db.add(
+                EstimationRateSupersession(
+                    predecessor_rate_id=rate.id,
+                    successor_rate_id=successor_rate.id,
+                )
+            )
+            await db.commit()
+
+    request_body["catalog_refs"][0]["selection_id"] = str(rate.id)
+    request_body["catalog_refs"][1]["selection_id"] = str(formula.id)
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = await async_client.post(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}/estimate-versions",
+        json=request_body,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert publish_calls == []
+
+    async with session_factory() as db:
+        estimate_jobs = (
+            (
+                await db.execute(
+                    select(Job).where(
+                        (Job.project_id == seed.project_id)
+                        & (Job.job_type == JobType.ESTIMATE.value)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_inputs = (
+            (
+                await db.execute(
+                    select(EstimateJobInput).where(EstimateJobInput.project_id == seed.project_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_refs = (
+            (
+                await db.execute(
+                    select(EstimateJobInputCatalogRef).where(
+                        EstimateJobInputCatalogRef.estimate_job_id.in_(
+                            [job.id for job in estimate_jobs]
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert estimate_jobs == []
+    assert estimate_inputs == []
+    assert estimate_refs == []
+
+
+@pytest.mark.anyio
+@requires_database
+async def test_create_revision_estimate_version_rejects_cross_project_project_refs_before_insert(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    request_body = _build_estimate_request_body(quantity_item_id=seed.quantity_item_id)
+    request_body["pricing"]["effective_date"] = "2026-05-20"
+    publish_calls: list[UUID] = []
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    other_project_id = uuid4()
+    rate = _build_rate_catalog_entry(
+        scope_type="project",
+        project_id=other_project_id,
+        rate_key="labour:install",
+        checksum_sha256="a" * 64,
+        effective_from=date(2026, 1, 1),
+    )
+    formula = _build_formula_definition(
+        scope_type="project",
+        project_id=seed.project_id,
+        formula_id="formula:waste",
+        checksum_sha256="b" * 64,
+    )
+
+    async with session_factory() as db:
+        db.add(Project(id=other_project_id, name="Other project"))
+        await db.commit()
+        db.add(rate)
+        db.add(formula)
+        await db.commit()
+
+    request_body["catalog_refs"][0]["selection_id"] = str(rate.id)
+    request_body["catalog_refs"][1]["selection_id"] = str(formula.id)
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = await async_client.post(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}/estimate-versions",
+        json=request_body,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert publish_calls == []
+
+    async with session_factory() as db:
+        estimate_jobs = (
+            (
+                await db.execute(
+                    select(Job).where(
+                        (Job.project_id == seed.project_id)
+                        & (Job.job_type == JobType.ESTIMATE.value)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_inputs = (
+            (
+                await db.execute(
+                    select(EstimateJobInput).where(EstimateJobInput.project_id == seed.project_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert estimate_jobs == []
+    assert estimate_inputs == []
+
+
+@pytest.mark.anyio
+@requires_database
+async def test_create_revision_estimate_version_rejects_non_executable_quantity_items_before_insert(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+) -> None:
+    seed = await _seed_quantity_lineage()
+    request_body = _build_estimate_request_body(quantity_item_id=seed.quantity_item_id)
+    request_body["pricing"]["effective_date"] = "2026-05-20"
+    publish_calls: list[UUID] = []
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    rate = _build_rate_catalog_entry(
+        scope_type="project",
+        project_id=seed.project_id,
+        rate_key="labour:install",
+        checksum_sha256="a" * 64,
+        effective_from=date(2026, 1, 1),
+    )
+    formula = _build_formula_definition(
+        scope_type="project",
+        project_id=seed.project_id,
+        formula_id="formula:waste",
+        checksum_sha256="b" * 64,
+    )
+
+    async with session_factory() as db:
+        db.add(rate)
+        db.add(formula)
+        await db.commit()
+
+        quantity_item = await db.get(QuantityItem, seed.quantity_item_id)
+        assert quantity_item is not None
+        quantity_item.item_kind = QuantityItemKind.EXCLUSION.value
+        quantity_item.value = None
+        quantity_item.source_entity_id = "entity-1"
+        await db.commit()
+
+    request_body["catalog_refs"][0]["selection_id"] = str(rate.id)
+    request_body["catalog_refs"][1]["selection_id"] = str(formula.id)
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+
+    response = await async_client.post(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}/estimate-versions",
+        json=request_body,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error"]["code"] == "INPUT_INVALID"
+    assert publish_calls == []
+
+    async with session_factory() as db:
+        estimate_jobs = (
+            (
+                await db.execute(
+                    select(Job).where(
+                        (Job.project_id == seed.project_id)
+                        & (Job.job_type == JobType.ESTIMATE.value)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_inputs = (
+            (
+                await db.execute(
+                    select(EstimateJobInput).where(EstimateJobInput.project_id == seed.project_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert estimate_jobs == []
+    assert estimate_inputs == []
+
+
 def test_list_and_get_revision_quantity_takeoffs(monkeypatch: Any) -> None:
     revision = _build_revision()
     created_at = datetime(2026, 5, 16, tzinfo=UTC)
@@ -512,9 +1723,7 @@ def test_list_and_get_revision_quantity_takeoffs(monkeypatch: Any) -> None:
     assert [item["id"] for item in list_body["items"]] == [str(first_takeoff.id)]
     assert list_body["next_cursor"] is not None
 
-    read_response = client.get(
-        f"/v1/revisions/{revision.id}/quantity-takeoffs/{first_takeoff.id}"
-    )
+    read_response = client.get(f"/v1/revisions/{revision.id}/quantity-takeoffs/{first_takeoff.id}")
 
     assert read_response.status_code == 200
     assert read_response.json()["id"] == str(first_takeoff.id)

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -404,7 +404,7 @@ def _build_formula_definition(
         output_contract_json={"type": "number"},
         declared_inputs_json=[{"key": "waste_factor", "type": "number"}],
         expression_json={"kind": "literal", "value": "1.10"},
-        rounding_json=None,
+        rounding_json={},
         checksum_sha256=checksum_sha256,
     )
 


### PR DESCRIPTION
Closes #206

## Summary
- add `POST /v1/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions` to enqueue estimate jobs from trusted quantity takeoffs
- persist immutable estimate job inputs and ordered explicit catalog refs with API-side validation for trust gates, catalog visibility/currentness, executable quantity items, and assumptions shape
- cover idempotency, enqueue behavior, and rejection paths in quantity takeoff API tests

## Test plan
- [x] `uv run ruff check app/api/v1/revisions.py app/schemas/estimate.py tests/test_quantity_takeoff_api.py`
- [x] `uv run ruff format --check app/api/v1/revisions.py app/schemas/estimate.py tests/test_quantity_takeoff_api.py`
- [x] `uv run mypy app/api/v1/revisions.py app/schemas/estimate.py tests/test_quantity_takeoff_api.py`
- [x] `uv run pytest tests/test_quantity_takeoff_api.py tests/test_estimate_job_input_contract.py tests/test_estimate_read_api.py`
- [x] pre-push hook full pytest run (`399 passed, 411 skipped`)

## Notes
- Follow-up issues from deep review: #224, #225
