### PR TITLE
test(estimation): cover reproducibility and trust gates

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -230,6 +230,83 @@ def _quantity_takeoff_semantic_payload(
     }
 
 
+def _estimate_persisted_semantic_payload(
+    estimate_version: EstimateVersion,
+    snapshot_entries: list[EstimateSnapshotEntry],
+    line_items: list[EstimateItem],
+) -> dict[str, Any]:
+    """Return rerun-comparable persisted estimate semantics without row identity fields."""
+    snapshot_payloads = [
+        {
+            "entry_type": entry.entry_type,
+            "entry_key": entry.entry_key,
+            "entry_label": entry.entry_label,
+            "sort_order": entry.sort_order,
+            "currency": entry.currency,
+            "quantity_value": entry.quantity_value,
+            "unit": entry.unit,
+            "effective_date": entry.effective_date,
+            "unit_amount": entry.unit_amount,
+            "source_payload_json": deepcopy(entry.source_payload_json),
+            "rounding_json": deepcopy(entry.rounding_json),
+            "source_rate_id": entry.source_rate_id,
+            "source_material_id": entry.source_material_id,
+            "source_formula_id": entry.source_formula_id,
+            "source_quantity_takeoff_id": entry.source_quantity_takeoff_id,
+            "source_quantity_item_id": entry.source_quantity_item_id,
+            "source_checksum_sha256": entry.source_checksum_sha256,
+        }
+        for entry in snapshot_entries
+    ]
+
+    line_item_payloads = [
+        {
+            "line_type": item.line_type,
+            "line_number": item.line_number,
+            "line_key": item.line_key,
+            "description": item.description,
+            "currency": item.currency,
+            "quantity_value": item.quantity_value,
+            "quantity_unit": item.quantity_unit,
+            "unit_rate_amount": item.unit_rate_amount,
+            "effective_date": item.effective_date,
+            "subtotal_amount": item.subtotal_amount,
+            "tax_amount": item.tax_amount,
+            "total_amount": item.total_amount,
+            "rounding_json": deepcopy(item.rounding_json),
+            "quantity_snapshot_entry_id": item.quantity_snapshot_entry_id,
+            "rate_snapshot_entry_id": item.rate_snapshot_entry_id,
+            "material_snapshot_entry_id": item.material_snapshot_entry_id,
+            "formula_snapshot_entry_id": item.formula_snapshot_entry_id,
+            "assumption_snapshot_entry_id": item.assumption_snapshot_entry_id,
+        }
+        for item in line_items
+    ]
+
+    return {
+        "version": {
+            "source_job_id": estimate_version.source_job_id,
+            "quantity_takeoff_id": estimate_version.quantity_takeoff_id,
+            "source_file_id": estimate_version.source_file_id,
+            "drawing_revision_id": estimate_version.drawing_revision_id,
+            "quantity_gate": estimate_version.quantity_gate,
+            "trusted_totals": estimate_version.trusted_totals,
+            "currency": estimate_version.currency,
+            "subtotal_amount": estimate_version.subtotal_amount,
+            "tax_amount": estimate_version.tax_amount,
+            "total_amount": estimate_version.total_amount,
+        },
+        "snapshot_entries": sorted(
+            snapshot_payloads,
+            key=lambda entry: (entry["sort_order"], entry["entry_key"]),
+        ),
+        "line_items": sorted(
+            line_item_payloads,
+            key=lambda item: (item["line_number"], item["line_key"]),
+        ),
+    }
+
+
 def _estimate_catalog_ref_stub(
     *,
     ref_type: str,
@@ -7404,7 +7481,6 @@ class TestJobs:
 
             with pytest.raises(IntegrityError):
                 await session.commit()
-
             await session.rollback()
 
     @pytest.mark.parametrize("job_type", ["ingest", "reprocess"])
@@ -7438,3 +7514,183 @@ class TestJobs:
                 await session.commit()
 
             await session.rollback()
+
+    async def test_estimate_worker_persists_replayable_historical_output_after_catalog_evolution(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate outputs should stay replayable after append-only catalog evolution."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        (
+            _,
+            _,
+            _,
+            _,
+            _,
+            quantity_takeoff,
+            quantity_items,
+            estimate_job,
+        ) = await _create_ready_estimate_execution_job(async_client, monkeypatch)
+        quantity_item = _select_eligible_aggregate_quantity_item(quantity_items)
+        assert quantity_item.value is not None
+        assert quantity_item.value > 0
+
+        rate_key = "historical-paint-labor"
+        original_rate_id = uuid.UUID("00000000-0000-0000-0000-000000000291")
+        evolved_rate_id = uuid.UUID("00000000-0000-0000-0000-000000000292")
+        original_checksum = "1" * 64
+        evolved_checksum = "2" * 64
+
+        await _persist_estimate_job_input(
+            estimate_job=estimate_job,
+            quantity_takeoff=quantity_takeoff,
+            assumptions_json={"tax_rate": "0.20"},
+            catalog_refs=[
+                {
+                    "ref_type": "rate",
+                    "selection_key": rate_key,
+                    "ref_order": 20,
+                    "rate_catalog_entry_id": original_rate_id,
+                    "catalog_checksum_sha256": original_checksum,
+                    "selection_context_json": {
+                        "worker_mapping_version": worker_module._ESTIMATE_WORKER_MAPPING_VERSION,
+                        "line_key": "historical-rate-line",
+                        "line_type": "rate",
+                        "description": "Historical paint labor",
+                        "quantity_item_id": str(quantity_item.id),
+                    },
+                }
+            ],
+        )
+
+        async def _resolve_latest_rate(*args: Any, **kwargs: Any) -> Any:
+            _ = (args, kwargs)
+            session_maker = session_module.AsyncSessionLocal
+            assert session_maker is not None
+
+            async with session_maker() as session:
+                rate_row = (
+                    (
+                        await session.execute(
+                            select(EstimationRate)
+                            .where(
+                                EstimationRate.project_id == estimate_job.project_id,
+                                EstimationRate.rate_key == rate_key,
+                            )
+                            .order_by(
+                                EstimationRate.effective_from.desc(),
+                                EstimationRate.created_at.desc(),
+                                EstimationRate.id.desc(),
+                            )
+                            .limit(1)
+                        )
+                    )
+                    .scalars()
+                    .one()
+                )
+
+            return types.SimpleNamespace(
+                id=rate_row.id,
+                rate_key=rate_row.rate_key,
+                item_type=rate_row.item_type,
+                unit=quantity_item.unit,
+                currency=rate_row.currency,
+                value=rate_row.amount,
+                effective_start=rate_row.effective_from,
+                checksum_sha256=rate_row.checksum_sha256,
+                metadata=deepcopy(rate_row.metadata_json),
+            )
+
+        monkeypatch.setattr(worker_module, "resolve_rate", _resolve_latest_rate)
+
+        await worker_module.process_estimate_job(estimate_job.id)
+
+        updated_job = await _get_job(estimate_job.id)
+        estimate_versions = await _get_estimate_versions_for_job(estimate_job.id)
+        assert updated_job.status == "succeeded"
+        assert len(estimate_versions) == 1
+        estimate_version = estimate_versions[0]
+        snapshot_entries = await _get_estimate_snapshot_entries_for_version(estimate_version.id)
+        line_items = await _get_estimate_items_for_version(estimate_version.id)
+        assert snapshot_entries != []
+        assert line_items != []
+
+        original_payload = _estimate_persisted_semantic_payload(
+            estimate_version,
+            snapshot_entries,
+            line_items,
+        )
+        original_rate_snapshot = next(
+            entry for entry in original_payload["snapshot_entries"] if entry["entry_type"] == "rate"
+        )
+        assert original_rate_snapshot["source_checksum_sha256"] == original_checksum
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            session.add(
+                EstimationRate(
+                    id=evolved_rate_id,
+                    scope_type=CatalogScopeType.PROJECT,
+                    project_id=estimate_job.project_id,
+                    rate_key=rate_key,
+                    source="tests.test_jobs",
+                    metadata_json={"catalog_generation": "evolved"},
+                    name=rate_key,
+                    item_type="labor",
+                    per_unit="square_meter",
+                    currency="GBP",
+                    amount=Decimal("99.00"),
+                    effective_from=date(2026, 1, 3),
+                    effective_to=None,
+                    checksum_sha256=evolved_checksum,
+                )
+            )
+            replay_attempt_token = uuid.uuid4()
+            persisted_job = await session.get(Job, estimate_job.id)
+            assert persisted_job is not None
+            persisted_job.status = "running"
+            persisted_job.finished_at = None
+            persisted_job.attempt_token = replay_attempt_token
+            persisted_job.attempt_lease_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+            await session.commit()
+
+        replay_input = await worker_module._build_estimate_engine_input(
+            estimate_job.id,
+            attempt_token=replay_attempt_token,
+        )
+        replay_output = real_compose_estimate(replay_input)
+        replay_version_kwargs = replay_output.estimate_version_model_kwargs()
+        replay_snapshot_kwargs = replay_output.snapshot_entry_model_kwargs()
+        replay_rate_snapshot = next(
+            entry for entry in replay_snapshot_kwargs if entry["entry_type"] == "rate"
+        )
+        assert replay_rate_snapshot["source_checksum_sha256"] == evolved_checksum
+        assert replay_rate_snapshot["unit_amount"] != original_rate_snapshot["unit_amount"]
+        assert replay_version_kwargs["total_amount"] != original_payload["version"]["total_amount"]
+
+        finalized_again = await worker_module._finalize_estimate_job(
+            estimate_job.id,
+            attempt_token=replay_attempt_token,
+            output=replay_output,
+        )
+        assert finalized_again is False
+
+        estimate_versions_after = await _get_estimate_versions_for_job(estimate_job.id)
+        assert len(estimate_versions_after) == 1
+        snapshot_entries_after = await _get_estimate_snapshot_entries_for_version(
+            estimate_versions_after[0].id
+        )
+        line_items_after = await _get_estimate_items_for_version(estimate_versions_after[0].id)
+        evolved_payload = _estimate_persisted_semantic_payload(
+            estimate_versions_after[0],
+            snapshot_entries_after,
+            line_items_after,
+        )
+        assert evolved_payload == original_payload

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -27,6 +27,7 @@ from app.db.session import get_db
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
 from app.models.estimation_catalog import (
     EstimationFormula,
     EstimationRate,
@@ -186,7 +187,11 @@ def _build_estimate_request_body(
     }
 
 
-async def _seed_quantity_lineage() -> _QuantityLineageSeed:
+async def _seed_quantity_lineage(
+    *,
+    quantity_gate: str = QuantityGate.ALLOWED.value,
+    trusted_totals: bool = True,
+) -> _QuantityLineageSeed:
     session_factory = session_module.AsyncSessionLocal
     assert session_factory is not None
 
@@ -306,8 +311,8 @@ async def _seed_quantity_lineage() -> _QuantityLineageSeed:
             source_job_type=JobType.QUANTITY_TAKEOFF.value,
             review_state="approved",
             validation_status="valid",
-            quantity_gate=QuantityGate.ALLOWED.value,
-            trusted_totals=True,
+            quantity_gate=quantity_gate,
+            trusted_totals=trusted_totals,
         )
         item = QuantityItem(
             quantity_takeoff_id=takeoff_id,
@@ -319,7 +324,7 @@ async def _seed_quantity_lineage() -> _QuantityLineageSeed:
             unit="sq_ft",
             review_state="approved",
             validation_status="valid",
-            quantity_gate=QuantityGate.ALLOWED.value,
+            quantity_gate=quantity_gate,
             source_entity_id=None,
             excluded_source_entity_ids_json=[],
         )
@@ -356,6 +361,96 @@ async def _seed_quantity_lineage() -> _QuantityLineageSeed:
         takeoff_id=takeoff_id,
         quantity_item_id=item.id,
     )
+
+
+async def _assert_no_estimate_persistence_for_project(seed: _QuantityLineageSeed) -> None:
+    session_factory = session_module.AsyncSessionLocal
+    assert session_factory is not None
+
+    async with session_factory() as db:
+        estimate_jobs = (
+            (
+                await db.execute(
+                    select(Job).where(
+                        (Job.project_id == seed.project_id)
+                        & (Job.job_type == JobType.ESTIMATE.value)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_inputs = (
+            (
+                await db.execute(
+                    select(EstimateJobInput).where(EstimateJobInput.project_id == seed.project_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_refs = (
+            (
+                await db.execute(
+                    select(EstimateJobInputCatalogRef).where(
+                        EstimateJobInputCatalogRef.estimate_job_id.in_(
+                            select(Job.id).where(
+                                (Job.project_id == seed.project_id)
+                                & (Job.job_type == JobType.ESTIMATE.value)
+                            )
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_versions = (
+            (
+                await db.execute(
+                    select(EstimateVersion).where(EstimateVersion.project_id == seed.project_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        snapshot_entries = (
+            (
+                await db.execute(
+                    select(EstimateSnapshotEntry).where(
+                        EstimateSnapshotEntry.estimate_version_id.in_(
+                            select(EstimateVersion.id).where(
+                                EstimateVersion.project_id == seed.project_id
+                            )
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        estimate_items = (
+            (
+                await db.execute(
+                    select(EstimateItem).where(
+                        EstimateItem.estimate_version_id.in_(
+                            select(EstimateVersion.id).where(
+                                EstimateVersion.project_id == seed.project_id
+                            )
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert estimate_jobs == []
+    assert estimate_inputs == []
+    assert estimate_refs == []
+    assert estimate_versions == []
+    assert snapshot_entries == []
+    assert estimate_items == []
 
 
 async def _soft_delete_lineage(seed: _QuantityLineageSeed, *, target: str) -> None:
@@ -1279,6 +1374,80 @@ def test_create_revision_estimate_version_rejects_catalog_validation_before_enqu
     assert session.added == []
     assert session.commits == 0
     assert publish_calls == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("quantity_gate", "trusted_totals"),
+    [
+        pytest.param(
+            QuantityGate.REVIEW_GATED.value,
+            False,
+            id="review_gated",
+        ),
+        pytest.param(QuantityGate.ALLOWED.value, False, id="untrusted"),
+    ],
+)
+@requires_database
+async def test_create_revision_estimate_version_rejects_trust_gate_takeoff_before_insert(
+    async_client: AsyncClient,
+    monkeypatch: Any,
+    quantity_gate: str,
+    trusted_totals: bool,
+) -> None:
+    seed = await _seed_quantity_lineage(quantity_gate=quantity_gate, trusted_totals=trusted_totals)
+    request_body = _build_estimate_request_body(quantity_item_id=seed.quantity_item_id)
+    publish_calls: list[UUID] = []
+    enqueue_calls: list[UUID] = []
+    catalog_resolver_called = False
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = (publisher, suppress_exceptions)
+        publish_calls.append(job_id)
+
+    def fake_enqueue_estimate_job(job_id: UUID) -> None:
+        enqueue_calls.append(job_id)
+
+    async def fake_resolve_estimate_catalog_refs(
+        revision_value: Any,
+        takeoff_value: Any,
+        request_refs: Any,
+        pricing_effective_date: date,
+        db: AsyncSession,
+    ) -> list[Any]:
+        _ = (revision_value, takeoff_value, request_refs, pricing_effective_date, db)
+        nonlocal catalog_resolver_called
+        catalog_resolver_called = True
+        return []
+
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(revisions_module, "enqueue_estimate_job", fake_enqueue_estimate_job)
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_catalog_refs",
+        fake_resolve_estimate_catalog_refs,
+    )
+
+    response = await async_client.post(
+        f"/v1/revisions/{seed.revision_id}/quantity-takeoffs/{seed.takeoff_id}/estimate-versions",
+        json=request_body,
+    )
+
+    assert response.status_code == 400
+    assert _response_error_code(response) == "INPUT_INVALID"
+    assert catalog_resolver_called is False
+    assert publish_calls == []
+    assert enqueue_calls == []
+    await _assert_no_estimate_persistence_for_project(seed)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #207

## Summary
- add worker-backed coverage proving persisted estimate outputs remain stable after catalog evolution
- add DB-backed API rejection coverage for non-trusted quantity takeoffs before enqueue or estimate persistence
- verify rejected trust-gate requests do not persist estimate jobs, inputs, versions, snapshots, or items

## Test plan
- [x] uv run ruff check tests/test_jobs.py tests/test_quantity_takeoff_api.py
- [x] uv run mypy tests/test_jobs.py tests/test_quantity_takeoff_api.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest tests/test_jobs.py -k "job_constraints_reject_invalid_string_writes or job_constraints_reject_profile_required_job_without_extraction_profile or replayable_historical_output_after_catalog_evolution"
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest tests/test_quantity_takeoff_api.py -k "trust_gate or review_gated or untrusted"