### PR TITLE
fix(estimation): prevalidate exponent-form decimal literals

### DIFF
--- a/app/estimating/formulas/evaluator.py
+++ b/app/estimating/formulas/evaluator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from decimal import (
@@ -32,6 +33,10 @@ _MAX_NODE_COUNT: Final = 512
 _MAX_NODE_ARGS: Final = 64
 _MAX_LITERAL_LENGTH: Final = 256
 _MAX_ROUNDING_SCALE: Final = 28
+_CANONICAL_DECIMAL_PATTERN: Final = re.compile(
+    r"(?:0|-?(?:[1-9][0-9]*|0\.[0-9]*[1-9]|[1-9][0-9]*\.[0-9]*[1-9]))\Z",
+    re.ASCII,
+)
 _EVALUATION_CONTEXT: Final = Context(
     prec=16_384,
     rounding=ROUND_HALF_EVEN,
@@ -570,6 +575,11 @@ def _parse_canonical_decimal(value: str) -> Decimal:
         _raise_input_invalid(
             "literal_invalid",
             f"Decimal literals cannot exceed {_MAX_LITERAL_LENGTH} characters.",
+        )
+    if _CANONICAL_DECIMAL_PATTERN.fullmatch(value) is None:
+        _raise_input_invalid(
+            "literal_not_canonical",
+            f"Decimal literal '{value}' is not canonical.",
         )
     try:
         decimal_value = Decimal(value)

--- a/tests/test_formula_dsl.py
+++ b/tests/test_formula_dsl.py
@@ -13,6 +13,7 @@ from app.estimating.formulas import (
     ValueContract,
     evaluate_formula,
 )
+from app.estimating.formulas import evaluator as evaluator_module
 
 SCALAR = ValueContract(kind="scalar")
 MONEY_GBP = ValueContract(kind="money", currency="GBP")
@@ -299,6 +300,73 @@ def test_evaluate_formula_raises_input_invalid_for_invalid_decimal_literal() -> 
     assert exc_info.value.code == "INPUT_INVALID"
 
 
+@pytest.mark.parametrize(
+    "literal",
+    ["1E-999999", "1e2", "+1", "01", "1.0", "1.", ".1", "-0"],
+)
+def test_evaluate_formula_rejects_non_canonical_decimal_literals(literal: str) -> None:
+    definition = FormulaDefinition(
+        formula_id="formula.non_canonical_decimal_literal",
+        name="Non canonical decimal literal",
+        version=23,
+        checksum="sha256:non-canonical-decimal-literal",
+        output_key="result",
+        output_contract=SCALAR,
+        declared_inputs=(),
+        expression=FormulaNode(kind="literal", value=literal),
+    )
+
+    with pytest.raises(FormulaEvaluationError) as exc_info:
+        evaluate_formula(definition, {})
+
+    assert exc_info.value.code == "INPUT_INVALID"
+    assert exc_info.value.reason == "literal_not_canonical"
+
+
+def test_evaluate_formula_rejects_exponent_literals_before_canonical_formatting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = FormulaDefinition(
+        formula_id="formula.exponent_literal_precheck",
+        name="Exponent literal precheck",
+        version=24,
+        checksum="sha256:exponent-literal-precheck",
+        output_key="result",
+        output_contract=SCALAR,
+        declared_inputs=(),
+        expression=FormulaNode(kind="literal", value="1E-999999"),
+    )
+
+    def fail_if_called(_: Decimal) -> str:
+        raise AssertionError("_canonical_decimal_string must not run")
+
+    monkeypatch.setattr(evaluator_module, "_canonical_decimal_string", fail_if_called)
+
+    with pytest.raises(FormulaEvaluationError) as exc_info:
+        evaluate_formula(definition, {})
+
+    assert exc_info.value.code == "INPUT_INVALID"
+    assert exc_info.value.reason == "literal_not_canonical"
+
+
+@pytest.mark.parametrize("literal", ["0", "-1", "0.001", "12.34"])
+def test_evaluate_formula_accepts_canonical_decimal_literals(literal: str) -> None:
+    definition = FormulaDefinition(
+        formula_id="formula.valid_decimal_literal",
+        name="Valid decimal literal",
+        version=25,
+        checksum="sha256:valid-decimal-literal",
+        output_key="result",
+        output_contract=SCALAR,
+        declared_inputs=(),
+        expression=FormulaNode(kind="literal", value=literal),
+    )
+
+    result = evaluate_formula(definition, {})
+
+    assert result.value == FormulaValue(amount=Decimal(literal), contract=SCALAR)
+
+
 def test_formula_node_rejects_unknown_extra_ast_keys() -> None:
     payload: Any = {"kind": "literal", "value": "1", "extra_key": "unexpected"}
 
@@ -582,9 +650,7 @@ def test_evaluate_formula_raises_input_invalid_for_excessive_node_count() -> Non
             if index + 1 == len(nodes):
                 next_level.append(nodes[index])
                 continue
-            next_level.append(
-                FormulaNode(kind="add", args=(nodes[index], nodes[index + 1]))
-            )
+            next_level.append(FormulaNode(kind="add", args=(nodes[index], nodes[index + 1])))
         nodes = next_level
 
     definition = FormulaDefinition(


### PR DESCRIPTION
Closes #209

## Summary
- reject exponent-form and other non-canonical Formula DSL decimal literals before Decimal parsing and fixed-point canonical formatting
- preserve deterministic `INPUT_INVALID` / `literal_not_canonical` errors for invalid literals
- add regression coverage for rejected literals, accepted canonical literals, and the precheck-before-formatting guard

## Test plan
- [x] uv run pytest tests/test_formula_dsl.py
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv run pytest