### PR TITLE
refactor(api): extract shared idempotency workflow

### DIFF
--- a/app/api/idempotency.py
+++ b/app/api/idempotency.py
@@ -167,6 +167,22 @@ async def replay_idempotency(
     )
 
 
+async def replay_idempotency_response(
+    db: AsyncSession,
+    *,
+    key: str | None,
+    fingerprint: str,
+) -> Response | None:
+    """Return an optional replay response for routes with an Idempotency-Key."""
+
+    if key is None:
+        return None
+    replay = await replay_idempotency(db, key=key, fingerprint=fingerprint)
+    if replay is None:
+        return None
+    return replay.response
+
+
 async def claim_idempotency(
     db: AsyncSession,
     *,
@@ -209,6 +225,30 @@ async def claim_idempotency(
     )
 
 
+async def claim_idempotency_response(
+    db: AsyncSession,
+    *,
+    key: str | None,
+    fingerprint: str,
+    method: str,
+    path: str,
+) -> IdempotencyReservation | Response | None:
+    """Claim an optional idempotency reservation or return an immediate response."""
+
+    if key is None:
+        return None
+    claim = await claim_idempotency(
+        db,
+        key=key,
+        fingerprint=fingerprint,
+        method=method,
+        path=path,
+    )
+    if isinstance(claim, IdempotencyReplay):
+        return claim.response
+    return claim
+
+
 async def mark_idempotency_completed(
     db: AsyncSession,
     reservation: IdempotencyReservation,
@@ -231,3 +271,24 @@ async def mark_idempotency_completed(
     record.response_status_code = status_code
     record.response_body_json = response_body
     record.completed_at = datetime.now(UTC)
+
+
+async def complete_idempotency_response(
+    db: AsyncSession,
+    reservation: IdempotencyReservation | None,
+    *,
+    status_code: int,
+    response_body: dict[str, Any] | None,
+) -> Response:
+    """Snapshot an optional reservation and build a replay-safe HTTP response."""
+
+    if reservation is not None:
+        await mark_idempotency_completed(
+            db,
+            reservation,
+            status_code=status_code,
+            response_body=response_body,
+        )
+    if status_code == status.HTTP_204_NO_CONTENT:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return JSONResponse(status_code=status_code, content=response_body)

--- a/app/api/v1/estimation.py
+++ b/app/api/v1/estimation.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
@@ -15,13 +15,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.api.idempotency import (
-    IdempotencyReplay,
     IdempotencyReservation,
     build_idempotency_fingerprint,
-    claim_idempotency,
+    claim_idempotency_response,
+    complete_idempotency_response,
     get_idempotency_key,
-    mark_idempotency_completed,
-    replay_idempotency,
+    replay_idempotency_response,
 )
 from app.api.pagination import decode_cursor_payload, encode_cursor_payload, raise_invalid_cursor
 from app.core.errors import ErrorCode
@@ -119,7 +118,7 @@ async def _raise_catalog_conflict(
 ) -> None:
     error_body = _catalog_conflict_body(kind)
     if reservation is not None:
-        await mark_idempotency_completed(
+        await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_409_CONFLICT,
@@ -422,9 +421,13 @@ async def create_rate(
             "estimation.rates.create",
             rate_in.model_dump(mode="json"),
         )
-        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        replay = await replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
         if replay is not None:
-            return replay.response
+            return replay
 
     if rate_in.project_id is not None:
         await _get_active_project_or_404(db, rate_in.project_id)
@@ -441,15 +444,16 @@ async def create_rate(
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path="/estimation/catalog/rates",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
         reservation = claim
 
     rate = EstimationRate(
@@ -503,8 +507,9 @@ async def create_rate(
         supersedes_rate_id=rate_in.supersedes_rate_id,
     )
     response_body = body.model_dump(mode="json")
+    idempotent_response: Response | None = None
     if reservation is not None:
-        await mark_idempotency_completed(
+        idempotent_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_201_CREATED,
@@ -512,8 +517,8 @@ async def create_rate(
         )
     await db.commit()
 
-    if reservation is not None:
-        return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_body)
+    if idempotent_response is not None:
+        return idempotent_response
     return body
 
 
@@ -627,9 +632,13 @@ async def create_material(
             "estimation.materials.create",
             material_in.model_dump(mode="json"),
         )
-        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        replay = await replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
         if replay is not None:
-            return replay.response
+            return replay
 
     if material_in.project_id is not None:
         await _get_active_project_or_404(db, material_in.project_id)
@@ -646,15 +655,16 @@ async def create_material(
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path="/estimation/catalog/materials",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
         reservation = claim
 
     material = EstimationMaterial(
@@ -706,8 +716,9 @@ async def create_material(
         supersedes_material_id=material_in.supersedes_material_id,
     )
     response_body = body.model_dump(mode="json")
+    idempotent_response: Response | None = None
     if reservation is not None:
-        await mark_idempotency_completed(
+        idempotent_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_201_CREATED,
@@ -715,8 +726,8 @@ async def create_material(
         )
     await db.commit()
 
-    if reservation is not None:
-        return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_body)
+    if idempotent_response is not None:
+        return idempotent_response
     return body
 
 
@@ -834,9 +845,13 @@ async def create_formula(
             "estimation.formulas.create",
             formula_in.model_dump(mode="json"),
         )
-        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
+        replay = await replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
         if replay is not None:
-            return replay.response
+            return replay
 
     if formula_in.project_id is not None:
         await _get_active_project_or_404(db, formula_in.project_id)
@@ -848,15 +863,16 @@ async def create_formula(
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path="/estimation/formulas",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
         reservation = claim
 
     formula = EstimationFormula(
@@ -908,8 +924,9 @@ async def create_formula(
         supersedes_formula_id=formula_in.supersedes_formula_id,
     )
     response_body = body.model_dump(mode="json")
+    idempotent_response: Response | None = None
     if reservation is not None:
-        await mark_idempotency_completed(
+        idempotent_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_201_CREATED,
@@ -917,8 +934,8 @@ async def create_formula(
         )
     await db.commit()
 
-    if reservation is not None:
-        return JSONResponse(status_code=status.HTTP_201_CREATED, content=response_body)
+    if idempotent_response is not None:
+        return idempotent_response
     return body
 
 

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -11,18 +11,17 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
 from fastapi import File as FilePart
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReplay,
     IdempotencyReservation,
     build_idempotency_fingerprint,
-    claim_idempotency,
+    claim_idempotency_response,
+    complete_idempotency_response,
     get_idempotency_key,
-    mark_idempotency_completed,
-    replay_idempotency,
+    replay_idempotency_response,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -89,9 +88,7 @@ def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
     """Decode cursor to typed created_at and id values."""
     try:
         cursor_data = decode_cursor_payload(cursor)
-        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(
-            str(cursor_data["id"])
-        )
+        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
     except (KeyError, TypeError, ValueError) as exc:
         raise_invalid_cursor(exc)
 
@@ -250,9 +247,7 @@ async def _get_active_project_or_404(
     for_update: bool = False,
 ) -> Project:
     """Return an active project row or raise not found."""
-    query = select(Project).where(
-        (Project.id == project_id) & (Project.deleted_at.is_(None))
-    )
+    query = select(Project).where((Project.id == project_id) & (Project.deleted_at.is_(None)))
     if for_update:
         query = query.with_for_update()
     project = (await db.execute(query)).scalar_one_or_none()
@@ -310,8 +305,7 @@ async def _get_latest_finalized_revision(
     query = (
         select(DrawingRevision)
         .where(
-            (DrawingRevision.project_id == project_id)
-            & (DrawingRevision.source_file_id == file_id)
+            (DrawingRevision.project_id == project_id) & (DrawingRevision.source_file_id == file_id)
         )
         .order_by(DrawingRevision.revision_sequence.desc())
         .limit(1)
@@ -347,7 +341,7 @@ async def _raise_upload_storage_failure(
         details=None,
     )
     if reservation is not None:
-        await mark_idempotency_completed(
+        await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -490,23 +484,24 @@ async def upload_project_file(
                     "checksum_sha256": checksum,
                 },
             )
-            replay = await replay_idempotency(
+            replay = await replay_idempotency_response(
                 db,
                 key=idempotency_key,
                 fingerprint=fingerprint,
             )
             if replay is not None:
-                return replay.response
+                return replay
             await _get_active_project_or_404(db, project_id)
-            claim = await claim_idempotency(
+            claim = await claim_idempotency_response(
                 db,
                 key=idempotency_key,
                 fingerprint=fingerprint,
                 method="POST",
                 path=f"/projects/{project_id}/files",
             )
-            if isinstance(claim, IdempotencyReplay):
-                return claim.response
+            if isinstance(claim, Response):
+                return claim
+            assert claim is not None
             reservation = claim
 
         try:
@@ -590,11 +585,12 @@ async def upload_project_file(
     await db.refresh(ingest_job)
 
     success_body: dict[str, Any] | None = None
+    idempotent_response: Response | None = None
     if reservation is not None:
         success_body = FileRead.model_validate(
             _attach_initial_upload_metadata(file_row)
         ).model_dump(mode="json")
-        await mark_idempotency_completed(
+        idempotent_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_201_CREATED,
@@ -608,9 +604,8 @@ async def upload_project_file(
         suppress_exceptions=True,
     )
 
-    if reservation is not None:
-        assert success_body is not None
-        return JSONResponse(status_code=status.HTTP_201_CREATED, content=success_body)
+    if idempotent_response is not None:
+        return idempotent_response
 
     return _attach_initial_upload_metadata(file_row)
 
@@ -635,13 +630,13 @@ async def reprocess_project_file(
             f"files.reprocess:{project_id}:{file_id}",
             request.model_dump(mode="json"),
         )
-        replay = await replay_idempotency(
+        replay = await replay_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
         )
         if replay is not None:
-            return replay.response
+            return replay
 
     await _get_active_project_or_404(db, project_id)
     await _get_project_file_or_404(db, project_id, file_id)
@@ -661,15 +656,16 @@ async def reprocess_project_file(
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path=f"/projects/{project_id}/files/{file_id}/reprocess",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
         reservation = claim
     await _get_active_project_or_404(db, project_id, for_update=True)
     await _get_project_file_or_404(db, project_id, file_id, for_update=True)
@@ -698,9 +694,10 @@ async def reprocess_project_file(
     await db.refresh(ingest_job)
 
     success_body: dict[str, Any] | None = None
+    idempotent_response: Response | None = None
     if reservation is not None:
         success_body = JobRead.model_validate(ingest_job).model_dump(mode="json")
-        await mark_idempotency_completed(
+        idempotent_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_202_ACCEPTED,
@@ -714,9 +711,8 @@ async def reprocess_project_file(
         suppress_exceptions=True,
     )
 
-    if reservation is not None:
-        assert success_body is not None
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
+    if idempotent_response is not None:
+        return idempotent_response
 
     return ingest_job
 
@@ -736,9 +732,7 @@ async def list_project_files(
 
     query = (
         select(FileModel)
-        .where(
-            (FileModel.project_id == project_id) & (FileModel.deleted_at.is_(None))
-        )
+        .where((FileModel.project_id == project_id) & (FileModel.deleted_at.is_(None)))
         .order_by(FileModel.created_at.desc(), FileModel.id.desc())
     )
 

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -5,18 +5,17 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReplay,
     IdempotencyReservation,
     build_idempotency_fingerprint,
-    claim_idempotency,
+    claim_idempotency_response,
+    complete_idempotency_response,
     get_idempotency_key,
-    mark_idempotency_completed,
-    replay_idempotency,
+    replay_idempotency_response,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -60,9 +59,7 @@ async def _get_job_lock_metadata_or_404(
     job_id: UUID,
 ) -> tuple[UUID, UUID]:
     """Return project/file identifiers needed for ordered job locking."""
-    result = await db.execute(
-        select(Job.project_id, Job.file_id).where(Job.id == job_id)
-    )
+    result = await db.execute(select(Job.project_id, Job.file_id).where(Job.id == job_id))
     row = result.one_or_none()
     if row is None:
         raise_not_found("Job", str(job_id))
@@ -80,9 +77,7 @@ async def _get_project_for_job_update_or_404(
 ) -> Project:
     """Lock a job's project row before any job/file row locks."""
     result = await db.execute(
-        select(Project)
-        .where(Project.id == project_id)
-        .with_for_update(of=Project)
+        select(Project).where(Project.id == project_id).with_for_update(of=Project)
     )
     project = result.scalar_one_or_none()
     if project is None:
@@ -100,11 +95,7 @@ async def _get_job_for_update_or_404(
     expected_file_id: UUID | None = None,
 ) -> Job:
     """Return a persisted job with a row lock or raise not found."""
-    result = await db.execute(
-        select(Job)
-        .where(Job.id == job_id)
-        .with_for_update(of=Job)
-    )
+    result = await db.execute(select(Job).where(Job.id == job_id).with_for_update(of=Job))
     job = result.scalar_one_or_none()
     if job is None:
         raise_not_found("Job", str(job_id))
@@ -293,27 +284,27 @@ async def cancel_job(
             f"jobs.cancel:{job_id}",
             {"job_id": str(job_id)},
         )
-        replay = await replay_idempotency(
+        replay = await replay_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
         )
         if replay is not None:
-            return replay.response
+            return replay
 
     project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path=f"/jobs/{job_id}/cancel",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
         reservation = claim
 
     await _get_project_for_job_update_or_404(
@@ -329,30 +320,28 @@ async def cancel_job(
     )
     if job.status in _TERMINAL_JOB_STATUSES:
         if reservation is not None:
-            body = JobRead.model_validate(job).model_dump(mode="json")
-            await mark_idempotency_completed(
+            response = await complete_idempotency_response(
                 db,
                 reservation,
                 status_code=status.HTTP_202_ACCEPTED,
-                response_body=body,
+                response_body=JobRead.model_validate(job).model_dump(mode="json"),
             )
             await db.commit()
-            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+            return response
         return job
 
     job.cancel_requested = True
     if reservation is not None:
         await db.flush()
         await db.refresh(job)
-        body = JobRead.model_validate(job).model_dump(mode="json")
-        await mark_idempotency_completed(
+        response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_202_ACCEPTED,
-            response_body=body,
+            response_body=JobRead.model_validate(job).model_dump(mode="json"),
         )
         await db.commit()
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+        return response
 
     await db.commit()
     await db.refresh(job)
@@ -377,27 +366,27 @@ async def retry_job(
             f"jobs.retry:{job_id}",
             {"job_id": str(job_id)},
         )
-        replay = await replay_idempotency(
+        replay = await replay_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
         )
         if replay is not None:
-            return replay.response
+            return replay
 
     project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path=f"/jobs/{job_id}/retry",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
         reservation = claim
 
     job = await _lock_retry_source_or_404(
@@ -408,41 +397,38 @@ async def retry_job(
     )
     if job.status != "failed" or job.attempts >= job.max_attempts:
         if reservation is not None:
-            body = JobRead.model_validate(job).model_dump(mode="json")
-            await mark_idempotency_completed(
+            response = await complete_idempotency_response(
                 db,
                 reservation,
                 status_code=status.HTTP_202_ACCEPTED,
-                response_body=body,
+                response_body=JobRead.model_validate(job).model_dump(mode="json"),
             )
             await db.commit()
-            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+            return response
         return job
 
     if job.error_code == ErrorCode.REVISION_CONFLICT.value:
         if reservation is not None:
-            body = JobRead.model_validate(job).model_dump(mode="json")
-            await mark_idempotency_completed(
+            response = await complete_idempotency_response(
                 db,
                 reservation,
                 status_code=status.HTTP_202_ACCEPTED,
-                response_body=body,
+                response_body=JobRead.model_validate(job).model_dump(mode="json"),
             )
             await db.commit()
-            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+            return response
         return job
 
     if not is_recoverable_enqueue_job_type(job.job_type):
         if reservation is not None:
-            body = JobRead.model_validate(job).model_dump(mode="json")
-            await mark_idempotency_completed(
+            response = await complete_idempotency_response(
                 db,
                 reservation,
                 status_code=status.HTTP_202_ACCEPTED,
-                response_body=body,
+                response_body=JobRead.model_validate(job).model_dump(mode="json"),
             )
             await db.commit()
-            return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=body)
+            return response
         return job
 
     job.status = "pending"
@@ -455,21 +441,20 @@ async def retry_job(
     await db.flush()
     await db.refresh(job)
 
-    success_body: dict[str, object] | None = None
+    retry_response: Response | None = None
     if reservation is not None:
-        success_body = JobRead.model_validate(job).model_dump(mode="json")
-        await mark_idempotency_completed(
+        retry_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_202_ACCEPTED,
-            response_body=success_body,
+            response_body=JobRead.model_validate(job).model_dump(mode="json"),
         )
 
     await db.commit()
     await publish_job_enqueue_intent(job.id, suppress_exceptions=True)
 
     if reservation is not None:
-        assert success_body is not None
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
+        assert retry_response is not None
+        return retry_response
 
     return job

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -5,18 +5,17 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReplay,
     IdempotencyReservation,
     build_idempotency_fingerprint,
-    claim_idempotency,
+    claim_idempotency_response,
+    complete_idempotency_response,
     get_idempotency_key,
-    mark_idempotency_completed,
-    replay_idempotency,
+    replay_idempotency_response,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -47,9 +46,7 @@ async def _get_active_project_or_404(
     for_update: bool = False,
 ) -> Project:
     """Return an active project row or raise not found."""
-    query = select(Project).where(
-        (Project.id == project_id) & (Project.deleted_at.is_(None))
-    )
+    query = select(Project).where((Project.id == project_id) & (Project.deleted_at.is_(None)))
     if for_update:
         query = query.with_for_update()
     project = (await db.execute(query)).scalar_one_or_none()
@@ -74,9 +71,7 @@ def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
     """Decode cursor to typed created_at and id values."""
     try:
         cursor_data = decode_cursor_payload(cursor)
-        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(
-            str(cursor_data["id"])
-        )
+        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
     except (KeyError, TypeError, ValueError) as exc:
         raise_invalid_cursor(exc)
 
@@ -92,21 +87,19 @@ async def create_project(
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> Project | Response:
     """Create a new project."""
-    reservation: IdempotencyReservation | None = None
-    if idempotency_key is not None:
-        claim = await claim_idempotency(
-            db,
-            key=idempotency_key,
-            fingerprint=build_idempotency_fingerprint(
-                "projects.create",
-                project_in.model_dump(mode="json", exclude_unset=True),
-            ),
-            method="POST",
-            path="/projects",
-        )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
-        reservation = claim
+    claim = await claim_idempotency_response(
+        db,
+        key=idempotency_key,
+        fingerprint=build_idempotency_fingerprint(
+            "projects.create",
+            project_in.model_dump(mode="json", exclude_unset=True),
+        ),
+        method="POST",
+        path="/projects",
+    )
+    if isinstance(claim, Response):
+        return claim
+    reservation = claim
 
     project = Project(
         name=project_in.name,
@@ -118,15 +111,14 @@ async def create_project(
     if reservation is not None:
         await db.flush()
         await db.refresh(project)
-        body = ProjectRead.model_validate(project).model_dump(mode="json")
-        await mark_idempotency_completed(
+        response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_201_CREATED,
-            response_body=body,
+            response_body=ProjectRead.model_validate(project).model_dump(mode="json"),
         )
         await db.commit()
-        return JSONResponse(status_code=status.HTTP_201_CREATED, content=body)
+        return response
 
     await db.commit()
     await db.refresh(project)
@@ -160,10 +152,7 @@ async def list_projects(
         # Filter for items after the cursor position
         query = query.filter(
             (Project.created_at < created_at)
-            | (
-                (Project.created_at == created_at)
-                & (Project.id < project_id)
-            )
+            | ((Project.created_at == created_at) & (Project.id < project_id))
         )
 
     # Fetch limit + 1 to determine if there's a next page
@@ -215,26 +204,26 @@ async def update_project(
             f"projects.update:{project_id}",
             project_in.model_dump(mode="json", exclude_unset=True),
         )
-        replay = await replay_idempotency(
+        replay = await replay_idempotency_response(
             db,
-            key=idempotency_key,
             fingerprint=fingerprint,
+            key=idempotency_key,
         )
         if replay is not None:
-            return replay.response
+            return replay
 
     project = await _get_active_project_or_404(db, project_id)
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="PATCH",
             path=f"/projects/{project_id}",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
         reservation = claim
         project = await _get_active_project_or_404(db, project_id)
 
@@ -246,15 +235,14 @@ async def update_project(
     if reservation is not None:
         await db.flush()
         await db.refresh(project)
-        body = ProjectRead.model_validate(project).model_dump(mode="json")
-        await mark_idempotency_completed(
+        response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_200_OK,
-            response_body=body,
+            response_body=ProjectRead.model_validate(project).model_dump(mode="json"),
         )
         await db.commit()
-        return JSONResponse(status_code=status.HTTP_200_OK, content=body)
+        return response
 
     await db.commit()
     await db.refresh(project)
@@ -278,41 +266,42 @@ async def delete_project(
             f"projects.delete:{project_id}",
             {"project_id": str(project_id)},
         )
-        replay = await replay_idempotency(
+        replay = await replay_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
         )
         if replay is not None:
-            return replay.response
+            return replay
 
     await _get_active_project_or_404(db, project_id)
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="DELETE",
             path=f"/projects/{project_id}",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
         reservation = claim
 
     project = await _get_active_project_or_404(db, project_id, for_update=True)
     locked_jobs = (
-        await db.execute(
-            select(Job)
-            .where(
-                (Job.project_id == project_id)
-                & (Job.status.in_(("pending", "running")))
+        (
+            await db.execute(
+                select(Job)
+                .where((Job.project_id == project_id) & (Job.status.in_(("pending", "running"))))
+                .order_by(Job.created_at.asc(), Job.id.asc())
+                .with_for_update(of=Job)
             )
-            .order_by(Job.created_at.asc(), Job.id.asc())
-            .with_for_update(of=Job)
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     deleted_at = datetime.now(UTC)
     project.deleted_at = deleted_at
     for job in locked_jobs:
@@ -331,17 +320,18 @@ async def delete_project(
     await db.execute(
         update(GeneratedArtifact)
         .where(
-            (GeneratedArtifact.project_id == project_id)
-            & (GeneratedArtifact.deleted_at.is_(None))
+            (GeneratedArtifact.project_id == project_id) & (GeneratedArtifact.deleted_at.is_(None))
         )
         .values(deleted_at=deleted_at)
     )
     if reservation is not None:
-        await mark_idempotency_completed(
+        response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_204_NO_CONTENT,
             response_body=None,
         )
+        await db.commit()
+        return response
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -11,19 +11,18 @@ from typing import Annotated, Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from pydantic import BaseModel, ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReplay,
     IdempotencyReservation,
     build_idempotency_fingerprint,
-    claim_idempotency,
+    claim_idempotency_response,
+    complete_idempotency_response,
     get_idempotency_key,
-    mark_idempotency_completed,
-    replay_idempotency,
+    replay_idempotency_response,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -1650,9 +1649,13 @@ async def create_revision_estimate_version(
                 "body": normalized_body,
             },
         )
-        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
-        if replay is not None:
-            return replay.response
+        replay_response = await replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
+        if replay_response is not None:
+            return replay_response
 
     revision = await _get_active_revision(revision_id, db)
     if revision is None:
@@ -1687,15 +1690,16 @@ async def create_revision_estimate_version(
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path=f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
         reservation = claim
 
     estimate_job = Job(
@@ -1742,14 +1746,13 @@ async def create_revision_estimate_version(
     for ref_payload in ref_payloads:
         db.add(_build_mapped_instance(estimate_job_input_ref_model, ref_payload))
 
-    success_body: dict[str, object] | None = None
+    success_response: Response | None = None
     if reservation is not None:
-        success_body = JobRead.model_validate(estimate_job).model_dump(mode="json")
-        await mark_idempotency_completed(
+        success_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_202_ACCEPTED,
-            response_body=success_body,
+            response_body=JobRead.model_validate(estimate_job).model_dump(mode="json"),
         )
 
     await db.commit()
@@ -1759,9 +1762,8 @@ async def create_revision_estimate_version(
         suppress_exceptions=True,
     )
 
-    if reservation is not None:
-        assert success_body is not None
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
+    if success_response is not None:
+        return success_response
 
     return estimate_job
 
@@ -1937,9 +1939,13 @@ async def create_revision_quantity_takeoff(
             f"revisions.quantity_takeoffs:{revision_id}",
             {"revision_id": str(revision_id)},
         )
-        replay = await replay_idempotency(db, key=idempotency_key, fingerprint=fingerprint)
-        if replay is not None:
-            return replay.response
+        replay_response = await replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
+        if replay_response is not None:
+            return replay_response
 
     revision = await _get_active_revision(revision_id, db)
     if revision is None:
@@ -1961,15 +1967,16 @@ async def create_revision_quantity_takeoff(
 
     if idempotency_key is not None:
         assert fingerprint is not None
-        claim = await claim_idempotency(
+        claim = await claim_idempotency_response(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path=f"/revisions/{revision_id}/quantity-takeoffs",
         )
-        if isinstance(claim, IdempotencyReplay):
-            return claim.response
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
         reservation = claim
 
     quantity_job = Job(
@@ -1996,14 +2003,13 @@ async def create_revision_quantity_takeoff(
     await db.flush()
     await db.refresh(quantity_job)
 
-    success_body: dict[str, object] | None = None
+    success_response: Response | None = None
     if reservation is not None:
-        success_body = JobRead.model_validate(quantity_job).model_dump(mode="json")
-        await mark_idempotency_completed(
+        success_response = await complete_idempotency_response(
             db,
             reservation,
             status_code=status.HTTP_202_ACCEPTED,
-            response_body=success_body,
+            response_body=JobRead.model_validate(quantity_job).model_dump(mode="json"),
         )
 
     await db.commit()
@@ -2013,9 +2019,8 @@ async def create_revision_quantity_takeoff(
         suppress_exceptions=True,
     )
 
-    if reservation is not None:
-        assert success_body is not None
-        return JSONResponse(status_code=status.HTTP_202_ACCEPTED, content=success_body)
+    if success_response is not None:
+        return success_response
 
     return quantity_job
 

--- a/tests/test_estimation_catalog_api.py
+++ b/tests/test_estimation_catalog_api.py
@@ -621,6 +621,39 @@ class TestEstimationCatalogApiRateIdempotency:
         assert isinstance(body["error"].get("code"), str)
         assert body["error"]["code"]
 
+    async def test_create_rate_replays_db_conflict_for_same_idempotency_key(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Idempotency Conflict Replay Project")
+        payload = _valid_rate_payload(project_id=project_id)
+        headers = {"Idempotency-Key": "rate-create-db-conflict-replay-key"}
+
+        initial_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+        )
+        first_conflict_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+            headers=headers,
+        )
+        second_conflict_response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+            headers=headers,
+        )
+
+        assert initial_response.status_code == 201
+        assert first_conflict_response.status_code == 409
+        assert second_conflict_response.status_code == 409
+        assert first_conflict_response.json() == second_conflict_response.json()
+        assert first_conflict_response.json()["error"]["code"] == "DB_CONFLICT"
+
 
 @requires_database
 class TestEstimationCatalogApiSupersessionAndAsOf:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -152,9 +152,7 @@ class RecordingStorage:
             key=key,
             storage_uri=f"memory://{key}",
             size_bytes=len(body),
-            checksum_sha256=(
-                self.returned_checksum_sha256 or hashlib.sha256(body).hexdigest()
-            ),
+            checksum_sha256=(self.returned_checksum_sha256 or hashlib.sha256(body).hexdigest()),
         )
 
     async def get(
@@ -220,6 +218,24 @@ class LocalChecksumMismatchStorage(LocalFilesystemStorage):
             size_bytes=meta.size_bytes,
             checksum_sha256="0" * 64,
         )
+
+
+class CountingLocalChecksumMismatchStorage(LocalChecksumMismatchStorage):
+    """Checksum-mismatch storage that tracks put calls for replay assertions."""
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.put_call_count = 0
+
+    async def put(
+        self,
+        key: str,
+        data: bytes | Path,
+        *,
+        immutable: bool = False,
+    ) -> StoredObjectMeta:
+        self.put_call_count += 1
+        return await super().put(key, data, immutable=immutable)
 
 
 @requires_database
@@ -367,9 +383,7 @@ class TestProjectFiles:
         finally:
             app.dependency_overrides.pop(get_storage, None)
 
-        expected_key = (
-            f"originals/{uploaded['id']}/{hashlib.sha256(payload).hexdigest()}"
-        )
+        expected_key = f"originals/{uploaded['id']}/{hashlib.sha256(payload).hexdigest()}"
         assert len(storage.put_calls) == 1
         put_key, put_path, put_body, put_immutable = storage.put_calls[0]
         assert put_key == expected_key
@@ -417,6 +431,68 @@ class TestProjectFiles:
                 "details": None,
             }
         }
+        staging_root = upload_root / ".staging"
+        assert not staging_root.exists() or not any(staging_root.iterdir())
+        originals_root = upload_root / "originals"
+        assert not originals_root.exists() or not any(
+            path.is_file() for path in originals_root.rglob("*")
+        )
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            file_result = await session.execute(
+                select(FileModel).where(
+                    FileModel.project_id == uuid.UUID(str(created_project["id"]))
+                )
+            )
+            job_result = await session.execute(
+                select(Job).where(Job.project_id == uuid.UUID(str(created_project["id"])))
+            )
+
+        assert file_result.scalars().all() == []
+        assert job_result.scalars().all() == []
+
+    async def test_upload_file_replays_storage_failure_for_same_idempotency_key(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        app: FastAPI,
+    ) -> None:
+        """POST should replay finalized storage failures without re-persisting staged bytes."""
+        _ = self
+        payload = b"%PDF-1.7\nidempotent-checksum-mismatch"
+        upload_root = Path(settings.upload_storage_root).resolve()
+        storage = CountingLocalChecksumMismatchStorage(upload_root)
+        app.dependency_overrides[get_storage] = lambda: storage
+        headers = {"Idempotency-Key": "upload-storage-failure-replay-key"}
+        try:
+            first_response = await async_client.post(
+                f"/v1/projects/{created_project['id']}/files",
+                files={"file": ("mismatch.pdf", payload, "application/pdf")},
+                headers=headers,
+            )
+            second_response = await async_client.post(
+                f"/v1/projects/{created_project['id']}/files",
+                files={"file": ("mismatch.pdf", payload, "application/pdf")},
+                headers=headers,
+            )
+        finally:
+            app.dependency_overrides.pop(get_storage, None)
+
+        expected_body = {
+            "error": {
+                "code": "STORAGE_FAILED",
+                "message": "Stored file checksum mismatch detected.",
+                "details": None,
+            }
+        }
+        assert first_response.status_code == 500
+        assert second_response.status_code == 500
+        assert first_response.json() == expected_body
+        assert second_response.json() == expected_body
+        assert storage.put_call_count == 1
+
         staging_root = upload_root / ".staging"
         assert not staging_root.exists() or not any(staging_root.iterdir())
         originals_root = upload_root / "originals"
@@ -1338,8 +1414,8 @@ class TestProjectFiles:
         _ = self
         payload = b"%PDF-1.7\npayload"
 
-        app.dependency_overrides[session_module.get_db] = (
-            _make_get_db_override_with_commit_error(RuntimeError("forced commit failure"))
+        app.dependency_overrides[session_module.get_db] = _make_get_db_override_with_commit_error(
+            RuntimeError("forced commit failure")
         )
         try:
             with pytest.raises(RuntimeError, match="forced commit failure"):
@@ -1369,8 +1445,8 @@ class TestProjectFiles:
         _ = self
         payload = b"%PDF-1.7\npayload"
 
-        app.dependency_overrides[session_module.get_db] = (
-            _make_get_db_override_with_commit_error(asyncio.CancelledError())
+        app.dependency_overrides[session_module.get_db] = _make_get_db_override_with_commit_error(
+            asyncio.CancelledError()
         )
         try:
             caught: BaseException | None = None

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -10,19 +10,25 @@ from typing import Any, cast
 import httpx
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy import func, select
 
+import app.api.idempotency as idempotency_api
 import app.api.v1.files as files_api
 import app.api.v1.jobs as jobs_api
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.api.idempotency import (
+    IdempotencyReplay,
     IdempotencyReservation,
     build_idempotency_fingerprint,
+    claim_idempotency_response,
+    complete_idempotency_response,
     get_idempotency_key,
     hash_idempotency_key,
     mark_idempotency_completed,
     replay_idempotency,
+    replay_idempotency_response,
 )
 from app.core.config import settings
 from app.core.errors import ErrorCode
@@ -115,6 +121,181 @@ async def test_get_idempotency_key_rejects_invalid_rfc9110_token() -> None:
         await get_idempotency_key("contains space")
 
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_replay_idempotency_response_returns_none_without_key() -> None:
+    """Optional replay helper should no-op when no key is supplied."""
+
+    result = await replay_idempotency_response(
+        cast(Any, object()),
+        key=None,
+        fingerprint="fingerprint-1",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_replay_idempotency_response_unwraps_replay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional replay helper should unwrap short-circuit replay responses."""
+
+    replay_response = Response(status_code=204)
+
+    async def _fake_replay_idempotency(_: Any, *, key: str, fingerprint: str) -> IdempotencyReplay:
+        assert key == "replay-key-1"
+        assert fingerprint == "fingerprint-2"
+        return IdempotencyReplay(response=replay_response)
+
+    monkeypatch.setattr(idempotency_api, "replay_idempotency", _fake_replay_idempotency)
+
+    result = await replay_idempotency_response(
+        cast(Any, object()),
+        key="replay-key-1",
+        fingerprint="fingerprint-2",
+    )
+
+    assert result is replay_response
+
+
+@pytest.mark.asyncio
+async def test_claim_idempotency_response_returns_none_without_key() -> None:
+    """Optional claim helper should no-op when no key is supplied."""
+
+    result = await claim_idempotency_response(
+        cast(Any, object()),
+        key=None,
+        fingerprint="fingerprint-3",
+        method="POST",
+        path="/v1/projects",
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_claim_idempotency_response_unwraps_replay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Optional claim helper should unwrap replay conflicts into a response."""
+
+    replay_response = JSONResponse(status_code=409, content={"error": {"code": "conflict"}})
+
+    async def _fake_claim_idempotency(
+        _: Any,
+        *,
+        key: str,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReplay:
+        assert (key, fingerprint, method, path) == (
+            "claim-key-1",
+            "fingerprint-4",
+            "PATCH",
+            "/v1/projects/project-1",
+        )
+        return IdempotencyReplay(response=replay_response)
+
+    monkeypatch.setattr(idempotency_api, "claim_idempotency", _fake_claim_idempotency)
+
+    result = await claim_idempotency_response(
+        cast(Any, object()),
+        key="claim-key-1",
+        fingerprint="fingerprint-4",
+        method="PATCH",
+        path="/v1/projects/project-1",
+    )
+
+    assert result is replay_response
+
+
+class _FakeScalarResult:
+    """Minimal async execute result wrapper for idempotency unit tests."""
+
+    def __init__(self, record: IdempotencyKey) -> None:
+        self._record = record
+
+    def scalar_one(self) -> IdempotencyKey:
+        return self._record
+
+
+class _FakeIdempotencySession:
+    """Small session double to verify helper commit behavior."""
+
+    def __init__(self, record: IdempotencyKey) -> None:
+        self._record = record
+        self.commit_calls = 0
+
+    async def execute(self, _: Any) -> _FakeScalarResult:
+        return _FakeScalarResult(self._record)
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_complete_idempotency_response_marks_snapshot_and_returns_json() -> None:
+    """Completion helper should snapshot success bodies without committing the session."""
+
+    record = IdempotencyKey(
+        id=uuid.uuid4(),
+        key_hash=hash_idempotency_key("complete-json-1"),
+        request_fingerprint="fingerprint-5",
+        request_method="POST",
+        request_path="/v1/projects",
+        status=IdempotencyStatus.IN_PROGRESS.value,
+    )
+    session = _FakeIdempotencySession(record)
+    reservation = IdempotencyReservation(record_id=record.id)
+    response_body = {"id": "project-1", "name": "Replay Project"}
+
+    response = await complete_idempotency_response(
+        cast(Any, session),
+        reservation,
+        status_code=201,
+        response_body=response_body,
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 201
+    assert json.loads(bytes(response.body)) == response_body
+    assert record.status == IdempotencyStatus.COMPLETED.value
+    assert record.response_status_code == 201
+    assert record.response_body_json == response_body
+    assert record.completed_at is not None
+    assert session.commit_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_complete_idempotency_response_returns_204_without_commit() -> None:
+    """Completion helper should build empty replay responses without committing."""
+
+    record = IdempotencyKey(
+        id=uuid.uuid4(),
+        key_hash=hash_idempotency_key("complete-empty-1"),
+        request_fingerprint="fingerprint-6",
+        request_method="DELETE",
+        request_path="/v1/projects/project-1",
+        status=IdempotencyStatus.IN_PROGRESS.value,
+    )
+    session = _FakeIdempotencySession(record)
+    reservation = IdempotencyReservation(record_id=record.id)
+
+    response = await complete_idempotency_response(
+        cast(Any, session),
+        reservation,
+        status_code=204,
+        response_body=None,
+    )
+
+    assert isinstance(response, Response)
+    assert not isinstance(response, JSONResponse)
+    assert response.status_code == 204
+    assert response.body == b""
+    assert record.status == IdempotencyStatus.COMPLETED.value
+    assert record.response_status_code == 204
+    assert record.response_body_json is None
+    assert record.completed_at is not None
+    assert session.commit_calls == 0
 
 
 @pytest.fixture(autouse=True)
@@ -550,9 +731,7 @@ class TestEndpointIdempotency:
         assert second.json() == {
             "error": {
                 "code": "IDEMPOTENCY_CONFLICT",
-                "message": (
-                    "This Idempotency-Key is already associated with a different request."
-                ),
+                "message": ("This Idempotency-Key is already associated with a different request."),
                 "details": {"reason": "request_mismatch"},
             }
         }

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -19,7 +19,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.idempotency import IdempotencyReplay, IdempotencyReservation
+from app.api.idempotency import IdempotencyReservation
 from app.api.v1 import revisions as revisions_module
 from app.api.v1.revisions import revisions_router
 from app.db import session as session_module
@@ -560,24 +560,22 @@ def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatc
             raise AssertionError("Unexpected revision lookup")
         return _build_validation_report()
 
-    async def fake_replay_idempotency(
+    async def fake_replay_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
         fingerprint: str,
-    ) -> IdempotencyReplay | None:
+    ) -> JSONResponse | None:
         _ = db
         record = idempotency_state.get(key)
         if record is None or record["fingerprint"] != fingerprint or not record["completed"]:
             return None
-        return IdempotencyReplay(
-            response=JSONResponse(
-                status_code=record["status_code"],
-                content=record["response_body"],
-            )
+        return JSONResponse(
+            status_code=record["status_code"],
+            content=record["response_body"],
         )
 
-    async def fake_claim_idempotency(
+    async def fake_claim_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
@@ -595,19 +593,21 @@ def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatc
             idempotency_state[key] = record
         return IdempotencyReservation(record_id=uuid4())
 
-    async def fake_mark_idempotency_completed(
+    async def fake_complete_idempotency_response(
         db: AsyncSession,
-        reservation: IdempotencyReservation,
+        reservation: IdempotencyReservation | None,
         *,
         status_code: int,
         response_body: dict[str, Any] | None,
-    ) -> None:
+    ) -> JSONResponse | None:
         _ = (db, reservation)
+        assert reservation is not None
         idempotency_state["quantity-1"].update(
             completed=True,
             status_code=status_code,
             response_body=response_body,
         )
+        return JSONResponse(status_code=status_code, content=response_body)
 
     def fake_prepare_job_enqueue_intent(job: Any) -> None:
         _ = job
@@ -635,12 +635,20 @@ def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatc
         "_get_active_validation_report_or_404",
         fake_get_validation_report,
     )
-    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
-    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
     monkeypatch.setattr(
         revisions_module,
-        "mark_idempotency_completed",
-        fake_mark_idempotency_completed,
+        "replay_idempotency_response",
+        fake_replay_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "claim_idempotency_response",
+        fake_claim_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "complete_idempotency_response",
+        fake_complete_idempotency_response,
     )
     monkeypatch.setattr(
         revisions_module,
@@ -685,6 +693,109 @@ def test_create_revision_quantity_takeoff_replays_idempotent_response(monkeypatc
     assert replay_response.status_code == 202
     assert replay_response.json() == first_body
     assert len(session.added) == 1
+
+
+def test_create_revision_quantity_takeoff_returns_job_without_idempotency_key(
+    monkeypatch: Any,
+) -> None:
+    revision = _build_revision()
+    session = _AsyncSessionStub()
+    app = _build_app(session)
+    client = TestClient(app)
+    manifest = SimpleNamespace(id=uuid4())
+    enqueued_job_ids: list[UUID] = []
+    complete_calls = 0
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_manifest(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace | None:
+        _ = db
+        return manifest if revision_id == revision.id else None
+
+    async def fake_get_validation_report(
+        revision_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id:
+            raise AssertionError("Unexpected revision lookup")
+        return _build_validation_report()
+
+    async def fake_complete_idempotency_response(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> JSONResponse | None:
+        _ = (db, reservation, response_body)
+        nonlocal complete_calls
+        complete_calls += 1
+        return JSONResponse(status_code=status_code, content=None)
+
+    def fake_prepare_job_enqueue_intent(job: Any) -> None:
+        _ = job
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = suppress_exceptions
+        assert publisher is revisions_module.enqueue_quantity_takeoff_job
+        publisher(job_id)
+
+    def fake_enqueue_quantity_takeoff_job(job_id: UUID) -> None:
+        enqueued_job_ids.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(revisions_module, "_get_revision_manifest", fake_get_revision_manifest)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_active_validation_report_or_404",
+        fake_get_validation_report,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "complete_idempotency_response",
+        fake_complete_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "prepare_job_enqueue_intent",
+        fake_prepare_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "enqueue_quantity_takeoff_job",
+        fake_enqueue_quantity_takeoff_job,
+    )
+
+    response = client.post(f"/v1/revisions/{revision.id}/quantity-takeoffs")
+
+    assert response.status_code == 202
+    assert response.json()["job_type"] == "quantity_takeoff"
+    assert response.json()["base_revision_id"] == str(revision.id)
+    assert len(session.added) == 1
+    assert session.commits == 1
+    assert enqueued_job_ids == [UUID(response.json()["id"])]
+    assert complete_calls == 0
 
 
 def test_create_revision_estimate_version_replays_idempotent_response(monkeypatch: Any) -> None:
@@ -757,24 +868,22 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
             ),
         ]
 
-    async def fake_replay_idempotency(
+    async def fake_replay_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
         fingerprint: str,
-    ) -> IdempotencyReplay | None:
+    ) -> JSONResponse | None:
         _ = db
         record = idempotency_state.get(key)
         if record is None or record["fingerprint"] != fingerprint or not record["completed"]:
             return None
-        return IdempotencyReplay(
-            response=JSONResponse(
-                status_code=record["status_code"],
-                content=record["response_body"],
-            )
+        return JSONResponse(
+            status_code=record["status_code"],
+            content=record["response_body"],
         )
 
-    async def fake_claim_idempotency(
+    async def fake_claim_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
@@ -788,19 +897,21 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
             idempotency_state[key] = {"fingerprint": fingerprint, "completed": False}
         return IdempotencyReservation(record_id=uuid4())
 
-    async def fake_mark_idempotency_completed(
+    async def fake_complete_idempotency_response(
         db: AsyncSession,
-        reservation: IdempotencyReservation,
+        reservation: IdempotencyReservation | None,
         *,
         status_code: int,
         response_body: dict[str, Any] | None,
-    ) -> None:
+    ) -> JSONResponse | None:
         _ = (db, reservation)
+        assert reservation is not None
         idempotency_state["estimate-1"].update(
             completed=True,
             status_code=status_code,
             response_body=response_body,
         )
+        return JSONResponse(status_code=status_code, content=response_body)
 
     def fake_prepare_job_enqueue_intent(job: Any) -> None:
         _ = job
@@ -837,12 +948,20 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
         "_resolve_estimate_catalog_refs",
         fake_resolve_estimate_catalog_refs,
     )
-    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
-    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
     monkeypatch.setattr(
         revisions_module,
-        "mark_idempotency_completed",
-        fake_mark_idempotency_completed,
+        "replay_idempotency_response",
+        fake_replay_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "claim_idempotency_response",
+        fake_claim_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "complete_idempotency_response",
+        fake_complete_idempotency_response,
     )
     monkeypatch.setattr(
         revisions_module,
@@ -912,6 +1031,156 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
     assert replay_response.status_code == 202
     assert replay_response.json() == first_body
     assert len(session.added) == 4
+
+
+def test_create_revision_estimate_version_returns_job_without_idempotency_key(
+    monkeypatch: Any,
+) -> None:
+    revision = _build_revision()
+    takeoff = _build_takeoff(revision)
+    quantity_item_id = uuid4()
+    request_body = _build_estimate_request_body(quantity_item_id=quantity_item_id)
+    session = _AsyncSessionStub(refresh_created_at=datetime(2026, 5, 20, 9, 30, tzinfo=UTC))
+    app = _build_app(session)
+    client = TestClient(app)
+    enqueued_job_ids: list[UUID] = []
+    complete_calls = 0
+
+    class _EstimateJobInputRecord:
+        pass
+
+    class _EstimateJobInputCatalogRefRecord:
+        pass
+
+    async def fake_get_active_revision(
+        revision_id: UUID,
+        db: AsyncSession,
+        *,
+        for_update: bool = False,
+    ) -> SimpleNamespace | None:
+        _ = (db, for_update)
+        return revision if revision_id == revision.id else None
+
+    async def fake_get_revision_quantity_takeoff_or_404(
+        revision_id: UUID,
+        takeoff_id: UUID,
+        db: AsyncSession,
+    ) -> SimpleNamespace:
+        _ = db
+        if revision_id != revision.id or takeoff_id != takeoff.id:
+            raise AssertionError("Unexpected takeoff lookup")
+        return takeoff
+
+    async def fake_resolve_estimate_catalog_refs(
+        revision_value: Any,
+        takeoff_value: Any,
+        request_refs: Any,
+        pricing_effective_date: date,
+        db: AsyncSession,
+    ) -> list[Any]:
+        _ = (revision_value, takeoff_value, pricing_effective_date, db)
+        return [
+            revisions_module._NormalizedEstimateCatalogRef(
+                ref_type=request_refs[0].ref_type,
+                selection_id=request_refs[0].selection_id,
+                selection_key=request_refs[0].selection_key,
+                selection_checksum_sha256=request_refs[0].selection_checksum_sha256,
+                description=request_refs[0].description,
+                line_key=request_refs[0].line_key,
+                quantity_item_id=request_refs[0].quantity_item_id,
+                formula_inputs=request_refs[0].formula_inputs,
+            ),
+            revisions_module._NormalizedEstimateCatalogRef(
+                ref_type=request_refs[1].ref_type,
+                selection_id=request_refs[1].selection_id,
+                selection_key=request_refs[1].selection_key,
+                selection_checksum_sha256=request_refs[1].selection_checksum_sha256,
+                description=request_refs[1].description,
+                line_key=request_refs[1].line_key,
+                quantity_item_id=request_refs[1].quantity_item_id,
+                formula_inputs=request_refs[1].formula_inputs,
+            ),
+        ]
+
+    async def fake_complete_idempotency_response(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> JSONResponse | None:
+        _ = (db, reservation, response_body)
+        nonlocal complete_calls
+        complete_calls += 1
+        return JSONResponse(status_code=status_code, content=None)
+
+    def fake_prepare_job_enqueue_intent(job: Any) -> None:
+        _ = job
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: Any = None,
+        suppress_exceptions: bool = False,
+    ) -> None:
+        _ = suppress_exceptions
+        assert publisher is revisions_module.enqueue_estimate_job
+        publisher(job_id)
+
+    def fake_enqueue_estimate_job(job_id: UUID) -> None:
+        enqueued_job_ids.append(job_id)
+
+    monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
+    monkeypatch.setattr(
+        revisions_module,
+        "_get_revision_quantity_takeoff_or_404",
+        fake_get_revision_quantity_takeoff_or_404,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_catalog_refs",
+        fake_resolve_estimate_catalog_refs,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "complete_idempotency_response",
+        fake_complete_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "prepare_job_enqueue_intent",
+        fake_prepare_job_enqueue_intent,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
+    monkeypatch.setattr(revisions_module, "enqueue_estimate_job", fake_enqueue_estimate_job)
+    monkeypatch.setattr(
+        revisions_module,
+        "_resolve_estimate_job_model_classes",
+        lambda: (_EstimateJobInputRecord, _EstimateJobInputCatalogRefRecord),
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "_build_mapped_instance",
+        lambda _model_class, values: type("StubRecord", (), values.copy())(),
+    )
+
+    response = client.post(
+        f"/v1/revisions/{revision.id}/quantity-takeoffs/{takeoff.id}/estimate-versions",
+        json=request_body,
+    )
+
+    assert response.status_code == 202
+    assert response.json()["job_type"] == "estimate"
+    assert response.json()["base_revision_id"] == str(revision.id)
+    assert response.json()["parent_job_id"] == str(takeoff.source_job_id)
+    assert len(session.added) == 4
+    assert session.commits == 1
+    assert enqueued_job_ids == [UUID(response.json()["id"])]
+    assert complete_calls == 0
 
 
 def test_create_revision_estimate_version_rejects_idempotency_reuse_with_different_payload(
@@ -985,41 +1254,37 @@ def test_create_revision_estimate_version_rejects_idempotency_reuse_with_differe
             ),
         ]
 
-    async def fake_replay_idempotency(
+    async def fake_replay_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
         fingerprint: str,
-    ) -> IdempotencyReplay | None:
+    ) -> JSONResponse | None:
         _ = db
         record = idempotency_state.get(key)
         if record is None:
             return None
         if record["fingerprint"] != fingerprint:
-            return IdempotencyReplay(
-                response=JSONResponse(
-                    status_code=409,
-                    content={
-                        "detail": {
-                            "error": {
-                                "code": "IDEMPOTENCY_CONFLICT",
-                                "message": "Idempotency-Key already used with different payload.",
-                                "details": None,
-                            }
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "detail": {
+                        "error": {
+                            "code": "IDEMPOTENCY_CONFLICT",
+                            "message": "Idempotency-Key already used with different payload.",
+                            "details": None,
                         }
-                    },
-                )
+                    }
+                },
             )
         if not record["completed"]:
             return None
-        return IdempotencyReplay(
-            response=JSONResponse(
-                status_code=record["status_code"],
-                content=record["response_body"],
-            )
+        return JSONResponse(
+            status_code=record["status_code"],
+            content=record["response_body"],
         )
 
-    async def fake_claim_idempotency(
+    async def fake_claim_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
@@ -1033,19 +1298,21 @@ def test_create_revision_estimate_version_rejects_idempotency_reuse_with_differe
             idempotency_state[key] = {"fingerprint": fingerprint, "completed": False}
         return IdempotencyReservation(record_id=uuid4())
 
-    async def fake_mark_idempotency_completed(
+    async def fake_complete_idempotency_response(
         db: AsyncSession,
-        reservation: IdempotencyReservation,
+        reservation: IdempotencyReservation | None,
         *,
         status_code: int,
         response_body: dict[str, Any] | None,
-    ) -> None:
+    ) -> JSONResponse | None:
         _ = (db, reservation)
+        assert reservation is not None
         idempotency_state["estimate-1"].update(
             completed=True,
             status_code=status_code,
             response_body=response_body,
         )
+        return JSONResponse(status_code=status_code, content=response_body)
 
     def fake_prepare_job_enqueue_intent(job: Any) -> None:
         _ = job
@@ -1074,12 +1341,20 @@ def test_create_revision_estimate_version_rejects_idempotency_reuse_with_differe
         "_resolve_estimate_catalog_refs",
         fake_resolve_estimate_catalog_refs,
     )
-    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
-    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
     monkeypatch.setattr(
         revisions_module,
-        "mark_idempotency_completed",
-        fake_mark_idempotency_completed,
+        "replay_idempotency_response",
+        fake_replay_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "claim_idempotency_response",
+        fake_claim_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "complete_idempotency_response",
+        fake_complete_idempotency_response,
     )
     monkeypatch.setattr(
         revisions_module,
@@ -1362,7 +1637,7 @@ def test_create_revision_estimate_version_rejects_catalog_validation_before_idem
         )
         raise AssertionError("unreachable")
 
-    async def fake_claim_idempotency(
+    async def fake_claim_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
@@ -1375,25 +1650,26 @@ def test_create_revision_estimate_version_rejects_catalog_validation_before_idem
         idempotency_claimed = True
         return IdempotencyReservation(record_id=uuid4())
 
-    async def fake_replay_idempotency(
+    async def fake_replay_idempotency_response(
         db: AsyncSession,
         *,
         key: str,
         fingerprint: str,
-    ) -> IdempotencyReplay | None:
+    ) -> JSONResponse | None:
         _ = (db, key, fingerprint)
         return None
 
-    async def fake_mark_idempotency_completed(
+    async def fake_complete_idempotency_response(
         db: AsyncSession,
-        reservation: IdempotencyReservation,
+        reservation: IdempotencyReservation | None,
         *,
         status_code: int,
         response_body: dict[str, Any] | None,
-    ) -> None:
+    ) -> JSONResponse | None:
         _ = (db, reservation, status_code, response_body)
         nonlocal idempotency_completed
         idempotency_completed = True
+        return JSONResponse(status_code=status_code, content=response_body)
 
     async def fake_publish_job_enqueue_intent(
         job_id: UUID,
@@ -1415,12 +1691,20 @@ def test_create_revision_estimate_version_rejects_catalog_validation_before_idem
         "_resolve_estimate_catalog_refs",
         fake_resolve_estimate_catalog_refs,
     )
-    monkeypatch.setattr(revisions_module, "replay_idempotency", fake_replay_idempotency)
-    monkeypatch.setattr(revisions_module, "claim_idempotency", fake_claim_idempotency)
     monkeypatch.setattr(
         revisions_module,
-        "mark_idempotency_completed",
-        fake_mark_idempotency_completed,
+        "replay_idempotency_response",
+        fake_replay_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "claim_idempotency_response",
+        fake_claim_idempotency_response,
+    )
+    monkeypatch.setattr(
+        revisions_module,
+        "complete_idempotency_response",
+        fake_complete_idempotency_response,
     )
     monkeypatch.setattr(
         revisions_module,


### PR DESCRIPTION
Closes #231

## Summary
- add shared response helpers for mutating-route idempotency in `app/api/idempotency.py`
- refactor project, job, file, estimation, and revision routes to use the shared helpers while preserving local validation and commit/publish ordering
- extend regression coverage for replay/conflict behavior plus finalized storage-failure and catalog-conflict snapshots

## Test plan
- [x] uv run ruff check app/api/idempotency.py app/api/v1/estimation.py app/api/v1/files.py app/api/v1/jobs.py app/api/v1/projects.py app/api/v1/revisions.py tests/test_estimation_catalog_api.py tests/test_files.py tests/test_idempotency.py tests/test_quantity_takeoff_api.py
- [x] uv run mypy app/api/idempotency.py app/api/v1/estimation.py app/api/v1/files.py app/api/v1/jobs.py app/api/v1/projects.py app/api/v1/revisions.py tests/test_estimation_catalog_api.py tests/test_files.py tests/test_idempotency.py tests/test_quantity_takeoff_api.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir uv run pytest tests/test_idempotency.py tests/test_projects.py tests/test_jobs.py tests/test_files.py tests/test_estimation_catalog_api.py tests/test_quantity_takeoff_api.py