### PR TITLE
refactor(api): split revision router and extract lineage helpers

### DIFF
--- a/app/api/v1/revision_compat.py
+++ b/app/api/v1/revision_compat.py
@@ -1,0 +1,158 @@
+"""Runtime compatibility wrappers for revision route collaborators.
+
+Split revision route modules should call these wrappers instead of importing
+``app.api.v1.revisions`` at module import time. Each wrapper resolves the
+facade symbol at request time so tests and callers that monkeypatch the legacy
+``app.api.v1.revisions`` names continue to affect route execution.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from importlib import import_module
+from typing import Any, cast
+
+
+def _resolve(name: str) -> Any:
+    """Resolve a symbol from the revision facade at call time."""
+
+    return getattr(import_module("app.api.v1.revisions"), name)
+
+
+def _resolve_callable(name: str) -> Callable[..., Any]:
+    """Resolve a callable from the revision facade at call time."""
+
+    return cast(Callable[..., Any], _resolve(name))
+
+
+async def _get_active_file(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_active_file")(*args, **kwargs)
+
+
+async def _get_active_revision(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_active_revision")(*args, **kwargs)
+
+
+async def _get_active_validation_report(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_active_validation_report")(*args, **kwargs)
+
+
+async def _get_active_validation_report_or_404(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_active_validation_report_or_404")(*args, **kwargs)
+
+
+async def _get_revision_manifest(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_revision_manifest")(*args, **kwargs)
+
+
+async def _get_active_revision_manifest_or_409(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_active_revision_manifest_or_409")(*args, **kwargs)
+
+
+async def _get_revision_quantity_takeoff_or_404(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_revision_quantity_takeoff_or_404")(*args, **kwargs)
+
+
+async def _get_revision_estimate_version_or_404(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_get_revision_estimate_version_or_404")(*args, **kwargs)
+
+
+def _raise_entities_not_materialized(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_raise_entities_not_materialized")(*args, **kwargs)
+
+
+def _manifest_counts(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_manifest_counts")(*args, **kwargs)
+
+
+def _raise_quantity_takeoff_gate_invalid(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_raise_quantity_takeoff_gate_invalid")(*args, **kwargs)
+
+
+def _raise_estimate_input_invalid(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_raise_estimate_input_invalid")(*args, **kwargs)
+
+
+def _raise_estimate_takeoff_gate_invalid(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_raise_estimate_takeoff_gate_invalid")(*args, **kwargs)
+
+
+async def _resolve_estimate_catalog_refs(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("_resolve_estimate_catalog_refs")(*args, **kwargs)
+
+
+def _resolve_estimate_job_model_classes(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_resolve_estimate_job_model_classes")(*args, **kwargs)
+
+
+def _build_mapped_instance(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_build_mapped_instance")(*args, **kwargs)
+
+
+def _build_estimate_job_input_payload(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("_build_estimate_job_input_payload")(*args, **kwargs)
+
+
+def enqueue_quantity_takeoff_job(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("enqueue_quantity_takeoff_job")(*args, **kwargs)
+
+
+def enqueue_estimate_job(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("enqueue_estimate_job")(*args, **kwargs)
+
+
+async def replay_idempotency_response(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("replay_idempotency_response")(*args, **kwargs)
+
+
+async def claim_idempotency_response(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("claim_idempotency_response")(*args, **kwargs)
+
+
+async def complete_idempotency_response(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("complete_idempotency_response")(*args, **kwargs)
+
+
+def prepare_job_enqueue_intent(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("prepare_job_enqueue_intent")(*args, **kwargs)
+
+
+async def publish_job_enqueue_intent(*args: Any, **kwargs: Any) -> Any:
+    return await _resolve_callable("publish_job_enqueue_intent")(*args, **kwargs)
+
+
+def utc_now() -> Any:
+    """Return current UTC time through the monkeypatchable facade clock."""
+
+    facade_datetime = _resolve("datetime")
+    facade_utc = _resolve("UTC")
+    return facade_datetime.now(facade_utc)
+
+
+__all__ = [
+    "_build_estimate_job_input_payload",
+    "_build_mapped_instance",
+    "_get_active_file",
+    "_get_active_revision",
+    "_get_active_revision_manifest_or_409",
+    "_get_active_validation_report",
+    "_get_active_validation_report_or_404",
+    "_get_revision_estimate_version_or_404",
+    "_get_revision_manifest",
+    "_get_revision_quantity_takeoff_or_404",
+    "_manifest_counts",
+    "_raise_entities_not_materialized",
+    "_raise_estimate_input_invalid",
+    "_raise_estimate_takeoff_gate_invalid",
+    "_raise_quantity_takeoff_gate_invalid",
+    "_resolve_estimate_catalog_refs",
+    "_resolve_estimate_job_model_classes",
+    "claim_idempotency_response",
+    "complete_idempotency_response",
+    "enqueue_estimate_job",
+    "enqueue_quantity_takeoff_job",
+    "prepare_job_enqueue_intent",
+    "publish_job_enqueue_intent",
+    "replay_idempotency_response",
+    "utc_now",
+]

--- a/app/api/v1/revision_cursors.py
+++ b/app/api/v1/revision_cursors.py
@@ -1,0 +1,124 @@
+"""Revision cursor helpers."""
+
+import base64
+import binascii
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ValidationError
+
+from app.api.pagination import decode_cursor_payload, encode_cursor_payload, raise_invalid_cursor
+
+
+class _DrawingRevisionCursor(BaseModel):
+    """Opaque cursor payload for drawing revision pagination."""
+
+    revision_sequence: int
+    created_at: datetime
+    id: UUID
+
+
+class _GeneratedArtifactCursor(BaseModel):
+    """Opaque cursor payload for generated artifact pagination."""
+
+    created_at: datetime
+    id: UUID
+
+
+def _encode_cursor(payload: BaseModel) -> str:
+    """Encode a pagination cursor payload as an opaque token."""
+
+    return (
+        base64.urlsafe_b64encode(payload.model_dump_json().encode("utf-8"))
+        .decode("utf-8")
+        .rstrip("=")
+    )
+
+
+def _decode_revision_cursor(cursor: str) -> _DrawingRevisionCursor:
+    """Decode and validate an opaque drawing revision cursor."""
+
+    try:
+        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
+        return _DrawingRevisionCursor.model_validate_json(decoded)
+    except (ValueError, ValidationError, binascii.Error) as exc:
+        raise_invalid_cursor(exc)
+
+
+def _decode_artifact_cursor(cursor: str) -> _GeneratedArtifactCursor:
+    """Decode and validate an opaque generated artifact cursor."""
+
+    try:
+        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
+        return _GeneratedArtifactCursor.model_validate_json(decoded)
+    except (ValueError, ValidationError, binascii.Error) as exc:
+        raise_invalid_cursor(exc)
+
+
+def _encode_materialization_cursor(sequence_index: int, row_id: UUID) -> str:
+    """Encode a materialization cursor from sequence index and row identifier."""
+
+    return encode_cursor_payload(
+        {
+            "sequence_index": sequence_index,
+            "id": str(row_id),
+        }
+    )
+
+
+def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
+    """Encode an opaque timestamp/id pagination cursor."""
+
+    return encode_cursor_payload({"created_at": created_at.isoformat(), "id": str(row_id)})
+
+
+def _encode_estimate_item_cursor(line_number: int, row_id: UUID) -> str:
+    """Encode an opaque line-number/id pagination cursor."""
+
+    return encode_cursor_payload({"line_number": line_number, "id": str(row_id)})
+
+
+def _encode_estimate_snapshot_entry_cursor(sort_order: int, row_id: UUID) -> str:
+    """Encode an opaque sort-order/id pagination cursor."""
+
+    return encode_cursor_payload({"sort_order": sort_order, "id": str(row_id)})
+
+
+def _decode_timestamp_cursor(cursor: str) -> tuple[datetime, UUID]:
+    """Decode a timestamp/id pagination cursor."""
+
+    try:
+        cursor_data = decode_cursor_payload(cursor)
+        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def _decode_estimate_item_cursor(cursor: str) -> tuple[int, UUID]:
+    """Decode a line-number/id pagination cursor."""
+
+    try:
+        cursor_data = decode_cursor_payload(cursor)
+        return int(cursor_data["line_number"]), UUID(str(cursor_data["id"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def _decode_estimate_snapshot_entry_cursor(cursor: str) -> tuple[int, UUID]:
+    """Decode a sort-order/id pagination cursor."""
+
+    try:
+        cursor_data = decode_cursor_payload(cursor)
+        return int(cursor_data["sort_order"]), UUID(str(cursor_data["id"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def _decode_materialization_cursor(cursor: str) -> tuple[int, UUID]:
+    """Decode a materialization cursor into typed values."""
+
+    try:
+        cursor_data = decode_cursor_payload(cursor)
+        return int(cursor_data["sequence_index"]), UUID(str(cursor_data["id"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)

--- a/app/api/v1/revision_estimate_inputs.py
+++ b/app/api/v1/revision_estimate_inputs.py
@@ -1,0 +1,564 @@
+"""Estimate input helpers extracted from revisions router."""
+
+import importlib
+import pkgutil
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from math import isfinite
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response
+from app.models.drawing_revision import DrawingRevision
+from app.models.job import Job, JobType
+from app.models.quantity_takeoff import (
+    QuantityGate,
+    QuantityItem,
+    QuantityItemKind,
+    QuantityTakeoff,
+)
+from app.schemas.estimate import EstimateVersionCreateCatalogRef, EstimateVersionCreateRequest
+
+_APP_MODEL_MODULES_LOADED = False
+
+
+@dataclass(slots=True)
+class _NormalizedEstimateCatalogRef:
+    ref_type: str
+    selection_id: UUID
+    selection_key: str
+    selection_checksum_sha256: str
+    description: str
+    line_key: str
+    quantity_item_id: UUID | None
+    formula_inputs: dict[str, Any] | None
+
+
+def _raise_estimate_input_invalid(
+    message: str,
+    *,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Raise the standard estimate input validation error."""
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INPUT_INVALID,
+            message=message,
+            details=details,
+        ),
+    )
+
+
+def _raise_estimate_takeoff_gate_invalid(
+    takeoff: QuantityTakeoff,
+    *,
+    raise_estimate_input_invalid: Callable[..., None] = _raise_estimate_input_invalid,
+) -> None:
+    """Raise the standard pre-enqueue error for non-runnable estimate inputs."""
+
+    raise_estimate_input_invalid(
+        "Estimate jobs require a trusted quantity takeoff with an allowed quantity gate.",
+        details={
+            "quantity_gate": takeoff.quantity_gate,
+            "trusted_totals": takeoff.trusted_totals,
+            "review_state": takeoff.review_state,
+            "validation_status": takeoff.validation_status,
+        },
+    )
+
+
+def _normalize_estimate_request_body(payload: EstimateVersionCreateRequest) -> dict[str, Any]:
+    """Return the normalized create-request body used for idempotency fingerprints."""
+
+    return payload.model_dump(mode="json", by_alias=False, exclude_none=False)
+
+
+def _mapped_attribute_keys(model_class: type[Any]) -> set[str]:
+    """Return mapped SQLAlchemy attribute keys for a model class."""
+
+    return {attribute.key for attribute in model_class.__mapper__.attrs}
+
+
+def _build_mapped_instance(
+    model_class: type[Any],
+    values: dict[str, Any],
+    *,
+    mapped_attribute_keys: Callable[[type[Any]], set[str]] = _mapped_attribute_keys,
+) -> Any:
+    """Instantiate a mapped object while ignoring unknown compatibility fields."""
+
+    instance = model_class()
+    valid_keys = mapped_attribute_keys(model_class)
+    for key, value in values.items():
+        if key in valid_keys:
+            setattr(instance, key, value)
+    return instance
+
+
+def _first_present_attribute(instance: Any, names: tuple[str, ...]) -> Any:
+    """Return the first present attribute value from a candidate name list."""
+
+    for name in names:
+        if hasattr(instance, name):
+            return getattr(instance, name)
+    return None
+
+
+def _load_app_model_modules() -> None:
+    """Import app model modules so mapped classes are registered."""
+
+    import app.models as models_package
+
+    global _APP_MODEL_MODULES_LOADED
+
+    if not _APP_MODEL_MODULES_LOADED:
+        for module_info in pkgutil.iter_modules(models_package.__path__):
+            importlib.import_module(f"{models_package.__name__}.{module_info.name}")
+        _APP_MODEL_MODULES_LOADED = True
+
+
+def _resolve_estimate_job_model_classes(
+    *,
+    load_app_model_modules: Callable[[], None] = _load_app_model_modules,
+) -> tuple[type[Any], type[Any]]:
+    """Resolve mapped model classes used to persist estimate job inputs."""
+
+    load_app_model_modules()
+    class_map = {mapper.class_.__name__: mapper.class_ for mapper in Job.registry.mappers}
+    input_model = class_map.get("EstimateJobInput")
+    ref_model = class_map.get("EstimateJobInputCatalogRef")
+    if input_model is None or ref_model is None:
+        raise RuntimeError("Estimate job input models are unavailable")
+    return input_model, ref_model
+
+
+def _resolve_catalog_model(
+    ref_type: str,
+    *,
+    load_app_model_modules: Callable[[], None] = _load_app_model_modules,
+) -> type[Any]:
+    """Resolve the mapped catalog/formula model for a request ref type."""
+
+    load_app_model_modules()
+    candidates: dict[str, list[type[Any]]] = {"rate": [], "material": [], "formula": []}
+    for mapper in Job.registry.mappers:
+        model_class = mapper.class_
+        name = model_class.__name__.lower()
+        table_name = getattr(model_class, "__tablename__", "").lower()
+        if "estimatejobinput" in name or "quantity" in name:
+            continue
+        if "supersession" in name or "supersession" in table_name:
+            continue
+        if (
+            "catalog" in name
+            or "catalog" in table_name
+            or "formula" in name
+            or "formula" in table_name
+        ):
+            if "rate" in name or "rate" in table_name:
+                candidates["rate"].append(model_class)
+            if "material" in name or "material" in table_name:
+                candidates["material"].append(model_class)
+            if "formula" in name or "formula" in table_name:
+                candidates["formula"].append(model_class)
+
+    matches = candidates.get(ref_type, [])
+    if not matches:
+        raise RuntimeError(f"Catalog model for ref type '{ref_type}' is unavailable")
+
+    def _model_score(model_class: type[Any]) -> tuple[int, int]:
+        name = model_class.__name__.lower()
+        table_name = getattr(model_class, "__tablename__", "").lower()
+        return (
+            int("catalog" in name or "catalog" in table_name),
+            int(ref_type in name or ref_type in table_name),
+        )
+
+    return sorted(matches, key=_model_score, reverse=True)[0]
+
+
+def _resolve_catalog_supersession_model(
+    ref_type: str,
+    *,
+    load_app_model_modules: Callable[[], None] = _load_app_model_modules,
+) -> type[Any]:
+    """Resolve the mapped supersession model for a request ref type."""
+
+    load_app_model_modules()
+    for mapper in Job.registry.mappers:
+        model_class = mapper.class_
+        name = model_class.__name__.lower()
+        table_name = getattr(model_class, "__tablename__", "").lower()
+        if "supersession" not in name and "supersession" not in table_name:
+            continue
+        if ref_type == "rate" and "rate" in name:
+            return model_class
+        if ref_type == "material" and "material" in name:
+            return model_class
+        if ref_type == "formula" and "formula" in name:
+            return model_class
+    raise RuntimeError(f"Catalog supersession model for ref type '{ref_type}' is unavailable")
+
+
+async def _catalog_selection_is_superseded(
+    ref_type: str,
+    selection_id: UUID,
+    db: AsyncSession,
+    *,
+    resolve_catalog_supersession_model: Callable[
+        [str], type[Any]
+    ] = _resolve_catalog_supersession_model,
+) -> bool:
+    """Return whether a catalog selection has been superseded."""
+
+    supersession_model = resolve_catalog_supersession_model(ref_type)
+    predecessor_field_name = {
+        "rate": "predecessor_rate_id",
+        "material": "predecessor_material_id",
+        "formula": "predecessor_formula_id",
+    }[ref_type]
+    result = await db.execute(
+        select(supersession_model).where(
+            getattr(supersession_model, predecessor_field_name) == selection_id
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+def _resolve_estimate_pricing_contract(
+    request: EstimateVersionCreateRequest,
+    *,
+    job_created_at: datetime | None = None,
+) -> tuple[str, date]:
+    """Resolve the persisted pricing contract for an estimate request."""
+
+    if request.pricing.effective_date is not None:
+        return "explicit", request.pricing.effective_date
+    resolved_at = job_created_at or datetime.now(UTC)
+    return "derived_from_job_created_at_utc", resolved_at.date()
+
+
+def _quantity_item_is_executable(quantity_item: QuantityItem) -> bool:
+    """Return whether a quantity item can back a rate/material estimate ref."""
+
+    if quantity_item.item_kind not in {
+        QuantityItemKind.CONTRIBUTOR.value,
+        QuantityItemKind.AGGREGATE.value,
+    }:
+        return False
+
+    value = quantity_item.value
+    return value is not None and isfinite(value)
+
+
+async def _get_estimate_catalog_selection(
+    ref_type: str,
+    selection_id: UUID,
+    db: AsyncSession,
+    *,
+    resolve_catalog_model: Callable[[str], type[Any]] = _resolve_catalog_model,
+) -> Any | None:
+    """Return the selected catalog/formula row for a request ref."""
+
+    model_class = resolve_catalog_model(ref_type)
+    result = await db.execute(select(model_class).where(model_class.id == selection_id))
+    return result.scalar_one_or_none()
+
+
+async def _resolve_estimate_catalog_refs(
+    revision: DrawingRevision,
+    takeoff: QuantityTakeoff,
+    request_refs: list[EstimateVersionCreateCatalogRef],
+    pricing_effective_date: date,
+    db: AsyncSession,
+    *,
+    raise_estimate_input_invalid: Callable[..., None] = _raise_estimate_input_invalid,
+    get_estimate_catalog_selection: Callable[
+        [str, UUID, AsyncSession], Awaitable[Any | None]
+    ] = _get_estimate_catalog_selection,
+    catalog_selection_is_superseded: Callable[
+        [str, UUID, AsyncSession], Awaitable[bool]
+    ] = _catalog_selection_is_superseded,
+    first_present_attribute: Callable[[Any, tuple[str, ...]], Any] = _first_present_attribute,
+    quantity_item_is_executable: Callable[[QuantityItem], bool] = _quantity_item_is_executable,
+) -> list[_NormalizedEstimateCatalogRef]:
+    """Validate request refs and normalize worker mapping inputs."""
+
+    if not request_refs:
+        raise_estimate_input_invalid(
+            "Estimate jobs require at least one catalog or formula reference.",
+            details={"catalog_refs": []},
+        )
+
+    normalized_refs: list[_NormalizedEstimateCatalogRef] = []
+    seen_line_keys: set[str] = set()
+    for request_ref in request_refs:
+        if request_ref.ref_type not in {"rate", "material", "formula"}:
+            raise_estimate_input_invalid(
+                "Estimate refs must use supported ref types.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        selection = await get_estimate_catalog_selection(
+            request_ref.ref_type,
+            request_ref.selection_id,
+            db,
+        )
+        if selection is None:
+            raise_estimate_input_invalid(
+                "Estimate refs must point to visible catalog selections.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        selection_project_id = getattr(selection, "project_id", None)
+        if selection_project_id not in {None, revision.project_id}:
+            raise_estimate_input_invalid(
+                "Estimate refs must belong to the same project lineage as the revision.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        if await catalog_selection_is_superseded(
+            request_ref.ref_type, request_ref.selection_id, db
+        ):
+            raise_estimate_input_invalid(
+                "Estimate refs must point to current catalog selections.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        if getattr(selection, "deleted_at", None) is not None:
+            raise_estimate_input_invalid(
+                "Estimate refs must point to visible catalog selections.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        selection_key = first_present_attribute(
+            selection,
+            (
+                "selection_key",
+                "entry_key",
+                "key",
+                "formula_key",
+                "formula_id",
+                "rate_key",
+                "material_key",
+            ),
+        )
+        if selection_key is not None and str(selection_key) != request_ref.selection_key:
+            raise_estimate_input_invalid(
+                "Estimate refs must use the current catalog selection key.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "selection_key": request_ref.selection_key,
+                },
+            )
+
+        selection_checksum = first_present_attribute(
+            selection,
+            ("checksum_sha256", "source_checksum_sha256"),
+        )
+        if (
+            selection_checksum is not None
+            and str(selection_checksum) != request_ref.selection_checksum_sha256
+        ):
+            raise_estimate_input_invalid(
+                "Estimate refs must use the current catalog selection checksum.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "selection_checksum_sha256": request_ref.selection_checksum_sha256,
+                },
+            )
+
+        selection_currency = first_present_attribute(selection, ("currency",))
+        if selection_currency is not None and str(selection_currency).upper() != "GBP":
+            raise_estimate_input_invalid(
+                "Estimate jobs only support GBP pricing inputs.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "currency": str(selection_currency),
+                },
+            )
+
+        effective_from = first_present_attribute(selection, ("effective_from",))
+        effective_to = first_present_attribute(selection, ("effective_to",))
+        if effective_from is not None and (
+            pricing_effective_date < effective_from
+            or (effective_to is not None and pricing_effective_date >= effective_to)
+        ):
+            raise_estimate_input_invalid(
+                "Estimate refs must be effective for the resolved pricing date.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                    "pricing_effective_date": pricing_effective_date.isoformat(),
+                },
+            )
+
+        if request_ref.ref_type in {"rate", "material"}:
+            if request_ref.quantity_item_id is None:
+                raise_estimate_input_invalid(
+                    "Rate and material refs require a quantity item.",
+                    details={
+                        "ref_type": request_ref.ref_type,
+                        "selection_id": str(request_ref.selection_id),
+                    },
+                )
+
+            quantity_item_result = await db.execute(
+                select(QuantityItem).where(
+                    (QuantityItem.id == request_ref.quantity_item_id)
+                    & (QuantityItem.quantity_takeoff_id == takeoff.id)
+                    & (QuantityItem.project_id == revision.project_id)
+                    & (QuantityItem.drawing_revision_id == revision.id)
+                    & (QuantityItem.quantity_gate == QuantityGate.ALLOWED.value)
+                )
+            )
+            quantity_item = quantity_item_result.scalar_one_or_none()
+            if quantity_item is None or not quantity_item_is_executable(quantity_item):
+                raise_estimate_input_invalid(
+                    "Rate and material refs must target quantity items on the requested takeoff.",
+                    details={
+                        "ref_type": request_ref.ref_type,
+                        "selection_id": str(request_ref.selection_id),
+                        "quantity_item_id": str(request_ref.quantity_item_id),
+                    },
+                )
+
+        if request_ref.ref_type == "formula" and request_ref.formula_inputs is None:
+            raise_estimate_input_invalid(
+                "Formula refs require formula_inputs.",
+                details={
+                    "ref_type": request_ref.ref_type,
+                    "selection_id": str(request_ref.selection_id),
+                },
+            )
+
+        line_key = request_ref.line_key or f"{request_ref.ref_type}:{request_ref.selection_key}"
+        if line_key in seen_line_keys:
+            raise_estimate_input_invalid(
+                "Estimate refs must use unique line keys.",
+                details={"line_key": line_key},
+            )
+        seen_line_keys.add(line_key)
+
+        normalized_refs.append(
+            _NormalizedEstimateCatalogRef(
+                ref_type=request_ref.ref_type,
+                selection_id=request_ref.selection_id,
+                selection_key=request_ref.selection_key,
+                selection_checksum_sha256=request_ref.selection_checksum_sha256,
+                description=request_ref.description,
+                line_key=line_key,
+                quantity_item_id=request_ref.quantity_item_id,
+                formula_inputs=request_ref.formula_inputs,
+            )
+        )
+
+    return normalized_refs
+
+
+def _build_estimate_job_input_payload(
+    estimate_job: Job,
+    revision: DrawingRevision,
+    takeoff: QuantityTakeoff,
+    request: EstimateVersionCreateRequest,
+    normalized_refs: list[_NormalizedEstimateCatalogRef],
+    *,
+    pricing_mode: str,
+    pricing_effective_date: date,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build persistence payloads for estimate job input rows."""
+
+    input_payload = {
+        "estimate_job_id": estimate_job.id,
+        "project_id": revision.project_id,
+        "source_file_id": revision.source_file_id,
+        "drawing_revision_id": revision.id,
+        "quantity_takeoff_id": takeoff.id,
+        "source_job_type": JobType.ESTIMATE.value,
+        "currency": request.pricing.currency,
+        "quantity_gate": takeoff.quantity_gate,
+        "trusted_totals": takeoff.trusted_totals,
+        "pricing_mode": pricing_mode,
+        "pricing_effective_date": pricing_effective_date,
+        "assumptions_json": request.assumptions,
+    }
+
+    ref_payloads: list[dict[str, Any]] = []
+    for ref_order, ref in enumerate(normalized_refs, start=1):
+        selection_context_json = {
+            "worker_mapping_version": "estimate-line-v1",
+            "line_number": ref_order,
+            "line_key": ref.line_key,
+            "line_type": ref.ref_type,
+            "ref_type": ref.ref_type,
+            "description": ref.description,
+            "catalog_entry_key": f"{ref.ref_type}:{ref.selection_key}",
+            "formula_inputs": ref.formula_inputs,
+        }
+        if ref.quantity_item_id is not None:
+            selection_context_json["quantity_item_id"] = str(ref.quantity_item_id)
+
+        ref_payloads.append(
+            {
+                "estimate_job_id": estimate_job.id,
+                "ref_order": ref_order,
+                "ref_type": ref.ref_type,
+                "selection_key": ref.selection_key,
+                "catalog_checksum_sha256": ref.selection_checksum_sha256,
+                "selection_context_json": selection_context_json,
+                "rate_catalog_entry_id": ref.selection_id if ref.ref_type == "rate" else None,
+                "material_catalog_entry_id": (
+                    ref.selection_id if ref.ref_type == "material" else None
+                ),
+                "formula_definition_id": ref.selection_id if ref.ref_type == "formula" else None,
+            }
+        )
+
+    return input_payload, ref_payloads
+
+
+__all__ = [
+    "_NormalizedEstimateCatalogRef",
+    "_build_estimate_job_input_payload",
+    "_build_mapped_instance",
+    "_catalog_selection_is_superseded",
+    "_first_present_attribute",
+    "_get_estimate_catalog_selection",
+    "_load_app_model_modules",
+    "_mapped_attribute_keys",
+    "_normalize_estimate_request_body",
+    "_quantity_item_is_executable",
+    "_raise_estimate_input_invalid",
+    "_raise_estimate_takeoff_gate_invalid",
+    "_resolve_catalog_model",
+    "_resolve_catalog_supersession_model",
+    "_resolve_estimate_catalog_refs",
+    "_resolve_estimate_job_model_classes",
+    "_resolve_estimate_pricing_contract",
+]

--- a/app/api/v1/revision_lineage.py
+++ b/app/api/v1/revision_lineage.py
@@ -1,0 +1,233 @@
+"""Revision lineage helpers."""
+
+from collections.abc import Awaitable, Callable
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response, raise_not_found
+from app.models.drawing_revision import DrawingRevision
+from app.models.estimate_version import EstimateVersion
+from app.models.file import File
+from app.models.project import Project
+from app.models.quantity_takeoff import QuantityTakeoff
+from app.models.revision_materialization import RevisionEntityManifest
+from app.models.validation_report import ValidationReport
+from app.schemas.revision import RevisionMaterializationCounts
+
+
+def _raise_entities_not_materialized(revision_id: UUID) -> None:
+    """Raise the standard conflict when revision entities are not materialized."""
+
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=create_error_response(
+            code=ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED,
+            message=(
+                f"Normalized entities for drawing revision '{revision_id}' "
+                "have not been materialized"
+            ),
+            details=None,
+        ),
+    )
+
+
+async def _get_active_file(file_id: UUID, db: AsyncSession) -> File | None:
+    """Return an active file visible through a non-deleted project."""
+
+    result = await db.execute(
+        select(File)
+        .join(Project, Project.id == File.project_id)
+        .where((File.id == file_id) & (File.deleted_at.is_(None)) & (Project.deleted_at.is_(None)))
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_active_revision(
+    revision_id: UUID,
+    db: AsyncSession,
+    *,
+    for_update: bool = False,
+) -> DrawingRevision | None:
+    """Return an active revision visible through a non-deleted file and project."""
+
+    query = (
+        select(DrawingRevision)
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (DrawingRevision.id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if for_update:
+        query = query.with_for_update(
+            of=(DrawingRevision.__table__, File.__table__, Project.__table__)
+        )
+
+    result = await db.execute(query)
+    return result.scalar_one_or_none()
+
+
+async def _get_active_validation_report(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> ValidationReport | None:
+    """Return the persisted validation report for an active revision, if present."""
+
+    result = await db.execute(
+        select(ValidationReport)
+        .join(
+            DrawingRevision,
+            DrawingRevision.id == ValidationReport.drawing_revision_id,
+        )
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (ValidationReport.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_active_validation_report_or_404(
+    revision_id: UUID,
+    db: AsyncSession,
+    *,
+    get_active_validation_report: Callable[
+        [UUID, AsyncSession], Awaitable[ValidationReport | None]
+    ] = _get_active_validation_report,
+    get_active_revision: Callable[..., Awaitable[DrawingRevision | None]] = _get_active_revision,
+) -> ValidationReport:
+    """Return an active revision validation report or raise not found."""
+
+    report = await get_active_validation_report(revision_id, db)
+    if report is None:
+        revision = await get_active_revision(revision_id, db)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+        raise_not_found("Validation report", str(revision_id))
+
+    assert report is not None
+    return report
+
+
+async def _get_revision_manifest(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> RevisionEntityManifest | None:
+    """Return the persisted materialization manifest for a revision, if present."""
+
+    result = await db.execute(
+        select(RevisionEntityManifest).where(
+            RevisionEntityManifest.drawing_revision_id == revision_id
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_active_revision_manifest_or_409(
+    revision_id: UUID,
+    db: AsyncSession,
+    *,
+    get_active_revision: Callable[..., Awaitable[DrawingRevision | None]] = _get_active_revision,
+    get_revision_manifest: Callable[
+        [UUID, AsyncSession], Awaitable[RevisionEntityManifest | None]
+    ] = _get_revision_manifest,
+    raise_entities_not_materialized: Callable[[UUID], None] = _raise_entities_not_materialized,
+) -> RevisionEntityManifest:
+    """Return an active revision manifest or raise the standard missing errors."""
+
+    revision = await get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
+
+    manifest = await get_revision_manifest(revision_id, db)
+    if manifest is None:
+        raise_entities_not_materialized(revision_id)
+
+    assert manifest is not None
+    return manifest
+
+
+def _manifest_counts(
+    manifest: RevisionEntityManifest,
+) -> RevisionMaterializationCounts:
+    """Convert persisted manifest counts to the public schema."""
+
+    return RevisionMaterializationCounts.model_validate(manifest.counts_json)
+
+
+async def _get_revision_quantity_takeoff_or_404(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: AsyncSession,
+) -> QuantityTakeoff:
+    """Return a committed quantity takeoff scoped to an active revision."""
+
+    result = await db.execute(
+        select(QuantityTakeoff)
+        .join(
+            File,
+            (File.id == QuantityTakeoff.source_file_id)
+            & (File.project_id == QuantityTakeoff.project_id),
+        )
+        .join(Project, Project.id == QuantityTakeoff.project_id)
+        .where(
+            (QuantityTakeoff.id == takeoff_id)
+            & (QuantityTakeoff.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    takeoff = result.scalar_one_or_none()
+    if takeoff is None:
+        raise_not_found("Quantity takeoff", str(takeoff_id))
+
+    assert takeoff is not None
+    return takeoff
+
+
+async def _get_revision_estimate_version_or_404(
+    revision_id: UUID,
+    estimate_version_id: UUID,
+    db: AsyncSession,
+) -> EstimateVersion:
+    """Return a committed estimate version scoped to an active revision."""
+
+    result = await db.execute(
+        select(EstimateVersion)
+        .join(
+            File,
+            (File.id == EstimateVersion.source_file_id)
+            & (File.project_id == EstimateVersion.project_id),
+        )
+        .join(Project, Project.id == EstimateVersion.project_id)
+        .where(
+            (EstimateVersion.id == estimate_version_id)
+            & (EstimateVersion.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    estimate_version = result.scalar_one_or_none()
+    if estimate_version is None:
+        raise_not_found("Estimate version", str(estimate_version_id))
+
+    assert estimate_version is not None
+    return estimate_version

--- a/app/api/v1/revision_routes/__init__.py
+++ b/app/api/v1/revision_routes/__init__.py
@@ -1,0 +1,13 @@
+"""Revision child-route modules."""
+
+from app.api.v1.revision_routes.estimates import estimates_router
+from app.api.v1.revision_routes.quantity_takeoffs import (
+    quantity_takeoff_create_router,
+    quantity_takeoffs_router,
+)
+
+__all__ = [
+    "estimates_router",
+    "quantity_takeoff_create_router",
+    "quantity_takeoffs_router",
+]

--- a/app/api/v1/revision_routes/adapter_outputs.py
+++ b/app/api/v1/revision_routes/adapter_outputs.py
@@ -1,0 +1,85 @@
+"""Revision adapter-output read routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.revision_compat import _get_active_revision
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.drawing_revision import DrawingRevision
+from app.models.file import File
+from app.models.project import Project
+from app.schemas.revision import AdapterRunOutputRead
+
+adapter_outputs_router = APIRouter()
+
+
+@adapter_outputs_router.get(
+    "/revisions/{revision_id}/adapter-output",
+    response_model=AdapterRunOutputRead,
+)
+async def get_revision_adapter_output(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> AdapterRunOutputRead:
+    """Return adapter output metadata for an active drawing revision."""
+
+    result = await db.execute(
+        select(AdapterRunOutput)
+        .join(DrawingRevision, DrawingRevision.adapter_run_output_id == AdapterRunOutput.id)
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (DrawingRevision.id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    adapter_output = result.scalar_one_or_none()
+    if adapter_output is None:
+        revision = await _get_active_revision(revision_id, db)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+        raise_not_found("Adapter run output", str(revision_id))
+
+    return AdapterRunOutputRead.model_validate(adapter_output)
+
+
+@adapter_outputs_router.get(
+    "/adapter-outputs/{adapter_output_id}",
+    response_model=AdapterRunOutputRead,
+)
+async def get_adapter_output(
+    adapter_output_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> AdapterRunOutputRead:
+    """Return adapter output metadata by identifier."""
+
+    result = await db.execute(
+        select(AdapterRunOutput)
+        .join(
+            File,
+            (File.id == AdapterRunOutput.source_file_id)
+            & (File.project_id == AdapterRunOutput.project_id),
+        )
+        .join(Project, Project.id == AdapterRunOutput.project_id)
+        .where(
+            (AdapterRunOutput.id == adapter_output_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    adapter_output = result.scalar_one_or_none()
+    if adapter_output is None:
+        raise_not_found("Adapter run output", str(adapter_output_id))
+
+    return AdapterRunOutputRead.model_validate(adapter_output)

--- a/app/api/v1/revision_routes/estimates.py
+++ b/app/api/v1/revision_routes/estimates.py
@@ -1,0 +1,929 @@
+"""Revision estimate routes."""
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, date, datetime
+from typing import Annotated, Any, cast
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, Query, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.idempotency import (
+    IdempotencyReservation,
+    get_idempotency_key,
+)
+from app.api.idempotency import (
+    build_idempotency_fingerprint as _build_idempotency_fingerprint_direct,
+)
+from app.api.idempotency import (
+    claim_idempotency_response as _claim_idempotency_response_direct,
+)
+from app.api.idempotency import (
+    complete_idempotency_response as _complete_idempotency_response_direct,
+)
+from app.api.idempotency import (
+    replay_idempotency_response as _replay_idempotency_response_direct,
+)
+from app.api.v1.revision_cursors import (
+    _decode_estimate_item_cursor,
+    _decode_estimate_snapshot_entry_cursor,
+    _decode_timestamp_cursor,
+    _encode_estimate_item_cursor,
+    _encode_estimate_snapshot_entry_cursor,
+    _encode_timestamp_cursor,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _build_estimate_job_input_payload as _build_estimate_job_input_payload_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _build_mapped_instance as _build_mapped_instance_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _catalog_selection_is_superseded as _catalog_selection_is_superseded_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _first_present_attribute as _first_present_attribute_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _get_estimate_catalog_selection as _get_estimate_catalog_selection_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _load_app_model_modules as _load_app_model_modules_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _mapped_attribute_keys as _mapped_attribute_keys_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _normalize_estimate_request_body as _normalize_estimate_request_body_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _NormalizedEstimateCatalogRef as _NormalizedEstimateCatalogRefDirect,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _quantity_item_is_executable as _quantity_item_is_executable_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _raise_estimate_input_invalid as _raise_estimate_input_invalid_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _raise_estimate_takeoff_gate_invalid as _raise_estimate_takeoff_gate_invalid_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_catalog_model as _resolve_catalog_model_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_catalog_supersession_model as _resolve_catalog_supersession_model_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_estimate_catalog_refs as _resolve_estimate_catalog_refs_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_estimate_job_model_classes as _resolve_estimate_job_model_classes_direct,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_estimate_pricing_contract as _resolve_estimate_pricing_contract_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_revision as _get_active_revision_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_revision_estimate_version_or_404 as _get_revision_estimate_version_or_404_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_revision_quantity_takeoff_or_404 as _get_revision_quantity_takeoff_or_404_direct,
+)
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.jobs import worker as jobs_worker_module
+from app.jobs.worker import (
+    prepare_job_enqueue_intent as _prepare_job_enqueue_intent_direct,
+)
+from app.jobs.worker import (
+    publish_job_enqueue_intent as _publish_job_enqueue_intent_direct,
+)
+from app.models.drawing_revision import DrawingRevision
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
+from app.models.file import File
+from app.models.job import Job, JobType
+from app.models.project import Project
+from app.models.quantity_takeoff import QuantityGate, QuantityItem, QuantityTakeoff
+from app.schemas.estimate import (
+    EstimateItemListResponse,
+    EstimateItemRead,
+    EstimateSnapshotEntryListResponse,
+    EstimateSnapshotEntryRead,
+    EstimateVersionCreateCatalogRef,
+    EstimateVersionCreateRequest,
+    EstimateVersionListResponse,
+    EstimateVersionRead,
+)
+from app.schemas.job import JobRead
+
+estimates_router = APIRouter()
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+_MISSING = object()
+
+type _NormalizedEstimateCatalogRef = _NormalizedEstimateCatalogRefDirect
+
+type _ActiveRevisionGetter = Callable[..., Awaitable[DrawingRevision | None]]
+type _RevisionTakeoffGetter = Callable[[UUID, UUID, AsyncSession], Awaitable[QuantityTakeoff]]
+type _EstimateVersionGetter = Callable[[UUID, UUID, AsyncSession], Awaitable[EstimateVersion]]
+type _FingerprintBuilder = Callable[..., str]
+type _ReplayIdempotencyResponse = Callable[..., Awaitable[Response | None]]
+type _CompleteIdempotencyResponse = Callable[..., Awaitable[Response]]
+type _Clock = Callable[[], datetime]
+type _EstimateRequestNormalizer = Callable[[EstimateVersionCreateRequest], dict[str, Any]]
+type _EstimateJobModelResolver = Callable[[], tuple[type[Any], type[Any]]]
+type _EstimatePricingContractResolver = Callable[..., tuple[str, date]]
+type _EstimateCatalogRefResolver = Callable[
+    [DrawingRevision, QuantityTakeoff, list[EstimateVersionCreateCatalogRef], date, AsyncSession],
+    Awaitable[list[_NormalizedEstimateCatalogRef]],
+]
+type _EstimateJobInputPayloadBuilder = Callable[..., tuple[dict[str, Any], list[dict[str, Any]]]]
+
+
+def _compat_attr(*names: str, default: Any = _MISSING) -> Any:
+    """Return the first matching revision_compat attribute."""
+
+    from app.api.v1 import revision_compat
+
+    for name in names:
+        if hasattr(revision_compat, name):
+            return getattr(revision_compat, name)
+    if default is not _MISSING:
+        return default
+    joined = ", ".join(names)
+    raise AttributeError(f"revision_compat is missing expected helper: {joined}")
+
+
+async def _get_active_revision(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for active revision lookup."""
+
+    helper = cast(
+        _ActiveRevisionGetter,
+        _compat_attr(
+            "_get_active_revision",
+            "get_active_revision",
+            default=_get_active_revision_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+async def _get_revision_quantity_takeoff_or_404(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: AsyncSession,
+) -> QuantityTakeoff:
+    """Compatibility wrapper for revision quantity takeoff lookup."""
+
+    helper = cast(
+        _RevisionTakeoffGetter,
+        _compat_attr(
+            "_get_revision_quantity_takeoff_or_404",
+            "get_revision_quantity_takeoff_or_404",
+            default=_get_revision_quantity_takeoff_or_404_direct,
+        ),
+    )
+    return await helper(revision_id, takeoff_id, db)
+
+
+async def _get_revision_estimate_version_or_404(
+    revision_id: UUID,
+    estimate_version_id: UUID,
+    db: AsyncSession,
+) -> EstimateVersion:
+    """Compatibility wrapper for revision estimate lookup."""
+
+    helper = cast(
+        _EstimateVersionGetter,
+        _compat_attr(
+            "_get_revision_estimate_version_or_404",
+            "get_revision_estimate_version_or_404",
+            default=_get_revision_estimate_version_or_404_direct,
+        ),
+    )
+    return await helper(revision_id, estimate_version_id, db)
+
+
+def _build_idempotency_fingerprint(*args: Any, **kwargs: Any) -> str:
+    """Compatibility wrapper for fingerprint construction."""
+
+    helper = cast(
+        _FingerprintBuilder,
+        _compat_attr(
+            "build_idempotency_fingerprint",
+            default=_build_idempotency_fingerprint_direct,
+        ),
+    )
+    return helper(*args, **kwargs)
+
+
+async def _replay_idempotency_response(*args: Any, **kwargs: Any) -> Response | None:
+    """Compatibility wrapper for idempotency replay."""
+
+    helper = cast(
+        _ReplayIdempotencyResponse,
+        _compat_attr(
+            "replay_idempotency_response",
+            default=_replay_idempotency_response_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+async def _claim_idempotency_response(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for idempotency claim."""
+
+    helper = _compat_attr(
+        "claim_idempotency_response",
+        default=_claim_idempotency_response_direct,
+    )
+    return await helper(*args, **kwargs)
+
+
+async def _complete_idempotency_response(*args: Any, **kwargs: Any) -> Response:
+    """Compatibility wrapper for idempotency completion."""
+
+    helper = cast(
+        _CompleteIdempotencyResponse,
+        _compat_attr(
+            "complete_idempotency_response",
+            default=_complete_idempotency_response_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+def _prepare_job_enqueue_intent(job: Job) -> None:
+    """Compatibility wrapper for enqueue intent staging."""
+
+    helper = _compat_attr(
+        "prepare_job_enqueue_intent",
+        default=_prepare_job_enqueue_intent_direct,
+    )
+    helper(job)
+
+
+async def _publish_job_enqueue_intent(*args: Any, **kwargs: Any) -> None:
+    """Compatibility wrapper for enqueue publication."""
+
+    helper = _compat_attr(
+        "publish_job_enqueue_intent",
+        default=_publish_job_enqueue_intent_direct,
+    )
+    await helper(*args, **kwargs)
+
+
+def enqueue_estimate_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+
+    publisher = _compat_attr(
+        "enqueue_estimate_job",
+        default=jobs_worker_module.enqueue_estimate_job,
+    )
+    publisher(job_id)
+
+
+def _revisions_module() -> Any:
+    """Return the revisions module for compatibility-sensitive callbacks."""
+
+    from app.api.v1 import revisions
+
+    return revisions
+
+
+def _utc_now() -> datetime:
+    """Compatibility wrapper for the facade clock."""
+
+    helper = cast(
+        _Clock,
+        _compat_attr(
+            "utc_now",
+            default=lambda: datetime.now(UTC),
+        ),
+    )
+    return helper()
+
+
+def _raise_estimate_input_invalid(
+    message: str,
+    *,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Raise the standard estimate input validation error."""
+
+    helper = _compat_attr(
+        "_raise_estimate_input_invalid",
+        "raise_estimate_input_invalid",
+        default=_raise_estimate_input_invalid_direct,
+    )
+    helper(message, details=details)
+
+
+def _raise_estimate_takeoff_gate_invalid(takeoff: QuantityTakeoff) -> None:
+    """Raise the standard pre-enqueue error for non-runnable estimate inputs."""
+
+    helper = _compat_attr(
+        "_raise_estimate_takeoff_gate_invalid",
+        "raise_estimate_takeoff_gate_invalid",
+        default=None,
+    )
+    if helper is not None:
+        helper(takeoff)
+        return
+
+    _raise_estimate_takeoff_gate_invalid_direct(
+        takeoff,
+        raise_estimate_input_invalid=_raise_estimate_input_invalid,
+    )
+
+
+def _normalize_estimate_request_body(payload: EstimateVersionCreateRequest) -> dict[str, Any]:
+    """Return the normalized create-request body used for idempotency fingerprints."""
+
+    helper = cast(
+        _EstimateRequestNormalizer,
+        _compat_attr(
+            "_normalize_estimate_request_body",
+            "normalize_estimate_request_body",
+            default=_normalize_estimate_request_body_direct,
+        ),
+    )
+    return helper(payload)
+
+
+def _mapped_attribute_keys(model_class: type[Any]) -> set[str]:
+    """Return mapped SQLAlchemy attribute keys for a model class."""
+
+    return _mapped_attribute_keys_direct(model_class)
+
+
+def _build_mapped_instance(model_class: type[Any], values: dict[str, Any]) -> Any:
+    """Instantiate a mapped object while ignoring unknown compatibility fields."""
+
+    helper = _compat_attr(
+        "_build_mapped_instance",
+        "build_mapped_instance",
+        default=None,
+    )
+    if helper is not None:
+        return helper(model_class, values)
+
+    return _build_mapped_instance_direct(
+        model_class,
+        values,
+        mapped_attribute_keys=_mapped_attribute_keys,
+    )
+
+
+def _first_present_attribute(instance: Any, names: tuple[str, ...]) -> Any:
+    """Return the first present attribute value from a candidate name list."""
+
+    return _first_present_attribute_direct(instance, names)
+
+
+def _load_app_model_modules() -> None:
+    """Import app model modules so mapped classes are registered."""
+
+    _load_app_model_modules_direct()
+
+
+def _resolve_estimate_job_model_classes() -> tuple[type[Any], type[Any]]:
+    """Resolve mapped model classes used to persist estimate job inputs."""
+
+    helper = cast(
+        _EstimateJobModelResolver | None,
+        _compat_attr(
+            "_resolve_estimate_job_model_classes",
+            "resolve_estimate_job_model_classes",
+            default=None,
+        ),
+    )
+    if helper is not None:
+        return helper()
+
+    return _resolve_estimate_job_model_classes_direct(
+        load_app_model_modules=_load_app_model_modules,
+    )
+
+
+def _resolve_catalog_model(ref_type: str) -> type[Any]:
+    """Resolve the mapped catalog/formula model for a request ref type."""
+
+    return _resolve_catalog_model_direct(
+        ref_type,
+        load_app_model_modules=_load_app_model_modules,
+    )
+
+
+def _resolve_catalog_supersession_model(ref_type: str) -> type[Any]:
+    """Resolve the mapped supersession model for a request ref type."""
+
+    return _resolve_catalog_supersession_model_direct(
+        ref_type,
+        load_app_model_modules=_load_app_model_modules,
+    )
+
+
+async def _catalog_selection_is_superseded(
+    ref_type: str,
+    selection_id: UUID,
+    db: AsyncSession,
+) -> bool:
+    """Return whether a catalog selection has been superseded."""
+
+    return await _catalog_selection_is_superseded_direct(
+        ref_type,
+        selection_id,
+        db,
+        resolve_catalog_supersession_model=_resolve_catalog_supersession_model,
+    )
+
+
+def _resolve_estimate_pricing_contract(
+    request: EstimateVersionCreateRequest,
+    *,
+    job_created_at: datetime | None = None,
+) -> tuple[str, date]:
+    """Resolve the persisted pricing contract for an estimate request."""
+
+    helper = cast(
+        _EstimatePricingContractResolver | None,
+        _compat_attr(
+            "_resolve_estimate_pricing_contract",
+            "resolve_estimate_pricing_contract",
+            default=None,
+        ),
+    )
+    if helper is not None:
+        return helper(request, job_created_at=job_created_at)
+
+    return _resolve_estimate_pricing_contract_direct(
+        request,
+        job_created_at=job_created_at,
+    )
+
+
+def _quantity_item_is_executable(quantity_item: QuantityItem) -> bool:
+    """Return whether a quantity item can back a rate/material estimate ref."""
+
+    return _quantity_item_is_executable_direct(quantity_item)
+
+
+async def _get_estimate_catalog_selection(
+    ref_type: str,
+    selection_id: UUID,
+    db: AsyncSession,
+) -> Any | None:
+    """Return the selected catalog/formula row for a request ref."""
+
+    return await _get_estimate_catalog_selection_direct(
+        ref_type,
+        selection_id,
+        db,
+        resolve_catalog_model=_resolve_catalog_model,
+    )
+
+
+async def _resolve_estimate_catalog_refs(
+    revision: DrawingRevision,
+    takeoff: QuantityTakeoff,
+    request_refs: list[EstimateVersionCreateCatalogRef],
+    pricing_effective_date: date,
+    db: AsyncSession,
+) -> list[_NormalizedEstimateCatalogRef]:
+    """Validate request refs and normalize worker mapping inputs."""
+
+    helper = cast(
+        _EstimateCatalogRefResolver | None,
+        _compat_attr(
+            "_resolve_estimate_catalog_refs",
+            "resolve_estimate_catalog_refs",
+            default=None,
+        ),
+    )
+    if helper is not None:
+        return await helper(
+            revision,
+            takeoff,
+            request_refs,
+            pricing_effective_date,
+            db,
+        )
+
+    return await _resolve_estimate_catalog_refs_direct(
+        revision,
+        takeoff,
+        request_refs,
+        pricing_effective_date,
+        db,
+        raise_estimate_input_invalid=_raise_estimate_input_invalid,
+        get_estimate_catalog_selection=_get_estimate_catalog_selection,
+        catalog_selection_is_superseded=_catalog_selection_is_superseded,
+        first_present_attribute=_first_present_attribute,
+        quantity_item_is_executable=_quantity_item_is_executable,
+    )
+
+
+def _build_estimate_job_input_payload(
+    estimate_job: Job,
+    revision: DrawingRevision,
+    takeoff: QuantityTakeoff,
+    request: EstimateVersionCreateRequest,
+    normalized_refs: list[_NormalizedEstimateCatalogRef],
+    *,
+    pricing_mode: str,
+    pricing_effective_date: date,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Build persistence payloads for estimate job input rows."""
+
+    helper = cast(
+        _EstimateJobInputPayloadBuilder | None,
+        _compat_attr(
+            "_build_estimate_job_input_payload",
+            "build_estimate_job_input_payload",
+            default=None,
+        ),
+    )
+    if helper is not None:
+        return helper(
+            estimate_job,
+            revision,
+            takeoff,
+            request,
+            normalized_refs,
+            pricing_mode=pricing_mode,
+            pricing_effective_date=pricing_effective_date,
+        )
+
+    return _build_estimate_job_input_payload_direct(
+        estimate_job,
+        revision,
+        takeoff,
+        request,
+        normalized_refs,
+        pricing_mode=pricing_mode,
+        pricing_effective_date=pricing_effective_date,
+    )
+
+
+@estimates_router.get(
+    "/revisions/{revision_id}/estimates",
+    response_model=EstimateVersionListResponse,
+)
+async def list_revision_estimates(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> EstimateVersionListResponse:
+    """List committed estimate versions for an active drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
+    query = (
+        select(EstimateVersion)
+        .join(
+            File,
+            (File.id == EstimateVersion.source_file_id)
+            & (File.project_id == EstimateVersion.project_id),
+        )
+        .join(Project, Project.id == EstimateVersion.project_id)
+        .where(
+            (EstimateVersion.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        created_at, row_id = pagination_cursor
+        query = query.where(
+            (EstimateVersion.created_at > created_at)
+            | ((EstimateVersion.created_at == created_at) & (EstimateVersion.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(EstimateVersion.created_at.asc(), EstimateVersion.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
+
+    return EstimateVersionListResponse(
+        items=[EstimateVersionRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@estimates_router.post(
+    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_revision_estimate_version(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    request: EstimateVersionCreateRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> Job | Response:
+    """Create a pending estimate job for an active revision quantity takeoff."""
+
+    if request.pricing.currency != "GBP":
+        _raise_estimate_input_invalid(
+            "Estimate jobs only support GBP pricing inputs.",
+            details={"currency": request.pricing.currency},
+        )
+
+    normalized_body = _normalize_estimate_request_body(request)
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = _build_idempotency_fingerprint(
+            f"revisions.quantity_takeoffs.estimate_versions:{revision_id}:{takeoff_id}",
+            {
+                "revision_id": str(revision_id),
+                "takeoff_id": str(takeoff_id),
+                "body": normalized_body,
+            },
+        )
+        replay_response = await _replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
+        if replay_response is not None:
+            return replay_response
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
+
+    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
+        _raise_estimate_takeoff_gate_invalid(takeoff)
+
+    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
+    if locked_revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert locked_revision is not None
+    revision = locked_revision
+    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
+        _raise_estimate_takeoff_gate_invalid(takeoff)
+
+    job_created_at = _utc_now()
+    pricing_mode, pricing_effective_date = _resolve_estimate_pricing_contract(
+        request,
+        job_created_at=job_created_at,
+    )
+    normalized_refs = await _resolve_estimate_catalog_refs(
+        revision,
+        takeoff,
+        request.catalog_refs,
+        pricing_effective_date,
+        db,
+    )
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await _claim_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path=f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
+        )
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
+        reservation = claim
+
+    estimate_job = Job(
+        id=uuid4(),
+        project_id=revision.project_id,
+        file_id=revision.source_file_id,
+        extraction_profile_id=None,
+        base_revision_id=revision.id,
+        parent_job_id=(
+            takeoff.source_job_id
+            if takeoff.project_id == revision.project_id
+            and takeoff.source_file_id == revision.source_file_id
+            else None
+        ),
+        job_type=JobType.ESTIMATE.value,
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        enqueue_status="pending",
+        enqueue_attempts=0,
+        cancel_requested=False,
+        error_code=None,
+        error_message=None,
+        started_at=None,
+        finished_at=None,
+        created_at=job_created_at,
+    )
+    db.add(estimate_job)
+    _prepare_job_enqueue_intent(estimate_job)
+    await db.flush()
+    await db.refresh(estimate_job)
+
+    estimate_job_input_model, estimate_job_input_ref_model = _resolve_estimate_job_model_classes()
+    input_payload, ref_payloads = _build_estimate_job_input_payload(
+        estimate_job,
+        revision,
+        takeoff,
+        request,
+        normalized_refs,
+        pricing_mode=pricing_mode,
+        pricing_effective_date=pricing_effective_date,
+    )
+    db.add(_build_mapped_instance(estimate_job_input_model, input_payload))
+    for ref_payload in ref_payloads:
+        db.add(_build_mapped_instance(estimate_job_input_ref_model, ref_payload))
+
+    success_response: Response | None = None
+    if reservation is not None:
+        success_response = await _complete_idempotency_response(
+            db,
+            reservation,
+            status_code=status.HTTP_202_ACCEPTED,
+            response_body=JobRead.model_validate(estimate_job).model_dump(mode="json"),
+        )
+
+    await db.commit()
+    await _publish_job_enqueue_intent(
+        estimate_job.id,
+        publisher=_revisions_module().enqueue_estimate_job,
+        suppress_exceptions=True,
+    )
+
+    if success_response is not None:
+        return success_response
+
+    return estimate_job
+
+
+@estimates_router.get(
+    "/revisions/{revision_id}/estimates/{estimate_version_id}",
+    response_model=EstimateVersionRead,
+)
+async def get_revision_estimate(
+    revision_id: UUID,
+    estimate_version_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> EstimateVersionRead:
+    """Return a committed estimate version for an active drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    estimate_version = await _get_revision_estimate_version_or_404(
+        revision_id, estimate_version_id, db
+    )
+    return EstimateVersionRead.model_validate(estimate_version)
+
+
+@estimates_router.get(
+    "/revisions/{revision_id}/estimates/{estimate_version_id}/items",
+    response_model=EstimateItemListResponse,
+)
+async def list_revision_estimate_items(
+    revision_id: UUID,
+    estimate_version_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> EstimateItemListResponse:
+    """List committed estimate items for a revision-scoped estimate version."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    await _get_revision_estimate_version_or_404(revision_id, estimate_version_id, db)
+    pagination_cursor = _decode_estimate_item_cursor(cursor) if cursor else None
+    query = (
+        select(EstimateItem)
+        .join(
+            EstimateVersion,
+            (EstimateVersion.id == EstimateItem.estimate_version_id)
+            & (EstimateVersion.project_id == EstimateItem.project_id)
+            & (EstimateVersion.drawing_revision_id == EstimateItem.drawing_revision_id),
+        )
+        .join(
+            File,
+            (File.id == EstimateVersion.source_file_id)
+            & (File.project_id == EstimateVersion.project_id),
+        )
+        .join(Project, Project.id == EstimateVersion.project_id)
+        .where(
+            (EstimateItem.estimate_version_id == estimate_version_id)
+            & (EstimateItem.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        line_number, row_id = pagination_cursor
+        query = query.where(
+            (EstimateItem.line_number > line_number)
+            | ((EstimateItem.line_number == line_number) & (EstimateItem.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(EstimateItem.line_number.asc(), EstimateItem.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_estimate_item_cursor(last_row.line_number, last_row.id)
+
+    return EstimateItemListResponse(
+        items=[EstimateItemRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@estimates_router.get(
+    "/revisions/{revision_id}/estimates/{estimate_version_id}/snapshot-entries",
+    response_model=EstimateSnapshotEntryListResponse,
+)
+async def list_revision_estimate_snapshot_entries(
+    revision_id: UUID,
+    estimate_version_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> EstimateSnapshotEntryListResponse:
+    """List committed estimate snapshot entries for a revision-scoped estimate version."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    await _get_revision_estimate_version_or_404(revision_id, estimate_version_id, db)
+    pagination_cursor = _decode_estimate_snapshot_entry_cursor(cursor) if cursor else None
+    query = (
+        select(EstimateSnapshotEntry)
+        .join(
+            EstimateVersion,
+            (EstimateVersion.id == EstimateSnapshotEntry.estimate_version_id)
+            & (EstimateVersion.project_id == EstimateSnapshotEntry.project_id)
+            & (EstimateVersion.drawing_revision_id == EstimateSnapshotEntry.drawing_revision_id),
+        )
+        .join(
+            File,
+            (File.id == EstimateVersion.source_file_id)
+            & (File.project_id == EstimateVersion.project_id),
+        )
+        .join(Project, Project.id == EstimateVersion.project_id)
+        .where(
+            (EstimateSnapshotEntry.estimate_version_id == estimate_version_id)
+            & (EstimateSnapshotEntry.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        sort_order, row_id = pagination_cursor
+        query = query.where(
+            (EstimateSnapshotEntry.sort_order > sort_order)
+            | (
+                (EstimateSnapshotEntry.sort_order == sort_order)
+                & (EstimateSnapshotEntry.id > row_id)
+            )
+        )
+
+    result = await db.execute(
+        query.order_by(
+            EstimateSnapshotEntry.sort_order.asc(), EstimateSnapshotEntry.id.asc()
+        ).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_estimate_snapshot_entry_cursor(last_row.sort_order, last_row.id)
+
+    return EstimateSnapshotEntryListResponse(
+        items=[EstimateSnapshotEntryRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )

--- a/app/api/v1/revision_routes/file_revisions.py
+++ b/app/api/v1/revision_routes/file_revisions.py
@@ -1,0 +1,97 @@
+"""Revision file-read routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.revision_compat import _get_active_file
+from app.api.v1.revision_cursors import (
+    _decode_revision_cursor,
+    _DrawingRevisionCursor,
+    _encode_cursor,
+)
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.drawing_revision import DrawingRevision
+from app.models.file import File
+from app.models.project import Project
+from app.schemas.revision import DrawingRevisionListResponse, DrawingRevisionRead
+
+file_revisions_router = APIRouter()
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+
+
+@file_revisions_router.get("/files/{file_id}/revisions", response_model=DrawingRevisionListResponse)
+async def list_file_revisions(
+    file_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> DrawingRevisionListResponse:
+    """List active drawing revisions for a file."""
+
+    file = await _get_active_file(file_id, db)
+    if file is None:
+        raise_not_found("File", str(file_id))
+
+    pagination_cursor = _decode_revision_cursor(cursor) if cursor else None
+
+    query = (
+        select(DrawingRevision)
+        .join(
+            File,
+            (File.id == DrawingRevision.source_file_id)
+            & (File.project_id == DrawingRevision.project_id),
+        )
+        .join(Project, Project.id == DrawingRevision.project_id)
+        .where(
+            (DrawingRevision.source_file_id == file_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+
+    if pagination_cursor is not None:
+        query = query.where(
+            (DrawingRevision.revision_sequence > pagination_cursor.revision_sequence)
+            | (
+                (DrawingRevision.revision_sequence == pagination_cursor.revision_sequence)
+                & (DrawingRevision.created_at > pagination_cursor.created_at)
+            )
+            | (
+                (DrawingRevision.revision_sequence == pagination_cursor.revision_sequence)
+                & (DrawingRevision.created_at == pagination_cursor.created_at)
+                & (DrawingRevision.id > pagination_cursor.id)
+            )
+        )
+
+    result = await db.execute(
+        query.order_by(
+            DrawingRevision.revision_sequence.asc(),
+            DrawingRevision.created_at.asc(),
+            DrawingRevision.id.asc(),
+        ).limit(limit + 1)
+    )
+    revisions = result.scalars().all()
+    page = revisions[:limit]
+    next_cursor = None
+
+    if len(revisions) > limit and page:
+        last_revision = page[-1]
+        next_cursor = _encode_cursor(
+            _DrawingRevisionCursor(
+                revision_sequence=last_revision.revision_sequence,
+                created_at=last_revision.created_at,
+                id=last_revision.id,
+            )
+        )
+
+    return DrawingRevisionListResponse(
+        items=[DrawingRevisionRead.model_validate(revision) for revision in page],
+        next_cursor=next_cursor,
+    )

--- a/app/api/v1/revision_routes/generated_artifacts.py
+++ b/app/api/v1/revision_routes/generated_artifacts.py
@@ -1,0 +1,160 @@
+"""Revision generated-artifact read routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.revision_compat import _get_active_file, _get_active_revision
+from app.api.v1.revision_cursors import (
+    _decode_artifact_cursor,
+    _encode_cursor,
+    _GeneratedArtifactCursor,
+)
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.file import File
+from app.models.generated_artifact import GeneratedArtifact
+from app.models.project import Project
+from app.schemas.revision import GeneratedArtifactListResponse, GeneratedArtifactRead
+
+generated_artifacts_router = APIRouter()
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+
+
+@generated_artifacts_router.get(
+    "/files/{file_id}/generated-artifacts",
+    response_model=GeneratedArtifactListResponse,
+)
+async def list_file_generated_artifacts(
+    file_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> GeneratedArtifactListResponse:
+    """List active generated artifacts for a file."""
+
+    file = await _get_active_file(file_id, db)
+    if file is None:
+        raise_not_found("File", str(file_id))
+
+    pagination_cursor = _decode_artifact_cursor(cursor) if cursor else None
+
+    query = (
+        select(GeneratedArtifact)
+        .join(
+            File,
+            (File.id == GeneratedArtifact.source_file_id)
+            & (File.project_id == GeneratedArtifact.project_id),
+        )
+        .join(Project, Project.id == GeneratedArtifact.project_id)
+        .where(
+            (GeneratedArtifact.source_file_id == file_id)
+            & (GeneratedArtifact.deleted_at.is_(None))
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+
+    if pagination_cursor is not None:
+        query = query.where(
+            (GeneratedArtifact.created_at > pagination_cursor.created_at)
+            | (
+                (GeneratedArtifact.created_at == pagination_cursor.created_at)
+                & (GeneratedArtifact.id > pagination_cursor.id)
+            )
+        )
+
+    result = await db.execute(
+        query.order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc()).limit(
+            limit + 1
+        )
+    )
+    artifacts = result.scalars().all()
+    page = artifacts[:limit]
+    next_cursor = None
+
+    if len(artifacts) > limit and page:
+        last_artifact = page[-1]
+        next_cursor = _encode_cursor(
+            _GeneratedArtifactCursor(
+                created_at=last_artifact.created_at,
+                id=last_artifact.id,
+            )
+        )
+
+    return GeneratedArtifactListResponse(
+        items=[GeneratedArtifactRead.model_validate(artifact) for artifact in page],
+        next_cursor=next_cursor,
+    )
+
+
+@generated_artifacts_router.get(
+    "/revisions/{revision_id}/generated-artifacts",
+    response_model=GeneratedArtifactListResponse,
+)
+async def list_revision_generated_artifacts(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> GeneratedArtifactListResponse:
+    """List active generated artifacts associated with a drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    pagination_cursor = _decode_artifact_cursor(cursor) if cursor else None
+
+    query = (
+        select(GeneratedArtifact)
+        .join(
+            File,
+            (File.id == GeneratedArtifact.source_file_id)
+            & (File.project_id == GeneratedArtifact.project_id),
+        )
+        .join(Project, Project.id == GeneratedArtifact.project_id)
+        .where(
+            (GeneratedArtifact.drawing_revision_id == revision_id)
+            & (GeneratedArtifact.deleted_at.is_(None))
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+
+    if pagination_cursor is not None:
+        query = query.where(
+            (GeneratedArtifact.created_at > pagination_cursor.created_at)
+            | (
+                (GeneratedArtifact.created_at == pagination_cursor.created_at)
+                & (GeneratedArtifact.id > pagination_cursor.id)
+            )
+        )
+
+    result = await db.execute(
+        query.order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc()).limit(
+            limit + 1
+        )
+    )
+    artifacts = result.scalars().all()
+    page = artifacts[:limit]
+    next_cursor = None
+
+    if len(artifacts) > limit and page:
+        last_artifact = page[-1]
+        next_cursor = _encode_cursor(
+            _GeneratedArtifactCursor(
+                created_at=last_artifact.created_at,
+                id=last_artifact.id,
+            )
+        )
+
+    return GeneratedArtifactListResponse(
+        items=[GeneratedArtifactRead.model_validate(artifact) for artifact in page],
+        next_cursor=next_cursor,
+    )

--- a/app/api/v1/revision_routes/materialization.py
+++ b/app/api/v1/revision_routes/materialization.py
@@ -1,0 +1,269 @@
+"""Revision materialization read routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.revision_compat import (
+    _get_active_revision_manifest_or_409,
+    _manifest_counts,
+)
+from app.api.v1.revision_cursors import (
+    _decode_materialization_cursor,
+    _encode_materialization_cursor,
+)
+from app.core.exceptions import raise_not_found
+from app.db.session import get_db
+from app.models.revision_materialization import (
+    RevisionBlock,
+    RevisionEntity,
+    RevisionLayer,
+    RevisionLayout,
+)
+from app.schemas.revision import (
+    RevisionBlockListResponse,
+    RevisionBlockRead,
+    RevisionEntityListResponse,
+    RevisionEntityManifestRead,
+    RevisionEntityRead,
+    RevisionLayerListResponse,
+    RevisionLayerRead,
+    RevisionLayoutListResponse,
+    RevisionLayoutRead,
+)
+
+materialization_router = APIRouter()
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+
+
+@materialization_router.get(
+    "/revisions/{revision_id}/layouts",
+    response_model=RevisionLayoutListResponse,
+)
+async def list_revision_layouts(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> RevisionLayoutListResponse:
+    """List materialized layout rows for a drawing revision."""
+
+    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
+    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
+
+    query = select(RevisionLayout).where(RevisionLayout.drawing_revision_id == revision_id)
+    if pagination_cursor is not None:
+        sequence_index, row_id = pagination_cursor
+        query = query.where(
+            (RevisionLayout.sequence_index > sequence_index)
+            | ((RevisionLayout.sequence_index == sequence_index) & (RevisionLayout.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(
+            RevisionLayout.sequence_index.asc(),
+            RevisionLayout.id.asc(),
+        ).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
+
+    counts = _manifest_counts(manifest)
+    return RevisionLayoutListResponse(
+        manifest=RevisionEntityManifestRead.model_validate(manifest),
+        counts=counts,
+        items=[RevisionLayoutRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@materialization_router.get(
+    "/revisions/{revision_id}/layers",
+    response_model=RevisionLayerListResponse,
+)
+async def list_revision_layers(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> RevisionLayerListResponse:
+    """List materialized layer rows for a drawing revision."""
+
+    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
+    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
+
+    query = select(RevisionLayer).where(RevisionLayer.drawing_revision_id == revision_id)
+    if pagination_cursor is not None:
+        sequence_index, row_id = pagination_cursor
+        query = query.where(
+            (RevisionLayer.sequence_index > sequence_index)
+            | ((RevisionLayer.sequence_index == sequence_index) & (RevisionLayer.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(RevisionLayer.sequence_index.asc(), RevisionLayer.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
+
+    counts = _manifest_counts(manifest)
+    return RevisionLayerListResponse(
+        manifest=RevisionEntityManifestRead.model_validate(manifest),
+        counts=counts,
+        items=[RevisionLayerRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@materialization_router.get(
+    "/revisions/{revision_id}/blocks",
+    response_model=RevisionBlockListResponse,
+)
+async def list_revision_blocks(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> RevisionBlockListResponse:
+    """List materialized block rows for a drawing revision."""
+
+    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
+    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
+
+    query = select(RevisionBlock).where(RevisionBlock.drawing_revision_id == revision_id)
+    if pagination_cursor is not None:
+        sequence_index, row_id = pagination_cursor
+        query = query.where(
+            (RevisionBlock.sequence_index > sequence_index)
+            | ((RevisionBlock.sequence_index == sequence_index) & (RevisionBlock.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(RevisionBlock.sequence_index.asc(), RevisionBlock.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
+
+    counts = _manifest_counts(manifest)
+    return RevisionBlockListResponse(
+        manifest=RevisionEntityManifestRead.model_validate(manifest),
+        counts=counts,
+        items=[RevisionBlockRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@materialization_router.get(
+    "/revisions/{revision_id}/entities",
+    response_model=RevisionEntityListResponse,
+)
+async def list_revision_entities(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+    entity_id: str | None = Query(default=None),
+    entity_type: str | None = Query(default=None),
+    layout_ref: str | None = Query(default=None),
+    layer_ref: str | None = Query(default=None),
+    block_ref: str | None = Query(default=None),
+    parent_entity_ref: str | None = Query(default=None),
+    source_identity: str | None = Query(default=None),
+    source_hash: str | None = Query(default=None),
+) -> RevisionEntityListResponse:
+    """List materialized entity rows for a drawing revision."""
+
+    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
+    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
+
+    query = select(RevisionEntity).where(RevisionEntity.drawing_revision_id == revision_id)
+    if entity_id is not None:
+        query = query.where(RevisionEntity.entity_id == entity_id)
+    if entity_type is not None:
+        query = query.where(RevisionEntity.entity_type == entity_type)
+    if layout_ref is not None:
+        query = query.where(RevisionEntity.layout_ref == layout_ref)
+    if layer_ref is not None:
+        query = query.where(RevisionEntity.layer_ref == layer_ref)
+    if block_ref is not None:
+        query = query.where(RevisionEntity.block_ref == block_ref)
+    if parent_entity_ref is not None:
+        query = query.where(RevisionEntity.parent_entity_ref == parent_entity_ref)
+    if source_identity is not None:
+        query = query.where(RevisionEntity.source_identity == source_identity)
+    if source_hash is not None:
+        query = query.where(RevisionEntity.source_hash == source_hash)
+    if pagination_cursor is not None:
+        sequence_index, row_id = pagination_cursor
+        query = query.where(
+            (RevisionEntity.sequence_index > sequence_index)
+            | ((RevisionEntity.sequence_index == sequence_index) & (RevisionEntity.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(
+            RevisionEntity.sequence_index.asc(),
+            RevisionEntity.id.asc(),
+        ).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
+
+    counts = _manifest_counts(manifest)
+    return RevisionEntityListResponse(
+        manifest=RevisionEntityManifestRead.model_validate(manifest),
+        counts=counts,
+        items=[RevisionEntityRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@materialization_router.get(
+    "/revisions/{revision_id}/entities/{entity_id:path}",
+    response_model=RevisionEntityRead,
+)
+async def get_revision_entity(
+    revision_id: UUID,
+    entity_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> RevisionEntityRead:
+    """Return a materialized entity row for a drawing revision by entity identifier."""
+
+    await _get_active_revision_manifest_or_409(revision_id, db)
+
+    result = await db.execute(
+        select(RevisionEntity).where(
+            (RevisionEntity.drawing_revision_id == revision_id)
+            & (RevisionEntity.entity_id == entity_id)
+        )
+    )
+    entity = result.scalar_one_or_none()
+    if entity is None:
+        raise_not_found("Revision entity", entity_id)
+
+    return RevisionEntityRead.model_validate(entity)

--- a/app/api/v1/revision_routes/quantity_takeoffs.py
+++ b/app/api/v1/revision_routes/quantity_takeoffs.py
@@ -1,0 +1,543 @@
+"""Revision quantity takeoff routes."""
+
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Any, cast
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.idempotency import (
+    IdempotencyReservation,
+    get_idempotency_key,
+)
+from app.api.idempotency import (
+    build_idempotency_fingerprint as _build_idempotency_fingerprint_direct,
+)
+from app.api.idempotency import (
+    claim_idempotency_response as _claim_idempotency_response_direct,
+)
+from app.api.idempotency import (
+    complete_idempotency_response as _complete_idempotency_response_direct,
+)
+from app.api.idempotency import (
+    replay_idempotency_response as _replay_idempotency_response_direct,
+)
+from app.api.v1.revision_cursors import _decode_timestamp_cursor, _encode_timestamp_cursor
+from app.api.v1.revision_lineage import (
+    _get_active_revision as _get_active_revision_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_revision_manifest_or_409 as _lineage_get_active_revision_manifest_or_409_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_validation_report as _get_active_validation_report_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_validation_report_or_404 as _lineage_get_active_validation_report_or_404_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_revision_manifest as _get_revision_manifest_direct,
+)
+from app.api.v1.revision_lineage import (
+    _get_revision_quantity_takeoff_or_404 as _get_revision_quantity_takeoff_or_404_direct,
+)
+from app.api.v1.revision_lineage import (
+    _raise_entities_not_materialized as _raise_entities_not_materialized_direct,
+)
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response, raise_not_found
+from app.db.session import get_db
+from app.jobs.worker import (
+    enqueue_quantity_takeoff_job as _enqueue_quantity_takeoff_job_direct,
+)
+from app.jobs.worker import (
+    prepare_job_enqueue_intent as _prepare_job_enqueue_intent_direct,
+)
+from app.jobs.worker import (
+    publish_job_enqueue_intent as _publish_job_enqueue_intent_direct,
+)
+from app.models.drawing_revision import DrawingRevision
+from app.models.file import File
+from app.models.job import Job, JobType
+from app.models.project import Project
+from app.models.quantity_takeoff import QuantityGate, QuantityItem, QuantityTakeoff
+from app.models.revision_materialization import RevisionEntityManifest
+from app.models.validation_report import ValidationReport
+from app.schemas.job import JobRead
+from app.schemas.quantity_takeoff import (
+    QuantityItemListResponse,
+    QuantityItemRead,
+    QuantityTakeoffListResponse,
+    QuantityTakeoffRead,
+)
+
+quantity_takeoffs_router = APIRouter()
+quantity_takeoff_create_router = APIRouter()
+
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 200
+_MISSING = object()
+
+type _ActiveRevisionGetter = Callable[..., Awaitable[DrawingRevision | None]]
+type _ValidationReportGetter = Callable[[UUID, AsyncSession], Awaitable[ValidationReport]]
+type _RevisionManifestGetter = Callable[[UUID, AsyncSession], Awaitable[RevisionEntityManifest]]
+type _RevisionTakeoffGetter = Callable[[UUID, UUID, AsyncSession], Awaitable[QuantityTakeoff]]
+type _FingerprintBuilder = Callable[..., str]
+type _ReplayIdempotencyResponse = Callable[..., Awaitable[Response | None]]
+type _CompleteIdempotencyResponse = Callable[..., Awaitable[Response]]
+
+
+def _compat_attr(*names: str, default: Any = _MISSING) -> Any:
+    """Return the first matching revision_compat attribute."""
+
+    from app.api.v1 import revision_compat
+
+    for name in names:
+        if hasattr(revision_compat, name):
+            return getattr(revision_compat, name)
+    if default is not _MISSING:
+        return default
+    joined = ", ".join(names)
+    raise AttributeError(f"revision_compat is missing expected helper: {joined}")
+
+
+async def _get_active_revision(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for active revision lookup."""
+
+    helper = cast(
+        _ActiveRevisionGetter,
+        _compat_attr(
+            "_get_active_revision",
+            "get_active_revision",
+            default=_get_active_revision_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+async def _get_active_validation_report_or_404(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> ValidationReport:
+    """Return an active revision validation report or raise not found."""
+
+    helper = cast(
+        _ValidationReportGetter | None,
+        _compat_attr(
+            "_get_active_validation_report_or_404",
+            "get_active_validation_report_or_404",
+            default=None,
+        ),
+    )
+    if helper is not None:
+        return await helper(revision_id, db)
+
+    return await _lineage_get_active_validation_report_or_404_direct(
+        revision_id,
+        db,
+        get_active_validation_report=_get_active_validation_report_direct,
+        get_active_revision=_get_active_revision_direct,
+    )
+
+
+async def _get_active_revision_manifest_or_409(
+    revision_id: UUID,
+    db: AsyncSession,
+) -> RevisionEntityManifest:
+    """Return an active revision manifest or raise the standard missing errors."""
+
+    helper = cast(
+        _RevisionManifestGetter | None,
+        _compat_attr(
+            "_get_active_revision_manifest_or_409",
+            "get_active_revision_manifest_or_409",
+            default=None,
+        ),
+    )
+    if helper is not None:
+        return await helper(revision_id, db)
+
+    return await _lineage_get_active_revision_manifest_or_409_direct(
+        revision_id,
+        db,
+        get_active_revision=_get_active_revision_direct,
+        get_revision_manifest=_get_revision_manifest_direct,
+        raise_entities_not_materialized=_raise_entities_not_materialized_direct,
+    )
+
+
+async def _get_revision_quantity_takeoff_or_404(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: AsyncSession,
+) -> QuantityTakeoff:
+    """Compatibility wrapper for revision quantity takeoff lookup."""
+
+    helper = cast(
+        _RevisionTakeoffGetter,
+        _compat_attr(
+            "_get_revision_quantity_takeoff_or_404",
+            "get_revision_quantity_takeoff_or_404",
+            default=_get_revision_quantity_takeoff_or_404_direct,
+        ),
+    )
+    return await helper(revision_id, takeoff_id, db)
+
+
+def _build_idempotency_fingerprint(*args: Any, **kwargs: Any) -> str:
+    """Compatibility wrapper for fingerprint construction."""
+
+    helper = cast(
+        _FingerprintBuilder,
+        _compat_attr(
+            "build_idempotency_fingerprint",
+            default=_build_idempotency_fingerprint_direct,
+        ),
+    )
+    return helper(*args, **kwargs)
+
+
+async def _replay_idempotency_response(*args: Any, **kwargs: Any) -> Response | None:
+    """Compatibility wrapper for idempotency replay."""
+
+    helper = cast(
+        _ReplayIdempotencyResponse,
+        _compat_attr(
+            "replay_idempotency_response",
+            default=_replay_idempotency_response_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+async def _claim_idempotency_response(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for idempotency claim."""
+
+    helper = _compat_attr(
+        "claim_idempotency_response",
+        default=_claim_idempotency_response_direct,
+    )
+    return await helper(*args, **kwargs)
+
+
+async def _complete_idempotency_response(*args: Any, **kwargs: Any) -> Response:
+    """Compatibility wrapper for idempotency completion."""
+
+    helper = cast(
+        _CompleteIdempotencyResponse,
+        _compat_attr(
+            "complete_idempotency_response",
+            default=_complete_idempotency_response_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+def _prepare_job_enqueue_intent(job: Job) -> None:
+    """Compatibility wrapper for enqueue intent staging."""
+
+    helper = _compat_attr(
+        "prepare_job_enqueue_intent",
+        default=_prepare_job_enqueue_intent_direct,
+    )
+    helper(job)
+
+
+async def _publish_job_enqueue_intent(*args: Any, **kwargs: Any) -> None:
+    """Compatibility wrapper for enqueue publication."""
+
+    helper = _compat_attr(
+        "publish_job_enqueue_intent",
+        default=_publish_job_enqueue_intent_direct,
+    )
+    await helper(*args, **kwargs)
+
+
+def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+
+    publisher = _compat_attr(
+        "enqueue_quantity_takeoff_job",
+        default=_enqueue_quantity_takeoff_job_direct,
+    )
+    publisher(job_id)
+
+
+def _revisions_module() -> Any:
+    """Return the revisions module for compatibility-sensitive callbacks."""
+
+    from app.api.v1 import revisions
+
+    return revisions
+
+
+def _raise_quantity_takeoff_gate_invalid(report: ValidationReport) -> None:
+    """Raise the standard pre-enqueue error for non-runnable quantity gates."""
+
+    helper = _compat_attr(
+        "_raise_quantity_takeoff_gate_invalid",
+        "raise_quantity_takeoff_gate_invalid",
+        default=None,
+    )
+    if helper is not None:
+        helper(report)
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INPUT_INVALID,
+            message=("Quantity takeoff requires a revision with an allowed quantity gate."),
+            details={
+                "quantity_gate": report.quantity_gate,
+                "review_state": report.review_state,
+                "validation_status": report.validation_status,
+            },
+        ),
+    )
+
+
+@quantity_takeoffs_router.get(
+    "/revisions/{revision_id}/quantity-takeoffs",
+    response_model=QuantityTakeoffListResponse,
+)
+async def list_revision_quantity_takeoffs(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> QuantityTakeoffListResponse:
+    """List committed quantity takeoffs for an active drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
+    query = (
+        select(QuantityTakeoff)
+        .join(
+            File,
+            (File.id == QuantityTakeoff.source_file_id)
+            & (File.project_id == QuantityTakeoff.project_id),
+        )
+        .join(Project, Project.id == QuantityTakeoff.project_id)
+        .where(
+            (QuantityTakeoff.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        created_at, row_id = pagination_cursor
+        query = query.where(
+            (QuantityTakeoff.created_at > created_at)
+            | ((QuantityTakeoff.created_at == created_at) & (QuantityTakeoff.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(QuantityTakeoff.created_at.asc(), QuantityTakeoff.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
+
+    return QuantityTakeoffListResponse(
+        items=[QuantityTakeoffRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@quantity_takeoffs_router.get(
+    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}",
+    response_model=QuantityTakeoffRead,
+)
+async def get_revision_quantity_takeoff(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> QuantityTakeoffRead:
+    """Return a committed quantity takeoff for an active drawing revision."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
+
+    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    return QuantityTakeoffRead.model_validate(takeoff)
+
+
+@quantity_takeoffs_router.get(
+    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/items",
+    response_model=QuantityItemListResponse,
+)
+async def list_revision_quantity_takeoff_items(
+    revision_id: UUID,
+    takeoff_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
+    cursor: str | None = Query(default=None),
+) -> QuantityItemListResponse:
+    """List committed quantity items for a revision-scoped takeoff."""
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+
+    await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
+    query = (
+        select(QuantityItem)
+        .join(
+            QuantityTakeoff,
+            (QuantityTakeoff.id == QuantityItem.quantity_takeoff_id)
+            & (QuantityTakeoff.project_id == QuantityItem.project_id)
+            & (QuantityTakeoff.drawing_revision_id == QuantityItem.drawing_revision_id)
+            & (QuantityTakeoff.quantity_gate == QuantityItem.quantity_gate),
+        )
+        .join(
+            File,
+            (File.id == QuantityTakeoff.source_file_id)
+            & (File.project_id == QuantityTakeoff.project_id),
+        )
+        .join(Project, Project.id == QuantityTakeoff.project_id)
+        .where(
+            (QuantityItem.quantity_takeoff_id == takeoff_id)
+            & (QuantityItem.drawing_revision_id == revision_id)
+            & (File.deleted_at.is_(None))
+            & (Project.deleted_at.is_(None))
+        )
+    )
+    if pagination_cursor is not None:
+        created_at, row_id = pagination_cursor
+        query = query.where(
+            (QuantityItem.created_at > created_at)
+            | ((QuantityItem.created_at == created_at) & (QuantityItem.id > row_id))
+        )
+
+    result = await db.execute(
+        query.order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc()).limit(limit + 1)
+    )
+    rows = result.scalars().all()
+    page = rows[:limit]
+    next_cursor = None
+    if len(rows) > limit and page:
+        last_row = page[-1]
+        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
+
+    return QuantityItemListResponse(
+        items=[QuantityItemRead.model_validate(row) for row in page],
+        next_cursor=next_cursor,
+    )
+
+
+@quantity_takeoff_create_router.post(
+    "/revisions/{revision_id}/quantity-takeoffs",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_revision_quantity_takeoff(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> Job | Response:
+    """Create a pending quantity takeoff job for an active drawing revision."""
+
+    reservation: IdempotencyReservation | None = None
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = _build_idempotency_fingerprint(
+            f"revisions.quantity_takeoffs:{revision_id}",
+            {"revision_id": str(revision_id)},
+        )
+        replay_response = await _replay_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+        )
+        if replay_response is not None:
+            return replay_response
+
+    revision = await _get_active_revision(revision_id, db)
+    if revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    assert revision is not None
+    await _get_active_revision_manifest_or_409(revision_id, db)
+    report = await _get_active_validation_report_or_404(revision_id, db)
+    if report.quantity_gate in {
+        QuantityGate.REVIEW_GATED.value,
+        QuantityGate.BLOCKED.value,
+    }:
+        _raise_quantity_takeoff_gate_invalid(report)
+
+    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
+    if locked_revision is None:
+        raise_not_found("Drawing revision", str(revision_id))
+    revision = locked_revision
+    assert revision is not None
+
+    if idempotency_key is not None:
+        assert fingerprint is not None
+        claim = await _claim_idempotency_response(
+            db,
+            key=idempotency_key,
+            fingerprint=fingerprint,
+            method="POST",
+            path=f"/revisions/{revision_id}/quantity-takeoffs",
+        )
+        if isinstance(claim, Response):
+            return claim
+        assert claim is not None
+        reservation = claim
+
+    quantity_job = Job(
+        id=uuid4(),
+        project_id=revision.project_id,
+        file_id=revision.source_file_id,
+        extraction_profile_id=None,
+        base_revision_id=revision.id,
+        parent_job_id=None,
+        job_type=JobType.QUANTITY_TAKEOFF.value,
+        status="pending",
+        attempts=0,
+        max_attempts=3,
+        enqueue_status="pending",
+        enqueue_attempts=0,
+        cancel_requested=False,
+        error_code=None,
+        error_message=None,
+        started_at=None,
+        finished_at=None,
+    )
+    db.add(quantity_job)
+    _prepare_job_enqueue_intent(quantity_job)
+    await db.flush()
+    await db.refresh(quantity_job)
+
+    success_response: Response | None = None
+    if reservation is not None:
+        success_response = await _complete_idempotency_response(
+            db,
+            reservation,
+            status_code=status.HTTP_202_ACCEPTED,
+            response_body=JobRead.model_validate(quantity_job).model_dump(mode="json"),
+        )
+
+    await db.commit()
+    await _publish_job_enqueue_intent(
+        quantity_job.id,
+        publisher=_revisions_module().enqueue_quantity_takeoff_job,
+        suppress_exceptions=True,
+    )
+
+    if success_response is not None:
+        return success_response
+
+    return quantity_job

--- a/app/api/v1/revision_routes/validation_reports.py
+++ b/app/api/v1/revision_routes/validation_reports.py
@@ -1,0 +1,30 @@
+"""Revision validation-report read routes."""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.revision_compat import _get_active_validation_report_or_404
+from app.db.session import get_db
+from app.schemas.validation_report import (
+    ValidationReportResponse,
+    build_validation_report_response,
+)
+
+validation_reports_router = APIRouter()
+
+
+@validation_reports_router.get(
+    "/revisions/{revision_id}/validation-report",
+    response_model=ValidationReportResponse,
+)
+async def get_validation_report(
+    revision_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ValidationReportResponse:
+    """Return the persisted canonical validation report for a drawing revision."""
+
+    report = await _get_active_validation_report_or_404(revision_id, db)
+    return build_validation_report_response(report)

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -1,173 +1,160 @@
 """Revision API routes."""
 
-import base64
-import binascii
-import importlib
-import pkgutil
-from dataclasses import dataclass
-from datetime import UTC, date, datetime
-from math import isfinite
-from typing import Annotated, Any
-from uuid import UUID, uuid4
+from datetime import UTC as _UTC
+from datetime import date, datetime
+from typing import Any
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import Response
-from pydantic import BaseModel, ValidationError
-from sqlalchemy import select
+from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReservation,
-    build_idempotency_fingerprint,
-    claim_idempotency_response,
-    complete_idempotency_response,
-    get_idempotency_key,
-    replay_idempotency_response,
+    claim_idempotency_response as _claim_idempotency_response,
 )
-from app.api.pagination import (
-    decode_cursor_payload,
-    encode_cursor_payload,
-    raise_invalid_cursor,
+from app.api.idempotency import (
+    complete_idempotency_response as _complete_idempotency_response,
+)
+from app.api.idempotency import (
+    replay_idempotency_response as _replay_idempotency_response,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _build_estimate_job_input_payload as _estimate_inputs_build_estimate_job_input_payload,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _build_mapped_instance as _estimate_inputs_build_mapped_instance,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _catalog_selection_is_superseded as _estimate_inputs_catalog_selection_is_superseded,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _first_present_attribute as _estimate_inputs_first_present_attribute,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _get_estimate_catalog_selection as _estimate_inputs_get_estimate_catalog_selection,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _load_app_model_modules as _estimate_inputs_load_app_model_modules,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _mapped_attribute_keys as _estimate_inputs_mapped_attribute_keys,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _normalize_estimate_request_body as _estimate_inputs_normalize_estimate_request_body,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _NormalizedEstimateCatalogRef as _estimate_inputs_NormalizedEstimateCatalogRef,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _quantity_item_is_executable as _estimate_inputs_quantity_item_is_executable,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _raise_estimate_input_invalid as _estimate_inputs_raise_estimate_input_invalid,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _raise_estimate_takeoff_gate_invalid as _estimate_inputs_raise_estimate_takeoff_gate_invalid,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_catalog_model as _estimate_inputs_resolve_catalog_model,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_catalog_supersession_model as _estimate_inputs_resolve_catalog_supersession_model,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_estimate_catalog_refs as _estimate_inputs_resolve_estimate_catalog_refs,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_estimate_job_model_classes as _estimate_inputs_resolve_estimate_job_model_classes,
+)
+from app.api.v1.revision_estimate_inputs import (
+    _resolve_estimate_pricing_contract as _estimate_inputs_resolve_estimate_pricing_contract,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_file as _lineage_get_active_file,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_revision as _lineage_get_active_revision,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_revision_manifest_or_409 as _lineage_get_active_revision_manifest_or_409,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_validation_report,
+    _get_revision_manifest,
+    _raise_entities_not_materialized,
+)
+from app.api.v1.revision_lineage import (
+    _get_active_validation_report_or_404 as _lineage_get_active_validation_report_or_404,
+)
+from app.api.v1.revision_lineage import (
+    _get_revision_estimate_version_or_404 as _lineage_get_revision_estimate_version_or_404,
+)
+from app.api.v1.revision_lineage import (
+    _get_revision_quantity_takeoff_or_404 as _lineage_get_revision_quantity_takeoff_or_404,
+)
+from app.api.v1.revision_routes.adapter_outputs import (
+    adapter_outputs_router,
+)
+from app.api.v1.revision_routes.estimates import (
+    estimates_router,
+)
+from app.api.v1.revision_routes.file_revisions import (
+    file_revisions_router,
+)
+from app.api.v1.revision_routes.generated_artifacts import (
+    generated_artifacts_router,
+)
+from app.api.v1.revision_routes.materialization import (
+    materialization_router,
+)
+from app.api.v1.revision_routes.quantity_takeoffs import (
+    quantity_takeoff_create_router,
+    quantity_takeoffs_router,
+)
+from app.api.v1.revision_routes.validation_reports import (
+    validation_reports_router,
 )
 from app.core.errors import ErrorCode
-from app.core.exceptions import create_error_response, raise_not_found
-from app.db.session import get_db
+from app.core.exceptions import create_error_response
 from app.jobs import worker as jobs_worker_module
-from app.jobs.worker import enqueue_quantity_takeoff_job as _enqueue_quantity_takeoff_job
-from app.jobs.worker import prepare_job_enqueue_intent, publish_job_enqueue_intent
-from app.models.adapter_run_output import AdapterRunOutput
+from app.jobs.worker import (
+    enqueue_quantity_takeoff_job as _enqueue_quantity_takeoff_job,
+)
+from app.jobs.worker import (
+    prepare_job_enqueue_intent as _prepare_job_enqueue_intent,
+)
+from app.jobs.worker import (
+    publish_job_enqueue_intent as _publish_job_enqueue_intent,
+)
 from app.models.drawing_revision import DrawingRevision
-from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
-from app.models.file import File
-from app.models.generated_artifact import GeneratedArtifact
-from app.models.job import Job, JobType
-from app.models.project import Project
+from app.models.job import Job
 from app.models.quantity_takeoff import (
-    QuantityGate,
     QuantityItem,
-    QuantityItemKind,
     QuantityTakeoff,
 )
-from app.models.revision_materialization import (
-    RevisionBlock,
-    RevisionEntity,
-    RevisionEntityManifest,
-    RevisionLayer,
-    RevisionLayout,
-)
+from app.models.revision_materialization import RevisionEntityManifest
 from app.models.validation_report import ValidationReport
 from app.schemas.estimate import (
-    EstimateItemListResponse,
-    EstimateItemRead,
-    EstimateSnapshotEntryListResponse,
-    EstimateSnapshotEntryRead,
     EstimateVersionCreateCatalogRef,
     EstimateVersionCreateRequest,
-    EstimateVersionListResponse,
-    EstimateVersionRead,
-)
-from app.schemas.job import JobRead
-from app.schemas.quantity_takeoff import (
-    QuantityItemListResponse,
-    QuantityItemRead,
-    QuantityTakeoffListResponse,
-    QuantityTakeoffRead,
-)
-from app.schemas.revision import (
-    AdapterRunOutputRead,
-    DrawingRevisionListResponse,
-    DrawingRevisionRead,
-    GeneratedArtifactListResponse,
-    GeneratedArtifactRead,
-    RevisionBlockListResponse,
-    RevisionBlockRead,
-    RevisionEntityListResponse,
-    RevisionEntityManifestRead,
-    RevisionEntityRead,
-    RevisionLayerListResponse,
-    RevisionLayerRead,
-    RevisionLayoutListResponse,
-    RevisionLayoutRead,
-    RevisionMaterializationCounts,
-)
-from app.schemas.validation_report import (
-    ValidationReportResponse,
-    build_validation_report_response,
 )
 
 revisions_router = APIRouter()
 
 _DEFAULT_PAGE_SIZE = 50
 _MAX_PAGE_SIZE = 200
-_APP_MODEL_MODULES_LOADED = False
 
 
-class _DrawingRevisionCursor(BaseModel):
-    """Opaque cursor payload for drawing revision pagination."""
-
-    revision_sequence: int
-    created_at: datetime
-    id: UUID
-
-
-class _GeneratedArtifactCursor(BaseModel):
-    """Opaque cursor payload for generated artifact pagination."""
-
-    created_at: datetime
-    id: UUID
-
-
-@dataclass(slots=True)
-class _NormalizedEstimateCatalogRef:
-    ref_type: str
-    selection_id: UUID
-    selection_key: str
-    selection_checksum_sha256: str
-    description: str
-    line_key: str
-    quantity_item_id: UUID | None
-    formula_inputs: dict[str, Any] | None
-
-
-def _encode_cursor(payload: BaseModel) -> str:
-    """Encode a pagination cursor payload as an opaque token."""
-
-    return (
-        base64.urlsafe_b64encode(payload.model_dump_json().encode("utf-8"))
-        .decode("utf-8")
-        .rstrip("=")
-    )
-
-
-def _decode_revision_cursor(cursor: str) -> _DrawingRevisionCursor:
-    """Decode and validate an opaque drawing revision cursor."""
-
-    try:
-        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
-        return _DrawingRevisionCursor.model_validate_json(decoded)
-    except (ValueError, ValidationError, binascii.Error) as exc:
-        raise_invalid_cursor(exc)
-
-
-def _decode_artifact_cursor(cursor: str) -> _GeneratedArtifactCursor:
-    """Decode and validate an opaque generated artifact cursor."""
-
-    try:
-        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
-        return _GeneratedArtifactCursor.model_validate_json(decoded)
-    except (ValueError, ValidationError, binascii.Error) as exc:
-        raise_invalid_cursor(exc)
-
-
-def _encode_materialization_cursor(sequence_index: int, row_id: UUID) -> str:
-    """Encode a materialization cursor from sequence index and row identifier."""
-
-    return encode_cursor_payload(
-        {
-            "sequence_index": sequence_index,
-            "id": str(row_id),
-        }
-    )
+_get_active_file = _lineage_get_active_file
+_get_active_revision = _lineage_get_active_revision
+_get_revision_quantity_takeoff_or_404 = _lineage_get_revision_quantity_takeoff_or_404
+_get_revision_estimate_version_or_404 = _lineage_get_revision_estimate_version_or_404
+_NormalizedEstimateCatalogRef = _estimate_inputs_NormalizedEstimateCatalogRef
+UTC = _UTC
+replay_idempotency_response = _replay_idempotency_response
+claim_idempotency_response = _claim_idempotency_response
+complete_idempotency_response = _complete_idempotency_response
+prepare_job_enqueue_intent = _prepare_job_enqueue_intent
+publish_job_enqueue_intent = _publish_job_enqueue_intent
 
 
 def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
@@ -183,178 +170,18 @@ def enqueue_estimate_job(job_id: UUID) -> None:
     publisher(job_id)
 
 
-def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
-    """Encode an opaque timestamp/id pagination cursor."""
-
-    return encode_cursor_payload({"created_at": created_at.isoformat(), "id": str(row_id)})
-
-
-def _encode_estimate_item_cursor(line_number: int, row_id: UUID) -> str:
-    """Encode an opaque line-number/id pagination cursor."""
-
-    return encode_cursor_payload({"line_number": line_number, "id": str(row_id)})
-
-
-def _encode_estimate_snapshot_entry_cursor(sort_order: int, row_id: UUID) -> str:
-    """Encode an opaque sort-order/id pagination cursor."""
-
-    return encode_cursor_payload({"sort_order": sort_order, "id": str(row_id)})
-
-
-def _decode_timestamp_cursor(cursor: str) -> tuple[datetime, UUID]:
-    """Decode a timestamp/id pagination cursor."""
-
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
-
-
-def _decode_estimate_item_cursor(cursor: str) -> tuple[int, UUID]:
-    """Decode a line-number/id pagination cursor."""
-
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return int(cursor_data["line_number"]), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
-
-
-def _decode_estimate_snapshot_entry_cursor(cursor: str) -> tuple[int, UUID]:
-    """Decode a sort-order/id pagination cursor."""
-
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return int(cursor_data["sort_order"]), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
-
-
-def _decode_materialization_cursor(cursor: str) -> tuple[int, UUID]:
-    """Decode a materialization cursor into typed values."""
-
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return int(cursor_data["sequence_index"]), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
-
-
-def _raise_entities_not_materialized(revision_id: UUID) -> None:
-    """Raise the standard conflict when revision entities are not materialized."""
-
-    raise HTTPException(
-        status_code=status.HTTP_409_CONFLICT,
-        detail=create_error_response(
-            code=ErrorCode.NORMALIZED_ENTITIES_NOT_MATERIALIZED,
-            message=(
-                f"Normalized entities for drawing revision '{revision_id}' "
-                "have not been materialized"
-            ),
-            details=None,
-        ),
-    )
-
-
-async def _get_active_file(file_id: UUID, db: AsyncSession) -> File | None:
-    """Return an active file visible through a non-deleted project."""
-
-    result = await db.execute(
-        select(File)
-        .join(Project, Project.id == File.project_id)
-        .where((File.id == file_id) & (File.deleted_at.is_(None)) & (Project.deleted_at.is_(None)))
-    )
-    return result.scalar_one_or_none()
-
-
-async def _get_active_revision(
-    revision_id: UUID,
-    db: AsyncSession,
-    *,
-    for_update: bool = False,
-) -> DrawingRevision | None:
-    """Return an active revision visible through a non-deleted file and project."""
-
-    query = (
-        select(DrawingRevision)
-        .join(
-            File,
-            (File.id == DrawingRevision.source_file_id)
-            & (File.project_id == DrawingRevision.project_id),
-        )
-        .join(Project, Project.id == DrawingRevision.project_id)
-        .where(
-            (DrawingRevision.id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    if for_update:
-        query = query.with_for_update(
-            of=(DrawingRevision.__table__, File.__table__, Project.__table__)
-        )
-
-    result = await db.execute(query)
-    return result.scalar_one_or_none()
-
-
-async def _get_active_validation_report(
-    revision_id: UUID,
-    db: AsyncSession,
-) -> ValidationReport | None:
-    """Return the persisted validation report for an active revision, if present."""
-
-    result = await db.execute(
-        select(ValidationReport)
-        .join(
-            DrawingRevision,
-            DrawingRevision.id == ValidationReport.drawing_revision_id,
-        )
-        .join(
-            File,
-            (File.id == DrawingRevision.source_file_id)
-            & (File.project_id == DrawingRevision.project_id),
-        )
-        .join(Project, Project.id == DrawingRevision.project_id)
-        .where(
-            (ValidationReport.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    return result.scalar_one_or_none()
-
-
 async def _get_active_validation_report_or_404(
     revision_id: UUID,
     db: AsyncSession,
 ) -> ValidationReport:
     """Return an active revision validation report or raise not found."""
 
-    report = await _get_active_validation_report(revision_id, db)
-    if report is None:
-        revision = await _get_active_revision(revision_id, db)
-        if revision is None:
-            raise_not_found("Drawing revision", str(revision_id))
-        raise_not_found("Validation report", str(revision_id))
-
-    assert report is not None
-    return report
-
-
-async def _get_revision_manifest(
-    revision_id: UUID,
-    db: AsyncSession,
-) -> RevisionEntityManifest | None:
-    """Return the persisted materialization manifest for a revision, if present."""
-
-    result = await db.execute(
-        select(RevisionEntityManifest).where(
-            RevisionEntityManifest.drawing_revision_id == revision_id
-        )
+    return await _lineage_get_active_validation_report_or_404(
+        revision_id,
+        db,
+        get_active_validation_report=_get_active_validation_report,
+        get_active_revision=_get_active_revision,
     )
-    return result.scalar_one_or_none()
 
 
 async def _get_active_revision_manifest_or_409(
@@ -363,25 +190,13 @@ async def _get_active_revision_manifest_or_409(
 ) -> RevisionEntityManifest:
     """Return an active revision manifest or raise the standard missing errors."""
 
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert revision is not None
-
-    manifest = await _get_revision_manifest(revision_id, db)
-    if manifest is None:
-        _raise_entities_not_materialized(revision_id)
-
-    assert manifest is not None
-    return manifest
-
-
-def _manifest_counts(
-    manifest: RevisionEntityManifest,
-) -> RevisionMaterializationCounts:
-    """Convert persisted manifest counts to the public schema."""
-
-    return RevisionMaterializationCounts.model_validate(manifest.counts_json)
+    return await _lineage_get_active_revision_manifest_or_409(
+        revision_id,
+        db,
+        get_active_revision=_get_active_revision,
+        get_revision_manifest=_get_revision_manifest,
+        raise_entities_not_materialized=_raise_entities_not_materialized,
+    )
 
 
 def _raise_quantity_takeoff_gate_invalid(report: ValidationReport) -> None:
@@ -408,145 +223,76 @@ def _raise_estimate_input_invalid(
 ) -> None:
     """Raise the standard estimate input validation error."""
 
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail=create_error_response(
-            code=ErrorCode.INPUT_INVALID,
-            message=message,
-            details=details,
-        ),
-    )
+    _estimate_inputs_raise_estimate_input_invalid(message, details=details)
 
 
 def _raise_estimate_takeoff_gate_invalid(takeoff: QuantityTakeoff) -> None:
     """Raise the standard pre-enqueue error for non-runnable estimate inputs."""
 
-    _raise_estimate_input_invalid(
-        "Estimate jobs require a trusted quantity takeoff with an allowed quantity gate.",
-        details={
-            "quantity_gate": takeoff.quantity_gate,
-            "trusted_totals": takeoff.trusted_totals,
-            "review_state": takeoff.review_state,
-            "validation_status": takeoff.validation_status,
-        },
+    _estimate_inputs_raise_estimate_takeoff_gate_invalid(
+        takeoff,
+        raise_estimate_input_invalid=_raise_estimate_input_invalid,
     )
 
 
 def _normalize_estimate_request_body(payload: EstimateVersionCreateRequest) -> dict[str, Any]:
     """Return the normalized create-request body used for idempotency fingerprints."""
 
-    return payload.model_dump(mode="json", by_alias=False, exclude_none=False)
+    return _estimate_inputs_normalize_estimate_request_body(payload)
 
 
 def _mapped_attribute_keys(model_class: type[Any]) -> set[str]:
     """Return mapped SQLAlchemy attribute keys for a model class."""
 
-    return {attribute.key for attribute in model_class.__mapper__.attrs}
+    return _estimate_inputs_mapped_attribute_keys(model_class)
 
 
 def _build_mapped_instance(model_class: type[Any], values: dict[str, Any]) -> Any:
     """Instantiate a mapped object while ignoring unknown compatibility fields."""
 
-    instance = model_class()
-    valid_keys = _mapped_attribute_keys(model_class)
-    for key, value in values.items():
-        if key in valid_keys:
-            setattr(instance, key, value)
-    return instance
+    return _estimate_inputs_build_mapped_instance(
+        model_class,
+        values,
+        mapped_attribute_keys=_mapped_attribute_keys,
+    )
 
 
 def _first_present_attribute(instance: Any, names: tuple[str, ...]) -> Any:
     """Return the first present attribute value from a candidate name list."""
 
-    for name in names:
-        if hasattr(instance, name):
-            return getattr(instance, name)
-    return None
+    return _estimate_inputs_first_present_attribute(instance, names)
 
 
 def _load_app_model_modules() -> None:
     """Import app model modules so mapped classes are registered."""
 
-    import app.models as models_package
-
-    global _APP_MODEL_MODULES_LOADED
-
-    if not _APP_MODEL_MODULES_LOADED:
-        for module_info in pkgutil.iter_modules(models_package.__path__):
-            importlib.import_module(f"{models_package.__name__}.{module_info.name}")
-        _APP_MODEL_MODULES_LOADED = True
+    _estimate_inputs_load_app_model_modules()
 
 
 def _resolve_estimate_job_model_classes() -> tuple[type[Any], type[Any]]:
     """Resolve mapped model classes used to persist estimate job inputs."""
 
-    _load_app_model_modules()
-    class_map = {mapper.class_.__name__: mapper.class_ for mapper in Job.registry.mappers}
-    input_model = class_map.get("EstimateJobInput")
-    ref_model = class_map.get("EstimateJobInputCatalogRef")
-    if input_model is None or ref_model is None:
-        raise RuntimeError("Estimate job input models are unavailable")
-    return input_model, ref_model
+    return _estimate_inputs_resolve_estimate_job_model_classes(
+        load_app_model_modules=_load_app_model_modules,
+    )
 
 
 def _resolve_catalog_model(ref_type: str) -> type[Any]:
     """Resolve the mapped catalog/formula model for a request ref type."""
 
-    _load_app_model_modules()
-    candidates: dict[str, list[type[Any]]] = {"rate": [], "material": [], "formula": []}
-    for mapper in Job.registry.mappers:
-        model_class = mapper.class_
-        name = model_class.__name__.lower()
-        table_name = getattr(model_class, "__tablename__", "").lower()
-        if "estimatejobinput" in name or "quantity" in name:
-            continue
-        if "supersession" in name or "supersession" in table_name:
-            continue
-        if (
-            "catalog" in name
-            or "catalog" in table_name
-            or "formula" in name
-            or "formula" in table_name
-        ):
-            if "rate" in name or "rate" in table_name:
-                candidates["rate"].append(model_class)
-            if "material" in name or "material" in table_name:
-                candidates["material"].append(model_class)
-            if "formula" in name or "formula" in table_name:
-                candidates["formula"].append(model_class)
-
-    matches = candidates.get(ref_type, [])
-    if not matches:
-        raise RuntimeError(f"Catalog model for ref type '{ref_type}' is unavailable")
-
-    def _model_score(model_class: type[Any]) -> tuple[int, int]:
-        name = model_class.__name__.lower()
-        table_name = getattr(model_class, "__tablename__", "").lower()
-        return (
-            int("catalog" in name or "catalog" in table_name),
-            int(ref_type in name or ref_type in table_name),
-        )
-
-    return sorted(matches, key=_model_score, reverse=True)[0]
+    return _estimate_inputs_resolve_catalog_model(
+        ref_type,
+        load_app_model_modules=_load_app_model_modules,
+    )
 
 
 def _resolve_catalog_supersession_model(ref_type: str) -> type[Any]:
     """Resolve the mapped supersession model for a request ref type."""
 
-    _load_app_model_modules()
-    for mapper in Job.registry.mappers:
-        model_class = mapper.class_
-        name = model_class.__name__.lower()
-        table_name = getattr(model_class, "__tablename__", "").lower()
-        if "supersession" not in name and "supersession" not in table_name:
-            continue
-        if ref_type == "rate" and "rate" in name:
-            return model_class
-        if ref_type == "material" and "material" in name:
-            return model_class
-        if ref_type == "formula" and "formula" in name:
-            return model_class
-    raise RuntimeError(f"Catalog supersession model for ref type '{ref_type}' is unavailable")
+    return _estimate_inputs_resolve_catalog_supersession_model(
+        ref_type,
+        load_app_model_modules=_load_app_model_modules,
+    )
 
 
 async def _catalog_selection_is_superseded(
@@ -556,18 +302,12 @@ async def _catalog_selection_is_superseded(
 ) -> bool:
     """Return whether a catalog selection has been superseded."""
 
-    supersession_model = _resolve_catalog_supersession_model(ref_type)
-    predecessor_field_name = {
-        "rate": "predecessor_rate_id",
-        "material": "predecessor_material_id",
-        "formula": "predecessor_formula_id",
-    }[ref_type]
-    result = await db.execute(
-        select(supersession_model).where(
-            getattr(supersession_model, predecessor_field_name) == selection_id
-        )
+    return await _estimate_inputs_catalog_selection_is_superseded(
+        ref_type,
+        selection_id,
+        db,
+        resolve_catalog_supersession_model=_resolve_catalog_supersession_model,
     )
-    return result.scalar_one_or_none() is not None
 
 
 def _resolve_estimate_pricing_contract(
@@ -577,23 +317,16 @@ def _resolve_estimate_pricing_contract(
 ) -> tuple[str, date]:
     """Resolve the persisted pricing contract for an estimate request."""
 
-    if request.pricing.effective_date is not None:
-        return "explicit", request.pricing.effective_date
-    resolved_at = job_created_at or datetime.now(UTC)
-    return "derived_from_job_created_at_utc", resolved_at.date()
+    return _estimate_inputs_resolve_estimate_pricing_contract(
+        request,
+        job_created_at=job_created_at,
+    )
 
 
 def _quantity_item_is_executable(quantity_item: QuantityItem) -> bool:
     """Return whether a quantity item can back a rate/material estimate ref."""
 
-    if quantity_item.item_kind not in {
-        QuantityItemKind.CONTRIBUTOR.value,
-        QuantityItemKind.AGGREGATE.value,
-    }:
-        return False
-
-    value = quantity_item.value
-    return value is not None and isfinite(value)
+    return _estimate_inputs_quantity_item_is_executable(quantity_item)
 
 
 async def _get_estimate_catalog_selection(
@@ -603,9 +336,12 @@ async def _get_estimate_catalog_selection(
 ) -> Any | None:
     """Return the selected catalog/formula row for a request ref."""
 
-    model_class = _resolve_catalog_model(ref_type)
-    result = await db.execute(select(model_class).where(model_class.id == selection_id))
-    return result.scalar_one_or_none()
+    return await _estimate_inputs_get_estimate_catalog_selection(
+        ref_type,
+        selection_id,
+        db,
+        resolve_catalog_model=_resolve_catalog_model,
+    )
 
 
 async def _resolve_estimate_catalog_refs(
@@ -617,254 +353,18 @@ async def _resolve_estimate_catalog_refs(
 ) -> list[_NormalizedEstimateCatalogRef]:
     """Validate request refs and normalize worker mapping inputs."""
 
-    if not request_refs:
-        _raise_estimate_input_invalid(
-            "Estimate jobs require at least one catalog or formula reference.",
-            details={"catalog_refs": []},
-        )
-
-    normalized_refs: list[_NormalizedEstimateCatalogRef] = []
-    seen_line_keys: set[str] = set()
-    for request_ref in request_refs:
-        if request_ref.ref_type not in {"rate", "material", "formula"}:
-            _raise_estimate_input_invalid(
-                "Estimate refs must use supported ref types.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                },
-            )
-
-        selection = await _get_estimate_catalog_selection(
-            request_ref.ref_type,
-            request_ref.selection_id,
-            db,
-        )
-        if selection is None:
-            _raise_estimate_input_invalid(
-                "Estimate refs must point to visible catalog selections.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                },
-            )
-
-        selection_project_id = getattr(selection, "project_id", None)
-        if selection_project_id not in {None, revision.project_id}:
-            _raise_estimate_input_invalid(
-                "Estimate refs must belong to the same project lineage as the revision.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                },
-            )
-
-        if await _catalog_selection_is_superseded(
-            request_ref.ref_type, request_ref.selection_id, db
-        ):
-            _raise_estimate_input_invalid(
-                "Estimate refs must point to current catalog selections.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                },
-            )
-
-        if getattr(selection, "deleted_at", None) is not None:
-            _raise_estimate_input_invalid(
-                "Estimate refs must point to visible catalog selections.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                },
-            )
-
-        selection_key = _first_present_attribute(
-            selection,
-            (
-                "selection_key",
-                "entry_key",
-                "key",
-                "formula_key",
-                "formula_id",
-                "rate_key",
-                "material_key",
-            ),
-        )
-        if selection_key is not None and str(selection_key) != request_ref.selection_key:
-            _raise_estimate_input_invalid(
-                "Estimate refs must use the current catalog selection key.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                    "selection_key": request_ref.selection_key,
-                },
-            )
-
-        selection_checksum = _first_present_attribute(
-            selection,
-            ("checksum_sha256", "source_checksum_sha256"),
-        )
-        if (
-            selection_checksum is not None
-            and str(selection_checksum) != request_ref.selection_checksum_sha256
-        ):
-            _raise_estimate_input_invalid(
-                "Estimate refs must use the current catalog selection checksum.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                    "selection_checksum_sha256": request_ref.selection_checksum_sha256,
-                },
-            )
-
-        selection_currency = _first_present_attribute(selection, ("currency",))
-        if selection_currency is not None and str(selection_currency).upper() != "GBP":
-            _raise_estimate_input_invalid(
-                "Estimate jobs only support GBP pricing inputs.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                    "currency": str(selection_currency),
-                },
-            )
-
-        effective_from = _first_present_attribute(selection, ("effective_from",))
-        effective_to = _first_present_attribute(selection, ("effective_to",))
-        if effective_from is not None and (
-            pricing_effective_date < effective_from
-            or (effective_to is not None and pricing_effective_date >= effective_to)
-        ):
-            _raise_estimate_input_invalid(
-                "Estimate refs must be effective for the resolved pricing date.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                    "pricing_effective_date": pricing_effective_date.isoformat(),
-                },
-            )
-
-        if request_ref.ref_type in {"rate", "material"}:
-            if request_ref.quantity_item_id is None:
-                _raise_estimate_input_invalid(
-                    "Rate and material refs require a quantity item.",
-                    details={
-                        "ref_type": request_ref.ref_type,
-                        "selection_id": str(request_ref.selection_id),
-                    },
-                )
-
-            quantity_item_result = await db.execute(
-                select(QuantityItem).where(
-                    (QuantityItem.id == request_ref.quantity_item_id)
-                    & (QuantityItem.quantity_takeoff_id == takeoff.id)
-                    & (QuantityItem.project_id == revision.project_id)
-                    & (QuantityItem.drawing_revision_id == revision.id)
-                    & (QuantityItem.quantity_gate == QuantityGate.ALLOWED.value)
-                )
-            )
-            quantity_item = quantity_item_result.scalar_one_or_none()
-            if quantity_item is None or not _quantity_item_is_executable(quantity_item):
-                _raise_estimate_input_invalid(
-                    "Rate and material refs must target quantity items on the requested takeoff.",
-                    details={
-                        "ref_type": request_ref.ref_type,
-                        "selection_id": str(request_ref.selection_id),
-                        "quantity_item_id": str(request_ref.quantity_item_id),
-                    },
-                )
-
-        if request_ref.ref_type == "formula" and request_ref.formula_inputs is None:
-            _raise_estimate_input_invalid(
-                "Formula refs require formula_inputs.",
-                details={
-                    "ref_type": request_ref.ref_type,
-                    "selection_id": str(request_ref.selection_id),
-                },
-            )
-
-        line_key = request_ref.line_key or f"{request_ref.ref_type}:{request_ref.selection_key}"
-        if line_key in seen_line_keys:
-            _raise_estimate_input_invalid(
-                "Estimate refs must use unique line keys.",
-                details={"line_key": line_key},
-            )
-        seen_line_keys.add(line_key)
-
-        normalized_refs.append(
-            _NormalizedEstimateCatalogRef(
-                ref_type=request_ref.ref_type,
-                selection_id=request_ref.selection_id,
-                selection_key=request_ref.selection_key,
-                selection_checksum_sha256=request_ref.selection_checksum_sha256,
-                description=request_ref.description,
-                line_key=line_key,
-                quantity_item_id=request_ref.quantity_item_id,
-                formula_inputs=request_ref.formula_inputs,
-            )
-        )
-
-    return normalized_refs
-
-
-async def _get_revision_quantity_takeoff_or_404(
-    revision_id: UUID,
-    takeoff_id: UUID,
-    db: AsyncSession,
-) -> QuantityTakeoff:
-    """Return a committed quantity takeoff scoped to an active revision."""
-
-    result = await db.execute(
-        select(QuantityTakeoff)
-        .join(
-            File,
-            (File.id == QuantityTakeoff.source_file_id)
-            & (File.project_id == QuantityTakeoff.project_id),
-        )
-        .join(Project, Project.id == QuantityTakeoff.project_id)
-        .where(
-            (QuantityTakeoff.id == takeoff_id)
-            & (QuantityTakeoff.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
+    return await _estimate_inputs_resolve_estimate_catalog_refs(
+        revision,
+        takeoff,
+        request_refs,
+        pricing_effective_date,
+        db,
+        raise_estimate_input_invalid=_raise_estimate_input_invalid,
+        get_estimate_catalog_selection=_get_estimate_catalog_selection,
+        catalog_selection_is_superseded=_catalog_selection_is_superseded,
+        first_present_attribute=_first_present_attribute,
+        quantity_item_is_executable=_quantity_item_is_executable,
     )
-    takeoff = result.scalar_one_or_none()
-    if takeoff is None:
-        raise_not_found("Quantity takeoff", str(takeoff_id))
-
-    assert takeoff is not None
-    return takeoff
-
-
-async def _get_revision_estimate_version_or_404(
-    revision_id: UUID,
-    estimate_version_id: UUID,
-    db: AsyncSession,
-) -> EstimateVersion:
-    """Return a committed estimate version scoped to an active revision."""
-
-    result = await db.execute(
-        select(EstimateVersion)
-        .join(
-            File,
-            (File.id == EstimateVersion.source_file_id)
-            & (File.project_id == EstimateVersion.project_id),
-        )
-        .join(Project, Project.id == EstimateVersion.project_id)
-        .where(
-            (EstimateVersion.id == estimate_version_id)
-            & (EstimateVersion.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    estimate_version = result.scalar_one_or_none()
-    if estimate_version is None:
-        raise_not_found("Estimate version", str(estimate_version_id))
-
-    assert estimate_version is not None
-    return estimate_version
 
 
 def _build_estimate_job_input_payload(
@@ -879,861 +379,7 @@ def _build_estimate_job_input_payload(
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Build persistence payloads for estimate job input rows."""
 
-    input_payload = {
-        "estimate_job_id": estimate_job.id,
-        "project_id": revision.project_id,
-        "source_file_id": revision.source_file_id,
-        "drawing_revision_id": revision.id,
-        "quantity_takeoff_id": takeoff.id,
-        "source_job_type": JobType.ESTIMATE.value,
-        "currency": request.pricing.currency,
-        "quantity_gate": takeoff.quantity_gate,
-        "trusted_totals": takeoff.trusted_totals,
-        "pricing_mode": pricing_mode,
-        "pricing_effective_date": pricing_effective_date,
-        "assumptions_json": request.assumptions,
-    }
-
-    ref_payloads: list[dict[str, Any]] = []
-    for ref_order, ref in enumerate(normalized_refs, start=1):
-        line_key = ref.line_key
-        selection_context_json = {
-            "worker_mapping_version": "estimate-line-v1",
-            "line_number": ref_order,
-            "line_key": line_key,
-            "line_type": ref.ref_type,
-            "ref_type": ref.ref_type,
-            "description": ref.description,
-            "catalog_entry_key": f"{ref.ref_type}:{ref.selection_key}",
-            "formula_inputs": ref.formula_inputs,
-        }
-        if ref.quantity_item_id is not None:
-            selection_context_json["quantity_item_id"] = str(ref.quantity_item_id)
-
-        ref_payload = {
-            "estimate_job_id": estimate_job.id,
-            "ref_order": ref_order,
-            "ref_type": ref.ref_type,
-            "selection_key": ref.selection_key,
-            "catalog_checksum_sha256": ref.selection_checksum_sha256,
-            "selection_context_json": selection_context_json,
-            "rate_catalog_entry_id": ref.selection_id if ref.ref_type == "rate" else None,
-            "material_catalog_entry_id": ref.selection_id if ref.ref_type == "material" else None,
-            "formula_definition_id": ref.selection_id if ref.ref_type == "formula" else None,
-        }
-        ref_payloads.append(ref_payload)
-
-    return input_payload, ref_payloads
-
-
-@revisions_router.get("/files/{file_id}/revisions", response_model=DrawingRevisionListResponse)
-async def list_file_revisions(
-    file_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> DrawingRevisionListResponse:
-    """List active drawing revisions for a file."""
-
-    file = await _get_active_file(file_id, db)
-    if file is None:
-        raise_not_found("File", str(file_id))
-
-    pagination_cursor = _decode_revision_cursor(cursor) if cursor else None
-
-    query = (
-        select(DrawingRevision)
-        .join(
-            File,
-            (File.id == DrawingRevision.source_file_id)
-            & (File.project_id == DrawingRevision.project_id),
-        )
-        .join(Project, Project.id == DrawingRevision.project_id)
-        .where(
-            (DrawingRevision.source_file_id == file_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-
-    if pagination_cursor is not None:
-        query = query.where(
-            (DrawingRevision.revision_sequence > pagination_cursor.revision_sequence)
-            | (
-                (DrawingRevision.revision_sequence == pagination_cursor.revision_sequence)
-                & (DrawingRevision.created_at > pagination_cursor.created_at)
-            )
-            | (
-                (DrawingRevision.revision_sequence == pagination_cursor.revision_sequence)
-                & (DrawingRevision.created_at == pagination_cursor.created_at)
-                & (DrawingRevision.id > pagination_cursor.id)
-            )
-        )
-
-    result = await db.execute(
-        query.order_by(
-            DrawingRevision.revision_sequence.asc(),
-            DrawingRevision.created_at.asc(),
-            DrawingRevision.id.asc(),
-        ).limit(limit + 1)
-    )
-    revisions = result.scalars().all()
-    page = revisions[:limit]
-    next_cursor = None
-
-    if len(revisions) > limit and page:
-        last_revision = page[-1]
-        next_cursor = _encode_cursor(
-            _DrawingRevisionCursor(
-                revision_sequence=last_revision.revision_sequence,
-                created_at=last_revision.created_at,
-                id=last_revision.id,
-            )
-        )
-
-    return DrawingRevisionListResponse(
-        items=[DrawingRevisionRead.model_validate(revision) for revision in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/adapter-output",
-    response_model=AdapterRunOutputRead,
-)
-async def get_revision_adapter_output(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> AdapterRunOutputRead:
-    """Return adapter output metadata for an active drawing revision."""
-
-    result = await db.execute(
-        select(AdapterRunOutput)
-        .join(DrawingRevision, DrawingRevision.adapter_run_output_id == AdapterRunOutput.id)
-        .join(
-            File,
-            (File.id == DrawingRevision.source_file_id)
-            & (File.project_id == DrawingRevision.project_id),
-        )
-        .join(Project, Project.id == DrawingRevision.project_id)
-        .where(
-            (DrawingRevision.id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    adapter_output = result.scalar_one_or_none()
-    if adapter_output is None:
-        revision = await _get_active_revision(revision_id, db)
-        if revision is None:
-            raise_not_found("Drawing revision", str(revision_id))
-        raise_not_found("Adapter run output", str(revision_id))
-
-    return AdapterRunOutputRead.model_validate(adapter_output)
-
-
-@revisions_router.get(
-    "/adapter-outputs/{adapter_output_id}",
-    response_model=AdapterRunOutputRead,
-)
-async def get_adapter_output(
-    adapter_output_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> AdapterRunOutputRead:
-    """Return adapter output metadata by identifier."""
-
-    result = await db.execute(
-        select(AdapterRunOutput)
-        .join(
-            File,
-            (File.id == AdapterRunOutput.source_file_id)
-            & (File.project_id == AdapterRunOutput.project_id),
-        )
-        .join(Project, Project.id == AdapterRunOutput.project_id)
-        .where(
-            (AdapterRunOutput.id == adapter_output_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    adapter_output = result.scalar_one_or_none()
-    if adapter_output is None:
-        raise_not_found("Adapter run output", str(adapter_output_id))
-
-    return AdapterRunOutputRead.model_validate(adapter_output)
-
-
-@revisions_router.get(
-    "/files/{file_id}/generated-artifacts",
-    response_model=GeneratedArtifactListResponse,
-)
-async def list_file_generated_artifacts(
-    file_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> GeneratedArtifactListResponse:
-    """List active generated artifacts for a file."""
-
-    file = await _get_active_file(file_id, db)
-    if file is None:
-        raise_not_found("File", str(file_id))
-
-    pagination_cursor = _decode_artifact_cursor(cursor) if cursor else None
-
-    query = (
-        select(GeneratedArtifact)
-        .join(
-            File,
-            (File.id == GeneratedArtifact.source_file_id)
-            & (File.project_id == GeneratedArtifact.project_id),
-        )
-        .join(Project, Project.id == GeneratedArtifact.project_id)
-        .where(
-            (GeneratedArtifact.source_file_id == file_id)
-            & (GeneratedArtifact.deleted_at.is_(None))
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-
-    if pagination_cursor is not None:
-        query = query.where(
-            (GeneratedArtifact.created_at > pagination_cursor.created_at)
-            | (
-                (GeneratedArtifact.created_at == pagination_cursor.created_at)
-                & (GeneratedArtifact.id > pagination_cursor.id)
-            )
-        )
-
-    result = await db.execute(
-        query.order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc()).limit(
-            limit + 1
-        )
-    )
-    artifacts = result.scalars().all()
-    page = artifacts[:limit]
-    next_cursor = None
-
-    if len(artifacts) > limit and page:
-        last_artifact = page[-1]
-        next_cursor = _encode_cursor(
-            _GeneratedArtifactCursor(
-                created_at=last_artifact.created_at,
-                id=last_artifact.id,
-            )
-        )
-
-    return GeneratedArtifactListResponse(
-        items=[GeneratedArtifactRead.model_validate(artifact) for artifact in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/generated-artifacts",
-    response_model=GeneratedArtifactListResponse,
-)
-async def list_revision_generated_artifacts(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> GeneratedArtifactListResponse:
-    """List active generated artifacts associated with a drawing revision."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    pagination_cursor = _decode_artifact_cursor(cursor) if cursor else None
-
-    query = (
-        select(GeneratedArtifact)
-        .join(
-            File,
-            (File.id == GeneratedArtifact.source_file_id)
-            & (File.project_id == GeneratedArtifact.project_id),
-        )
-        .join(Project, Project.id == GeneratedArtifact.project_id)
-        .where(
-            (GeneratedArtifact.drawing_revision_id == revision_id)
-            & (GeneratedArtifact.deleted_at.is_(None))
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-
-    if pagination_cursor is not None:
-        query = query.where(
-            (GeneratedArtifact.created_at > pagination_cursor.created_at)
-            | (
-                (GeneratedArtifact.created_at == pagination_cursor.created_at)
-                & (GeneratedArtifact.id > pagination_cursor.id)
-            )
-        )
-
-    result = await db.execute(
-        query.order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc()).limit(
-            limit + 1
-        )
-    )
-    artifacts = result.scalars().all()
-    page = artifacts[:limit]
-    next_cursor = None
-
-    if len(artifacts) > limit and page:
-        last_artifact = page[-1]
-        next_cursor = _encode_cursor(
-            _GeneratedArtifactCursor(
-                created_at=last_artifact.created_at,
-                id=last_artifact.id,
-            )
-        )
-
-    return GeneratedArtifactListResponse(
-        items=[GeneratedArtifactRead.model_validate(artifact) for artifact in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/layouts",
-    response_model=RevisionLayoutListResponse,
-)
-async def list_revision_layouts(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> RevisionLayoutListResponse:
-    """List materialized layout rows for a drawing revision."""
-
-    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
-    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
-
-    query = select(RevisionLayout).where(RevisionLayout.drawing_revision_id == revision_id)
-    if pagination_cursor is not None:
-        sequence_index, row_id = pagination_cursor
-        query = query.where(
-            (RevisionLayout.sequence_index > sequence_index)
-            | ((RevisionLayout.sequence_index == sequence_index) & (RevisionLayout.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(
-            RevisionLayout.sequence_index.asc(),
-            RevisionLayout.id.asc(),
-        ).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
-
-    counts = _manifest_counts(manifest)
-    return RevisionLayoutListResponse(
-        manifest=RevisionEntityManifestRead.model_validate(manifest),
-        counts=counts,
-        items=[RevisionLayoutRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/layers",
-    response_model=RevisionLayerListResponse,
-)
-async def list_revision_layers(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> RevisionLayerListResponse:
-    """List materialized layer rows for a drawing revision."""
-
-    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
-    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
-
-    query = select(RevisionLayer).where(RevisionLayer.drawing_revision_id == revision_id)
-    if pagination_cursor is not None:
-        sequence_index, row_id = pagination_cursor
-        query = query.where(
-            (RevisionLayer.sequence_index > sequence_index)
-            | ((RevisionLayer.sequence_index == sequence_index) & (RevisionLayer.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(RevisionLayer.sequence_index.asc(), RevisionLayer.id.asc()).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
-
-    counts = _manifest_counts(manifest)
-    return RevisionLayerListResponse(
-        manifest=RevisionEntityManifestRead.model_validate(manifest),
-        counts=counts,
-        items=[RevisionLayerRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/blocks",
-    response_model=RevisionBlockListResponse,
-)
-async def list_revision_blocks(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> RevisionBlockListResponse:
-    """List materialized block rows for a drawing revision."""
-
-    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
-    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
-
-    query = select(RevisionBlock).where(RevisionBlock.drawing_revision_id == revision_id)
-    if pagination_cursor is not None:
-        sequence_index, row_id = pagination_cursor
-        query = query.where(
-            (RevisionBlock.sequence_index > sequence_index)
-            | ((RevisionBlock.sequence_index == sequence_index) & (RevisionBlock.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(RevisionBlock.sequence_index.asc(), RevisionBlock.id.asc()).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
-
-    counts = _manifest_counts(manifest)
-    return RevisionBlockListResponse(
-        manifest=RevisionEntityManifestRead.model_validate(manifest),
-        counts=counts,
-        items=[RevisionBlockRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/entities",
-    response_model=RevisionEntityListResponse,
-)
-async def list_revision_entities(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-    entity_id: str | None = Query(default=None),
-    entity_type: str | None = Query(default=None),
-    layout_ref: str | None = Query(default=None),
-    layer_ref: str | None = Query(default=None),
-    block_ref: str | None = Query(default=None),
-    parent_entity_ref: str | None = Query(default=None),
-    source_identity: str | None = Query(default=None),
-    source_hash: str | None = Query(default=None),
-) -> RevisionEntityListResponse:
-    """List materialized entity rows for a drawing revision."""
-
-    manifest = await _get_active_revision_manifest_or_409(revision_id, db)
-    pagination_cursor = _decode_materialization_cursor(cursor) if cursor else None
-
-    query = select(RevisionEntity).where(RevisionEntity.drawing_revision_id == revision_id)
-    if entity_id is not None:
-        query = query.where(RevisionEntity.entity_id == entity_id)
-    if entity_type is not None:
-        query = query.where(RevisionEntity.entity_type == entity_type)
-    if layout_ref is not None:
-        query = query.where(RevisionEntity.layout_ref == layout_ref)
-    if layer_ref is not None:
-        query = query.where(RevisionEntity.layer_ref == layer_ref)
-    if block_ref is not None:
-        query = query.where(RevisionEntity.block_ref == block_ref)
-    if parent_entity_ref is not None:
-        query = query.where(RevisionEntity.parent_entity_ref == parent_entity_ref)
-    if source_identity is not None:
-        query = query.where(RevisionEntity.source_identity == source_identity)
-    if source_hash is not None:
-        query = query.where(RevisionEntity.source_hash == source_hash)
-    if pagination_cursor is not None:
-        sequence_index, row_id = pagination_cursor
-        query = query.where(
-            (RevisionEntity.sequence_index > sequence_index)
-            | ((RevisionEntity.sequence_index == sequence_index) & (RevisionEntity.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(
-            RevisionEntity.sequence_index.asc(),
-            RevisionEntity.id.asc(),
-        ).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_materialization_cursor(last_row.sequence_index, last_row.id)
-
-    counts = _manifest_counts(manifest)
-    return RevisionEntityListResponse(
-        manifest=RevisionEntityManifestRead.model_validate(manifest),
-        counts=counts,
-        items=[RevisionEntityRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/entities/{entity_id:path}",
-    response_model=RevisionEntityRead,
-)
-async def get_revision_entity(
-    revision_id: UUID,
-    entity_id: str,
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> RevisionEntityRead:
-    """Return a materialized entity row for a drawing revision by entity identifier."""
-
-    await _get_active_revision_manifest_or_409(revision_id, db)
-
-    result = await db.execute(
-        select(RevisionEntity).where(
-            (RevisionEntity.drawing_revision_id == revision_id)
-            & (RevisionEntity.entity_id == entity_id)
-        )
-    )
-    entity = result.scalar_one_or_none()
-    if entity is None:
-        raise_not_found("Revision entity", entity_id)
-
-    return RevisionEntityRead.model_validate(entity)
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/quantity-takeoffs",
-    response_model=QuantityTakeoffListResponse,
-)
-async def list_revision_quantity_takeoffs(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> QuantityTakeoffListResponse:
-    """List committed quantity takeoffs for an active drawing revision."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
-    query = (
-        select(QuantityTakeoff)
-        .join(
-            File,
-            (File.id == QuantityTakeoff.source_file_id)
-            & (File.project_id == QuantityTakeoff.project_id),
-        )
-        .join(Project, Project.id == QuantityTakeoff.project_id)
-        .where(
-            (QuantityTakeoff.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    if pagination_cursor is not None:
-        created_at, row_id = pagination_cursor
-        query = query.where(
-            (QuantityTakeoff.created_at > created_at)
-            | ((QuantityTakeoff.created_at == created_at) & (QuantityTakeoff.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(QuantityTakeoff.created_at.asc(), QuantityTakeoff.id.asc()).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
-
-    return QuantityTakeoffListResponse(
-        items=[QuantityTakeoffRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}",
-    response_model=QuantityTakeoffRead,
-)
-async def get_revision_quantity_takeoff(
-    revision_id: UUID,
-    takeoff_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> QuantityTakeoffRead:
-    """Return a committed quantity takeoff for an active drawing revision."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert revision is not None
-
-    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
-    return QuantityTakeoffRead.model_validate(takeoff)
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/items",
-    response_model=QuantityItemListResponse,
-)
-async def list_revision_quantity_takeoff_items(
-    revision_id: UUID,
-    takeoff_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> QuantityItemListResponse:
-    """List committed quantity items for a revision-scoped takeoff."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
-    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
-    query = (
-        select(QuantityItem)
-        .join(
-            QuantityTakeoff,
-            (QuantityTakeoff.id == QuantityItem.quantity_takeoff_id)
-            & (QuantityTakeoff.project_id == QuantityItem.project_id)
-            & (QuantityTakeoff.drawing_revision_id == QuantityItem.drawing_revision_id)
-            & (QuantityTakeoff.quantity_gate == QuantityItem.quantity_gate),
-        )
-        .join(
-            File,
-            (File.id == QuantityTakeoff.source_file_id)
-            & (File.project_id == QuantityTakeoff.project_id),
-        )
-        .join(Project, Project.id == QuantityTakeoff.project_id)
-        .where(
-            (QuantityItem.quantity_takeoff_id == takeoff_id)
-            & (QuantityItem.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    if pagination_cursor is not None:
-        created_at, row_id = pagination_cursor
-        query = query.where(
-            (QuantityItem.created_at > created_at)
-            | ((QuantityItem.created_at == created_at) & (QuantityItem.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(QuantityItem.created_at.asc(), QuantityItem.id.asc()).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
-
-    return QuantityItemListResponse(
-        items=[QuantityItemRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/estimates",
-    response_model=EstimateVersionListResponse,
-)
-async def list_revision_estimates(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> EstimateVersionListResponse:
-    """List committed estimate versions for an active drawing revision."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    pagination_cursor = _decode_timestamp_cursor(cursor) if cursor else None
-    query = (
-        select(EstimateVersion)
-        .join(
-            File,
-            (File.id == EstimateVersion.source_file_id)
-            & (File.project_id == EstimateVersion.project_id),
-        )
-        .join(Project, Project.id == EstimateVersion.project_id)
-        .where(
-            (EstimateVersion.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    if pagination_cursor is not None:
-        created_at, row_id = pagination_cursor
-        query = query.where(
-            (EstimateVersion.created_at > created_at)
-            | ((EstimateVersion.created_at == created_at) & (EstimateVersion.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(EstimateVersion.created_at.asc(), EstimateVersion.id.asc()).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_timestamp_cursor(last_row.created_at, last_row.id)
-
-    return EstimateVersionListResponse(
-        items=[EstimateVersionRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.post(
-    "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
-    response_model=JobRead,
-    status_code=status.HTTP_202_ACCEPTED,
-)
-async def create_revision_estimate_version(
-    revision_id: UUID,
-    takeoff_id: UUID,
-    request: EstimateVersionCreateRequest,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
-) -> Job | Response:
-    """Create a pending estimate job for an active revision quantity takeoff."""
-
-    if request.pricing.currency != "GBP":
-        _raise_estimate_input_invalid(
-            "Estimate jobs only support GBP pricing inputs.",
-            details={"currency": request.pricing.currency},
-        )
-
-    normalized_body = _normalize_estimate_request_body(request)
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            f"revisions.quantity_takeoffs.estimate_versions:{revision_id}:{takeoff_id}",
-            {
-                "revision_id": str(revision_id),
-                "takeoff_id": str(takeoff_id),
-                "body": normalized_body,
-            },
-        )
-        replay_response = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert revision is not None
-
-    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
-    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
-        _raise_estimate_takeoff_gate_invalid(takeoff)
-
-    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
-    if locked_revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert locked_revision is not None
-    revision = locked_revision
-    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
-    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
-        _raise_estimate_takeoff_gate_invalid(takeoff)
-
-    job_created_at = datetime.now(UTC)
-    pricing_mode, pricing_effective_date = _resolve_estimate_pricing_contract(
-        request,
-        job_created_at=job_created_at,
-    )
-    normalized_refs = await _resolve_estimate_catalog_refs(
-        revision,
-        takeoff,
-        request.catalog_refs,
-        pricing_effective_date,
-        db,
-    )
-
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
-
-    estimate_job = Job(
-        id=uuid4(),
-        project_id=revision.project_id,
-        file_id=revision.source_file_id,
-        extraction_profile_id=None,
-        base_revision_id=revision.id,
-        parent_job_id=(
-            takeoff.source_job_id
-            if takeoff.project_id == revision.project_id
-            and takeoff.source_file_id == revision.source_file_id
-            else None
-        ),
-        job_type=JobType.ESTIMATE.value,
-        status="pending",
-        attempts=0,
-        max_attempts=3,
-        enqueue_status="pending",
-        enqueue_attempts=0,
-        cancel_requested=False,
-        error_code=None,
-        error_message=None,
-        started_at=None,
-        finished_at=None,
-        created_at=job_created_at,
-    )
-    db.add(estimate_job)
-    prepare_job_enqueue_intent(estimate_job)
-    await db.flush()
-    await db.refresh(estimate_job)
-
-    estimate_job_input_model, estimate_job_input_ref_model = _resolve_estimate_job_model_classes()
-    input_payload, ref_payloads = _build_estimate_job_input_payload(
+    return _estimate_inputs_build_estimate_job_input_payload(
         estimate_job,
         revision,
         takeoff,
@@ -1742,297 +388,15 @@ async def create_revision_estimate_version(
         pricing_mode=pricing_mode,
         pricing_effective_date=pricing_effective_date,
     )
-    db.add(_build_mapped_instance(estimate_job_input_model, input_payload))
-    for ref_payload in ref_payloads:
-        db.add(_build_mapped_instance(estimate_job_input_ref_model, ref_payload))
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(estimate_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await publish_job_enqueue_intent(
-        estimate_job.id,
-        publisher=enqueue_estimate_job,
-        suppress_exceptions=True,
-    )
-
-    if success_response is not None:
-        return success_response
-
-    return estimate_job
 
 
-@revisions_router.get(
-    "/revisions/{revision_id}/estimates/{estimate_version_id}",
-    response_model=EstimateVersionRead,
-)
-async def get_revision_estimate(
-    revision_id: UUID,
-    estimate_version_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> EstimateVersionRead:
-    """Return a committed estimate version for an active drawing revision."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    estimate_version = await _get_revision_estimate_version_or_404(
-        revision_id, estimate_version_id, db
-    )
-    return EstimateVersionRead.model_validate(estimate_version)
+revisions_router.include_router(file_revisions_router)
+revisions_router.include_router(adapter_outputs_router)
+revisions_router.include_router(generated_artifacts_router)
+revisions_router.include_router(materialization_router)
+revisions_router.include_router(quantity_takeoffs_router)
+revisions_router.include_router(estimates_router)
+revisions_router.include_router(quantity_takeoff_create_router)
 
 
-@revisions_router.get(
-    "/revisions/{revision_id}/estimates/{estimate_version_id}/items",
-    response_model=EstimateItemListResponse,
-)
-async def list_revision_estimate_items(
-    revision_id: UUID,
-    estimate_version_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> EstimateItemListResponse:
-    """List committed estimate items for a revision-scoped estimate version."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    await _get_revision_estimate_version_or_404(revision_id, estimate_version_id, db)
-    pagination_cursor = _decode_estimate_item_cursor(cursor) if cursor else None
-    query = (
-        select(EstimateItem)
-        .join(
-            EstimateVersion,
-            (EstimateVersion.id == EstimateItem.estimate_version_id)
-            & (EstimateVersion.project_id == EstimateItem.project_id)
-            & (EstimateVersion.drawing_revision_id == EstimateItem.drawing_revision_id),
-        )
-        .join(
-            File,
-            (File.id == EstimateVersion.source_file_id)
-            & (File.project_id == EstimateVersion.project_id),
-        )
-        .join(Project, Project.id == EstimateVersion.project_id)
-        .where(
-            (EstimateItem.estimate_version_id == estimate_version_id)
-            & (EstimateItem.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    if pagination_cursor is not None:
-        line_number, row_id = pagination_cursor
-        query = query.where(
-            (EstimateItem.line_number > line_number)
-            | ((EstimateItem.line_number == line_number) & (EstimateItem.id > row_id))
-        )
-
-    result = await db.execute(
-        query.order_by(EstimateItem.line_number.asc(), EstimateItem.id.asc()).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_estimate_item_cursor(last_row.line_number, last_row.id)
-
-    return EstimateItemListResponse(
-        items=[EstimateItemRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/estimates/{estimate_version_id}/snapshot-entries",
-    response_model=EstimateSnapshotEntryListResponse,
-)
-async def list_revision_estimate_snapshot_entries(
-    revision_id: UUID,
-    estimate_version_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    limit: Annotated[int, Query(ge=1, le=_MAX_PAGE_SIZE)] = _DEFAULT_PAGE_SIZE,
-    cursor: str | None = Query(default=None),
-) -> EstimateSnapshotEntryListResponse:
-    """List committed estimate snapshot entries for a revision-scoped estimate version."""
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-
-    await _get_revision_estimate_version_or_404(revision_id, estimate_version_id, db)
-    pagination_cursor = _decode_estimate_snapshot_entry_cursor(cursor) if cursor else None
-    query = (
-        select(EstimateSnapshotEntry)
-        .join(
-            EstimateVersion,
-            (EstimateVersion.id == EstimateSnapshotEntry.estimate_version_id)
-            & (EstimateVersion.project_id == EstimateSnapshotEntry.project_id)
-            & (EstimateVersion.drawing_revision_id == EstimateSnapshotEntry.drawing_revision_id),
-        )
-        .join(
-            File,
-            (File.id == EstimateVersion.source_file_id)
-            & (File.project_id == EstimateVersion.project_id),
-        )
-        .join(Project, Project.id == EstimateVersion.project_id)
-        .where(
-            (EstimateSnapshotEntry.estimate_version_id == estimate_version_id)
-            & (EstimateSnapshotEntry.drawing_revision_id == revision_id)
-            & (File.deleted_at.is_(None))
-            & (Project.deleted_at.is_(None))
-        )
-    )
-    if pagination_cursor is not None:
-        sort_order, row_id = pagination_cursor
-        query = query.where(
-            (EstimateSnapshotEntry.sort_order > sort_order)
-            | (
-                (EstimateSnapshotEntry.sort_order == sort_order)
-                & (EstimateSnapshotEntry.id > row_id)
-            )
-        )
-
-    result = await db.execute(
-        query.order_by(
-            EstimateSnapshotEntry.sort_order.asc(), EstimateSnapshotEntry.id.asc()
-        ).limit(limit + 1)
-    )
-    rows = result.scalars().all()
-    page = rows[:limit]
-    next_cursor = None
-    if len(rows) > limit and page:
-        last_row = page[-1]
-        next_cursor = _encode_estimate_snapshot_entry_cursor(last_row.sort_order, last_row.id)
-
-    return EstimateSnapshotEntryListResponse(
-        items=[EstimateSnapshotEntryRead.model_validate(row) for row in page],
-        next_cursor=next_cursor,
-    )
-
-
-@revisions_router.post(
-    "/revisions/{revision_id}/quantity-takeoffs",
-    response_model=JobRead,
-    status_code=status.HTTP_202_ACCEPTED,
-)
-async def create_revision_quantity_takeoff(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
-) -> Job | Response:
-    """Create a pending quantity takeoff job for an active drawing revision."""
-
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            f"revisions.quantity_takeoffs:{revision_id}",
-            {"revision_id": str(revision_id)},
-        )
-        replay_response = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert revision is not None
-    await _get_active_revision_manifest_or_409(revision_id, db)
-    report = await _get_active_validation_report_or_404(revision_id, db)
-    if report.quantity_gate in {
-        QuantityGate.REVIEW_GATED.value,
-        QuantityGate.BLOCKED.value,
-    }:
-        _raise_quantity_takeoff_gate_invalid(report)
-
-    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
-    if locked_revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    revision = locked_revision
-    assert revision is not None
-
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/revisions/{revision_id}/quantity-takeoffs",
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
-
-    quantity_job = Job(
-        id=uuid4(),
-        project_id=revision.project_id,
-        file_id=revision.source_file_id,
-        extraction_profile_id=None,
-        base_revision_id=revision.id,
-        parent_job_id=None,
-        job_type=JobType.QUANTITY_TAKEOFF.value,
-        status="pending",
-        attempts=0,
-        max_attempts=3,
-        enqueue_status="pending",
-        enqueue_attempts=0,
-        cancel_requested=False,
-        error_code=None,
-        error_message=None,
-        started_at=None,
-        finished_at=None,
-    )
-    db.add(quantity_job)
-    prepare_job_enqueue_intent(quantity_job)
-    await db.flush()
-    await db.refresh(quantity_job)
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(quantity_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await publish_job_enqueue_intent(
-        quantity_job.id,
-        publisher=enqueue_quantity_takeoff_job,
-        suppress_exceptions=True,
-    )
-
-    if success_response is not None:
-        return success_response
-
-    return quantity_job
-
-
-@revisions_router.get(
-    "/revisions/{revision_id}/validation-report",
-    response_model=ValidationReportResponse,
-)
-async def get_validation_report(
-    revision_id: UUID,
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> ValidationReportResponse:
-    """Return the persisted canonical validation report for a drawing revision."""
-    report = await _get_active_validation_report_or_404(revision_id, db)
-    return build_validation_report_response(report)
+revisions_router.include_router(validation_reports_router)

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -91,6 +91,9 @@ from app.api.v1.revision_lineage import (
 from app.api.v1.revision_lineage import (
     _get_revision_quantity_takeoff_or_404 as _lineage_get_revision_quantity_takeoff_or_404,
 )
+from app.api.v1.revision_lineage import (
+    _manifest_counts as _lineage_manifest_counts,
+)
 from app.api.v1.revision_routes.adapter_outputs import (
     adapter_outputs_router,
 )
@@ -146,6 +149,7 @@ _MAX_PAGE_SIZE = 200
 
 _get_active_file = _lineage_get_active_file
 _get_active_revision = _lineage_get_active_revision
+_manifest_counts = _lineage_manifest_counts
 _get_revision_quantity_takeoff_or_404 = _lineage_get_revision_quantity_takeoff_or_404
 _get_revision_estimate_version_or_404 = _lineage_get_revision_estimate_version_or_404
 _NormalizedEstimateCatalogRef = _estimate_inputs_NormalizedEstimateCatalogRef

--- a/tests/test_revision_router_contract.py
+++ b/tests/test_revision_router_contract.py
@@ -1,0 +1,470 @@
+"""Regression contract for the revision API route table."""
+
+from annotated_types import Ge, Le
+from fastapi.routing import APIRoute
+from pydantic_core import PydanticUndefined
+
+from app.api.v1.revisions import revisions_router
+
+type RouteParameterContract = tuple[
+    str,
+    str | None,
+    bool | None,
+    object | None,
+    object | None,
+    object | None,
+    str | None,
+]
+
+
+def _parameter_contract(route: APIRoute) -> tuple[RouteParameterContract, ...]:
+    """Return path/query/dependency metadata for a route."""
+
+    parameter_contract: list[RouteParameterContract] = []
+
+    for parameter in route.dependant.path_params:
+        ge: object | None = None
+        le: object | None = None
+        for metadata in parameter.field_info.metadata:
+            if isinstance(metadata, Ge):
+                ge = metadata.ge
+            elif isinstance(metadata, Le):
+                le = metadata.le
+
+        required = parameter.default is PydanticUndefined
+        default = None if required else parameter.default
+        parameter_contract.append(("path", parameter.name, required, default, ge, le, None))
+
+    for parameter in route.dependant.query_params:
+        ge = None
+        le = None
+        for metadata in parameter.field_info.metadata:
+            if isinstance(metadata, Ge):
+                ge = metadata.ge
+            elif isinstance(metadata, Le):
+                le = metadata.le
+
+        required = parameter.default is PydanticUndefined
+        default = None if required else parameter.default
+        parameter_contract.append(("query", parameter.name, required, default, ge, le, None))
+
+    for dependency in route.dependant.dependencies:
+        dependency_name = dependency.call.__name__ if dependency.call else None
+        parameter_contract.append(
+            (
+                "dependency",
+                dependency.name,
+                None,
+                None,
+                None,
+                None,
+                dependency_name,
+            )
+        )
+
+    return tuple(parameter_contract)
+
+
+def _route_contract() -> list[
+    tuple[
+        str,
+        str,
+        str,
+        str,
+        str | None,
+        int | None,
+        tuple[RouteParameterContract, ...],
+    ]
+]:
+    """Return ordered revision route contract tuples."""
+
+    contract: list[
+        tuple[
+            str,
+            str,
+            str,
+            str,
+            str | None,
+            int | None,
+            tuple[RouteParameterContract, ...],
+        ]
+    ] = []
+    for route in revisions_router.routes:
+        if not isinstance(route, APIRoute):
+            continue
+
+        method = next(iter(route.methods))
+        response_model_name = (
+            route.response_model.__name__ if route.response_model is not None else None
+        )
+        contract.append(
+            (
+                method,
+                route.path,
+                route.name,
+                route.endpoint.__name__,
+                response_model_name,
+                route.status_code,
+                _parameter_contract(route),
+            )
+        )
+
+    return contract
+
+
+def test_revision_router_routes_match_baseline_contract() -> None:
+    # Arrange
+    expected_contract = [
+        (
+            "GET",
+            "/files/{file_id}/revisions",
+            "list_file_revisions",
+            "list_file_revisions",
+            "DrawingRevisionListResponse",
+            None,
+            (
+                ("path", "file_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/adapter-output",
+            "get_revision_adapter_output",
+            "get_revision_adapter_output",
+            "AdapterRunOutputRead",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/adapter-outputs/{adapter_output_id}",
+            "get_adapter_output",
+            "get_adapter_output",
+            "AdapterRunOutputRead",
+            None,
+            (
+                ("path", "adapter_output_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/files/{file_id}/generated-artifacts",
+            "list_file_generated_artifacts",
+            "list_file_generated_artifacts",
+            "GeneratedArtifactListResponse",
+            None,
+            (
+                ("path", "file_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/generated-artifacts",
+            "list_revision_generated_artifacts",
+            "list_revision_generated_artifacts",
+            "GeneratedArtifactListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/layouts",
+            "list_revision_layouts",
+            "list_revision_layouts",
+            "RevisionLayoutListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/layers",
+            "list_revision_layers",
+            "list_revision_layers",
+            "RevisionLayerListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/blocks",
+            "list_revision_blocks",
+            "list_revision_blocks",
+            "RevisionBlockListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/entities",
+            "list_revision_entities",
+            "list_revision_entities",
+            "RevisionEntityListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("query", "entity_id", False, None, None, None, None),
+                ("query", "entity_type", False, None, None, None, None),
+                ("query", "layout_ref", False, None, None, None, None),
+                ("query", "layer_ref", False, None, None, None, None),
+                ("query", "block_ref", False, None, None, None, None),
+                ("query", "parent_entity_ref", False, None, None, None, None),
+                ("query", "source_identity", False, None, None, None, None),
+                ("query", "source_hash", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/entities/{entity_id:path}",
+            "get_revision_entity",
+            "get_revision_entity",
+            "RevisionEntityRead",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "entity_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/quantity-takeoffs",
+            "list_revision_quantity_takeoffs",
+            "list_revision_quantity_takeoffs",
+            "QuantityTakeoffListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}",
+            "get_revision_quantity_takeoff",
+            "get_revision_quantity_takeoff",
+            "QuantityTakeoffRead",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "takeoff_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/items",
+            "list_revision_quantity_takeoff_items",
+            "list_revision_quantity_takeoff_items",
+            "QuantityItemListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "takeoff_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/estimates",
+            "list_revision_estimates",
+            "list_revision_estimates",
+            "EstimateVersionListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "POST",
+            "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
+            "create_revision_estimate_version",
+            "create_revision_estimate_version",
+            "JobRead",
+            202,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "takeoff_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+                (
+                    "dependency",
+                    "idempotency_key",
+                    None,
+                    None,
+                    None,
+                    None,
+                    "get_idempotency_key",
+                ),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/estimates/{estimate_version_id}",
+            "get_revision_estimate",
+            "get_revision_estimate",
+            "EstimateVersionRead",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "estimate_version_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/estimates/{estimate_version_id}/items",
+            "list_revision_estimate_items",
+            "list_revision_estimate_items",
+            "EstimateItemListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "estimate_version_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/estimates/{estimate_version_id}/snapshot-entries",
+            "list_revision_estimate_snapshot_entries",
+            "list_revision_estimate_snapshot_entries",
+            "EstimateSnapshotEntryListResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("path", "estimate_version_id", True, None, None, None, None),
+                ("query", "limit", False, 50, 1, 200, None),
+                ("query", "cursor", False, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+        (
+            "POST",
+            "/revisions/{revision_id}/quantity-takeoffs",
+            "create_revision_quantity_takeoff",
+            "create_revision_quantity_takeoff",
+            "JobRead",
+            202,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+                (
+                    "dependency",
+                    "idempotency_key",
+                    None,
+                    None,
+                    None,
+                    None,
+                    "get_idempotency_key",
+                ),
+            ),
+        ),
+        (
+            "GET",
+            "/revisions/{revision_id}/validation-report",
+            "get_validation_report",
+            "get_validation_report",
+            "ValidationReportResponse",
+            None,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+            ),
+        ),
+    ]
+
+    # Act
+    actual_contract = _route_contract()
+
+    # Assert
+    assert actual_contract == expected_contract
+
+
+def test_revision_router_excludes_legacy_entity_and_estimate_post_routes() -> None:
+    # Arrange
+    forbidden_contract_entries = {
+        (
+            "GET",
+            "/revisions/{revision_id}/entities/{entity_id}",
+            "get_revision_entity",
+            "get_revision_entity",
+            "RevisionEntityRead",
+            None,
+            (),
+        ),
+        (
+            "POST",
+            "/revisions/{revision_id}/estimate-versions",
+            "create_revision_estimate_version",
+            "create_revision_estimate_version",
+            "JobRead",
+            202,
+            (),
+        ),
+    }
+
+    # Act
+    actual_contract = {
+        (
+            method,
+            path,
+            name,
+            endpoint_name,
+            response_model_name,
+            status_code,
+            (),
+        )
+        for (
+            method,
+            path,
+            name,
+            endpoint_name,
+            response_model_name,
+            status_code,
+            _,
+        ) in _route_contract()
+    }
+
+    # Assert
+    assert actual_contract.isdisjoint(forbidden_contract_entries)


### PR DESCRIPTION
Closes #232

## Summary
- split `app/api/v1/revisions.py` into focused child route modules while keeping the facade import/export surface stable
- extract shared cursor, lineage, estimate-input, and facade-compat helpers to preserve monkeypatch-sensitive tests and route behavior
- add a revision route contract regression test that locks route order, status codes, and dependency metadata

## Test plan
- [x] uv run pytest
- [x] uv run mypy app tests
- [x] uv run python -c \"import app.api.v1.revisions\"