### PR TITLE
test(pytest): add explicit smoke, integration, and compose-smoke lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,20 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
 
+      - name: Run pytest smoke lane
+        run: uv run pytest -m "smoke and not integration and not compose_smoke"
+
       - name: Run Alembic migrations
         run: uv run alembic upgrade head
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
 
-      - name: Run pytest
-        run: uv run pytest
+      - name: Run pytest non-integration lane
+        run: uv run pytest -m "not integration and not compose_smoke and not smoke"
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
+
+      - name: Run pytest integration lane
+        run: uv run pytest -m "integration and not compose_smoke"
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@
 #
 # NOTE: app/ and tests/ directories are scaffolded in a later step (#20/#21).
 # Lint and typecheck targets will report "no files found" until then.
-#   make test        — Run pytest
+#   make test        — Run full pytest suite
+#   make smoke       — Run fast smoke pytest lane
+#   make integration — Run DB-backed integration pytest lane
+#   make compose-smoke — Run opt-in Docker Compose smoke pytest lane
 #   make format      — Run ruff formatter on app/ and tests/
 #   make check       — Run lint + typecheck + test
 #   make hooks       — Install pre-commit + adaptive pre-push hooks
@@ -21,11 +24,15 @@
 #   make migrate     — Run Alembic migrations
 # =============================================================================
 
-UV_SYNC_ARGS = --extra db --extra jobs --extra dev --extra test
+UV_SYNC_ARGS = --extra db --extra jobs --extra ingestion --extra dev --extra test
 PRE_PUSH_HOOK = .git/hooks/pre-push
 PRE_PUSH_HOOK_VERSION = v1
+PYTEST_SMOKE_EXPRESSION = smoke and not integration and not compose_smoke
+PYTEST_INTEGRATION_EXPRESSION = integration and not compose_smoke
+PYTEST_COMPOSE_SMOKE_EXPRESSION = compose_smoke
+SMOKE_BASE_URL ?= http://localhost:8000
 
-.PHONY: sync lint typecheck test format check hooks up down logs ps shell-api shell-worker migrate
+.PHONY: sync lint typecheck test smoke integration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
 
 sync:
 	uv sync $(UV_SYNC_ARGS)
@@ -38,6 +45,16 @@ typecheck:
 
 test:
 	uv run pytest
+
+smoke:
+	uv run pytest -m "$(PYTEST_SMOKE_EXPRESSION)"
+
+integration:
+	uv run alembic upgrade head
+	uv run pytest -m "$(PYTEST_INTEGRATION_EXPRESSION)"
+
+compose-smoke:
+	COMPOSE_SMOKE=1 SMOKE_BASE_URL="$(SMOKE_BASE_URL)" uv run pytest -m "$(PYTEST_COMPOSE_SMOKE_EXPRESSION)"
 
 format:
 	uv run ruff format app tests

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Local Docker Compose development and GitHub Actions CI both run PostgreSQL 18.
 > [!WARNING]
 > Docker Compose now runs PostgreSQL 18. Existing local Docker volumes created
 > for PostgreSQL 17 will not boot as-is under PostgreSQL 18.
-> 
+>
 > - If the data matters, dump it from PostgreSQL 17 first and restore it into a
 >   fresh PostgreSQL 18 volume.
 > - If the data does not matter, reset the local stack destructively with:
@@ -102,6 +102,68 @@ make migrate        # Run database migrations
 make down -v        # Stop and remove volumes (destructive)
 ```
 
+### Pytest Lanes
+
+The repository keeps three explicit pytest lanes with non-overlapping marker expressions:
+
+- `make smoke` runs the fast smoke lane: `smoke and not integration and not compose_smoke`
+- `make integration` runs the database-backed integration lane: `integration and not compose_smoke`
+- `make compose-smoke` runs the opt-in Docker Compose lane: `compose_smoke`
+
+#### Smoke
+
+Purpose: fast host-side verification without Docker Compose.
+
+Prerequisites:
+
+- `uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test`
+
+Command:
+
+```bash
+make smoke
+# or: uv run pytest -m "smoke and not integration and not compose_smoke"
+```
+
+#### Integration
+
+Purpose: host-side tests that require PostgreSQL and a migrated schema.
+
+Prerequisites:
+
+- PostgreSQL 18 reachable via `DATABASE_URL`
+- Alembic migrations applied to that database
+
+Command:
+
+```bash
+export DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
+make integration
+# or: uv run alembic upgrade head && uv run pytest -m "integration and not compose_smoke"
+```
+
+CI keeps this lane separate from smoke and preserves the PostgreSQL service plus Alembic migration step before pytest.
+
+#### Compose smoke
+
+Purpose: opt-in/manual checks against a running Docker Compose stack.
+
+Prerequisites:
+
+- `make up` (or equivalent `docker compose up -d`) already running
+- `COMPOSE_SMOKE=1` enabled (the `make compose-smoke` target sets this for you)
+- `SMOKE_BASE_URL` set to the API base URL under test (defaults to `http://localhost:8000` in `make compose-smoke`)
+
+Command:
+
+```bash
+make compose-smoke
+# override base URL: make compose-smoke SMOKE_BASE_URL=http://localhost:8001
+# or: COMPOSE_SMOKE=1 SMOKE_BASE_URL=http://localhost:8000 uv run pytest -m "compose_smoke"
+```
+
+This lane stays manual and is not started automatically in CI.
+
 ### Local Development (without Docker)
 
 Prerequisite: use PostgreSQL 18 for host-side database development, or point
@@ -119,7 +181,7 @@ The reported version should be PostgreSQL 18.x.
 
 1. **Install dependencies**:
    ```bash
-   uv sync --locked --extra db --extra jobs --extra dev --extra test
+   uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
    ```
 
 2. **Set up environment**:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     ports:
       - "127.0.0.1:${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,3 +197,8 @@ strict_optional = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "smoke: fast in-memory smoke lane",
+    "integration: tests that require database or integration resources",
+    "compose_smoke: compose-backed real-server smoke lane",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,11 +61,21 @@ _LEGACY_APPEND_ONLY_TRIGGER_NAMES: tuple[str, ...] = (
 )
 _TEST_ONLY_CLEANUP_TABLES: tuple[str, ...] = ("idempotency_keys",)
 
-# Marker for tests that require a running database
-requires_database = pytest.mark.skipif(
-    not os.environ.get("DATABASE_URL"),
-    reason="DATABASE_URL not set - skipping database tests",
-)
+_DATABASE_REQUIRED_REASON = "DATABASE_URL not set - skipping database tests"
+
+# Marker for tests that require a running database.
+requires_database = pytest.mark.integration
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip integration tests when DATABASE_URL is not configured."""
+    if os.environ.get("DATABASE_URL"):
+        return
+
+    skip_database = pytest.mark.skip(reason=_DATABASE_REQUIRED_REASON)
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_database)
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -179,9 +189,7 @@ async def _set_append_only_triggers_enabled(
 
     action = "ENABLE" if enabled else "DISABLE"
     for table_name, trigger_name in triggers:
-        await session.execute(
-            text(f'ALTER TABLE "{table_name}" {action} TRIGGER {trigger_name}')
-        )
+        await session.execute(text(f'ALTER TABLE "{table_name}" {action} TRIGGER {trigger_name}'))
 
 
 async def _assert_append_only_triggers_enabled(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -33,6 +33,7 @@ from app.schemas.system import (
 from tests.conftest import requires_database
 
 
+@pytest.mark.smoke
 def test_version() -> None:
     """Test that version is a non-empty string."""
     assert isinstance(__version__, str)
@@ -71,6 +72,8 @@ def _fake_ingest_payload(*, generated_at: datetime) -> IngestFinalizationPayload
         generated_at=generated_at,
     )
 
+
+@pytest.mark.smoke
 class TestHealthEndpoint:
     """Smoke tests for the health check endpoint."""
 
@@ -125,8 +128,7 @@ class TestHealthEndpoint:
 
         # Assert request ID matches the expected pattern
         assert REQUEST_ID_PATTERN.match(request_id) is not None, (
-            f"Request ID '{request_id}' does not match pattern "
-            f"{REQUEST_ID_PATTERN.pattern}"
+            f"Request ID '{request_id}' does not match pattern {REQUEST_ID_PATTERN.pattern}"
         )
 
         # Assert request ID length is within bounds (max 64 chars)
@@ -197,6 +199,7 @@ class TestHealthEndpoint:
         )
 
 
+@pytest.mark.smoke
 class TestSystemHealthSmoke:
     """Smoke tests for degraded system health behavior."""
 
@@ -267,9 +270,7 @@ class TestIngestWorkflowSmoke:
         payload = _fake_ingest_payload(generated_at=generated_at)
         enqueued_job_ids: list[UUID] = []
 
-        async def _fake_run_ingestion(
-            *args: object, **kwargs: object
-        ) -> IngestFinalizationPayload:
+        async def _fake_run_ingestion(*args: object, **kwargs: object) -> IngestFinalizationPayload:
             del args, kwargs
             return payload
 
@@ -433,9 +434,9 @@ def _read_original_from_worker_storage(
 
     payload: object = json.loads(stdout_lines[-1])
     assert isinstance(payload, dict), "worker storage probe returned non-object JSON"
-    assert all(
-        isinstance(key, str) for key in payload
-    ), "worker storage probe returned non-string keys"
+    assert all(isinstance(key, str) for key in payload), (
+        "worker storage probe returned non-string keys"
+    )
 
     return cast(dict[str, object], payload)
 
@@ -444,6 +445,7 @@ def _read_original_from_worker_storage(
     not (COMPOSE_SMOKE and SMOKE_BASE_URL),
     reason="COMPOSE_SMOKE=1 and SMOKE_BASE_URL must be set for compose smoke",
 )
+@pytest.mark.compose_smoke
 class TestHealthEndpointRealServer:
     """Smoke tests against a real running server (compose stack)."""
 


### PR DESCRIPTION
Closes #235

## Summary
- add explicit pytest markers and collection behavior for smoke, integration, and compose-smoke lanes
- add Makefile and README lane commands, including opt-in compose smoke defaults
- split CI pytest coverage into explicit smoke, non-integration, and integration lanes
- fix local compose Postgres 18 volume mounting so compose-smoke runs against postgres:18-alpine

## Test plan
- [x] uv run pytest --collect-only
- [x] uv run pytest -m "smoke and not integration and not compose_smoke"
- [x] uv run pytest -m "not integration and not compose_smoke and not smoke"
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run alembic upgrade head && DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -m "integration and not compose_smoke"
- [x] COMPOSE_SMOKE=1 SMOKE_BASE_URL=http://localhost:8000 uv run pytest -m "compose_smoke"