### PR TITLE
test: add queue-backed upload-to-revision smoke

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,13 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 
 # Sync runtime dependencies before project source is available
-RUN uv sync --locked --no-install-project --no-dev --extra db --extra jobs
+RUN uv sync --locked --no-install-project --no-dev --extra db --extra jobs --extra dxf
 
 # Copy application source
 COPY app/ ./app/
 
 # Install project and runtime extras into the project environment
-RUN uv sync --locked --no-dev --extra db --extra jobs
+RUN uv sync --locked --no-dev --extra db --extra jobs --extra dxf
 
 # Create non-root user and shared upload root
 RUN useradd -m -u 1000 appuser \

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -3,13 +3,15 @@
 # ruff: noqa: SLF001
 
 import asyncio
+import atexit
 import hashlib
 import heapq
 import inspect
 import json
 import math
+import threading
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Coroutine, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -142,6 +144,9 @@ _SAFE_RUNNER_ERROR_DETAIL_KEYS = (
     "detected_format",
     "media_type",
 )
+
+_WORKER_LOOP_RUNNER: asyncio.Runner | None = None
+_WORKER_LOOP_RUNNER_LOCK = threading.Lock()
 
 
 def is_ingest_worker_job_type(job_type: JobType | str) -> bool:
@@ -386,6 +391,36 @@ celery_app.autodiscover_tasks(["app.jobs"], force=True)
 def _utcnow() -> datetime:
     """Return a timezone-aware UTC timestamp."""
     return datetime.now(UTC)
+
+
+def _get_worker_loop_runner() -> asyncio.Runner:
+    """Return the reusable asyncio runner for sync Celery entrypoints."""
+    global _WORKER_LOOP_RUNNER
+    if _WORKER_LOOP_RUNNER is None:
+        _WORKER_LOOP_RUNNER = asyncio.Runner()
+    return _WORKER_LOOP_RUNNER
+
+
+def _close_worker_loop_runner() -> None:
+    """Close and clear the reusable asyncio runner."""
+    global _WORKER_LOOP_RUNNER
+    with _WORKER_LOOP_RUNNER_LOCK:
+        runner = _WORKER_LOOP_RUNNER
+        if runner is None:
+            return
+        runner.close()
+        _WORKER_LOOP_RUNNER = None
+
+
+def _run_worker_loop[WorkerLoopResultT](
+    coro_factory: Callable[[], Coroutine[Any, Any, WorkerLoopResultT]],
+) -> WorkerLoopResultT:
+    """Run a worker coroutine on the process-local reusable event loop."""
+    with _WORKER_LOOP_RUNNER_LOCK:
+        return _get_worker_loop_runner().run(coro_factory())
+
+
+atexit.register(_close_worker_loop_runner)
 
 
 def _clear_job_attempt_lease(job: Job) -> None:
@@ -4136,7 +4171,7 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
 def recover_incomplete_ingest_jobs_on_worker_start(**_: object) -> None:
     """Requeue incomplete ingest/reprocess/quantity/estimate jobs when a worker starts."""
     try:
-        recovered_job_ids = asyncio.run(recover_incomplete_ingest_jobs())
+        recovered_job_ids = _run_worker_loop(recover_incomplete_ingest_jobs)
     except Exception as exc:
         logger.error("ingest_job_recovery_failed", error=str(exc), exc_info=True)
         return
@@ -4159,7 +4194,7 @@ worker_ready.connect(recover_incomplete_ingest_jobs_on_worker_start)
 )
 def run_ingest_job(job_id: str) -> None:
     """Celery task wrapper for the persisted ingest job processor."""
-    asyncio.run(process_ingest_job(UUID(job_id)))
+    _run_worker_loop(lambda: process_ingest_job(UUID(job_id)))
 
 
 def enqueue_ingest_job(job_id: UUID) -> None:
@@ -4307,7 +4342,7 @@ async def process_quantity_takeoff_job(job_id: UUID) -> None:
 )
 def run_quantity_takeoff_job(job_id: str) -> None:
     """Celery task wrapper for persisted quantity takeoff jobs."""
-    asyncio.run(process_quantity_takeoff_job(UUID(job_id)))
+    _run_worker_loop(lambda: process_quantity_takeoff_job(UUID(job_id)))
 
 
 def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
@@ -4437,7 +4472,7 @@ async def process_estimate_job(job_id: UUID) -> None:
 )
 def run_estimate_job(job_id: str) -> None:
     """Celery task wrapper for persisted estimate jobs."""
-    asyncio.run(process_estimate_job(UUID(job_id)))
+    _run_worker_loop(lambda: process_estimate_job(UUID(job_id)))
 
 
 def enqueue_estimate_job(job_id: UUID) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,11 @@ jobs = [
     "flower>=2.0",
 ]
 
+# DXF-only ingestion runtime — narrow compose/runtime path without PDF/IFC/raster deps
+dxf = [
+    "ezdxf>=1.2",
+]
+
 # Ingestion adapters — isolated behind the adapter contract (ADR-0006/0007/0008).
 # NOTE: LibreDWG still requires a system install; IfcOpenShell remains optional here.
 ingestion = [
@@ -134,7 +139,7 @@ test = [
 
 # Convenience: install everything
 all = [
-    "draupnir[db,jobs,ingestion,dev,test]",
+    "draupnir[db,jobs,dxf,ingestion,dev,test]",
 ]
 
 # ---------------------------------------------------------------------------

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -161,6 +161,53 @@ def _manifest_line_geometry(length: float) -> dict[str, Any]:
     }
 
 
+def test_worker_loop_reuses_same_running_loop_for_sequential_sync_entrypoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sync worker entrypoints should reuse one running loop across sequential calls."""
+    observed_calls: list[tuple[str, uuid.UUID, int]] = []
+    recovered_loop_ids: list[int] = []
+    ingest_job_id = uuid.uuid4()
+    quantity_job_id = uuid.uuid4()
+    estimate_job_id = uuid.uuid4()
+
+    async def _fake_recover() -> list[uuid.UUID]:
+        recovered_loop_ids.append(id(asyncio.get_running_loop()))
+        return []
+
+    async def _fake_process_ingest(job_id: uuid.UUID) -> None:
+        observed_calls.append(("ingest", job_id, id(asyncio.get_running_loop())))
+
+    async def _fake_process_quantity(job_id: uuid.UUID) -> None:
+        observed_calls.append(("quantity", job_id, id(asyncio.get_running_loop())))
+
+    async def _fake_process_estimate(job_id: uuid.UUID) -> None:
+        observed_calls.append(("estimate", job_id, id(asyncio.get_running_loop())))
+
+    worker_module._close_worker_loop_runner()
+    monkeypatch.setattr(worker_module, "recover_incomplete_ingest_jobs", _fake_recover)
+    monkeypatch.setattr(worker_module, "process_ingest_job", _fake_process_ingest)
+    monkeypatch.setattr(worker_module, "process_quantity_takeoff_job", _fake_process_quantity)
+    monkeypatch.setattr(worker_module, "process_estimate_job", _fake_process_estimate)
+
+    try:
+        worker_module.recover_incomplete_ingest_jobs_on_worker_start()
+        worker_module.run_ingest_job(str(ingest_job_id))
+        worker_module.run_quantity_takeoff_job(str(quantity_job_id))
+        worker_module.run_estimate_job(str(estimate_job_id))
+    finally:
+        worker_module._close_worker_loop_runner()
+
+    assert [call[:2] for call in observed_calls] == [
+        ("ingest", ingest_job_id),
+        ("quantity", quantity_job_id),
+        ("estimate", estimate_job_id),
+    ]
+    assert len(recovered_loop_ids) == 1
+    loop_ids = recovered_loop_ids + [loop_id for _, _, loop_id in observed_calls]
+    assert len(set(loop_ids)) == 1
+
+
 def _quantity_item_values_by_type(items: list[QuantityItem], *, item_kind: str) -> dict[str, float]:
     """Return persisted quantity item values keyed by quantity type."""
     values: dict[str, float] = {}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,6 @@
 """Smoke tests for Draupnir."""
 
+import asyncio
 import io
 import json
 import logging
@@ -9,7 +10,7 @@ from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -354,6 +355,8 @@ class TestIngestWorkflowSmoke:
 COMPOSE_SMOKE = os.environ.get("COMPOSE_SMOKE") == "1"
 SMOKE_BASE_URL = os.environ.get("SMOKE_BASE_URL", "")
 REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_DXF_FIXTURE_PATH = REPO_ROOT / "tests/fixtures/dxf/simple-line.dxf"
+COMPOSE_DXF_MEDIA_TYPE = "image/vnd.dxf"
 WORKER_STORAGE_READ_SCRIPT = """
 import asyncio
 import hashlib
@@ -441,6 +444,71 @@ def _read_original_from_worker_storage(
     return cast(dict[str, object], payload)
 
 
+async def _job_events_diagnostics(
+    *,
+    real_async_client: httpx.AsyncClient,
+    job_id: UUID,
+) -> str:
+    response = await real_async_client.get(f"/v1/jobs/{job_id}/events?limit=20")
+    if response.status_code != 200:
+        return f"events_status={response.status_code} events_body={response.text[:500]}"
+
+    data = response.json()
+    return json.dumps(data)[-1000:]
+
+
+async def _wait_for_job_success(
+    *,
+    real_async_client: httpx.AsyncClient,
+    job_id: UUID,
+    timeout_seconds: float = 90.0,
+    poll_interval_seconds: float = 0.5,
+) -> dict[str, object]:
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    last_status: object = None
+    last_error_code: object = None
+    last_error_message: object = None
+
+    while asyncio.get_running_loop().time() < deadline:
+        job_response = await real_async_client.get(f"/v1/jobs/{job_id}")
+        assert job_response.status_code == 200, job_response.text
+        job_data = cast(dict[str, object], job_response.json())
+
+        last_status = job_data.get("status")
+        last_error_code = job_data.get("error_code")
+        last_error_message = job_data.get("error_message")
+
+        if last_status == "succeeded":
+            return job_data
+
+        if last_status in {"failed", "cancelled"}:
+            events_diagnostics = await _job_events_diagnostics(
+                real_async_client=real_async_client,
+                job_id=job_id,
+            )
+            raise AssertionError(
+                "ingest job did not succeed: "
+                f"status={last_status} "
+                f"error_code={last_error_code} "
+                f"error_message={last_error_message} "
+                f"events={events_diagnostics}"
+            )
+
+        await asyncio.sleep(poll_interval_seconds)
+
+    events_diagnostics = await _job_events_diagnostics(
+        real_async_client=real_async_client,
+        job_id=job_id,
+    )
+    raise AssertionError(
+        "ingest job timed out before success: "
+        f"status={last_status} "
+        f"error_code={last_error_code} "
+        f"error_message={last_error_message} "
+        f"events={events_diagnostics}"
+    )
+
+
 @pytest.mark.skipif(
     not (COMPOSE_SMOKE and SMOKE_BASE_URL),
     reason="COMPOSE_SMOKE=1 and SMOKE_BASE_URL must be set for compose smoke",
@@ -492,7 +560,7 @@ class TestHealthEndpointRealServer:
         real_async_client: httpx.AsyncClient,
     ) -> None:
         """Compose stack shares immutable upload storage between API and worker."""
-        pdf_bytes = b"%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF\n"
+        dxf_bytes = COMPOSE_DXF_FIXTURE_PATH.read_bytes()
 
         project_response = await real_async_client.post(
             "/v1/projects",
@@ -503,7 +571,13 @@ class TestHealthEndpointRealServer:
 
         upload_response = await real_async_client.post(
             f"/v1/projects/{project_id}/files",
-            files={"file": ("compose-smoke.pdf", pdf_bytes, "application/pdf")},
+            files={
+                "file": (
+                    COMPOSE_DXF_FIXTURE_PATH.name,
+                    dxf_bytes,
+                    COMPOSE_DXF_MEDIA_TYPE,
+                )
+            },
         )
         assert upload_response.status_code == 201
 
@@ -521,5 +595,68 @@ class TestHealthEndpointRealServer:
         assert worker_data == {
             "path": storage_key,
             "sha256": checksum_sha256,
-            "size": len(pdf_bytes),
+            "size": len(dxf_bytes),
         }
+
+    async def test_upload_ingest_job_persists_revision_and_validation_via_public_apis(
+        self,
+        real_async_client: httpx.AsyncClient,
+    ) -> None:
+        """Compose smoke validates upload->worker->revision/validation API visibility."""
+        project_response = await real_async_client.post(
+            "/v1/projects",
+            json={"name": f"compose-smoke-ingest-{uuid4()}"},
+        )
+        assert project_response.status_code == 201
+        project_id = project_response.json()["id"]
+        UUID(project_id)
+
+        dxf_bytes = COMPOSE_DXF_FIXTURE_PATH.read_bytes()
+
+        upload_response = await real_async_client.post(
+            f"/v1/projects/{project_id}/files",
+            files={
+                "file": (
+                    COMPOSE_DXF_FIXTURE_PATH.name,
+                    dxf_bytes,
+                    COMPOSE_DXF_MEDIA_TYPE,
+                )
+            },
+        )
+        assert upload_response.status_code == 201, upload_response.text
+
+        upload_data = upload_response.json()
+        file_id = UUID(upload_data["id"])
+        job_id = UUID(upload_data["initial_job_id"])
+        extraction_profile_id = UUID(upload_data["initial_extraction_profile_id"])
+        assert str(file_id) == upload_data["id"]
+        assert str(job_id) == upload_data["initial_job_id"]
+        assert str(extraction_profile_id) == upload_data["initial_extraction_profile_id"]
+
+        _ = await _wait_for_job_success(
+            real_async_client=real_async_client,
+            job_id=job_id,
+        )
+
+        revisions_response = await real_async_client.get(f"/v1/files/{file_id}/revisions")
+        assert revisions_response.status_code == 200, revisions_response.text
+        revisions_data = revisions_response.json()
+        assert revisions_data["items"]
+
+        first_revision = revisions_data["items"][0]
+        revision_id = UUID(first_revision["id"])
+        assert first_revision["source_file_id"] == str(file_id)
+        assert first_revision["source_job_id"] == str(job_id)
+        assert first_revision["extraction_profile_id"] == str(extraction_profile_id)
+        assert first_revision["revision_sequence"] == 1
+
+        validation_response = await real_async_client.get(
+            f"/v1/revisions/{revision_id}/validation-report"
+        )
+        assert validation_response.status_code == 200, validation_response.text
+        validation_data = validation_response.json()
+        assert validation_data["drawing_revision_id"] == str(revision_id)
+        assert validation_data["source_job_id"] == str(job_id)
+        assert validation_data["validation_status"] == "valid"
+        assert validation_data["review_state"] == "approved"
+        assert validation_data["quantity_gate"] == "allowed"

--- a/uv.lock
+++ b/uv.lock
@@ -544,6 +544,9 @@ dev = [
     { name = "pre-commit" },
     { name = "ruff" },
 ]
+dxf = [
+    { name = "ezdxf" },
+]
 ingestion = [
     { name = "ezdxf" },
     { name = "ifcopenshell" },
@@ -574,7 +577,8 @@ requires-dist = [
     { name = "asyncpg", marker = "extra == 'db'", specifier = ">=0.29" },
     { name = "celery", marker = "extra == 'jobs'", specifier = ">=5.3" },
     { name = "celery-stubs", marker = "extra == 'jobs'", specifier = ">=0.1" },
-    { name = "draupnir", extras = ["db", "jobs", "ingestion", "dev", "test"], marker = "extra == 'all'" },
+    { name = "draupnir", extras = ["db", "jobs", "dxf", "ingestion", "dev", "test"], marker = "extra == 'all'" },
+    { name = "ezdxf", marker = "extra == 'dxf'", specifier = ">=1.2" },
     { name = "ezdxf", marker = "extra == 'ingestion'", specifier = ">=1.2" },
     { name = "factory-boy", marker = "extra == 'test'", specifier = ">=3.3" },
     { name = "fastapi", specifier = ">=0.110" },
@@ -605,7 +609,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.25" },
     { name = "vtracer", marker = "extra == 'ingestion'", specifier = ">=0.6" },
 ]
-provides-extras = ["db", "jobs", "ingestion", "dev", "test", "all"]
+provides-extras = ["db", "jobs", "dxf", "ingestion", "dev", "test", "all"]
 
 [[package]]
 name = "ecdsa"


### PR DESCRIPTION
Closes #236

## Summary
- add a compose-gated DXF upload smoke that verifies real worker-backed revision and validation visibility through public APIs
- install a narrow DXF-only runtime path in Docker instead of the full ingestion bundle
- reuse a process-local asyncio runner for sync Celery entrypoints to avoid asyncpg cross-event-loop failures

## Test plan
- [x] uv lock --check
- [x] uv run ruff check app/jobs/worker.py tests/test_jobs.py tests/test_smoke.py
- [x] uv run mypy app/jobs/worker.py tests/test_jobs.py tests/test_smoke.py
- [x] uv run pytest tests/test_jobs.py -k "run_estimate_job_dispatches_persisted_processor or worker_loop"
- [x] docker compose build api worker && docker compose up -d --force-recreate api worker && make migrate && make compose-smoke

## Notes
- Deep review approved with one non-blocking nice-to-have: the storage-sharing compose smoke now enqueues a DXF ingest job without waiting for completion, which could be isolated later if it becomes flaky.