### PR TITLE
docs(exports): define Phase 8 export contracts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -398,8 +398,12 @@ origin and lock anchor for the chain:
 ingest(file)
   -> [optional] quantity_takeoff(drawing_revision)
        -> [optional] estimate(quantity_takeoff, rate_catalog)
-            -> [optional] export(...)
+             -> [optional] export(...)
 ```
+
+`export(...)` is one shared downstream job type, not a separate worker contract
+per format. It consumes one pinned lineage context and commits one immutable
+artifact at most.
 
 `ingest(file)` produces a `drawing_revision` that becomes the pinned input for
 later revision-scoped work. `quantity_takeoff(drawing_revision)` worker
@@ -446,6 +450,24 @@ Operationally, this distinguishes retry from regeneration or re-export:
   new ids and storage keys per the artifact lifecycle rules below.
 - `job_events` are the durable trace for queueing, execution, cancellation,
   retry scheduling, and terminal outcome transitions across attempts.
+
+For export jobs specifically:
+
+- Pure export services are responsible for deterministic rendering/serialization
+  from already-pinned lineage inputs, but they do not commit database rows,
+  publish storage objects, or mark terminal success on their own.
+- Worker finalization exclusively owns committed artifact publication,
+  append-only artifact row creation, and the terminal `succeeded` transition.
+- One export job maps to one committed artifact. If a format later needs
+  multiple files, that must be modeled as a container artifact or a new
+  contract, not as multiple committed artifacts from one job under this MVP
+  rule.
+- Retry of a failed export job may rebuild attempt-local staged bytes, but must
+  never yield more than one committed artifact for that job.
+- Duplicate queue delivery, lease reclaim, or overlapping retry completions must
+  be fenced so only one finalization path commits an artifact.
+- Cancellation observed before finalization commits no artifact. Cancellation
+  after finalization does not retract or mutate the committed artifact.
 
 ## Deployment Topology
 
@@ -498,6 +520,29 @@ Rules:
   artifacts currently own a required quantity-takeoff foreign key.
 - Original uploads and generated artifacts remain separate immutable classes of
   stored objects.
+
+Phase 8 export kinds and boundaries:
+
+| Export kind | Format | Lineage anchor | Trust gate | Pure-service owner | Worker-finalization owner | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Revision JSON | JSON | revision | finalized revision; preserve upstream review/provisional metadata | #251 | #254 | planned |
+| Quantity CSV | CSV | quantity takeoff | trusted allowed takeoff only | #252 | #254 | planned |
+| Estimate CSV | CSV | estimate version | finalized estimate from trusted allowed takeoff | #252 | #254 | planned |
+| Estimate/report PDF | PDF | estimate version | finalized estimate from trusted allowed takeoff | #255 (after #249) | #256 | planned |
+| Debug overlay | SVG/PNG/PDF | source file, drawing revision, job, generator options, optional entity/takeoff/predecessor refs | debug/review use only; existing behavior with no new Phase 8 endpoint owner | none | none | existing |
+| DXF revised drawing | DXF | revision changeset/export context | validated edit/export flow required | none | none | deferred |
+
+Shared export semantics across all kinds:
+
+- Export output must be reproducible from the pinned lineage inputs plus
+  generator name, version, and options snapshot.
+- Export is append-only at the artifact layer even when the bytes are
+  byte-identical to an earlier export.
+- #249 owns only the PDF ADR decision, #250 owns export job type/input
+  persistence, and #253 owns create-endpoint/schema/idempotency work shared
+  across the MVP export kinds above.
+- Phase 8 does not assign an implementation owner for DXF revised drawing
+  export; that contract remains deferred.
 
 Append-only versus mutable record rules:
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -17,6 +17,20 @@
 - Webhook/SSE vs polling-only for MVP events
 - Generated artifact quantity foreign key remains deferred even though docs now
   describe append-only quantity takeoff persistence lineage.
+- DXF revised drawing export remains deferred from the Phase 8 export issue
+  split; there is currently no owner issue for that implementation.
+
+## Phase 8 Export Issue Boundaries
+
+- #249 — PDF ADR only; do not use it for JSON/CSV ownership
+- #250 — Export job type/input persistence
+- #251 — Pure revision JSON service
+- #252 — Pure quantity/estimate CSV services
+- #253 — Export create endpoints, schemas, and idempotency
+- #254 — JSON/CSV worker finalization
+- #255 — Pure PDF generation after #249
+- #256 — PDF worker finalization
+- #257 — End-to-end export smoke
 
 ## Resolved For Phase 7 Estimation Contracts
 

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -56,6 +56,20 @@ The MVP should support:
 - PDF estimate/report
 - DXF revised drawing/export
 
+Phase 8 contract notes:
+
+- The shared export job currently defines MVP-ready contract work for Revision
+  JSON, Quantity CSV, Estimate CSV, Estimate/report PDF, and Debug overlay.
+- Downstream ownership is split by shared responsibilities rather than one issue
+  per export kind: #249 PDF ADR only, #250 job type/input persistence, #251
+  revision JSON pure service, #252 quantity/estimate CSV pure services, #253
+  create endpoints/schemas/idempotency, #254 JSON/CSV worker finalization,
+  #255 PDF pure generation, #256 PDF worker finalization, #257 E2E smoke.
+- DXF revised drawing/export remains in MVP scope at the product level, but its
+  implementation contract is deferred from the current Phase 8 issue split.
+- Later outputs still include DWG/IFC/STEP/IGES and general SVG/PNG preview
+  exports; do not expand the current export contract to those formats yet.
+
 Planned later outputs:
 
 - DWG revised drawing/export through a licensed adapter

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -998,6 +998,52 @@ Generated artifacts are immutable, append-only outputs. The system must never
 overwrite an existing generated artifact row/object in place, even when
 regenerating the same logical export.
 
+Phase 8 export contract narrows this further:
+
+- MVP export kinds are fixed to: `revision_json`, `quantity_csv`,
+  `estimate_csv`, `estimate_pdf`, `debug_overlay`, and a later
+  `revised_dxf` contract that stays deferred for now.
+- Export remains one job type, `export`, across all artifact kinds.
+- One export job commits at most one visible artifact row/object. Bundles or
+  multi-file payloads are post-MVP.
+- Export services may build deterministic payload bytes in memory or in
+  attempt-local staging, but only worker finalization may publish the committed
+  artifact row/object and terminal job success.
+- Retries are for the same failed job and must still yield at most one
+  committed artifact. Re-export/regeneration is a new job and therefore a new
+  artifact id/storage key.
+- Duplicate delivery or overlapping retry completion must collapse to one
+  winning finalization path. Losers must not publish a second artifact.
+- Cancellation before final commit publishes no artifact. Cancellation after a
+  committed artifact leaves the artifact immutable and only changes workflow
+  history.
+
+### Export Kind Matrix
+
+| Export kind | MVP format | Required lineage refs | Trust gate | Pure-service owner | Worker-finalization owner | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `revision_json` | JSON | `source_file_id`, `drawing_revision_id`, `job_id` | finalized revision required; may reflect provisional/review metadata but not hide it | #251 | #254 | planned |
+| `quantity_csv` | CSV | `source_file_id`, `drawing_revision_id`, `quantity_takeoff_id`, `job_id` | trusted takeoff only (`quantity_gate = allowed`) | #252 | #254 | planned |
+| `estimate_csv` | CSV | `source_file_id`, `drawing_revision_id`, `quantity_takeoff_id`, `estimate_id`, `job_id` | finalized estimate only; estimate must derive from trusted allowed takeoff | #252 | #254 | planned |
+| `estimate_pdf` | PDF | `source_file_id`, `drawing_revision_id`, `quantity_takeoff_id`, `estimate_id`, `job_id` | finalized estimate only; estimate must derive from trusted allowed takeoff | #255 (after #249) | #256 | planned |
+| `debug_overlay` | SVG, PNG, or PDF | `source_file_id`, `drawing_revision_id`, `job_id`, generator options, optional entity/takeoff/predecessor refs | review/debug artifact; not a trusted-estimation substitute; existing behavior with no new Phase 8 endpoint owner | none | none | existing |
+| `revised_dxf` | DXF | would require `source_file_id`, `drawing_revision_id`, `changeset_id`, `job_id` | requires validated revision-edit/export path | none | none | deferred |
+
+Downstream export issue boundaries for this phase are:
+
+- #249 PDF ADR only; generator choice remains open until that ADR lands
+- #250 export job type/input persistence
+- #251 pure revision JSON service
+- #252 pure quantity/estimate CSV services
+- #253 export create endpoints, request/response schemas, and idempotency
+- #254 JSON/CSV worker finalization
+- #255 pure PDF generation after #249
+- #256 PDF worker finalization
+- #257 end-to-end export smoke coverage
+
+DXF revised drawing export is explicitly deferred in this phase and currently
+has no owning issue in the Phase 8 implementation split.
+
 Minimum artifact lineage fields:
 
 - `source_file_id`
@@ -1025,6 +1071,12 @@ Rules:
   key requirement.
 - Original uploads and generated artifacts follow the same immutability rule but
   remain distinct storage classes and records.
+- Export artifacts are constrained by kind-specific lineage and trust gates, but
+  they still use the same append-only artifact lifecycle.
+- Export payload generation should be deterministic for the same pinned lineage
+  inputs, generator identity, and options snapshot. If a generator version or
+  options change, that is a different export lineage and must produce a new
+  artifact.
 
 Database ownership and append-only policy:
 


### PR DESCRIPTION
Closes #248

## Summary
- define the shared Phase 8 export job and artifact lifecycle
- document export-kind ownership for JSON, CSV, PDF, DXF deferral, and debug overlay behavior
- fix downstream issue boundaries so #249-#257 can implement against a stable contract

## Test plan
- [x] git diff --check -- docs/TRD.md docs/ARCHITECTURE.md docs/MVP.md docs/HANDOFF.md
- [x] verify only scoped docs changed under docs/
- [x] pre-push pytest gate passed automatically during git push

## Notes
- DXF revised drawing export remains a deferred contract target with no owner in #249-#257.
- The working TRD under docs/trds/ remains uncommitted and will be deleted as part of ship cleanup.