### PR TITLE
docs: select ReportLab for PDF exports

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -10,9 +10,9 @@
 - [ADR-0006](./decisions/0006-dwg-adapter.md) — LibreDWG as first DWG adapter
 - [ADR-0007](./decisions/0007-vector-pdf-adapter.md) — PyMuPDF as first vector PDF adapter
 - [ADR-0008](./decisions/0008-raster-pdf-strategy.md) — Raster PDF candidate CAD pipeline with VTracer, centerline extraction, and Tesseract
+- [ADR-0009](./decisions/0009-pdf-report-generator.md) — ReportLab as first estimate PDF report generator
 
 ## Open
-- Final PDF report generator (WeasyPrint vs ReportLab)
 - Geometry validation engine (FreeCAD vs OCCT)
 - Webhook/SSE vs polling-only for MVP events
 - Generated artifact quantity foreign key remains deferred even though docs now
@@ -22,7 +22,7 @@
 
 ## Phase 8 Export Issue Boundaries
 
-- #249 — PDF ADR only; do not use it for JSON/CSV ownership
+- #249 — PDF ADR only; generator choice resolved by ADR-0009
 - #250 — Export job type/input persistence
 - #251 — Pure revision JSON service
 - #252 — Pure quantity/estimate CSV services

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -1031,7 +1031,7 @@ Phase 8 export contract narrows this further:
 
 Downstream export issue boundaries for this phase are:
 
-- #249 PDF ADR only; generator choice remains open until that ADR lands
+- #249 PDF ADR only; selects ReportLab as the first estimate PDF generator
 - #250 export job type/input persistence
 - #251 pure revision JSON service
 - #252 pure quantity/estimate CSV services
@@ -1646,7 +1646,6 @@ Probe rules:
 
 ## Open Technical Questions
 
-- Whether PDF generation uses WeasyPrint or ReportLab.
 - Whether geometry validation starts with FreeCAD or direct OCCT bindings.
 - Webhook/SSE event delivery vs polling-only for MVP.
 - Whether materials live in a shared catalog or per-project.

--- a/docs/decisions/0009-pdf-report-generator.md
+++ b/docs/decisions/0009-pdf-report-generator.md
@@ -1,0 +1,100 @@
+# ADR 0009 - ReportLab As First Estimate PDF Report Generator
+
+## Status
+
+Accepted
+
+## Context
+
+The MVP Phase 8 export plan includes `estimate_pdf` as a generated artifact for a
+finalized estimate derived from a trusted quantity takeoff. Issue #249 is limited
+to selecting the first PDF generator; implementation of pure PDF generation
+remains in #255 and worker finalization remains in #256.
+
+The first generator must fit the MVP export contract:
+
+- deterministic output for pinned lineage, generator version, and options
+- backend-first runtime with no browser dependency
+- acceptable layout control for estimate report tables, totals, headers, and
+  pagination
+- licensing that is safe to document and operate in MVP
+- a clean fallback path if formatting requirements outgrow the first choice
+
+Three options were evaluated:
+
+- **ReportLab** — Python PDF generation toolkit with direct drawing primitives,
+  table/layout helpers, and no browser runtime requirement. BSD-style license.
+
+- **WeasyPrint** — HTML/CSS to PDF engine for Python. Good paged-media layout and
+  print styling, but adds a larger rendering stack and shifts report generation
+  toward HTML templating.
+
+- **Playwright/Chromium print-to-PDF** — browser-based rendering fallback with
+  strong CSS fidelity, but heavyweight runtime and operational surface for MVP.
+
+## Decision
+
+Select **ReportLab** as the first estimate PDF report generator.
+
+Rationale:
+
+- More direct fit for backend-generated, structured estimate reports.
+- Better operational simplicity for MVP because it avoids bundling a browser or
+  HTML/CSS rendering stack.
+- Supports explicit programmatic layout for tables, totals, page headers,
+  footers, and page breaks.
+- Easier to keep export behavior deterministic because document structure is
+  produced from Python code rather than browser-style rendering behavior.
+- Matches the project preference for small, swappable backend components behind a
+  clear export contract.
+
+## Licensing Considerations
+
+- **ReportLab** uses a permissive BSD-style open-source license suitable for MVP
+  distribution and hosted operation.
+- **WeasyPrint** also uses a permissive BSD-style license, so licensing is not
+  the primary differentiator between the two candidates.
+- **Playwright** and **Chromium** are not selected for MVP; they remain a
+  deferred fallback because their heavier runtime and packaging footprint are the
+  main concern, not an immediate licensing blocker.
+- This ADR does not add a legal exception or require special runtime license
+  acknowledgement.
+
+## Alternatives Considered
+
+1. **WeasyPrint** — Main alternative. Advantages:
+   - Strong HTML/CSS paged-media model for branded documents and print styling.
+   - Potentially faster iteration if future reports need complex visual layouts
+     that map naturally to templates.
+
+   Deferred as the first generator because:
+   - it introduces a larger rendering/runtime dependency surface than ReportLab
+   - it pushes MVP report generation toward HTML/CSS template maintenance
+   - deterministic pagination and layout can become more sensitive to renderer
+     behavior, fonts, and environment differences than a direct PDF writer
+
+   **Designated fallback**: if estimate PDF requirements become more document-
+   design-heavy than data-report-heavy, WeasyPrint is the first alternative to
+   evaluate behind the same export contract.
+
+2. **Playwright/Chromium print-to-PDF** — Deferred heavyweight fallback. Useful
+   as a reference option when exact browser print rendering becomes necessary,
+   but rejected for MVP-first selection because it adds a browser runtime,
+   operational complexity, and larger dependency footprint.
+
+## Consequences
+
+- **Positive**: smaller backend runtime surface; explicit layout control;
+  deterministic, code-driven PDF generation; good fit for estimate tables and
+  totals.
+
+- **Negative**: visual composition is more programmatic and less designer-friendly
+  than HTML/CSS templating. Complex branded layouts may take more manual work.
+
+- **Mitigation**: keep PDF generation behind a swappable export generator
+  boundary so #255 can implement ReportLab first without locking out a later
+  WeasyPrint-based generator.
+
+- **Fallback**: if ReportLab proves too rigid for future document styling,
+  evaluate WeasyPrint first; use Playwright/Chromium print-to-PDF only if a
+  browser-rendered path becomes necessary after that.


### PR DESCRIPTION
Closes #249

## Summary
- add ADR-0009 selecting ReportLab as the first estimate PDF generator
- update HANDOFF to close the PDF generator decision and reference ADR-0009
- update TRD Phase 8 notes to remove the open PDF generator question

## Test plan
- [x] git diff --check
- [x] re-read ADR, HANDOFF, and TRD updates for consistency