### PR TITLE
feat(db): add immutable export job input contract #250

### DIFF
--- a/alembic/versions/2026_05_27_0024_add_export_job_input_contract.py
+++ b/alembic/versions/2026_05_27_0024_add_export_job_input_contract.py
@@ -1,0 +1,416 @@
+"""Add export job input contract."""
+
+import alembic.op as op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_05_27_0024"
+down_revision: str | None = "2026_05_18_0023"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+_JOB_TYPE_VALUES = (
+    "ingest",
+    "reprocess",
+    "quantity_takeoff",
+    "estimate",
+    "export",
+)
+_BASE_REQUIRED_JOB_TYPE_VALUES = (
+    "reprocess",
+    "quantity_takeoff",
+    "estimate",
+    "export",
+)
+_EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES = (
+    "quantity_takeoff",
+    "estimate",
+    "export",
+)
+_PRE_EXPORT_JOB_TYPE_VALUES = (
+    "ingest",
+    "reprocess",
+    "quantity_takeoff",
+    "estimate",
+)
+_PRE_EXPORT_BASE_REQUIRED_JOB_TYPE_VALUES = (
+    "reprocess",
+    "quantity_takeoff",
+    "estimate",
+)
+_PRE_EXPORT_EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES = (
+    "quantity_takeoff",
+    "estimate",
+)
+
+
+def _sql_in_list(values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
+
+
+def _replace_jobs_constraints(
+    *,
+    job_type_values: tuple[str, ...],
+    base_required_job_type_values: tuple[str, ...],
+    extraction_profile_forbidden_job_type_values: tuple[str, ...],
+) -> None:
+    op.drop_constraint("ck_jobs_job_type_valid", "jobs", type_="check")
+    op.drop_constraint(
+        "ck_jobs_revision_scoped_base_revision_required",
+        "jobs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_jobs_revision_scoped_extraction_profile_forbidden",
+        "jobs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_jobs_job_type_valid",
+        "jobs",
+        f"job_type IN ({_sql_in_list(job_type_values)})",
+    )
+    op.create_check_constraint(
+        "ck_jobs_revision_scoped_base_revision_required",
+        "jobs",
+        "job_type NOT IN "
+        f"({_sql_in_list(base_required_job_type_values)}) "
+        "OR base_revision_id IS NOT NULL",
+    )
+    op.create_check_constraint(
+        "ck_jobs_revision_scoped_extraction_profile_forbidden",
+        "jobs",
+        "job_type NOT IN "
+        f"({_sql_in_list(extraction_profile_forbidden_job_type_values)}) "
+        "OR extraction_profile_id IS NULL",
+    )
+
+
+def _create_export_job_inputs_append_only_triggers() -> None:
+    op.execute(
+        sa.text(
+            """
+        CREATE TRIGGER trg_append_only_row_guard
+        BEFORE UPDATE OR DELETE ON export_job_inputs
+        FOR EACH ROW
+        EXECUTE FUNCTION enforce_append_only_lineage_row();
+        """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+        CREATE TRIGGER trg_append_only_truncate_guard
+        BEFORE TRUNCATE ON export_job_inputs
+        FOR EACH STATEMENT
+        EXECUTE FUNCTION enforce_append_only_lineage_truncate();
+        """
+        )
+    )
+
+
+def _drop_export_job_inputs_append_only_triggers() -> None:
+    op.execute(sa.text("DROP TRIGGER IF EXISTS trg_append_only_row_guard ON export_job_inputs"))
+    op.execute(
+        sa.text("DROP TRIGGER IF EXISTS trg_append_only_truncate_guard ON export_job_inputs")
+    )
+
+
+def _assert_downgrade_safe() -> None:
+    bind = op.get_bind()
+    export_job_input_exists = bind.execute(
+        sa.text("SELECT 1 FROM export_job_inputs LIMIT 1")
+    ).scalar_one_or_none()
+    if export_job_input_exists is not None:
+        raise RuntimeError("Cannot downgrade with persisted export_job_inputs rows present.")
+
+    export_job_exists = bind.execute(
+        sa.text("SELECT 1 FROM jobs WHERE job_type = 'export' LIMIT 1")
+    ).scalar_one_or_none()
+    if export_job_exists is not None:
+        raise RuntimeError("Cannot downgrade with persisted export jobs present.")
+
+
+def upgrade() -> None:
+    _replace_jobs_constraints(
+        job_type_values=_JOB_TYPE_VALUES,
+        base_required_job_type_values=_BASE_REQUIRED_JOB_TYPE_VALUES,
+        extraction_profile_forbidden_job_type_values=(
+            _EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES
+        ),
+    )
+
+    op.create_table(
+        "export_job_inputs",
+        sa.Column(
+            "source_job_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning export job identifier.",
+        ),
+        sa.Column(
+            "project_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning project identifier copied from the source export job.",
+        ),
+        sa.Column(
+            "source_file_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Owning file identifier copied from the source export job.",
+        ),
+        sa.Column(
+            "drawing_revision_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=False,
+            comment="Pinned revision identifier copied from the source export job.",
+        ),
+        sa.Column(
+            "source_job_type",
+            sa.String(length=64),
+            nullable=False,
+            server_default=sa.text("'export'"),
+            comment="Mirrored job type used to pin this row to export jobs only.",
+        ),
+        sa.Column(
+            "export_kind",
+            sa.String(length=64),
+            nullable=False,
+            comment=(
+                "Export kind selector (revision_json, quantity_csv, estimate_csv, estimate_pdf)."
+            ),
+        ),
+        sa.Column(
+            "export_format",
+            sa.String(length=32),
+            nullable=False,
+            comment="Resolved export format required by the export kind.",
+        ),
+        sa.Column(
+            "media_type",
+            sa.String(length=128),
+            nullable=False,
+            comment="Resolved artifact media type required by the export kind.",
+        ),
+        sa.Column(
+            "options_json",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            comment="Immutable export options JSON object captured at enqueue time.",
+        ),
+        sa.Column(
+            "quantity_takeoff_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment=(
+                "Trusted quantity takeoff required for quantity_csv, estimate_csv, "
+                "and estimate_pdf exports."
+            ),
+        ),
+        sa.Column(
+            "quantity_gate",
+            sa.String(length=32),
+            nullable=True,
+            comment="Mirrored quantity gate used to enforce trusted quantity lineage.",
+        ),
+        sa.Column(
+            "trusted_totals",
+            sa.Boolean(),
+            nullable=True,
+            comment="Mirrored trusted-totals flag used to enforce trusted quantity lineage.",
+        ),
+        sa.Column(
+            "estimate_version_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=True,
+            comment=(
+                "Finalized estimate version required for estimate_csv and estimate_pdf exports."
+            ),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+            comment="Row creation timestamp.",
+        ),
+        sa.CheckConstraint(
+            "source_job_type = 'export'",
+            name="ck_export_job_inputs_source_job_type_export",
+        ),
+        sa.CheckConstraint(
+            "export_kind IN ('revision_json', 'quantity_csv', 'estimate_csv', 'estimate_pdf')",
+            name="ck_export_job_inputs_export_kind_valid",
+        ),
+        sa.CheckConstraint(
+            "export_format IN ('json', 'csv', 'pdf')",
+            name="ck_export_job_inputs_export_format_valid",
+        ),
+        sa.CheckConstraint(
+            "media_type IN ('application/json', 'text/csv', 'application/pdf')",
+            name="ck_export_job_inputs_media_type_valid",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(options_json) = 'object'",
+            name="ck_export_job_inputs_options_json_object",
+        ),
+        sa.CheckConstraint(
+            "(export_kind = 'revision_json' AND export_format = 'json' "
+            "AND media_type = 'application/json') OR "
+            "(export_kind = 'quantity_csv' AND export_format = 'csv' "
+            "AND media_type = 'text/csv') OR "
+            "(export_kind = 'estimate_csv' AND export_format = 'csv' "
+            "AND media_type = 'text/csv') OR "
+            "(export_kind = 'estimate_pdf' AND export_format = 'pdf' "
+            "AND media_type = 'application/pdf')",
+            name="ck_export_job_inputs_kind_format_media_type_matrix",
+        ),
+        sa.CheckConstraint(
+            "(export_kind = 'quantity_csv' AND quantity_takeoff_id IS NOT NULL "
+            "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+            "(export_kind IN ('estimate_csv', 'estimate_pdf') "
+            "AND quantity_takeoff_id IS NOT NULL AND quantity_gate = 'allowed' "
+            "AND trusted_totals IS TRUE) OR "
+            "(export_kind = 'revision_json' AND quantity_takeoff_id IS NULL "
+            "AND quantity_gate IS NULL AND trusted_totals IS NULL)",
+            name="ck_export_job_inputs_quantity_lineage",
+        ),
+        sa.CheckConstraint(
+            "(export_kind IN ('estimate_csv', 'estimate_pdf') "
+            "AND quantity_takeoff_id IS NOT NULL AND estimate_version_id IS NOT NULL) OR "
+            "(export_kind IN ('quantity_csv', 'revision_json') "
+            "AND estimate_version_id IS NULL)",
+            name="ck_export_job_inputs_estimate_lineage",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["projects.id"],
+            name="fk_export_job_inputs_project_id_projects",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_job_id"],
+            ["jobs.id"],
+            name="fk_export_job_inputs_source_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            name="fk_export_job_inputs_source_file_id_project_id_files",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id", "source_file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            name="fk_export_job_inputs_revision_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "source_job_id",
+                "project_id",
+                "source_file_id",
+                "drawing_revision_id",
+                "source_job_type",
+            ],
+            [
+                "jobs.id",
+                "jobs.project_id",
+                "jobs.file_id",
+                "jobs.base_revision_id",
+                "jobs.job_type",
+            ],
+            name="fk_export_job_inputs_source_job_lineage_jobs",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ],
+            [
+                "quantity_takeoffs.id",
+                "quantity_takeoffs.project_id",
+                "quantity_takeoffs.drawing_revision_id",
+                "quantity_takeoffs.quantity_gate",
+                "quantity_takeoffs.trusted_totals",
+            ],
+            name="fk_export_job_inputs_trusted_quantity_takeoff",
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            [
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_takeoff_id",
+            ],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+                "estimate_versions.quantity_takeoff_id",
+            ],
+            name="fk_export_job_inputs_estimate_version_lineage",
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("source_job_id", name="pk_export_job_inputs"),
+    )
+    op.create_index(
+        op.f("ix_export_job_inputs_project_id"),
+        "export_job_inputs",
+        ["project_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_export_job_inputs_source_file_id"),
+        "export_job_inputs",
+        ["source_file_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_export_job_inputs_drawing_revision_id"),
+        "export_job_inputs",
+        ["drawing_revision_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_export_job_inputs_quantity_takeoff_id"),
+        "export_job_inputs",
+        ["quantity_takeoff_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_export_job_inputs_estimate_version_id"),
+        "export_job_inputs",
+        ["estimate_version_id"],
+        unique=False,
+    )
+    _create_export_job_inputs_append_only_triggers()
+
+
+def downgrade() -> None:
+    _assert_downgrade_safe()
+    _drop_export_job_inputs_append_only_triggers()
+    op.drop_index(op.f("ix_export_job_inputs_estimate_version_id"), table_name="export_job_inputs")
+    op.drop_index(op.f("ix_export_job_inputs_quantity_takeoff_id"), table_name="export_job_inputs")
+    op.drop_index(op.f("ix_export_job_inputs_drawing_revision_id"), table_name="export_job_inputs")
+    op.drop_index(op.f("ix_export_job_inputs_source_file_id"), table_name="export_job_inputs")
+    op.drop_index(op.f("ix_export_job_inputs_project_id"), table_name="export_job_inputs")
+    op.drop_table("export_job_inputs")
+    _replace_jobs_constraints(
+        job_type_values=_PRE_EXPORT_JOB_TYPE_VALUES,
+        base_required_job_type_values=_PRE_EXPORT_BASE_REQUIRED_JOB_TYPE_VALUES,
+        extraction_profile_forbidden_job_type_values=(
+            _PRE_EXPORT_EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES
+        ),
+    )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -12,6 +12,7 @@ from . import drawing_revision as drawing_revision
 from . import estimate_job_input as estimate_job_input
 from . import estimate_version as estimate_version
 from . import estimation_catalog as estimation_catalog
+from . import export_job_input as export_job_input
 from . import extraction_profile as extraction_profile
 from . import file as file
 from . import generated_artifact as generated_artifact

--- a/app/models/export_job_input.py
+++ b/app/models/export_job_input.py
@@ -1,0 +1,258 @@
+"""Immutable export job input model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+from app.models.job import JobType, _sql_in_list
+
+
+class ExportKind(StrEnum):
+    """Supported export payload kinds."""
+
+    REVISION_JSON = "revision_json"
+    QUANTITY_CSV = "quantity_csv"
+    ESTIMATE_CSV = "estimate_csv"
+    ESTIMATE_PDF = "estimate_pdf"
+
+
+class ExportFormat(StrEnum):
+    """Supported export artifact formats."""
+
+    JSON = "json"
+    CSV = "csv"
+    PDF = "pdf"
+
+
+_EXPORT_KIND_VALUES = tuple(kind.value for kind in ExportKind)
+_EXPORT_FORMAT_VALUES = tuple(export_format.value for export_format in ExportFormat)
+_EXPORT_MEDIA_TYPES = (
+    "application/json",
+    "text/csv",
+    "application/pdf",
+)
+
+
+class ExportJobInput(Base):
+    """Immutable export job inputs pinned to a single export job."""
+
+    __tablename__ = "export_job_inputs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["source_file_id", "project_id"],
+            ["files.id", "files.project_id"],
+            ondelete="RESTRICT",
+            name="fk_export_job_inputs_source_file_id_project_id_files",
+        ),
+        ForeignKeyConstraint(
+            ["drawing_revision_id", "project_id", "source_file_id"],
+            [
+                "drawing_revisions.id",
+                "drawing_revisions.project_id",
+                "drawing_revisions.source_file_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_export_job_inputs_revision_lineage",
+        ),
+        ForeignKeyConstraint(
+            [
+                "source_job_id",
+                "project_id",
+                "source_file_id",
+                "drawing_revision_id",
+                "source_job_type",
+            ],
+            [
+                "jobs.id",
+                "jobs.project_id",
+                "jobs.file_id",
+                "jobs.base_revision_id",
+                "jobs.job_type",
+            ],
+            ondelete="RESTRICT",
+            name="fk_export_job_inputs_source_job_lineage_jobs",
+        ),
+        ForeignKeyConstraint(
+            [
+                "quantity_takeoff_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_gate",
+                "trusted_totals",
+            ],
+            [
+                "quantity_takeoffs.id",
+                "quantity_takeoffs.project_id",
+                "quantity_takeoffs.drawing_revision_id",
+                "quantity_takeoffs.quantity_gate",
+                "quantity_takeoffs.trusted_totals",
+            ],
+            ondelete="RESTRICT",
+            name="fk_export_job_inputs_trusted_quantity_takeoff",
+        ),
+        ForeignKeyConstraint(
+            [
+                "estimate_version_id",
+                "project_id",
+                "drawing_revision_id",
+                "quantity_takeoff_id",
+            ],
+            [
+                "estimate_versions.id",
+                "estimate_versions.project_id",
+                "estimate_versions.drawing_revision_id",
+                "estimate_versions.quantity_takeoff_id",
+            ],
+            ondelete="RESTRICT",
+            name="fk_export_job_inputs_estimate_version_lineage",
+        ),
+        CheckConstraint(
+            f"source_job_type = '{JobType.EXPORT.value}'",
+            name="ck_export_job_inputs_source_job_type_export",
+        ),
+        CheckConstraint(
+            f"export_kind IN ({_sql_in_list(_EXPORT_KIND_VALUES)})",
+            name="ck_export_job_inputs_export_kind_valid",
+        ),
+        CheckConstraint(
+            f"export_format IN ({_sql_in_list(_EXPORT_FORMAT_VALUES)})",
+            name="ck_export_job_inputs_export_format_valid",
+        ),
+        CheckConstraint(
+            f"media_type IN ({_sql_in_list(_EXPORT_MEDIA_TYPES)})",
+            name="ck_export_job_inputs_media_type_valid",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(options_json) = 'object'",
+            name="ck_export_job_inputs_options_json_object",
+        ),
+        CheckConstraint(
+            "(export_kind = 'revision_json' AND export_format = 'json' "
+            "AND media_type = 'application/json') OR "
+            "(export_kind = 'quantity_csv' AND export_format = 'csv' "
+            "AND media_type = 'text/csv') OR "
+            "(export_kind = 'estimate_csv' AND export_format = 'csv' "
+            "AND media_type = 'text/csv') OR "
+            "(export_kind = 'estimate_pdf' AND export_format = 'pdf' "
+            "AND media_type = 'application/pdf')",
+            name="ck_export_job_inputs_kind_format_media_type_matrix",
+        ),
+        CheckConstraint(
+            "(export_kind = 'quantity_csv' AND quantity_takeoff_id IS NOT NULL "
+            "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+            "(export_kind IN ('estimate_csv', 'estimate_pdf') AND quantity_takeoff_id IS NOT NULL "
+            "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+            "(export_kind = 'revision_json' AND quantity_takeoff_id IS NULL "
+            "AND quantity_gate IS NULL AND trusted_totals IS NULL)",
+            name="ck_export_job_inputs_quantity_lineage",
+        ),
+        CheckConstraint(
+            "(export_kind IN ('estimate_csv', 'estimate_pdf') "
+            "AND quantity_takeoff_id IS NOT NULL AND estimate_version_id IS NOT NULL) OR "
+            "(export_kind IN ('quantity_csv', 'revision_json') "
+            "AND estimate_version_id IS NULL)",
+            name="ck_export_job_inputs_estimate_lineage",
+        ),
+    )
+
+    source_job_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(
+            "jobs.id",
+            name="fk_export_job_inputs_source_job_id_jobs",
+            ondelete="RESTRICT",
+        ),
+        primary_key=True,
+        comment="Owning export job identifier.",
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(
+            "projects.id",
+            name="fk_export_job_inputs_project_id_projects",
+            ondelete="RESTRICT",
+        ),
+        nullable=False,
+        index=True,
+        comment="Owning project identifier copied from the source export job.",
+    )
+    source_file_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Owning file identifier copied from the source export job.",
+    )
+    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
+        nullable=False,
+        index=True,
+        comment="Pinned revision identifier copied from the source export job.",
+    )
+    source_job_type: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default=JobType.EXPORT.value,
+        comment="Mirrored job type used to pin this row to export jobs only.",
+    )
+    export_kind: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        comment="Export kind selector (revision_json, quantity_csv, estimate_csv, estimate_pdf).",
+    )
+    export_format: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="Resolved export format required by the export kind.",
+    )
+    media_type: Mapped[str] = mapped_column(
+        String(128),
+        nullable=False,
+        comment="Resolved artifact media type required by the export kind.",
+    )
+    options_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        comment="Immutable export options JSON object captured at enqueue time.",
+    )
+    quantity_takeoff_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment=(
+            "Trusted quantity takeoff required for quantity_csv, estimate_csv, "
+            "and estimate_pdf exports."
+        ),
+    )
+    quantity_gate: Mapped[str | None] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="Mirrored quantity gate used to enforce trusted quantity lineage.",
+    )
+    trusted_totals: Mapped[bool | None] = mapped_column(
+        Boolean,
+        nullable=True,
+        comment="Mirrored trusted-totals flag used to enforce trusted quantity lineage.",
+    )
+    estimate_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        nullable=True,
+        index=True,
+        comment="Finalized estimate version required for estimate_csv and estimate_pdf exports.",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=func.now(),
+        nullable=False,
+        comment="Row creation timestamp.",
+    )

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -28,6 +28,7 @@ class JobType(StrEnum):
     REPROCESS = "reprocess"
     QUANTITY_TAKEOFF = "quantity_takeoff"
     ESTIMATE = "estimate"
+    EXPORT = "export"
 
 
 class JobStatus(StrEnum):
@@ -49,10 +50,12 @@ _BASE_REQUIRED_JOB_TYPE_VALUES = (
     JobType.REPROCESS.value,
     JobType.QUANTITY_TAKEOFF.value,
     JobType.ESTIMATE.value,
+    JobType.EXPORT.value,
 )
 _EXTRACTION_PROFILE_FORBIDDEN_JOB_TYPE_VALUES = (
     JobType.QUANTITY_TAKEOFF.value,
     JobType.ESTIMATE.value,
+    JobType.EXPORT.value,
 )
 
 
@@ -104,8 +107,7 @@ class Job(Base):
             name="ck_jobs_status_valid",
         ),
         CheckConstraint(
-            "error_code IS NULL "
-            f"OR error_code IN ({_sql_in_list(_JOB_ERROR_CODE_VALUES)})",
+            f"error_code IS NULL OR error_code IN ({_sql_in_list(_JOB_ERROR_CODE_VALUES)})",
             name="ck_jobs_error_code_valid",
         ),
         CheckConstraint(
@@ -194,15 +196,12 @@ class Job(Base):
     parent_job_id: Mapped[uuid.UUID | None] = mapped_column(
         nullable=True,
         index=True,
-        comment=(
-            "Optional parent job identifier for same-project, same-file job "
-            "lineage."
-        ),
+        comment=("Optional parent job identifier for same-project, same-file job lineage."),
     )
     job_type: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
-        comment="Job type (e.g. ingest, reprocess, quantity_takeoff, estimate)",
+        comment=("Job type (e.g. ingest, reprocess, quantity_takeoff, estimate, export)"),
     )
     status: Mapped[str] = mapped_column(
         String(32),

--- a/app/schemas/export.py
+++ b/app/schemas/export.py
@@ -1,0 +1,96 @@
+"""Pydantic schemas for export job inputs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ExportKind(StrEnum):
+    """Export kind string constants."""
+
+    REVISION_JSON = "revision_json"
+    QUANTITY_CSV = "quantity_csv"
+    ESTIMATE_CSV = "estimate_csv"
+    ESTIMATE_PDF = "estimate_pdf"
+
+
+class ExportFormat(StrEnum):
+    """Export format string constants."""
+
+    JSON = "json"
+    CSV = "csv"
+    PDF = "pdf"
+
+
+EXPORT_KIND_MATRIX: dict[ExportKind, tuple[ExportFormat, str]] = {
+    ExportKind.REVISION_JSON: (ExportFormat.JSON, "application/json"),
+    ExportKind.QUANTITY_CSV: (ExportFormat.CSV, "text/csv"),
+    ExportKind.ESTIMATE_CSV: (ExportFormat.CSV, "text/csv"),
+    ExportKind.ESTIMATE_PDF: (ExportFormat.PDF, "application/pdf"),
+}
+ESTIMATE_EXPORT_KINDS = {ExportKind.ESTIMATE_CSV, ExportKind.ESTIMATE_PDF}
+
+
+class ExportJobInputBase(BaseModel):
+    """Shared immutable export job input payload fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    export_kind: ExportKind
+    export_format: ExportFormat
+    media_type: str
+    options_json: dict[str, Any] = Field(default_factory=dict)
+    quantity_takeoff_id: UUID | None = None
+    estimate_version_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def validate_export_contract(self) -> ExportJobInputBase:
+        matrix_entry = EXPORT_KIND_MATRIX.get(self.export_kind)
+        if matrix_entry is None:
+            raise ValueError(f"Unsupported export_kind: {self.export_kind}")
+
+        expected_format, expected_media_type = matrix_entry
+        if self.export_format != expected_format or self.media_type != expected_media_type:
+            raise ValueError(
+                "export_kind, export_format, and media_type must match the supported matrix"
+            )
+
+        if self.export_kind == ExportKind.QUANTITY_CSV:
+            if self.quantity_takeoff_id is None or self.estimate_version_id is not None:
+                raise ValueError(
+                    "quantity_csv exports require quantity_takeoff_id and forbid "
+                    "estimate_version_id"
+                )
+        elif self.export_kind in ESTIMATE_EXPORT_KINDS:
+            if self.estimate_version_id is None or self.quantity_takeoff_id is None:
+                raise ValueError(
+                    "estimate exports require both quantity_takeoff_id and estimate_version_id"
+                )
+        elif self.quantity_takeoff_id is not None or self.estimate_version_id is not None:
+            raise ValueError(
+                "revision_json exports forbid quantity_takeoff_id and estimate_version_id"
+            )
+
+        return self
+
+
+class ExportJobInputCreate(ExportJobInputBase):
+    """Schema used when persisting immutable export job inputs."""
+
+
+class ExportJobInputRead(ExportJobInputBase):
+    """Schema returned when reading persisted immutable export job inputs."""
+
+    source_job_id: UUID
+    project_id: UUID
+    source_file_id: UUID
+    drawing_revision_id: UUID
+    source_job_type: str
+    quantity_gate: str | None = None
+    trusted_totals: bool | None = None
+    created_at: datetime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
     "job_events",
     "estimate_versions",
     "estimate_job_inputs",
+    "export_job_inputs",
     "estimate_job_input_catalog_refs",
     "estimate_snapshot_entries",
     "estimate_items",

--- a/tests/test_append_only_lineage_tables.py
+++ b/tests/test_append_only_lineage_tables.py
@@ -27,6 +27,7 @@ from app.ingestion.runner import IngestionRunRequest
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry
 from app.models.estimation_catalog import EstimationRate
+from app.models.export_job_input import ExportJobInput
 from app.models.job import Job, JobStatus, JobType
 from tests import test_estimate_version_persistence as estimate_version_persistence
 from tests.conftest import (
@@ -71,6 +72,7 @@ class _ProtectedRowIds:
     generated_artifact_id: uuid.UUID
     job_event_id: uuid.UUID
     estimate_version_id: uuid.UUID
+    export_job_input_source_job_id: uuid.UUID
     estimate_job_input_id: uuid.UUID
     estimate_job_input_catalog_ref_key: tuple[uuid.UUID, str, str]
     estimate_snapshot_entry_id: uuid.UUID
@@ -213,6 +215,11 @@ def _row_filter_for_table(
             "estimate_job_id = :estimate_job_id",
             {"estimate_job_id": row_ids.estimate_job_input_id},
         )
+    if table_name == "export_job_inputs":
+        return (
+            "source_job_id = :source_job_id",
+            {"source_job_id": row_ids.export_job_input_source_job_id},
+        )
 
     return "id = :row_id", {"row_id": _row_id_for_table(row_ids, table_name)}
 
@@ -222,9 +229,12 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
 
     quantity_seed = await _seed_quantity_lineage(async_client)
 
-    adapter_outputs, drawing_revisions, validation_reports, generated_artifacts = (
-        await _load_project_outputs(str(quantity_seed.project_id))
-    )
+    (
+        adapter_outputs,
+        drawing_revisions,
+        validation_reports,
+        generated_artifacts,
+    ) = await _load_project_outputs(str(quantity_seed.project_id))
     manifests, layouts, layers, blocks, entities = await _load_project_materialization(
         str(quantity_seed.project_id)
     )
@@ -270,6 +280,7 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         assumption_snapshot_entry_type="assumption",
     )
     estimate_job_id = uuid.uuid4()
+    export_job_id = uuid.uuid4()
     rate_id = uuid.uuid4()
     rate_checksum = "d" * 64
     estimate_job_input = EstimateJobInput(
@@ -294,6 +305,21 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         rate_catalog_entry_id=rate_id,
         catalog_checksum_sha256=rate_checksum,
         selection_context_json={"source": "append-only"},
+    )
+    export_job_input = ExportJobInput(
+        source_job_id=export_job_id,
+        project_id=quantity_seed.project_id,
+        source_file_id=quantity_seed.file_id,
+        drawing_revision_id=quantity_seed.drawing_revision_id,
+        source_job_type=JobType.EXPORT.value,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"source": "append-only"},
+        quantity_takeoff_id=None,
+        quantity_gate=None,
+        trusted_totals=None,
+        estimate_version_id=None,
     )
 
     session_maker = session_module.AsyncSessionLocal
@@ -332,7 +358,25 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
             )
         )
         await session.flush()
+        session.add(
+            Job(
+                id=export_job_id,
+                project_id=quantity_seed.project_id,
+                file_id=quantity_seed.file_id,
+                extraction_profile_id=None,
+                base_revision_id=quantity_seed.drawing_revision_id,
+                parent_job_id=quantity_seed.quantity_job_id,
+                job_type=JobType.EXPORT.value,
+                status=JobStatus.PENDING.value,
+                enqueue_status="pending",
+                enqueue_attempts=0,
+                cancel_requested=False,
+            )
+        )
+        await session.flush()
         session.add(estimate_job_input)
+        await session.flush()
+        session.add(export_job_input)
         await session.flush()
         session.add(estimate_job_input_ref)
         await session.flush()
@@ -365,6 +409,7 @@ async def _seed_protected_rows(async_client: httpx.AsyncClient) -> _ProtectedRow
         generated_artifact_id=generated_artifacts[0].id,
         job_event_id=job_events[0].id,
         estimate_version_id=estimate_version.id,
+        export_job_input_source_job_id=export_job_input.source_job_id,
         estimate_job_input_id=estimate_job_input.estimate_job_id,
         estimate_job_input_catalog_ref_key=(
             estimate_job_input_ref.estimate_job_id,
@@ -1484,6 +1529,7 @@ class TestAppendOnlyLineageTables:
             ("generated_artifacts", "name", "mutated-debug-overlay.svg"),
             ("job_events", "message", "mutated job event"),
             ("estimate_versions", "total_amount", "121.00"),
+            ("export_job_inputs", "export_kind", "quantity_csv"),
             ("estimate_job_inputs", "currency", "USD"),
             (
                 "estimate_job_input_catalog_refs",
@@ -1558,9 +1604,7 @@ class TestAppendOnlyLineageTables:
                             "coordinates": [[0.0, 0.0], [1.0, 1.0]],
                         },
                         "properties_json": {"layer": "A-WALL"},
-                        "provenance_json": {
-                            "source_id": "entity-source-append-only-001"
-                        },
+                        "provenance_json": {"source_id": "entity-source-append-only-001"},
                     }
                 ],
                 "entity_counts": {
@@ -1576,8 +1620,8 @@ class TestAppendOnlyLineageTables:
         await _run_sql_and_expect_append_only_failure(
             (
                 'UPDATE "adapter_run_outputs" '
-                'SET canonical_json = CAST(:replacement_value AS json) '
-                'WHERE id = :row_id'
+                "SET canonical_json = CAST(:replacement_value AS json) "
+                "WHERE id = :row_id"
             ),
             {
                 "replacement_value": equivalent_canonical_json,
@@ -1613,8 +1657,8 @@ class TestAppendOnlyLineageTables:
         await _run_sql_and_expect_append_only_failure(
             (
                 'UPDATE "revision_entities" '
-                'SET canonical_entity_json = CAST(:replacement_value AS json) '
-                'WHERE id = :row_id'
+                "SET canonical_entity_json = CAST(:replacement_value AS json) "
+                "WHERE id = :row_id"
             ),
             {
                 "replacement_value": equivalent_entity_payload_json,
@@ -1782,9 +1826,9 @@ class TestAppendOnlyLineageTables:
                 _DOWNGRADE_TARGET_REVISION,
                 database_url=database_url,
             )
-            assert (
-                downgrade_result.returncode == 0
-            ), downgrade_result.stdout + downgrade_result.stderr
+            assert downgrade_result.returncode == 0, (
+                downgrade_result.stdout + downgrade_result.stderr
+            )
         finally:
             await _drop_temp_database(database_name)
 

--- a/tests/test_export_job_input_contract.py
+++ b/tests/test_export_job_input_contract.py
@@ -1,0 +1,766 @@
+"""Integration tests for immutable export job input persistence contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, cast
+
+import httpx
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+from app.models.estimate_version import EstimateVersion
+from app.models.export_job_input import ExportJobInput
+from app.models.job import Job, JobStatus, JobType
+from tests import test_quantity_takeoff_persistence as quantity_takeoff_persistence
+from tests.conftest import requires_database
+
+pytest_plugins = ("tests.test_quantity_takeoff_persistence",)
+pytestmark = [pytest.mark.asyncio, requires_database]
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "2026_05_27_0024_add_export_job_input_contract.py"
+)
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_projects: None) -> AsyncGenerator[AsyncSession, None]:
+    _ = cleanup_projects
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+def _normalize_ondelete(raw_foreign_key: Mapping[str, Any]) -> str:
+    options = raw_foreign_key.get("options")
+    if isinstance(options, dict):
+        return str(options.get("ondelete") or "").upper()
+    return ""
+
+
+def _normalize_constraint_sqltext(sqltext: str) -> str:
+    normalized = sqltext
+    for pg_cast in (
+        "::boolean",
+        "::character varying",
+        "::text",
+    ):
+        normalized = normalized.replace(pg_cast, "")
+    normalized = normalized.replace('"', " ")
+    normalized = normalized.replace("(", " ").replace(")", " ")
+    return " ".join(normalized.split())
+
+
+def _inspect_schema(sync_connection: sa.Connection) -> dict[str, Any]:
+    inspector = sa.inspect(sync_connection)
+    tables = ("jobs", "export_job_inputs")
+
+    triggers = tuple(
+        sync_connection.execute(
+            sa.text(
+                """
+                SELECT tgname
+                FROM pg_trigger
+                WHERE tgrelid = 'export_job_inputs'::regclass
+                AND NOT tgisinternal
+                ORDER BY tgname
+                """
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    return {
+        "columns": {
+            table_name: {
+                str(column["name"]): {"nullable": bool(column["nullable"])}
+                for column in inspector.get_columns(table_name)
+            }
+            for table_name in tables
+        },
+        "primary_keys": {
+            table_name: tuple(inspector.get_pk_constraint(table_name)["constrained_columns"])
+            for table_name in tables
+        },
+        "check_constraints": {
+            table_name: {
+                str(constraint["name"]): _normalize_constraint_sqltext(str(constraint["sqltext"]))
+                for constraint in inspector.get_check_constraints(table_name)
+            }
+            for table_name in tables
+        },
+        "foreign_keys": {
+            (
+                tuple(foreign_key["constrained_columns"]),
+                str(foreign_key["referred_table"]),
+                tuple(foreign_key["referred_columns"]),
+            ): _normalize_ondelete(foreign_key)
+            for foreign_key in inspector.get_foreign_keys("export_job_inputs")
+        },
+        "indexes": {
+            tuple(index["column_names"]): str(index["name"])
+            for index in inspector.get_indexes("export_job_inputs")
+        },
+        "triggers": triggers,
+    }
+
+
+async def _load_schema() -> dict[str, Any]:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+
+    async with session_maker() as session:
+        connection = await session.connection()
+        return await connection.run_sync(_inspect_schema)
+
+
+async def _assert_commit_fails(
+    session: AsyncSession,
+    obj: object,
+    expected_substring: str | tuple[str, ...],
+) -> None:
+    session.add(obj)
+    expected_substrings = (
+        [expected_substring] if isinstance(expected_substring, str) else list(expected_substring)
+    )
+
+    try:
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        constraint_name = getattr(getattr(exc, "orig", None), "constraint_name", None)
+        if constraint_name in expected_substrings:
+            return
+
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert any(substring.lower() in message for substring in expected_substrings)
+    else:
+        pytest.fail(f"Expected database error containing {expected_substrings!r}")
+
+
+async def _assert_append_only_sql_mutation_fails(
+    session: AsyncSession,
+    statement: str,
+    *,
+    operation: str,
+    table_name: str,
+    params: dict[str, object] | None = None,
+) -> None:
+    try:
+        await session.execute(text(statement), params or {})
+        await session.commit()
+    except (DBAPIError, IntegrityError) as exc:
+        await session.rollback()
+        message = "\n".join(
+            part
+            for part in (
+                str(exc),
+                repr(exc),
+                str(getattr(exc, "orig", "")),
+                repr(getattr(exc, "orig", "")),
+            )
+            if part
+        ).lower()
+        assert f"append-only trigger blocked {operation.lower()} on {table_name}" in message
+    else:
+        pytest.fail(f"Expected append-only mutation failure for {operation} on {table_name}")
+
+
+def _load_migration_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "migration_2026_05_27_0024_add_export_job_input_contract",
+        _MIGRATION_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _run_downgrade_guard(db_session: AsyncSession) -> None:
+    migration = _load_migration_module()
+    connection = await db_session.connection()
+
+    def _run_guard(sync_connection: sa.Connection) -> None:
+        migration_context = MigrationContext.configure(sync_connection)
+        migration.op = Operations(migration_context)
+        migration._assert_downgrade_safe()
+
+    await connection.run_sync(_run_guard)
+
+
+async def _create_export_job(
+    db_session: AsyncSession,
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    *,
+    base_revision_id: uuid.UUID | None = None,
+    extraction_profile_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    job_id = uuid.uuid4()
+    db_session.add(
+        Job(
+            id=job_id,
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=extraction_profile_id,
+            base_revision_id=(
+                base_revision_id if base_revision_id is not None else seed.drawing_revision_id
+            ),
+            parent_job_id=seed.quantity_job_id,
+            job_type=JobType.EXPORT.value,
+            status=JobStatus.PENDING.value,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        )
+    )
+    await db_session.flush()
+    return job_id
+
+
+async def _create_estimate_version(
+    db_session: AsyncSession,
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+) -> uuid.UUID:
+    estimate_job_id = uuid.uuid4()
+    db_session.add(
+        Job(
+            id=estimate_job_id,
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=None,
+            base_revision_id=seed.drawing_revision_id,
+            parent_job_id=seed.quantity_job_id,
+            job_type=JobType.ESTIMATE.value,
+            status=JobStatus.SUCCEEDED.value,
+            enqueue_status="published",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        )
+    )
+    await db_session.flush()
+
+    estimate_version_id = uuid.uuid4()
+    db_session.add(
+        EstimateVersion(
+            id=estimate_version_id,
+            project_id=seed.project_id,
+            source_file_id=seed.file_id,
+            drawing_revision_id=seed.drawing_revision_id,
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            source_job_id=estimate_job_id,
+            quantity_gate="allowed",
+            trusted_totals=True,
+            currency="GBP",
+            subtotal_amount=Decimal("100.00"),
+            tax_amount=Decimal("20.00"),
+            total_amount=Decimal("120.00"),
+        )
+    )
+    await db_session.flush()
+    return estimate_version_id
+
+
+def _build_export_input(
+    seed: quantity_takeoff_persistence._QuantityPersistenceSeed,
+    *,
+    source_job_id: uuid.UUID,
+    export_kind: str,
+    export_format: str,
+    media_type: str,
+    quantity_takeoff_id: uuid.UUID | None,
+    quantity_gate: str | None,
+    trusted_totals: bool | None,
+    estimate_version_id: uuid.UUID | None,
+    source_job_type: str = JobType.EXPORT.value,
+    options_json: object = cast(object, {"include_headers": True}),
+) -> ExportJobInput:
+    return ExportJobInput(
+        source_job_id=source_job_id,
+        project_id=seed.project_id,
+        source_file_id=seed.file_id,
+        drawing_revision_id=seed.drawing_revision_id,
+        source_job_type=source_job_type,
+        export_kind=export_kind,
+        export_format=export_format,
+        media_type=media_type,
+        options_json=cast(dict[str, Any], options_json),
+        quantity_takeoff_id=quantity_takeoff_id,
+        quantity_gate=quantity_gate,
+        trusted_totals=trusted_totals,
+        estimate_version_id=estimate_version_id,
+    )
+
+
+async def test_export_job_input_schema_matches_contract() -> None:
+    schema = await _load_schema()
+    columns = schema["columns"]
+    primary_keys = schema["primary_keys"]
+    check_constraints = schema["check_constraints"]
+    foreign_keys = schema["foreign_keys"]
+    indexes = schema["indexes"]
+    triggers = schema["triggers"]
+
+    assert "export" in check_constraints["jobs"]["ck_jobs_job_type_valid"]
+    assert "export" in check_constraints["jobs"]["ck_jobs_revision_scoped_base_revision_required"]
+    assert (
+        "export"
+        in check_constraints["jobs"]["ck_jobs_revision_scoped_extraction_profile_forbidden"]
+    )
+
+    for required_column in (
+        "source_job_id",
+        "project_id",
+        "source_file_id",
+        "drawing_revision_id",
+        "source_job_type",
+        "export_kind",
+        "export_format",
+        "media_type",
+        "options_json",
+        "created_at",
+    ):
+        assert columns["export_job_inputs"][required_column]["nullable"] is False
+
+    for nullable_column in (
+        "quantity_takeoff_id",
+        "quantity_gate",
+        "trusted_totals",
+        "estimate_version_id",
+    ):
+        assert columns["export_job_inputs"][nullable_column]["nullable"] is True
+
+    assert primary_keys["export_job_inputs"] == ("source_job_id",)
+
+    for constraint_name in (
+        "ck_export_job_inputs_source_job_type_export",
+        "ck_export_job_inputs_export_kind_valid",
+        "ck_export_job_inputs_export_format_valid",
+        "ck_export_job_inputs_media_type_valid",
+        "ck_export_job_inputs_options_json_object",
+        "ck_export_job_inputs_kind_format_media_type_matrix",
+        "ck_export_job_inputs_quantity_lineage",
+        "ck_export_job_inputs_estimate_lineage",
+    ):
+        assert constraint_name in check_constraints["export_job_inputs"]
+
+    assert (
+        (
+            "source_job_id",
+            "project_id",
+            "source_file_id",
+            "drawing_revision_id",
+            "source_job_type",
+        ),
+        "jobs",
+        ("id", "project_id", "file_id", "base_revision_id", "job_type"),
+    ) in foreign_keys
+    assert (
+        (
+            "quantity_takeoff_id",
+            "project_id",
+            "drawing_revision_id",
+            "quantity_gate",
+            "trusted_totals",
+        ),
+        "quantity_takeoffs",
+        ("id", "project_id", "drawing_revision_id", "quantity_gate", "trusted_totals"),
+    ) in foreign_keys
+    assert (
+        (
+            "estimate_version_id",
+            "project_id",
+            "drawing_revision_id",
+            "quantity_takeoff_id",
+        ),
+        "estimate_versions",
+        ("id", "project_id", "drawing_revision_id", "quantity_takeoff_id"),
+    ) in foreign_keys
+    assert all(ondelete == "RESTRICT" for ondelete in foreign_keys.values())
+
+    for index_columns in (
+        ("project_id",),
+        ("source_file_id",),
+        ("drawing_revision_id",),
+        ("quantity_takeoff_id",),
+        ("estimate_version_id",),
+    ):
+        assert index_columns in indexes
+
+    assert "trg_append_only_row_guard" in triggers
+    assert "trg_append_only_truncate_guard" in triggers
+
+
+async def test_export_job_input_persists_valid_revision_quantity_and_estimate_inputs(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    estimate_version_id = await _create_estimate_version(db_session, seed)
+
+    revision_job_id = await _create_export_job(db_session, seed)
+    quantity_job_id = await _create_export_job(db_session, seed)
+    estimate_csv_job_id = await _create_export_job(db_session, seed)
+    estimate_pdf_job_id = await _create_export_job(db_session, seed)
+
+    db_session.add_all(
+        [
+            _build_export_input(
+                seed,
+                source_job_id=revision_job_id,
+                export_kind="revision_json",
+                export_format="json",
+                media_type="application/json",
+                quantity_takeoff_id=None,
+                quantity_gate=None,
+                trusted_totals=None,
+                estimate_version_id=None,
+            ),
+            _build_export_input(
+                seed,
+                source_job_id=quantity_job_id,
+                export_kind="quantity_csv",
+                export_format="csv",
+                media_type="text/csv",
+                quantity_takeoff_id=seed.quantity_takeoff_id,
+                quantity_gate="allowed",
+                trusted_totals=True,
+                estimate_version_id=None,
+            ),
+            _build_export_input(
+                seed,
+                source_job_id=estimate_csv_job_id,
+                export_kind="estimate_csv",
+                export_format="csv",
+                media_type="text/csv",
+                quantity_takeoff_id=seed.quantity_takeoff_id,
+                quantity_gate="allowed",
+                trusted_totals=True,
+                estimate_version_id=estimate_version_id,
+            ),
+            _build_export_input(
+                seed,
+                source_job_id=estimate_pdf_job_id,
+                export_kind="estimate_pdf",
+                export_format="pdf",
+                media_type="application/pdf",
+                quantity_takeoff_id=seed.quantity_takeoff_id,
+                quantity_gate="allowed",
+                trusted_totals=True,
+                estimate_version_id=estimate_version_id,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    persisted = (
+        (
+            await db_session.execute(
+                select(ExportJobInput).order_by(ExportJobInput.source_job_id.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(persisted) == 4
+    by_job_id = {row.source_job_id: row for row in persisted}
+
+    assert by_job_id[revision_job_id].export_kind == "revision_json"
+    assert by_job_id[revision_job_id].export_format == "json"
+    assert by_job_id[revision_job_id].media_type == "application/json"
+    assert by_job_id[revision_job_id].quantity_takeoff_id is None
+    assert by_job_id[revision_job_id].estimate_version_id is None
+
+    assert by_job_id[quantity_job_id].export_kind == "quantity_csv"
+    assert by_job_id[quantity_job_id].export_format == "csv"
+    assert by_job_id[quantity_job_id].media_type == "text/csv"
+    assert by_job_id[quantity_job_id].quantity_takeoff_id == seed.quantity_takeoff_id
+    assert by_job_id[quantity_job_id].quantity_gate == "allowed"
+    assert by_job_id[quantity_job_id].trusted_totals is True
+    assert by_job_id[quantity_job_id].estimate_version_id is None
+
+    assert by_job_id[estimate_csv_job_id].export_kind == "estimate_csv"
+    assert by_job_id[estimate_csv_job_id].estimate_version_id == estimate_version_id
+
+    assert by_job_id[estimate_pdf_job_id].export_kind == "estimate_pdf"
+    assert by_job_id[estimate_pdf_job_id].estimate_version_id == estimate_version_id
+
+
+async def test_export_job_input_contract_rejects_ambiguous_and_invalid_lineage_inputs(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    estimate_version_id = await _create_estimate_version(db_session, seed)
+
+    await _assert_commit_fails(
+        db_session,
+        Job(
+            id=uuid.uuid4(),
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            job_type=JobType.EXPORT.value,
+            status=JobStatus.PENDING.value,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        ),
+        "ck_jobs_revision_scoped_base_revision_required",
+    )
+
+    await _assert_commit_fails(
+        db_session,
+        Job(
+            id=uuid.uuid4(),
+            project_id=seed.project_id,
+            file_id=seed.file_id,
+            extraction_profile_id=seed.extraction_profile_id,
+            base_revision_id=seed.drawing_revision_id,
+            job_type=JobType.EXPORT.value,
+            status=JobStatus.PENDING.value,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        ),
+        "ck_jobs_revision_scoped_extraction_profile_forbidden",
+    )
+
+    bad_job_ids = [await _create_export_job(db_session, seed) for _ in range(9)]
+    await db_session.commit()
+
+    invalid_cases: list[tuple[dict[str, object], str | tuple[str, ...]]] = [
+        (
+            {
+                "source_job_type": JobType.ESTIMATE.value,
+                "export_kind": "revision_json",
+                "export_format": "json",
+                "media_type": "application/json",
+                "quantity_takeoff_id": None,
+                "quantity_gate": None,
+                "trusted_totals": None,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_source_job_type_export",
+        ),
+        (
+            {
+                "export_kind": "quantity_csv",
+                "export_format": "pdf",
+                "media_type": "application/pdf",
+                "quantity_takeoff_id": seed.quantity_takeoff_id,
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_kind_format_media_type_matrix",
+        ),
+        (
+            {
+                "export_kind": "revision_json",
+                "export_format": "json",
+                "media_type": "application/json",
+                "quantity_takeoff_id": seed.quantity_takeoff_id,
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_quantity_lineage",
+        ),
+        (
+            {
+                "export_kind": "quantity_csv",
+                "export_format": "csv",
+                "media_type": "text/csv",
+                "quantity_takeoff_id": None,
+                "quantity_gate": None,
+                "trusted_totals": None,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_quantity_lineage",
+        ),
+        (
+            {
+                "export_kind": "quantity_csv",
+                "export_format": "csv",
+                "media_type": "text/csv",
+                "quantity_takeoff_id": seed.quantity_takeoff_id,
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": estimate_version_id,
+            },
+            "ck_export_job_inputs_estimate_lineage",
+        ),
+        (
+            {
+                "export_kind": "estimate_csv",
+                "export_format": "csv",
+                "media_type": "text/csv",
+                "quantity_takeoff_id": seed.quantity_takeoff_id,
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_estimate_lineage",
+        ),
+        (
+            {
+                "export_kind": "estimate_pdf",
+                "export_format": "pdf",
+                "media_type": "application/pdf",
+                "quantity_takeoff_id": uuid.uuid4(),
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": estimate_version_id,
+            },
+            "fk_export_job_inputs_trusted_quantity_takeoff",
+        ),
+        (
+            {
+                "export_kind": "estimate_pdf",
+                "export_format": "pdf",
+                "media_type": "application/pdf",
+                "quantity_takeoff_id": seed.quantity_takeoff_id,
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": uuid.uuid4(),
+            },
+            "fk_export_job_inputs_estimate_version_lineage",
+        ),
+        (
+            {
+                "export_kind": "revision_json",
+                "export_format": "json",
+                "media_type": "application/json",
+                "quantity_takeoff_id": None,
+                "quantity_gate": None,
+                "trusted_totals": None,
+                "estimate_version_id": None,
+                "source_file_id": uuid.uuid4(),
+            },
+            (
+                "fk_export_job_inputs_source_job_lineage_jobs",
+                "fk_export_job_inputs_source_file_id_project_id_files",
+            ),
+        ),
+    ]
+
+    for job_id, (overrides, expected_substring) in zip(bad_job_ids, invalid_cases, strict=True):
+        payload: dict[str, object] = {
+            "source_job_id": job_id,
+            "export_kind": "revision_json",
+            "export_format": "json",
+            "media_type": "application/json",
+            "quantity_takeoff_id": None,
+            "quantity_gate": None,
+            "trusted_totals": None,
+            "estimate_version_id": None,
+            "source_job_type": JobType.EXPORT.value,
+            "options_json": {"include_headers": True},
+        }
+        payload.update(overrides)
+
+        await _assert_commit_fails(
+            db_session,
+            ExportJobInput(
+                source_job_id=cast(uuid.UUID, payload["source_job_id"]),
+                project_id=seed.project_id,
+                source_file_id=cast(uuid.UUID, payload.get("source_file_id", seed.file_id)),
+                drawing_revision_id=seed.drawing_revision_id,
+                source_job_type=cast(str, payload["source_job_type"]),
+                export_kind=cast(str, payload["export_kind"]),
+                export_format=cast(str, payload["export_format"]),
+                media_type=cast(str, payload["media_type"]),
+                options_json=cast(dict[str, Any], payload["options_json"]),
+                quantity_takeoff_id=cast(uuid.UUID | None, payload["quantity_takeoff_id"]),
+                quantity_gate=cast(str | None, payload["quantity_gate"]),
+                trusted_totals=cast(bool | None, payload["trusted_totals"]),
+                estimate_version_id=cast(uuid.UUID | None, payload["estimate_version_id"]),
+            ),
+            expected_substring,
+        )
+
+
+async def test_export_job_inputs_are_append_only_and_downgrade_guarded(
+    async_client: httpx.AsyncClient,
+    db_session: AsyncSession,
+) -> None:
+    await _run_downgrade_guard(db_session)
+
+    seed = await quantity_takeoff_persistence._seed_quantity_lineage(async_client)
+    export_job_without_rows = await _create_export_job(db_session, seed)
+    await db_session.commit()
+
+    with pytest.raises(RuntimeError, match="persisted export jobs present"):
+        await _run_downgrade_guard(db_session)
+
+    estimate_version_id = await _create_estimate_version(db_session, seed)
+    row_job_id = await _create_export_job(db_session, seed)
+    db_session.add(
+        _build_export_input(
+            seed,
+            source_job_id=row_job_id,
+            export_kind="estimate_csv",
+            export_format="csv",
+            media_type="text/csv",
+            quantity_takeoff_id=seed.quantity_takeoff_id,
+            quantity_gate="allowed",
+            trusted_totals=True,
+            estimate_version_id=estimate_version_id,
+        )
+    )
+    await db_session.commit()
+
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        "UPDATE export_job_inputs SET export_format = 'pdf' WHERE source_job_id = :job_id",
+        operation="UPDATE",
+        table_name="export_job_inputs",
+        params={"job_id": row_job_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        "DELETE FROM export_job_inputs WHERE source_job_id = :job_id",
+        operation="DELETE",
+        table_name="export_job_inputs",
+        params={"job_id": row_job_id},
+    )
+    await _assert_append_only_sql_mutation_fails(
+        db_session,
+        "TRUNCATE export_job_inputs",
+        operation="TRUNCATE",
+        table_name="export_job_inputs",
+    )
+
+    _ = export_job_without_rows
+    with pytest.raises(RuntimeError, match="persisted export_job_inputs rows present"):
+        await _run_downgrade_guard(db_session)

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -126,9 +126,7 @@ def _write_ifc_with_capped_header(path: Path) -> None:
     )
 
 
-def _write_ifc_with_capped_fake_header_terminator(
-    path: Path, *, fake_terminator_line: str
-) -> None:
+def _write_ifc_with_capped_fake_header_terminator(path: Path, *, fake_terminator_line: str) -> None:
     oversized_description = "X" * adapter_module._HEADER_READ_LIMIT_BYTES
     path.write_text(
         "ISO-10303-21;\n"
@@ -289,12 +287,14 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
     )
     assert entities[0]["provenance"]["source_identity"] == "DUPLICATE"
     assert entities[0]["provenance"]["canonical_entity_ref"] == "entities.DUPLICATE"
-    assert entities[0]["provenance"]["source_hash"] == hashlib.sha256(
-        b"ifc://IfcWall/global-id:DUPLICATE"
-    ).hexdigest()
-    assert entities[0]["provenance"]["normalized_source_hash"] == hashlib.sha256(
-        b"ifc://IfcWall/global-id:DUPLICATE"
-    ).hexdigest()
+    assert (
+        entities[0]["provenance"]["source_hash"]
+        == hashlib.sha256(b"ifc://IfcWall/global-id:DUPLICATE").hexdigest()
+    )
+    assert (
+        entities[0]["provenance"]["normalized_source_hash"]
+        == hashlib.sha256(b"ifc://IfcWall/global-id:DUPLICATE").hexdigest()
+    )
     assert entities[0]["provenance"]["extraction_path"] == ["semantic_extract"]
     assert entities[0]["provenance"]["notes"] == ["semantic_ifc_metadata_only"]
     assert entities[0]["confidence"] == {
@@ -306,20 +306,21 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
     assert entities[0]["qtos"][0]["name"] == "Qto_WallBaseQuantities"
     assert entities[0]["material_refs"][0]["name"] == "Concrete"
     assert (
-        entities[0]["representation"]["representations"][0]["representation_identifier"]
-        == "Body"
+        entities[0]["representation"]["representations"][0]["representation_identifier"] == "Body"
     )
     assert entities[2]["provenance"]["source"] == "ifc://IfcDoor/step-id:42"
     assert entities[2]["provenance"]["source_ref"] == "ifc://IfcDoor/step-id:42"
     assert entities[2]["provenance"]["source_entity_ref"] == "ifc://IfcDoor/step-id:42"
     assert entities[2]["provenance"]["source_identity"] == "#42"
     assert entities[2]["provenance"]["canonical_entity_ref"] == "entities.#42"
-    assert entities[2]["provenance"]["source_hash"] == hashlib.sha256(
-        b"ifc://IfcDoor/step-id:42"
-    ).hexdigest()
-    assert entities[2]["provenance"]["normalized_source_hash"] == hashlib.sha256(
-        b"ifc://IfcDoor/step-id:42"
-    ).hexdigest()
+    assert (
+        entities[2]["provenance"]["source_hash"]
+        == hashlib.sha256(b"ifc://IfcDoor/step-id:42").hexdigest()
+    )
+    assert (
+        entities[2]["provenance"]["normalized_source_hash"]
+        == hashlib.sha256(b"ifc://IfcDoor/step-id:42").hexdigest()
+    )
     assert canonical["layers"] == [{"name": "IfcWall"}, {"name": "IfcDoor"}]
     assert payload.provenance_json["records"][1]["details"]["entity_count"] == 3
     assert {record["source_ref"] for record in payload.provenance_json["records"]} == {
@@ -801,7 +802,7 @@ async def test_ifcopenshell_adapter_non_step_payload_does_not_short_circuit_sche
             media_type="application/octet-stream",
             original_name="nested/input.ifc",
         ),
-        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=1)),
+        AdapterExecutionOptions(timeout=AdapterTimeout(seconds=5)),
     )
 
     assert runtime_called is True


### PR DESCRIPTION
Closes #250

## Summary
- add the export job type and immutable export_job_inputs persistence contract
- add the Alembic migration and DB-backed contract tests for export job inputs
- stabilize the flaky non-step IFC timeout test that blocked the pre-push gate

## Test plan
- [x] uv run ruff check app/models/job.py app/models/export_job_input.py app/models/__init__.py app/schemas/export.py alembic/versions/2026_05_27_0024_add_export_job_input_contract.py tests/test_export_job_input_contract.py tests/conftest.py
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_export_validation_tmp uv run pytest tests/test_export_job_input_contract.py -q
- [x] uv run pytest tests/test_ifcopenshell_adapter.py::test_ifcopenshell_adapter_non_step_payload_does_not_short_circuit_schema_path -q
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_export_validation_tmp uv run alembic downgrade 2026_05_18_0023 && DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_export_validation_tmp uv run alembic upgrade head

## Notes
- deep review approved with no must-fix findings
- export_job_inputs is append-only and debug_overlay remains out of scope for this contract