### PR TITLE
feat(jobs): finalize JSON and CSV export jobs

### DIFF
--- a/app/api/v1/revision_compat.py
+++ b/app/api/v1/revision_compat.py
@@ -101,6 +101,10 @@ def enqueue_estimate_job(*args: Any, **kwargs: Any) -> Any:
     return _resolve_callable("enqueue_estimate_job")(*args, **kwargs)
 
 
+def enqueue_export_job(*args: Any, **kwargs: Any) -> Any:
+    return _resolve_callable("enqueue_export_job")(*args, **kwargs)
+
+
 async def replay_idempotency_response(*args: Any, **kwargs: Any) -> Any:
     return await _resolve_callable("replay_idempotency_response")(*args, **kwargs)
 
@@ -150,6 +154,7 @@ __all__ = [
     "claim_idempotency_response",
     "complete_idempotency_response",
     "enqueue_estimate_job",
+    "enqueue_export_job",
     "enqueue_quantity_takeoff_job",
     "prepare_job_enqueue_intent",
     "publish_job_enqueue_intent",

--- a/app/api/v1/revision_routes/exports.py
+++ b/app/api/v1/revision_routes/exports.py
@@ -30,7 +30,9 @@ from app.api.v1.revision_lineage import (
 )
 from app.core.exceptions import raise_not_found
 from app.db.session import get_db
+from app.jobs.worker import enqueue_export_job as _enqueue_export_job_direct
 from app.jobs.worker import prepare_job_enqueue_intent as _prepare_job_enqueue_intent_direct
+from app.jobs.worker import publish_job_enqueue_intent as _publish_job_enqueue_intent_direct
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_version import EstimateVersion
 from app.models.export_job_input import ExportJobInput
@@ -54,6 +56,8 @@ type _ActiveRevisionGetter = Callable[..., Awaitable[DrawingRevision | None]]
 type _RevisionTakeoffGetter = Callable[[UUID, UUID, AsyncSession], Awaitable[QuantityTakeoff]]
 type _EstimateVersionGetter = Callable[[UUID, UUID, AsyncSession], Awaitable[EstimateVersion]]
 type _FingerprintBuilder = Callable[..., str]
+type _JobEnqueuePublisher = Callable[[UUID], None]
+type _PublishJobEnqueueIntent = Callable[..., Awaitable[bool]]
 type _ReplayIdempotencyResponse = Callable[..., Awaitable[Response | None]]
 type _CompleteIdempotencyResponse = Callable[..., Awaitable[Response]]
 
@@ -191,6 +195,32 @@ def _prepare_job_enqueue_intent(job: Job) -> None:
         default=_prepare_job_enqueue_intent_direct,
     )
     helper(job)
+
+
+async def _publish_job_enqueue_intent(*args: Any, **kwargs: Any) -> bool:
+    """Compatibility wrapper for durable enqueue publication."""
+
+    helper = cast(
+        _PublishJobEnqueueIntent,
+        _compat_attr(
+            "publish_job_enqueue_intent",
+            default=_publish_job_enqueue_intent_direct,
+        ),
+    )
+    return await helper(*args, **kwargs)
+
+
+def _enqueue_export_job(job_id: UUID) -> None:
+    """Compatibility wrapper for export job queue publication."""
+
+    helper = cast(
+        _JobEnqueuePublisher,
+        _compat_attr(
+            "enqueue_export_job",
+            default=_enqueue_export_job_direct,
+        ),
+    )
+    helper(job_id)
 
 
 def _raise_estimate_takeoff_gate_invalid(takeoff: QuantityTakeoff) -> None:
@@ -449,6 +479,11 @@ async def create_revision_json_export(
         )
 
     await db.commit()
+    await _publish_job_enqueue_intent(
+        export_job.id,
+        publisher=_enqueue_export_job,
+        suppress_exceptions=True,
+    )
 
     if success_response is not None:
         return success_response
@@ -541,6 +576,11 @@ async def create_revision_quantity_csv_export(
         )
 
     await db.commit()
+    await _publish_job_enqueue_intent(
+        export_job.id,
+        publisher=_enqueue_export_job,
+        suppress_exceptions=True,
+    )
 
     if success_response is not None:
         return success_response
@@ -649,6 +689,11 @@ async def create_revision_estimate_export(
         )
 
     await db.commit()
+    await _publish_job_enqueue_intent(
+        export_job.id,
+        publisher=_enqueue_export_job,
+        suppress_exceptions=True,
+    )
 
     if success_response is not None:
         return success_response

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -177,6 +177,13 @@ def enqueue_estimate_job(job_id: UUID) -> None:
     publisher(job_id)
 
 
+def enqueue_export_job(job_id: UUID) -> None:
+    """Compatibility wrapper kept for test fixture patching."""
+
+    publisher = jobs_worker_module.enqueue_export_job
+    publisher(job_id)
+
+
 async def _get_active_validation_report_or_404(
     revision_id: UUID,
     db: AsyncSession,

--- a/app/jobs/lifecycle.py
+++ b/app/jobs/lifecycle.py
@@ -838,3 +838,44 @@ async def _begin_or_resume_estimate_job(
         emit_job_event_func=emit_job_event_func,
         logger_instance=logger_instance,
     )
+
+
+async def _begin_or_resume_export_job(
+    job_id: UUID,
+    *,
+    terminal_job_statuses: Collection[str],
+    stale_after: timedelta,
+    session_maker_factory: Callable[[], Any] | None = None,
+    lock_job_source_for_terminal_mutation_func: (
+        Callable[..., Awaitable[_LockedJobSource]] | None
+    ) = None,
+    cancel_job_for_inactive_source_func: Callable[..., Awaitable[bool]] | None = None,
+    claim_job_attempt_lease_func: Callable[..., _JobAttemptLease] | None = None,
+    is_stale_running_job_func: Callable[..., bool] | None = None,
+    finalize_job_cancelled_func: Callable[[Job], None] | None = None,
+    emit_job_event_func: Callable[..., Awaitable[bool]] | None = None,
+    logger_instance: Any | None = None,
+) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted export job under a row lock."""
+    return await _begin_or_resume_job(
+        job_id,
+        supported_job_types={JobType.EXPORT.value},
+        terminal_job_statuses=terminal_job_statuses,
+        stale_after=stale_after,
+        log_keys=_BeginOrResumeLogKeys(
+            unsupported_type="export_job_unsupported_type_skipped",
+            terminal_status="export_job_skipped_terminal_status",
+            inactive_source="export_job_cancelled_inactive_source",
+            reclaimed_stale_running="export_job_reclaimed_stale_running_status",
+            duplicate_delivery="export_job_duplicate_delivery_skipped_running_attempt",
+            cancelled="export_job_cancelled",
+        ),
+        session_maker_factory=session_maker_factory,
+        lock_job_source_for_terminal_mutation_func=lock_job_source_for_terminal_mutation_func,
+        cancel_job_for_inactive_source_func=cancel_job_for_inactive_source_func,
+        claim_job_attempt_lease_func=claim_job_attempt_lease_func,
+        is_stale_running_job_func=is_stale_running_job_func,
+        finalize_job_cancelled_func=finalize_job_cancelled_func,
+        emit_job_event_func=emit_job_event_func,
+        logger_instance=logger_instance,
+    )

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -50,6 +50,18 @@ from app.estimating.quantities.contracts import (
     RevisionGateMetadata,
 )
 from app.estimating.quantities.engine import compute_quantities
+from app.exports.csv import (
+    CsvExportResult,
+    EstimateCsvExportError,
+    QuantityCsvExportError,
+    render_estimate_csv_export,
+    render_quantity_csv_export,
+)
+from app.exports.revision_json import (
+    RevisionJsonExportError,
+    RevisionJsonExportResult,
+    render_revision_json_export,
+)
 from app.ingestion.contracts import AdapterTimeout, ProgressUpdate
 from app.ingestion.debug_overlay import plan_svg_debug_overlay
 from app.ingestion.finalization import IngestFinalizationPayload
@@ -59,6 +71,7 @@ from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
+from app.models.export_job_input import ExportJobInput
 from app.models.file import File
 from app.models.generated_artifact import GeneratedArtifact
 from app.models.job import Job, JobType
@@ -82,6 +95,7 @@ _RECOVERABLE_ENQUEUE_JOB_TYPES = (
     JobType.REPROCESS.value,
     JobType.QUANTITY_TAKEOFF.value,
     JobType.ESTIMATE.value,
+    JobType.EXPORT.value,
 )
 _KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER: frozenset[str] = frozenset()
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
@@ -94,18 +108,25 @@ _ENQUEUE_LEASE_DURATION = timedelta(minutes=1)
 _JOB_CANCELLATION_POLL_INTERVAL_SECONDS = 0.1
 _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
 _ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
+_ENQUEUE_REPROCESS_JOB_ERROR_MESSAGE = "Failed to enqueue reprocess job"
+_ENQUEUE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to enqueue quantity takeoff job"
+_ENQUEUE_ESTIMATE_JOB_ERROR_MESSAGE = "Failed to enqueue estimate job"
+_ENQUEUE_EXPORT_JOB_ERROR_MESSAGE = "Failed to enqueue export job"
 _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
 _PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
 _FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to finalize quantity takeoff job"
 _FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE = "Failed to finalize estimate job"
+_FINALIZE_EXPORT_JOB_ERROR_MESSAGE = "Failed to finalize export job"
 _PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Quantity takeoff job failed unexpectedly."
 _PROCESS_ESTIMATE_JOB_ERROR_MESSAGE = "Estimate job failed unexpectedly."
+_PROCESS_EXPORT_JOB_ERROR_MESSAGE = "Export job failed unexpectedly."
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
 _DEBUG_OVERLAY_ARTIFACT_KIND = "debug_overlay"
 _DEBUG_OVERLAY_ARTIFACT_FORMAT = "svg"
 _DEBUG_OVERLAY_GENERATOR_NAME = "app.ingestion.debug_overlay"
 _DEBUG_OVERLAY_GENERATOR_VERSION = "1"
+_ESTIMATE_PDF_EXPORT_UNSUPPORTED_ERROR_MESSAGE = "Estimate PDF exports are not implemented."
 _NORMALIZED_ENTITY_INSERT_CHUNK_SIZE = 500
 _QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE = (
     "Quantity takeoff is blocked by the revision validation gate."
@@ -172,6 +193,7 @@ def get_job_enqueue_publisher(job_type: JobType | str) -> Callable[[UUID], None]
         JobType.REPROCESS.value: enqueue_ingest_job,
         JobType.QUANTITY_TAKEOFF.value: enqueue_quantity_takeoff_job,
         JobType.ESTIMATE.value: enqueue_estimate_job,
+        JobType.EXPORT.value: enqueue_export_job,
     }
     return registry.get(normalized_job_type)
 
@@ -233,6 +255,44 @@ class _EstimateJobInputError(Exception):
 
     def __str__(self) -> str:
         return self.message
+
+
+@dataclass(frozen=True, slots=True)
+class _ExportJobInputError(Exception):
+    """Raised for deterministic export job input failures."""
+
+    error_code: ErrorCode
+    message: str
+    details: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+@dataclass(frozen=True, slots=True)
+class _ExportExecutionInput:
+    """Resolved persisted inputs for a supported export job."""
+
+    drawing_revision_id: UUID
+    export_kind: str
+    export_format: str
+    media_type: str
+    artifact_name: str
+    options_json: dict[str, Any]
+    quantity_takeoff_id: UUID | None = None
+    estimate_version_id: UUID | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _RenderedExportArtifact:
+    """Deterministic rendered artifact bytes and metadata."""
+
+    content_bytes: bytes
+    checksum_sha256: str
+    size_bytes: int
+    media_type: str
+    generator_name: str
+    generator_version: str
 
 
 _JobAttemptLease = job_lifecycle._JobAttemptLease
@@ -565,6 +625,23 @@ async def _get_existing_estimate_version(
     """Load an existing committed estimate version for a job."""
     result = await session.execute(
         select(EstimateVersion).where(EstimateVersion.source_job_id == source_job_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _get_existing_generated_artifact(
+    session: AsyncSession,
+    *,
+    source_job_id: UUID,
+) -> GeneratedArtifact | None:
+    """Load an existing committed generated artifact for a job."""
+    result = await session.execute(
+        select(GeneratedArtifact)
+        .where(
+            (GeneratedArtifact.job_id == source_job_id) & (GeneratedArtifact.deleted_at.is_(None))
+        )
+        .order_by(GeneratedArtifact.created_at.asc(), GeneratedArtifact.id.asc())
+        .limit(1)
     )
     return result.scalar_one_or_none()
 
@@ -2414,6 +2491,17 @@ async def _cleanup_failed_storage_writes(
             )
 
 
+def _get_enqueue_job_error_message(job_type: str) -> str:
+    """Return the persisted enqueue failure message for a worker job type."""
+    return {
+        JobType.INGEST.value: _ENQUEUE_INGEST_JOB_ERROR_MESSAGE,
+        JobType.REPROCESS.value: _ENQUEUE_REPROCESS_JOB_ERROR_MESSAGE,
+        JobType.QUANTITY_TAKEOFF.value: _ENQUEUE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+        JobType.ESTIMATE.value: _ENQUEUE_ESTIMATE_JOB_ERROR_MESSAGE,
+        JobType.EXPORT.value: _ENQUEUE_EXPORT_JOB_ERROR_MESSAGE,
+    }.get(job_type, "Failed to enqueue job")
+
+
 async def _build_ingestion_run_request(job_id: UUID, *, attempt_token: UUID) -> IngestionRunRequest:
     """Load persisted job and file metadata for the ingestion runner."""
     session_maker = get_session_maker()
@@ -3046,6 +3134,562 @@ def _build_quantity_items(
         )
 
     return items
+
+
+def _build_export_artifact_name(
+    *,
+    export_kind: str,
+    export_format: str,
+    drawing_revision_id: UUID,
+    quantity_takeoff_id: UUID | None = None,
+    estimate_version_id: UUID | None = None,
+) -> str:
+    """Build a deterministic filename for a generated export artifact."""
+    if export_kind == "revision_json":
+        return f"revision-{drawing_revision_id}.{export_format}"
+    if export_kind == "quantity_csv":
+        assert quantity_takeoff_id is not None
+        return f"quantity-takeoff-{quantity_takeoff_id}.{export_format}"
+    if export_kind in {"estimate_csv", "estimate_pdf"}:
+        assert estimate_version_id is not None
+        return f"estimate-{estimate_version_id}.{export_format}"
+    return f"export-{drawing_revision_id}.{export_format}"
+
+
+def _build_export_job_input_error(
+    message: str,
+    *,
+    error_code: ErrorCode = ErrorCode.INPUT_INVALID,
+    details: dict[str, Any] | None = None,
+) -> _ExportJobInputError:
+    """Build a deterministic export job input failure."""
+    return _ExportJobInputError(error_code=error_code, message=message, details=details)
+
+
+def _build_export_artifact_lineage_json(
+    *,
+    source_file: File,
+    job: Job,
+    execution: _ExportExecutionInput,
+) -> dict[str, Any]:
+    """Build lineage metadata for a persisted export artifact."""
+    return {
+        "source_file": {
+            "id": str(source_file.id),
+            "original_filename": source_file.original_filename,
+            "detected_format": source_file.detected_format,
+            "media_type": source_file.media_type,
+            "checksum_sha256": source_file.checksum_sha256,
+        },
+        "job": {
+            "id": str(job.id),
+            "attempts": job.attempts,
+            "base_revision_id": (
+                str(job.base_revision_id) if job.base_revision_id is not None else None
+            ),
+        },
+        "drawing_revision": {"id": str(execution.drawing_revision_id)},
+        "export": {
+            "kind": execution.export_kind,
+            "format": execution.export_format,
+            "media_type": execution.media_type,
+            "quantity_takeoff_id": (
+                str(execution.quantity_takeoff_id)
+                if execution.quantity_takeoff_id is not None
+                else None
+            ),
+            "estimate_version_id": (
+                str(execution.estimate_version_id)
+                if execution.estimate_version_id is not None
+                else None
+            ),
+            "options": deepcopy(execution.options_json),
+        },
+    }
+
+
+async def _render_export_artifact(
+    session: AsyncSession,
+    execution: _ExportExecutionInput,
+) -> _RenderedExportArtifact:
+    """Render bytes for a supported export job."""
+    try:
+        result: RevisionJsonExportResult | CsvExportResult
+        if execution.export_kind == "revision_json":
+            result = await render_revision_json_export(
+                session,
+                execution.drawing_revision_id,
+                options=execution.options_json,
+            )
+        elif execution.export_kind == "quantity_csv":
+            assert execution.quantity_takeoff_id is not None
+            result = await render_quantity_csv_export(session, execution.quantity_takeoff_id)
+        elif execution.export_kind == "estimate_csv":
+            assert execution.estimate_version_id is not None
+            result = await render_estimate_csv_export(session, execution.estimate_version_id)
+        else:
+            raise _build_export_job_input_error(
+                "Export job kind is not supported by the worker.",
+                details={"export_kind": execution.export_kind},
+            )
+    except RevisionJsonExportError as exc:
+        raise _build_export_job_input_error(
+            str(exc),
+            error_code=ErrorCode.NOT_FOUND,
+            details={"drawing_revision_id": str(execution.drawing_revision_id)},
+        ) from exc
+    except QuantityCsvExportError as exc:
+        raise _build_export_job_input_error(
+            str(exc),
+            error_code=ErrorCode.NOT_FOUND,
+            details={
+                "drawing_revision_id": str(execution.drawing_revision_id),
+                "quantity_takeoff_id": str(execution.quantity_takeoff_id),
+            },
+        ) from exc
+    except EstimateCsvExportError as exc:
+        raise _build_export_job_input_error(
+            str(exc),
+            error_code=ErrorCode.NOT_FOUND,
+            details={
+                "drawing_revision_id": str(execution.drawing_revision_id),
+                "estimate_version_id": str(execution.estimate_version_id),
+            },
+        ) from exc
+
+    if result.media_type != execution.media_type:
+        raise ValueError("Rendered export media type does not match the persisted export job input")
+
+    computed_checksum = hashlib.sha256(result.content_bytes).hexdigest()
+    if computed_checksum != result.checksum_sha256:
+        raise ValueError("Rendered export checksum does not match the generated bytes")
+
+    if len(result.content_bytes) != result.size_bytes:
+        raise ValueError("Rendered export size does not match the generated bytes")
+
+    return _RenderedExportArtifact(
+        content_bytes=result.content_bytes,
+        checksum_sha256=result.checksum_sha256,
+        size_bytes=result.size_bytes,
+        media_type=result.media_type,
+        generator_name=result.generator_name,
+        generator_version=result.generator_version,
+    )
+
+
+async def _build_export_execution_input(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> _ExportExecutionInput:
+    """Load deterministic persisted inputs for a claimed export job."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
+        if job.job_type != JobType.EXPORT.value:
+            raise ValueError(f"Unsupported export job type '{job.job_type}'")
+        if job.base_revision_id is None:
+            raise _RevisionConflictError(
+                message="Export job is missing its finalized base revision.",
+                details={
+                    "base_revision_id": None,
+                    "current_revision_id": None,
+                },
+            )
+
+        export_input = await session.get(ExportJobInput, job.id)
+        if export_input is None:
+            raise _build_export_job_input_error(
+                "Export job input is missing.",
+                error_code=ErrorCode.NOT_FOUND,
+                details={"job_id": str(job.id)},
+            )
+        if (
+            export_input.project_id != job.project_id
+            or export_input.source_file_id != job.file_id
+            or export_input.drawing_revision_id != job.base_revision_id
+            or export_input.source_job_id != job.id
+            or export_input.source_job_type != JobType.EXPORT.value
+        ):
+            raise _build_export_job_input_error(
+                "Export job input lineage does not match the persisted job.",
+                details={
+                    "drawing_revision_id": str(export_input.drawing_revision_id),
+                    "base_revision_id": str(job.base_revision_id),
+                    "source_job_type": export_input.source_job_type,
+                },
+            )
+
+        drawing_revision = await _get_drawing_revision(session, revision_id=job.base_revision_id)
+        if drawing_revision is None:
+            raise _RevisionConflictError(
+                message="Export job base revision no longer exists.",
+                details={
+                    "base_revision_id": str(job.base_revision_id),
+                    "current_revision_id": None,
+                },
+            )
+        if (
+            drawing_revision.project_id != job.project_id
+            or drawing_revision.source_file_id != job.file_id
+        ):
+            raise ValueError("Export job base revision does not belong to the source file")
+
+        if export_input.export_kind == "estimate_pdf":
+            raise _build_export_job_input_error(
+                _ESTIMATE_PDF_EXPORT_UNSUPPORTED_ERROR_MESSAGE,
+                details={"export_kind": export_input.export_kind},
+            )
+
+        supported_exports: dict[str, tuple[str, str]] = {
+            "revision_json": ("json", "application/json"),
+            "quantity_csv": ("csv", "text/csv"),
+            "estimate_csv": ("csv", "text/csv"),
+        }
+        expected_export_metadata = supported_exports.get(export_input.export_kind)
+        if expected_export_metadata is None:
+            raise _build_export_job_input_error(
+                "Export job kind is not supported by the worker.",
+                details={"export_kind": export_input.export_kind},
+            )
+
+        expected_format, expected_media_type = expected_export_metadata
+        if (
+            export_input.export_format != expected_format
+            or export_input.media_type != expected_media_type
+        ):
+            raise _build_export_job_input_error(
+                "Export job metadata does not match the supported export kind.",
+                details={
+                    "export_kind": export_input.export_kind,
+                    "export_format": export_input.export_format,
+                    "media_type": export_input.media_type,
+                },
+            )
+
+        options_json = deepcopy(export_input.options_json)
+        if export_input.export_kind == "revision_json":
+            if (
+                export_input.quantity_takeoff_id is not None
+                or export_input.estimate_version_id is not None
+                or export_input.quantity_gate is not None
+                or export_input.trusted_totals is not None
+            ):
+                raise _build_export_job_input_error(
+                    "Revision JSON export input contains unexpected quantity or estimate lineage.",
+                    details={"export_kind": export_input.export_kind},
+                )
+            return _ExportExecutionInput(
+                drawing_revision_id=drawing_revision.id,
+                export_kind=export_input.export_kind,
+                export_format=export_input.export_format,
+                media_type=export_input.media_type,
+                artifact_name=_build_export_artifact_name(
+                    export_kind=export_input.export_kind,
+                    export_format=export_input.export_format,
+                    drawing_revision_id=drawing_revision.id,
+                ),
+                options_json=options_json,
+            )
+
+        quantity_takeoff_id = export_input.quantity_takeoff_id
+        if quantity_takeoff_id is None:
+            raise _build_export_job_input_error(
+                "Export job input is missing its quantity takeoff linkage.",
+                details={"export_kind": export_input.export_kind},
+            )
+        if export_input.quantity_gate != "allowed" or export_input.trusted_totals is not True:
+            raise _build_export_job_input_error(
+                "Export job input requires a trusted quantity takeoff with allowed gate.",
+                details={
+                    "quantity_takeoff_id": str(quantity_takeoff_id),
+                    "quantity_gate": export_input.quantity_gate,
+                    "trusted_totals": export_input.trusted_totals,
+                },
+            )
+
+        quantity_takeoff = await session.get(QuantityTakeoff, quantity_takeoff_id)
+        if quantity_takeoff is None:
+            raise _build_export_job_input_error(
+                "Export job quantity takeoff was not found.",
+                error_code=ErrorCode.NOT_FOUND,
+                details={"quantity_takeoff_id": str(quantity_takeoff_id)},
+            )
+        if (
+            quantity_takeoff.project_id != job.project_id
+            or quantity_takeoff.source_file_id != job.file_id
+            or quantity_takeoff.drawing_revision_id != drawing_revision.id
+            or quantity_takeoff.quantity_gate != export_input.quantity_gate
+            or quantity_takeoff.trusted_totals is not export_input.trusted_totals
+            or quantity_takeoff.source_job_type != JobType.QUANTITY_TAKEOFF.value
+        ):
+            raise _build_export_job_input_error(
+                "Export job quantity takeoff lineage does not match the persisted job input.",
+                details={
+                    "quantity_takeoff_id": str(quantity_takeoff.id),
+                    "drawing_revision_id": str(quantity_takeoff.drawing_revision_id),
+                    "quantity_gate": quantity_takeoff.quantity_gate,
+                    "trusted_totals": quantity_takeoff.trusted_totals,
+                },
+            )
+
+        if export_input.export_kind == "quantity_csv":
+            if export_input.estimate_version_id is not None:
+                raise _build_export_job_input_error(
+                    "Quantity CSV export input contains unexpected estimate linkage.",
+                    details={
+                        "quantity_takeoff_id": str(quantity_takeoff.id),
+                        "estimate_version_id": str(export_input.estimate_version_id),
+                    },
+                )
+            return _ExportExecutionInput(
+                drawing_revision_id=drawing_revision.id,
+                export_kind=export_input.export_kind,
+                export_format=export_input.export_format,
+                media_type=export_input.media_type,
+                artifact_name=_build_export_artifact_name(
+                    export_kind=export_input.export_kind,
+                    export_format=export_input.export_format,
+                    drawing_revision_id=drawing_revision.id,
+                    quantity_takeoff_id=quantity_takeoff.id,
+                ),
+                options_json=options_json,
+                quantity_takeoff_id=quantity_takeoff.id,
+            )
+
+        estimate_version_id = export_input.estimate_version_id
+        if estimate_version_id is None:
+            raise _build_export_job_input_error(
+                "Estimate CSV export input is missing its estimate version linkage.",
+                details={"quantity_takeoff_id": str(quantity_takeoff.id)},
+            )
+
+        estimate_version = await session.get(EstimateVersion, estimate_version_id)
+        if estimate_version is None:
+            raise _build_export_job_input_error(
+                "Export job estimate version was not found.",
+                error_code=ErrorCode.NOT_FOUND,
+                details={"estimate_version_id": str(estimate_version_id)},
+            )
+        if (
+            estimate_version.project_id != job.project_id
+            or estimate_version.source_file_id != job.file_id
+            or estimate_version.drawing_revision_id != drawing_revision.id
+            or estimate_version.quantity_takeoff_id != quantity_takeoff.id
+            or estimate_version.quantity_gate != export_input.quantity_gate
+            or estimate_version.trusted_totals is not export_input.trusted_totals
+        ):
+            raise _build_export_job_input_error(
+                "Export job estimate lineage does not match the persisted job input.",
+                details={
+                    "estimate_version_id": str(estimate_version.id),
+                    "drawing_revision_id": str(estimate_version.drawing_revision_id),
+                    "quantity_takeoff_id": str(estimate_version.quantity_takeoff_id),
+                    "quantity_gate": estimate_version.quantity_gate,
+                    "trusted_totals": estimate_version.trusted_totals,
+                },
+            )
+
+        return _ExportExecutionInput(
+            drawing_revision_id=drawing_revision.id,
+            export_kind=export_input.export_kind,
+            export_format=export_input.export_format,
+            media_type=export_input.media_type,
+            artifact_name=_build_export_artifact_name(
+                export_kind=export_input.export_kind,
+                export_format=export_input.export_format,
+                drawing_revision_id=drawing_revision.id,
+                quantity_takeoff_id=quantity_takeoff.id,
+                estimate_version_id=estimate_version.id,
+            ),
+            options_json=options_json,
+            quantity_takeoff_id=quantity_takeoff.id,
+            estimate_version_id=estimate_version.id,
+        )
+
+
+async def _finalize_export_job(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    execution: _ExportExecutionInput,
+    rendered: _RenderedExportArtifact,
+) -> bool:
+    """Atomically publish one export artifact and terminal job success."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
+        source_file = locked_source.source_file
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "export_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            logger.info(
+                "export_job_completion_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
+            await session.commit()
+            logger.info("export_job_cancelled", job_id=str(job_id))
+            return False
+
+        if job.status != "running":
+            logger.info(
+                "export_job_completion_skipped_non_running_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if (
+            locked_source.project.deleted_at is not None
+            or source_file is None
+            or source_file.deleted_at is not None
+        ):
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            logger.info("export_job_cancelled_inactive_source", job_id=str(job_id))
+            return False
+
+        if job.base_revision_id != execution.drawing_revision_id:
+            raise _RevisionConflictError(
+                message="Export base revision changed before finalization.",
+                details={
+                    "base_revision_id": (
+                        str(job.base_revision_id) if job.base_revision_id is not None else None
+                    ),
+                    "drawing_revision_id": str(execution.drawing_revision_id),
+                },
+            )
+
+        existing_artifact = await _get_existing_generated_artifact(session, source_job_id=job.id)
+        if existing_artifact is not None:
+            logger.info(
+                "export_job_completion_skipped_existing_artifact",
+                job_id=str(job_id),
+                generated_artifact_id=str(existing_artifact.id),
+            )
+            return False
+
+        generated_artifact_id = uuid.uuid4()
+        storage_key = build_generated_artifact_storage_key(
+            generated_artifact_id,
+            execution.artifact_name,
+        )
+        lineage_json = _build_export_artifact_lineage_json(
+            source_file=source_file,
+            job=job,
+            execution=execution,
+        )
+        storage = get_storage()
+        written_storage_objects: list[tuple[str, str]] = []
+        commit_started = False
+
+        try:
+            stored_object = await storage.put(storage_key, rendered.content_bytes, immutable=True)
+            written_storage_objects.append((stored_object.key, stored_object.storage_uri))
+
+            if stored_object.checksum_sha256 != rendered.checksum_sha256:
+                raise ValueError(
+                    "Stored export artifact checksum does not match the rendered bytes"
+                )
+            if stored_object.size_bytes != rendered.size_bytes:
+                raise ValueError("Stored export artifact size does not match the rendered bytes")
+
+            session.add(
+                GeneratedArtifact(
+                    id=generated_artifact_id,
+                    project_id=job.project_id,
+                    source_file_id=source_file.id,
+                    job_id=job.id,
+                    drawing_revision_id=execution.drawing_revision_id,
+                    artifact_kind=execution.export_kind,
+                    name=execution.artifact_name,
+                    format=execution.export_format,
+                    media_type=rendered.media_type,
+                    size_bytes=stored_object.size_bytes,
+                    checksum_sha256=stored_object.checksum_sha256,
+                    generator_name=rendered.generator_name,
+                    generator_version=rendered.generator_version,
+                    generator_config_json=deepcopy(execution.options_json),
+                    storage_key=stored_object.key,
+                    storage_uri=stored_object.storage_uri,
+                    lineage_json=lineage_json,
+                )
+            )
+
+            job.status = "succeeded"
+            job.finished_at = _utcnow()
+            job.error_code = None
+            job.error_message = None
+            _clear_job_attempt_lease(job)
+            await emit_job_event(
+                job.id,
+                level="info",
+                message="Job succeeded",
+                data_json={
+                    "status": "succeeded",
+                    "attempts": job.attempts,
+                    "generated_artifact_id": str(generated_artifact_id),
+                    "export_kind": execution.export_kind,
+                },
+                session=session,
+            )
+            await session.flush()
+            commit_started = True
+            await session.commit()
+        except asyncio.CancelledError:
+            if not commit_started:
+                await session.rollback()
+                await _cleanup_failed_storage_writes(
+                    storage,
+                    written_storage_objects,
+                    job_id=job_id,
+                )
+            raise
+        except Exception:
+            if not commit_started:
+                await session.rollback()
+                await _cleanup_failed_storage_writes(
+                    storage,
+                    written_storage_objects,
+                    job_id=job_id,
+                )
+            raise
+
+    return True
 
 
 async def _build_quantity_takeoff_execution_input(
@@ -3716,16 +4360,18 @@ async def _mark_job_failed_if_recovery_safe(
                 reason="source_deleted",
             )
             logger.info(
-                "ingest_job_recovery_enqueue_failure_mark_skipped_inactive_source",
+                "job_recovery_enqueue_failure_mark_skipped_inactive_source",
                 job_id=str(job_id),
+                job_type=job.job_type,
                 status=job.status,
             )
             return False
 
         if not _job_is_safe_recovery_failure_target(job):
             logger.info(
-                "ingest_job_recovery_enqueue_failure_mark_skipped_changed_state",
+                "job_recovery_enqueue_failure_mark_skipped_changed_state",
                 job_id=str(job_id),
+                job_type=job.job_type,
                 status=job.status,
             )
             return False
@@ -3833,6 +4479,7 @@ async def publish_job_enqueue_intent(
     suppress_exceptions: bool = False,
 ) -> bool:
     """Best-effort publish for a durable enqueue intent recorded in Postgres."""
+    claimed_intent: _ClaimedJobEnqueueIntent | None = None
     try:
         claimed_intent = await _claim_job_enqueue_intent(job_id)
         if claimed_intent is None:
@@ -3847,11 +4494,12 @@ async def publish_job_enqueue_intent(
         except Exception:
             await _release_job_enqueue_intent(job_id, lease_token=claimed_intent.lease.token)
             if recovery:
-                await _mark_recovery_enqueue_failed(job_id)
+                await _mark_recovery_enqueue_failed(job_id, job_type=claimed_intent.job_type)
             else:
                 logger.warning(
-                    "ingest_job_enqueue_deferred",
+                    "job_enqueue_deferred",
                     job_id=str(job_id),
+                    job_type=claimed_intent.job_type,
                     recovery_action="worker_start_recovery",
                 )
             return False
@@ -3863,25 +4511,27 @@ async def publish_job_enqueue_intent(
             raise
 
         logger.warning(
-            "ingest_job_enqueue_deferred",
+            "job_enqueue_deferred",
             job_id=str(job_id),
+            job_type=claimed_intent.job_type if claimed_intent is not None else None,
             recovery_action="worker_start_recovery",
         )
         return False
 
 
-async def _mark_recovery_enqueue_failed(job_id: UUID) -> bool:
+async def _mark_recovery_enqueue_failed(job_id: UUID, *, job_type: str) -> bool:
     """Persist and log a sanitized worker-recovery enqueue failure."""
     marked_failed = await _mark_job_failed_if_recovery_safe(
         job_id,
-        error_message=_ENQUEUE_INGEST_JOB_ERROR_MESSAGE,
+        error_message=_get_enqueue_job_error_message(job_type),
     )
     if not marked_failed:
         return False
 
     logger.error(
-        "ingest_job_recovery_enqueue_failed",
+        "job_recovery_enqueue_failed",
         job_id=str(job_id),
+        job_type=job_type,
         error_code=ErrorCode.INTERNAL_ERROR.value,
         recovery_action="mark_failed",
     )
@@ -3955,6 +4605,23 @@ async def _begin_or_resume_quantity_takeoff_job(job_id: UUID) -> _JobAttemptLeas
 async def _begin_or_resume_estimate_job(job_id: UUID) -> _JobAttemptLease | None:
     """Claim, resume, or cancel a persisted estimate job under a row lock."""
     return await job_lifecycle._begin_or_resume_estimate_job(
+        job_id,
+        terminal_job_statuses=_TERMINAL_JOB_STATUSES,
+        stale_after=_RUNNING_JOB_STALE_AFTER,
+        session_maker_factory=get_session_maker,
+        lock_job_source_for_terminal_mutation_func=_lock_job_source_for_terminal_mutation,
+        cancel_job_for_inactive_source_func=_cancel_job_for_inactive_source,
+        claim_job_attempt_lease_func=_claim_job_attempt_lease,
+        is_stale_running_job_func=_is_stale_running_job,
+        finalize_job_cancelled_func=_finalize_job_cancelled,
+        emit_job_event_func=emit_job_event,
+        logger_instance=logger,
+    )
+
+
+async def _begin_or_resume_export_job(job_id: UUID) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted export job under a row lock."""
+    return await job_lifecycle._begin_or_resume_export_job(
         job_id,
         terminal_job_statuses=_TERMINAL_JOB_STATUSES,
         stale_after=_RUNNING_JOB_STALE_AFTER,
@@ -4478,3 +5145,113 @@ def run_estimate_job(job_id: str) -> None:
 def enqueue_estimate_job(job_id: UUID) -> None:
     """Publish a persisted estimate job to Celery."""
     run_estimate_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)
+
+
+async def process_export_job(job_id: UUID) -> None:
+    """Load a persisted export job and atomically persist its generated artifact."""
+    _ensure_worker_database_configured()
+
+    lease = await _begin_or_resume_export_job(job_id)
+    if lease is None:
+        return
+
+    try:
+        execution = await _build_export_execution_input(job_id, attempt_token=lease.token)
+        session_maker = get_session_maker()
+        if session_maker is None:
+            raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+        async with session_maker() as session:
+            rendered = await _render_export_artifact(session, execution)
+    except _StaleJobAttemptError:
+        logger.info("export_job_stale_attempt_skipped", job_id=str(job_id))
+        return
+    except _RevisionConflictError as exc:
+        await _mark_job_failed_for_revision_conflict(
+            job_id,
+            attempt_token=lease.token,
+            log_event="export_job_revision_conflict",
+            exc=exc,
+        )
+        return
+    except _ExportJobInputError as exc:
+        failure_details = exc.details
+        await _mark_job_failed(
+            job_id,
+            error_message=exc.message,
+            error_code=exc.error_code,
+            attempt_token=lease.token,
+            error_details=failure_details,
+        )
+        logger.warning(
+            "export_job_input_failed",
+            job_id=str(job_id),
+            error_code=exc.error_code.value,
+            **(failure_details or {}),
+        )
+        return
+    except asyncio.CancelledError:
+        await _mark_job_cancelled_with_log(
+            job_id,
+            attempt_token=lease.token,
+            log_event="export_job_cancelled_during_execution",
+        )
+        raise
+    except Exception:
+        await _mark_job_failed_with_internal_error_log(
+            job_id,
+            attempt_token=lease.token,
+            error_message=_PROCESS_EXPORT_JOB_ERROR_MESSAGE,
+            log_event="export_job_failed",
+        )
+        raise
+
+    try:
+        finalized = await _finalize_export_job(
+            job_id,
+            attempt_token=lease.token,
+            execution=execution,
+            rendered=rendered,
+        )
+    except asyncio.CancelledError:
+        await _mark_job_cancelled_with_log(
+            job_id,
+            attempt_token=lease.token,
+            log_event="export_job_cancelled_during_finalization",
+        )
+        raise
+    except _RevisionConflictError as exc:
+        await _mark_job_failed_for_revision_conflict(
+            job_id,
+            attempt_token=lease.token,
+            log_event="export_job_revision_conflict",
+            exc=exc,
+        )
+        return
+    except Exception:
+        await _mark_job_failed_with_internal_error_log(
+            job_id,
+            attempt_token=lease.token,
+            error_message=_FINALIZE_EXPORT_JOB_ERROR_MESSAGE,
+            log_event="export_job_finalization_failed",
+        )
+        raise
+
+    if finalized:
+        logger.info("export_job_succeeded", job_id=str(job_id))
+
+
+@celery_app.task(
+    name="app.jobs.worker.run_export_job",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def run_export_job(job_id: str) -> None:
+    """Celery task wrapper for persisted export jobs."""
+    _run_worker_loop(lambda: process_export_job(UUID(job_id)))
+
+
+def enqueue_export_job(job_id: UUID) -> None:
+    """Publish a persisted export job to Celery."""
+
+    run_export_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)

--- a/tests/test_export_create_api.py
+++ b/tests/test_export_create_api.py
@@ -290,7 +290,13 @@ async def _count_export_side_effects(lineage: ExportLineage) -> tuple[int, int, 
             )
         )
         generated_artifact_count = await session.scalar(
-            select(func.count()).select_from(GeneratedArtifact)
+            select(func.count())
+            .select_from(GeneratedArtifact)
+            .where(
+                GeneratedArtifact.project_id == lineage.project_id,
+                GeneratedArtifact.source_file_id == lineage.file_id,
+                GeneratedArtifact.drawing_revision_id == lineage.revision_id,
+            )
         )
 
     assert export_job_count is not None
@@ -533,7 +539,13 @@ async def test_create_export_persists_pending_job_and_input(
             assert export_input.estimate_version_id == lineage.estimate_version_id
 
         generated_artifact_count = await session.scalar(
-            select(func.count()).select_from(GeneratedArtifact)
+            select(func.count())
+            .select_from(GeneratedArtifact)
+            .where(
+                GeneratedArtifact.project_id == lineage.project_id,
+                GeneratedArtifact.source_file_id == lineage.file_id,
+                GeneratedArtifact.drawing_revision_id == lineage.revision_id,
+            )
         )
         assert generated_artifact_count == 0
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1141,15 +1141,19 @@ async def test_mark_recovery_enqueue_failed_logs_only_safe_fields(
     )
     monkeypatch.setattr(worker_module.logger, "error", _capture_logger_error)
 
-    marked_failed = await worker_module._mark_recovery_enqueue_failed(job_id)
+    marked_failed = await worker_module._mark_recovery_enqueue_failed(
+        job_id,
+        job_type=JobType.INGEST.value,
+    )
 
     assert marked_failed is True
     assert marked_failed_job_ids == [job_id]
     assert logger_error_calls == [
         (
-            "ingest_job_recovery_enqueue_failed",
+            "job_recovery_enqueue_failed",
             {
                 "job_id": str(job_id),
+                "job_type": JobType.INGEST.value,
                 "error_code": ErrorCode.INTERNAL_ERROR.value,
                 "recovery_action": "mark_failed",
             },

--- a/tests/test_jobs_worker_exports.py
+++ b/tests/test_jobs_worker_exports.py
@@ -1,0 +1,691 @@
+"""Integration tests for export worker jobs."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import app.db.session as session_module
+import app.jobs.worker as worker_module
+from app.core.errors import ErrorCode
+from app.exports.csv import CsvExportResult, render_estimate_csv_export, render_quantity_csv_export
+from app.exports.revision_json import RevisionJsonExportResult, render_revision_json_export
+from app.models.drawing_revision import DrawingRevision
+from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
+from app.models.export_job_input import ExportJobInput
+from app.models.generated_artifact import GeneratedArtifact
+from app.models.job import Job, JobType
+from app.models.job_event import JobEvent
+from app.models.quantity_takeoff import QuantityItem, QuantityItemKind, QuantityTakeoff
+from app.storage import get_storage
+from tests.conftest import requires_database
+from tests.jobs_test_helpers import (
+    _create_project,
+    _get_generated_artifacts_for_job,
+    _get_job,
+    _get_job_for_file,
+    _update_job,
+    _upload_file,
+    fake_ingestion_runner,
+)
+
+pytestmark = [requires_database, pytest.mark.usefixtures(fake_ingestion_runner.__name__)]
+
+
+@dataclass(frozen=True, slots=True)
+class _ExportTestLineage:
+    project_id: uuid.UUID
+    file_id: uuid.UUID
+    drawing_revision_id: uuid.UUID
+    quantity_takeoff_id: uuid.UUID
+    estimate_version_id: uuid.UUID
+
+
+class _StorageSpy:
+    def __init__(self, wrapped: Any) -> None:
+        self._wrapped = wrapped
+        self.written_paths: list[Path] = []
+        self.cleaned_paths: list[Path] = []
+
+    async def put(self, key: str, content_bytes: bytes, *, immutable: bool) -> Any:
+        stored_object = await self._wrapped.put(key, content_bytes, immutable=immutable)
+        self.written_paths.append(Path(stored_object.storage_uri.removeprefix("file://")))
+        return stored_object
+
+    async def delete_failed_put(self, key: str, *, storage_uri: str) -> None:
+        self.cleaned_paths.append(Path(storage_uri.removeprefix("file://")))
+        await self._wrapped.delete_failed_put(key, storage_uri=storage_uri)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+
+def _get_session_maker() -> async_sessionmaker[AsyncSession]:
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+    return session_maker
+
+
+async def _get_latest_revision(file_id: uuid.UUID) -> DrawingRevision:
+    session_maker = _get_session_maker()
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(DrawingRevision)
+            .where(DrawingRevision.source_file_id == file_id)
+            .order_by(DrawingRevision.revision_sequence.desc(), DrawingRevision.id.desc())
+            .limit(1)
+        )
+        revision = result.scalar_one_or_none()
+
+    assert revision is not None
+    return revision
+
+
+async def _get_job_events(job_id: uuid.UUID) -> list[JobEvent]:
+    session_maker = _get_session_maker()
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(JobEvent)
+            .where(JobEvent.job_id == job_id)
+            .order_by(JobEvent.created_at.asc(), JobEvent.id.asc())
+        )
+        events = result.scalars().all()
+
+    return list(events)
+
+
+async def _create_completed_job(
+    *,
+    project_id: uuid.UUID,
+    file_id: uuid.UUID,
+    base_revision_id: uuid.UUID,
+    job_type: JobType,
+) -> Job:
+    session_maker = _get_session_maker()
+    now = datetime.now(UTC)
+
+    async with session_maker() as session:
+        job = Job(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            file_id=file_id,
+            base_revision_id=base_revision_id,
+            job_type=job_type.value,
+            status="succeeded",
+            attempts=1,
+            started_at=now,
+            finished_at=now,
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+
+    return job
+
+
+async def _persist_quantity_takeoff(
+    *,
+    project_id: uuid.UUID,
+    file_id: uuid.UUID,
+    drawing_revision_id: uuid.UUID,
+) -> QuantityTakeoff:
+    session_maker = _get_session_maker()
+    source_job = await _create_completed_job(
+        project_id=project_id,
+        file_id=file_id,
+        base_revision_id=drawing_revision_id,
+        job_type=JobType.QUANTITY_TAKEOFF,
+    )
+
+    async with session_maker() as session:
+        takeoff = QuantityTakeoff(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            source_file_id=file_id,
+            drawing_revision_id=drawing_revision_id,
+            source_job_id=source_job.id,
+            source_job_type=JobType.QUANTITY_TAKEOFF.value,
+            review_state="approved",
+            validation_status="valid",
+            quantity_gate="allowed",
+            trusted_totals=True,
+        )
+        item = QuantityItem(
+            id=uuid.uuid4(),
+            quantity_takeoff_id=takeoff.id,
+            project_id=project_id,
+            drawing_revision_id=drawing_revision_id,
+            item_kind=QuantityItemKind.AGGREGATE.value,
+            quantity_type="length",
+            value=12.5,
+            unit="m",
+            review_state="approved",
+            validation_status="valid",
+            quantity_gate="allowed",
+            source_entity_id=None,
+            excluded_source_entity_ids_json=[],
+        )
+        session.add(takeoff)
+        await session.flush()
+        session.add(item)
+        await session.commit()
+        await session.refresh(takeoff)
+
+    return takeoff
+
+
+async def _persist_estimate_version(
+    *,
+    project_id: uuid.UUID,
+    file_id: uuid.UUID,
+    drawing_revision_id: uuid.UUID,
+    quantity_takeoff_id: uuid.UUID,
+) -> EstimateVersion:
+    session_maker = _get_session_maker()
+    source_job = await _create_completed_job(
+        project_id=project_id,
+        file_id=file_id,
+        base_revision_id=drawing_revision_id,
+        job_type=JobType.ESTIMATE,
+    )
+
+    async with session_maker() as session:
+        estimate_version = EstimateVersion(
+            id=uuid.uuid4(),
+            project_id=project_id,
+            source_file_id=file_id,
+            drawing_revision_id=drawing_revision_id,
+            quantity_takeoff_id=quantity_takeoff_id,
+            source_job_id=source_job.id,
+            quantity_gate="allowed",
+            trusted_totals=True,
+            currency="GBP",
+            subtotal_amount=Decimal("40.00"),
+            tax_amount=Decimal("0.00"),
+            total_amount=Decimal("40.00"),
+        )
+        snapshot_entry = EstimateSnapshotEntry(
+            id=uuid.uuid4(),
+            estimate_version_id=estimate_version.id,
+            project_id=project_id,
+            drawing_revision_id=drawing_revision_id,
+            entry_type="assumption",
+            entry_key="assumption:1",
+            entry_label="Allowance",
+            sort_order=1,
+            source_payload_json={"kind": "assumption", "note": "manual allowance"},
+        )
+        item = EstimateItem(
+            id=uuid.uuid4(),
+            estimate_version_id=estimate_version.id,
+            project_id=project_id,
+            drawing_revision_id=drawing_revision_id,
+            line_type="assumption",
+            line_number=1,
+            line_key="line-1",
+            description="Linear wall allowance",
+            currency="GBP",
+            subtotal_amount=Decimal("40.00"),
+            tax_amount=Decimal("0.00"),
+            total_amount=Decimal("40.00"),
+            rounding_json={"mode": "HALF_UP", "scale": 2},
+            assumption_snapshot_entry_id=snapshot_entry.id,
+        )
+        session.add(estimate_version)
+        await session.flush()
+        session.add(snapshot_entry)
+        await session.flush()
+        session.add(item)
+        await session.commit()
+        await session.refresh(estimate_version)
+
+    return estimate_version
+
+
+async def _create_export_test_lineage(async_client: httpx.AsyncClient) -> _ExportTestLineage:
+    project = await _create_project(async_client)
+    uploaded_file = await _upload_file(async_client, project["id"])
+    ingest_job = await _get_job_for_file(uploaded_file["id"])
+    await worker_module.process_ingest_job(ingest_job.id)
+
+    file_id = uuid.UUID(uploaded_file["id"])
+    project_id = uuid.UUID(project["id"])
+    revision = await _get_latest_revision(file_id)
+    quantity_takeoff = await _persist_quantity_takeoff(
+        project_id=project_id,
+        file_id=file_id,
+        drawing_revision_id=revision.id,
+    )
+    estimate_version = await _persist_estimate_version(
+        project_id=project_id,
+        file_id=file_id,
+        drawing_revision_id=revision.id,
+        quantity_takeoff_id=quantity_takeoff.id,
+    )
+    return _ExportTestLineage(
+        project_id=project_id,
+        file_id=file_id,
+        drawing_revision_id=revision.id,
+        quantity_takeoff_id=quantity_takeoff.id,
+        estimate_version_id=estimate_version.id,
+    )
+
+
+async def _create_export_job(
+    *,
+    lineage: _ExportTestLineage,
+    export_kind: str,
+    export_format: str,
+    media_type: str,
+    options_json: dict[str, object],
+    quantity_takeoff_id: uuid.UUID | None = None,
+    estimate_version_id: uuid.UUID | None = None,
+    quantity_gate: str | None = None,
+    trusted_totals: bool | None = None,
+) -> uuid.UUID:
+    session_maker = _get_session_maker()
+    export_job_id = uuid.uuid4()
+
+    async with session_maker() as session:
+        session.add(
+            Job(
+                id=export_job_id,
+                project_id=lineage.project_id,
+                file_id=lineage.file_id,
+                base_revision_id=lineage.drawing_revision_id,
+                job_type=JobType.EXPORT.value,
+                status="pending",
+            )
+        )
+        await session.flush()
+        session.add(
+            ExportJobInput(
+                source_job_id=export_job_id,
+                project_id=lineage.project_id,
+                source_file_id=lineage.file_id,
+                drawing_revision_id=lineage.drawing_revision_id,
+                source_job_type=JobType.EXPORT.value,
+                export_kind=export_kind,
+                export_format=export_format,
+                media_type=media_type,
+                options_json=options_json,
+                quantity_takeoff_id=quantity_takeoff_id,
+                quantity_gate=quantity_gate,
+                trusted_totals=trusted_totals,
+                estimate_version_id=estimate_version_id,
+            )
+        )
+        await session.commit()
+
+    return export_job_id
+
+
+async def _expected_export_bytes(
+    *,
+    lineage: _ExportTestLineage,
+    export_kind: str,
+    options_json: dict[str, object],
+) -> tuple[bytes, str, str]:
+    session_maker = _get_session_maker()
+
+    async with session_maker() as session:
+        result: RevisionJsonExportResult | CsvExportResult
+        if export_kind == "revision_json":
+            result = await render_revision_json_export(
+                session,
+                lineage.drawing_revision_id,
+                options=options_json,
+            )
+        elif export_kind == "quantity_csv":
+            result = await render_quantity_csv_export(session, lineage.quantity_takeoff_id)
+        elif export_kind == "estimate_csv":
+            result = await render_estimate_csv_export(session, lineage.estimate_version_id)
+        else:
+            raise AssertionError(f"Unexpected export kind {export_kind}")
+
+    return result.content_bytes, result.generator_name, result.generator_version
+
+
+@pytest.mark.parametrize(
+    ("export_kind", "export_format", "media_type", "options_json"),
+    [
+        ("revision_json", "json", "application/json", {"include_manifest": True}),
+        ("quantity_csv", "csv", "text/csv", {}),
+        ("estimate_csv", "csv", "text/csv", {}),
+    ],
+)
+async def test_process_export_job_supported_kinds_persist_artifact(
+    async_client: httpx.AsyncClient,
+    export_kind: str,
+    export_format: str,
+    media_type: str,
+    options_json: dict[str, object],
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind=export_kind,
+        export_format=export_format,
+        media_type=media_type,
+        options_json=options_json,
+        quantity_takeoff_id=(
+            lineage.quantity_takeoff_id if export_kind in {"quantity_csv", "estimate_csv"} else None
+        ),
+        estimate_version_id=(
+            lineage.estimate_version_id if export_kind == "estimate_csv" else None
+        ),
+        quantity_gate=("allowed" if export_kind in {"quantity_csv", "estimate_csv"} else None),
+        trusted_totals=(True if export_kind in {"quantity_csv", "estimate_csv"} else None),
+    )
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "succeeded"
+    assert job.error_code is None
+    assert job.error_message is None
+
+    artifacts = await _get_generated_artifacts_for_job(export_job_id)
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    assert artifact.artifact_kind == export_kind
+    assert artifact.format == export_format
+    assert artifact.media_type == media_type
+    assert artifact.project_id == lineage.project_id
+    assert artifact.source_file_id == lineage.file_id
+    assert artifact.drawing_revision_id == lineage.drawing_revision_id
+    assert artifact.generator_config_json == options_json
+
+    (
+        expected_bytes,
+        expected_generator_name,
+        expected_generator_version,
+    ) = await _expected_export_bytes(
+        lineage=lineage,
+        export_kind=export_kind,
+        options_json=options_json,
+    )
+    storage_path = Path(artifact.storage_uri.removeprefix("file://"))
+    assert storage_path.exists()
+    stored_bytes = storage_path.read_bytes()
+    assert stored_bytes == expected_bytes
+    assert hashlib.sha256(stored_bytes).hexdigest() == artifact.checksum_sha256
+    assert len(stored_bytes) == artifact.size_bytes
+    assert artifact.generator_name == expected_generator_name
+    assert artifact.generator_version == expected_generator_version
+
+    success_events = [
+        event for event in await _get_job_events(export_job_id) if event.message == "Job succeeded"
+    ]
+    assert len(success_events) == 1
+    assert success_events[0].data_json == {
+        "status": "succeeded",
+        "attempts": 1,
+        "generated_artifact_id": str(artifact.id),
+        "export_kind": export_kind,
+    }
+
+
+async def test_process_export_job_duplicate_terminal_redelivery_is_noop(
+    async_client: httpx.AsyncClient,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+
+    await worker_module.process_export_job(export_job_id)
+    await worker_module.process_export_job(export_job_id)
+
+    artifacts = await _get_generated_artifacts_for_job(export_job_id)
+    assert len(artifacts) == 1
+
+    success_events = [
+        event for event in await _get_job_events(export_job_id) if event.message == "Job succeeded"
+    ]
+    assert len(success_events) == 1
+
+
+async def test_process_export_job_estimate_pdf_fails_without_artifact(
+    async_client: httpx.AsyncClient,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="estimate_pdf",
+        export_format="pdf",
+        media_type="application/pdf",
+        options_json={},
+        quantity_takeoff_id=lineage.quantity_takeoff_id,
+        estimate_version_id=lineage.estimate_version_id,
+        quantity_gate="allowed",
+        trusted_totals=True,
+    )
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == "INPUT_INVALID"
+    assert job.error_message == "Estimate PDF exports are not implemented."
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+
+async def test_process_export_job_honors_cancel_before_finalization(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+    original_build_execution_input = worker_module._build_export_execution_input
+
+    async def _cancel_after_input_load(
+        job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> worker_module._ExportExecutionInput:
+        execution = await original_build_execution_input(job_id, attempt_token=attempt_token)
+        await _update_job(job_id, cancel_requested=True)
+        return execution
+
+    monkeypatch.setattr(worker_module, "_build_export_execution_input", _cancel_after_input_load)
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "cancelled"
+    assert job.error_code == ErrorCode.JOB_CANCELLED.value
+    assert job.error_message is None
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+    assert (await _get_job_events(export_job_id))[-1].data_json == {"status": "cancelled"}
+
+
+async def test_process_export_job_revision_drift_fails_without_artifact(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+    original_build_execution_input = worker_module._build_export_execution_input
+
+    async def _load_stale_execution_input(
+        job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> worker_module._ExportExecutionInput:
+        execution = await original_build_execution_input(job_id, attempt_token=attempt_token)
+        return replace(execution, drawing_revision_id=uuid.uuid4())
+
+    async def _render_without_revision_lookup(
+        session: AsyncSession,
+        execution: worker_module._ExportExecutionInput,
+    ) -> worker_module._RenderedExportArtifact:
+        _ = (session, execution)
+        content_bytes = b"stale-rendered-export"
+        return worker_module._RenderedExportArtifact(
+            content_bytes=content_bytes,
+            checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
+            size_bytes=len(content_bytes),
+            media_type="application/json",
+            generator_name="test_export_renderer",
+            generator_version="1",
+        )
+
+    monkeypatch.setattr(worker_module, "_build_export_execution_input", _load_stale_execution_input)
+    monkeypatch.setattr(worker_module, "_render_export_artifact", _render_without_revision_lookup)
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.REVISION_CONFLICT.value
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+
+async def test_process_export_job_invalid_trust_gate_fails_without_artifact(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="quantity_csv",
+        export_format="csv",
+        media_type="text/csv",
+        options_json={},
+        quantity_takeoff_id=lineage.quantity_takeoff_id,
+        quantity_gate="allowed",
+        trusted_totals=True,
+    )
+
+    async def _raise_invalid_trust_gate(
+        job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> worker_module._ExportExecutionInput:
+        _ = (job_id, attempt_token)
+        raise worker_module._build_export_job_input_error(
+            "Export job input requires a trusted quantity takeoff with allowed gate.",
+            details={
+                "quantity_takeoff_id": str(lineage.quantity_takeoff_id),
+                "quantity_gate": "review_gated",
+                "trusted_totals": False,
+            },
+        )
+
+    monkeypatch.setattr(worker_module, "_build_export_execution_input", _raise_invalid_trust_gate)
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INPUT_INVALID.value
+    assert (
+        job.error_message
+        == "Export job input requires a trusted quantity takeoff with allowed gate."
+    )
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+
+async def test_process_export_job_flush_failure_cleans_up_storage_without_artifact(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+    storage_spy = _StorageSpy(get_storage())
+    original_flush = AsyncSession.flush
+
+    async def _fail_flush_after_storage_write(
+        self: AsyncSession,
+        objects: Sequence[Any] | None = None,
+    ) -> None:
+        if any(isinstance(instance, GeneratedArtifact) for instance in self.sync_session.new):
+            raise RuntimeError("flush failed after storage write")
+        await original_flush(self, objects)
+
+    monkeypatch.setattr(worker_module, "get_storage", lambda: storage_spy)
+    monkeypatch.setattr(AsyncSession, "flush", _fail_flush_after_storage_write)
+
+    with pytest.raises(RuntimeError, match="flush failed after storage write"):
+        await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INTERNAL_ERROR.value
+    assert job.error_message == worker_module._FINALIZE_EXPORT_JOB_ERROR_MESSAGE
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+    success_events = [
+        event for event in await _get_job_events(export_job_id) if event.message == "Job succeeded"
+    ]
+    assert success_events == []
+
+    assert len(storage_spy.written_paths) == 1
+    assert storage_spy.cleaned_paths == storage_spy.written_paths
+    assert not storage_spy.written_paths[0].exists()
+
+
+async def test_publish_export_job_recovery_failure_marks_export_specific_message(
+    async_client: httpx.AsyncClient,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+
+    def _raise_publish(job_id: uuid.UUID) -> None:
+        _ = job_id
+        raise RuntimeError("broker unavailable")
+
+    published = await worker_module.publish_job_enqueue_intent(
+        export_job_id,
+        recovery=True,
+        publisher=_raise_publish,
+    )
+
+    assert published is False
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INTERNAL_ERROR.value
+    assert job.error_message == worker_module._ENQUEUE_EXPORT_JOB_ERROR_MESSAGE

--- a/tests/test_jobs_worker_lifecycle.py
+++ b/tests/test_jobs_worker_lifecycle.py
@@ -19,7 +19,7 @@ from app.core.errors import ErrorCode
 from app.ingestion.contracts import CancellationHandle
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunRequest
-from app.models.job import Job
+from app.models.job import Job, JobType
 from app.models.project import Project
 from tests.conftest import requires_database
 from tests.jobs_test_helpers import (
@@ -1013,9 +1013,10 @@ class TestJobsWorkerLifecycle:
 
         assert logger_error_calls == [
             (
-                "ingest_job_recovery_enqueue_failed",
+                "job_recovery_enqueue_failed",
                 {
                     "job_id": str(job.id),
+                    "job_type": JobType.INGEST.value,
                     "error_code": ErrorCode.INTERNAL_ERROR.value,
                     "recovery_action": "mark_failed",
                 },
@@ -1054,7 +1055,10 @@ class TestJobsWorkerLifecycle:
             persisted_job.attempt_lease_expires_at = lease_expires_at
             await session.commit()
 
-        marked_failed = await worker_module._mark_recovery_enqueue_failed(job.id)
+        marked_failed = await worker_module._mark_recovery_enqueue_failed(
+            job.id,
+            job_type=JobType.INGEST.value,
+        )
 
         assert marked_failed is False
         updated_job = await _get_job(job.id)
@@ -1089,7 +1093,10 @@ class TestJobsWorkerLifecycle:
             persisted_job.finished_at = datetime.now(UTC)
             await session.commit()
 
-        marked_failed = await worker_module._mark_recovery_enqueue_failed(job.id)
+        marked_failed = await worker_module._mark_recovery_enqueue_failed(
+            job.id,
+            job_type=JobType.INGEST.value,
+        )
 
         assert marked_failed is False
         updated_job = await _get_job(job.id)


### PR DESCRIPTION
Closes #254

## Summary
- wire export jobs into durable enqueue, recovery, and worker execution for revision JSON and CSV exports
- finalize successful exports as immutable storage objects plus GeneratedArtifact rows with duplicate, cancel, drift, and cleanup safeguards
- add worker and regression coverage for success, no-duplicate redelivery, unsupported PDF, recovery failures, and updated recovery enqueue tests

## Test plan
- [x] uv run ruff check app/api/v1/revision_routes/exports.py app/api/v1/revisions.py app/api/v1/revision_compat.py app/jobs/lifecycle.py app/jobs/worker.py tests/test_jobs_worker_exports.py tests/jobs_test_helpers.py tests/test_export_create_api.py tests/test_jobs.py tests/test_jobs_worker_lifecycle.py
- [x] uv run mypy app/api/v1/revision_routes/exports.py app/api/v1/revisions.py app/api/v1/revision_compat.py app/jobs/lifecycle.py app/jobs/worker.py tests/test_jobs_worker_exports.py tests/jobs_test_helpers.py tests/test_export_create_api.py tests/test_jobs.py tests/test_jobs_worker_lifecycle.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_jobs_worker_exports.py tests/test_export_create_api.py tests/test_revision_router_contract.py tests/test_jobs_api.py tests/test_revision_json_export.py tests/test_csv_exports.py tests/test_export_job_input_contract.py tests/test_jobs_worker_quantity.py tests/test_jobs_worker_estimate.py
- [x] uv run pytest -q