### PR TITLE
feat(jobs): finalize PDF export jobs as immutable artifacts

### DIFF
--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -57,6 +57,11 @@ from app.exports.csv import (
     render_estimate_csv_export,
     render_quantity_csv_export,
 )
+from app.exports.estimate_pdf import (
+    EstimatePdfExportError,
+    EstimatePdfExportResult,
+    render_estimate_pdf_export,
+)
 from app.exports.revision_json import (
     RevisionJsonExportError,
     RevisionJsonExportResult,
@@ -126,7 +131,6 @@ _DEBUG_OVERLAY_ARTIFACT_KIND = "debug_overlay"
 _DEBUG_OVERLAY_ARTIFACT_FORMAT = "svg"
 _DEBUG_OVERLAY_GENERATOR_NAME = "app.ingestion.debug_overlay"
 _DEBUG_OVERLAY_GENERATOR_VERSION = "1"
-_ESTIMATE_PDF_EXPORT_UNSUPPORTED_ERROR_MESSAGE = "Estimate PDF exports are not implemented."
 _NORMALIZED_ENTITY_INSERT_CHUNK_SIZE = 500
 _QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE = (
     "Quantity takeoff is blocked by the revision validation gate."
@@ -3214,7 +3218,7 @@ async def _render_export_artifact(
 ) -> _RenderedExportArtifact:
     """Render bytes for a supported export job."""
     try:
-        result: RevisionJsonExportResult | CsvExportResult
+        result: RevisionJsonExportResult | CsvExportResult | EstimatePdfExportResult
         if execution.export_kind == "revision_json":
             result = await render_revision_json_export(
                 session,
@@ -3227,6 +3231,13 @@ async def _render_export_artifact(
         elif execution.export_kind == "estimate_csv":
             assert execution.estimate_version_id is not None
             result = await render_estimate_csv_export(session, execution.estimate_version_id)
+        elif execution.export_kind == "estimate_pdf":
+            assert execution.estimate_version_id is not None
+            result = await render_estimate_pdf_export(
+                session,
+                execution.estimate_version_id,
+                options=execution.options_json,
+            )
         else:
             raise _build_export_job_input_error(
                 "Export job kind is not supported by the worker.",
@@ -3248,6 +3259,15 @@ async def _render_export_artifact(
             },
         ) from exc
     except EstimateCsvExportError as exc:
+        raise _build_export_job_input_error(
+            str(exc),
+            error_code=ErrorCode.NOT_FOUND,
+            details={
+                "drawing_revision_id": str(execution.drawing_revision_id),
+                "estimate_version_id": str(execution.estimate_version_id),
+            },
+        ) from exc
+    except EstimatePdfExportError as exc:
         raise _build_export_job_input_error(
             str(exc),
             error_code=ErrorCode.NOT_FOUND,
@@ -3342,16 +3362,11 @@ async def _build_export_execution_input(
         ):
             raise ValueError("Export job base revision does not belong to the source file")
 
-        if export_input.export_kind == "estimate_pdf":
-            raise _build_export_job_input_error(
-                _ESTIMATE_PDF_EXPORT_UNSUPPORTED_ERROR_MESSAGE,
-                details={"export_kind": export_input.export_kind},
-            )
-
         supported_exports: dict[str, tuple[str, str]] = {
             "revision_json": ("json", "application/json"),
             "quantity_csv": ("csv", "text/csv"),
             "estimate_csv": ("csv", "text/csv"),
+            "estimate_pdf": ("pdf", "application/pdf"),
         }
         expected_export_metadata = supported_exports.get(export_input.export_kind)
         if expected_export_metadata is None:
@@ -3467,7 +3482,7 @@ async def _build_export_execution_input(
         estimate_version_id = export_input.estimate_version_id
         if estimate_version_id is None:
             raise _build_export_job_input_error(
-                "Estimate CSV export input is missing its estimate version linkage.",
+                "Estimate export input is missing its estimate version linkage.",
                 details={"quantity_takeoff_id": str(quantity_takeoff.id)},
             )
 

--- a/tests/test_jobs_worker_exports.py
+++ b/tests/test_jobs_worker_exports.py
@@ -20,6 +20,7 @@ import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
 from app.exports.csv import CsvExportResult, render_estimate_csv_export, render_quantity_csv_export
+from app.exports.estimate_pdf import EstimatePdfExportResult, render_estimate_pdf_export
 from app.exports.revision_json import RevisionJsonExportResult, render_revision_json_export
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
@@ -342,7 +343,7 @@ async def _expected_export_bytes(
     session_maker = _get_session_maker()
 
     async with session_maker() as session:
-        result: RevisionJsonExportResult | CsvExportResult
+        result: RevisionJsonExportResult | CsvExportResult | EstimatePdfExportResult
         if export_kind == "revision_json":
             result = await render_revision_json_export(
                 session,
@@ -353,6 +354,12 @@ async def _expected_export_bytes(
             result = await render_quantity_csv_export(session, lineage.quantity_takeoff_id)
         elif export_kind == "estimate_csv":
             result = await render_estimate_csv_export(session, lineage.estimate_version_id)
+        elif export_kind == "estimate_pdf":
+            result = await render_estimate_pdf_export(
+                session,
+                lineage.estimate_version_id,
+                options=options_json,
+            )
         else:
             raise AssertionError(f"Unexpected export kind {export_kind}")
 
@@ -365,6 +372,7 @@ async def _expected_export_bytes(
         ("revision_json", "json", "application/json", {"include_manifest": True}),
         ("quantity_csv", "csv", "text/csv", {}),
         ("estimate_csv", "csv", "text/csv", {}),
+        ("estimate_pdf", "pdf", "application/pdf", {}),
     ],
 )
 async def test_process_export_job_supported_kinds_persist_artifact(
@@ -382,13 +390,19 @@ async def test_process_export_job_supported_kinds_persist_artifact(
         media_type=media_type,
         options_json=options_json,
         quantity_takeoff_id=(
-            lineage.quantity_takeoff_id if export_kind in {"quantity_csv", "estimate_csv"} else None
+            lineage.quantity_takeoff_id
+            if export_kind in {"quantity_csv", "estimate_csv", "estimate_pdf"}
+            else None
         ),
         estimate_version_id=(
-            lineage.estimate_version_id if export_kind == "estimate_csv" else None
+            lineage.estimate_version_id if export_kind in {"estimate_csv", "estimate_pdf"} else None
         ),
-        quantity_gate=("allowed" if export_kind in {"quantity_csv", "estimate_csv"} else None),
-        trusted_totals=(True if export_kind in {"quantity_csv", "estimate_csv"} else None),
+        quantity_gate=(
+            "allowed" if export_kind in {"quantity_csv", "estimate_csv", "estimate_pdf"} else None
+        ),
+        trusted_totals=(
+            True if export_kind in {"quantity_csv", "estimate_csv", "estimate_pdf"} else None
+        ),
     )
 
     await worker_module.process_export_job(export_job_id)
@@ -461,31 +475,6 @@ async def test_process_export_job_duplicate_terminal_redelivery_is_noop(
         event for event in await _get_job_events(export_job_id) if event.message == "Job succeeded"
     ]
     assert len(success_events) == 1
-
-
-async def test_process_export_job_estimate_pdf_fails_without_artifact(
-    async_client: httpx.AsyncClient,
-) -> None:
-    lineage = await _create_export_test_lineage(async_client)
-    export_job_id = await _create_export_job(
-        lineage=lineage,
-        export_kind="estimate_pdf",
-        export_format="pdf",
-        media_type="application/pdf",
-        options_json={},
-        quantity_takeoff_id=lineage.quantity_takeoff_id,
-        estimate_version_id=lineage.estimate_version_id,
-        quantity_gate="allowed",
-        trusted_totals=True,
-    )
-
-    await worker_module.process_export_job(export_job_id)
-
-    job = await _get_job(export_job_id)
-    assert job.status == "failed"
-    assert job.error_code == "INPUT_INVALID"
-    assert job.error_message == "Estimate PDF exports are not implemented."
-    assert await _get_generated_artifacts_for_job(export_job_id) == []
 
 
 async def test_process_export_job_honors_cancel_before_finalization(


### PR DESCRIPTION
Closes #256

## Summary
- enable `estimate_pdf` export jobs in the worker using the existing PDF renderer
- finalize PDF exports through the shared immutable artifact path and existing retry/cancel/duplicate semantics
- update worker export tests to cover successful PDF artifact finalization

## Test plan
- [x] uv run ruff check app/jobs/worker.py tests/test_jobs_worker_exports.py
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_jobs_worker_exports.py tests/test_estimate_pdf_export.py tests/test_export_create_api.py