### PR TITLE
refactor(jobs): add JobHandler registry #274

### DIFF
--- a/app/core/clock.py
+++ b/app/core/clock.py
@@ -1,0 +1,10 @@
+"""Shared clock helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def utcnow() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(UTC)

--- a/app/ingestion/finalization.py
+++ b/app/ingestion/finalization.py
@@ -6,10 +6,11 @@ import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, is_dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
+from app.core.clock import utcnow as _clock_utcnow
 from app.ingestion.contracts import AdapterResult, InputFamily
 from app.ingestion.validation import (
     VALIDATION_REPORT_SCHEMA_VERSION,
@@ -63,7 +64,7 @@ class IngestFinalizationContext:
 
 def utcnow() -> datetime:
     """Return a timezone-aware UTC timestamp."""
-    return datetime.now(UTC)
+    return _clock_utcnow()
 
 
 def resolve_revision_kind(job_id: UUID, *, initial_job_id: UUID | None) -> str:
@@ -190,6 +191,8 @@ def _resolve_canonical_schema_version(canonical_json: dict[str, Any]) -> str:
     canonical_json["canonical_entity_schema_version"] = _CANONICAL_ENTITY_SCHEMA_VERSION
     canonical_json.setdefault("schema_version", _CANONICAL_ENTITY_SCHEMA_VERSION)
     return _CANONICAL_ENTITY_SCHEMA_VERSION
+
+
 def _json_compatible(value: Any) -> Any:
     if is_dataclass(value) and not isinstance(value, type):
         return _json_compatible(asdict(value))

--- a/app/jobs/lifecycle.py
+++ b/app/jobs/lifecycle.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.clock import utcnow as _clock_utcnow
 from app.core.errors import ErrorCode
 from app.core.logging import get_logger
 from app.db.session import get_session_maker
@@ -68,7 +69,7 @@ class _BeginOrResumeLogKeys:
 
 def _utcnow() -> datetime:
     """Return a timezone-aware UTC timestamp."""
-    return datetime.now(UTC)
+    return _clock_utcnow()
 
 
 def _clear_job_attempt_lease(job: Job) -> None:

--- a/app/jobs/runner.py
+++ b/app/jobs/runner.py
@@ -1,0 +1,182 @@
+"""Worker job handler metadata registry."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Final, Literal
+
+type JobTypeName = Literal["ingest", "reprocess", "quantity_takeoff", "estimate", "export"]
+
+
+@dataclass(frozen=True, slots=True)
+class BeginOrResumeLogKeys:
+    unsupported_type: str
+    terminal_status: str
+    inactive_source: str
+    reclaimed_stale_running: str
+    duplicate_delivery: str
+    cancelled: str
+
+
+@dataclass(frozen=True, slots=True)
+class BeginOrResumeRoute:
+    process_name: str
+    supported_job_types: tuple[JobTypeName, ...]
+    log_keys: BeginOrResumeLogKeys
+
+
+@dataclass(frozen=True, slots=True)
+class JobHandler:
+    job_type_name: JobTypeName
+    execute_name: str | None
+    finalize_name: str | None
+    process_name: str
+    run_task_name: str
+    enqueue_publisher_name: str | None
+    enqueue_error_message: str
+
+
+JOB_HANDLERS: Final[tuple[JobHandler, ...]] = (
+    JobHandler(
+        job_type_name="ingest",
+        execute_name="_execute_ingest_job_attempt",
+        finalize_name="_finalize_ingest_job",
+        process_name="process_ingest_job",
+        run_task_name="run_ingest_job",
+        enqueue_publisher_name="enqueue_ingest_job",
+        enqueue_error_message="Failed to enqueue ingest job",
+    ),
+    JobHandler(
+        job_type_name="reprocess",
+        execute_name="_execute_ingest_job_attempt",
+        finalize_name="_finalize_ingest_job",
+        process_name="process_ingest_job",
+        run_task_name="run_ingest_job",
+        enqueue_publisher_name="enqueue_ingest_job",
+        enqueue_error_message="Failed to enqueue reprocess job",
+    ),
+    JobHandler(
+        job_type_name="quantity_takeoff",
+        execute_name="_execute_quantity_takeoff_job_attempt",
+        finalize_name="_finalize_quantity_takeoff_job",
+        process_name="process_quantity_takeoff_job",
+        run_task_name="run_quantity_takeoff_job",
+        enqueue_publisher_name="enqueue_quantity_takeoff_job",
+        enqueue_error_message="Failed to enqueue quantity takeoff job",
+    ),
+    JobHandler(
+        job_type_name="estimate",
+        execute_name="_execute_estimate_job_attempt",
+        finalize_name="_finalize_estimate_job",
+        process_name="process_estimate_job",
+        run_task_name="run_estimate_job",
+        enqueue_publisher_name="enqueue_estimate_job",
+        enqueue_error_message="Failed to enqueue estimate job",
+    ),
+    JobHandler(
+        job_type_name="export",
+        execute_name="_execute_export_job",
+        finalize_name="_finalize_export_job",
+        process_name="process_export_job",
+        run_task_name="run_export_job",
+        enqueue_publisher_name="enqueue_export_job",
+        enqueue_error_message="Failed to enqueue export job",
+    ),
+)
+
+_JOB_HANDLERS_BY_TYPE: Final[dict[str, JobHandler]] = {
+    handler.job_type_name: handler for handler in JOB_HANDLERS
+}
+
+JOB_HANDLERS_BY_TYPE: Final[Mapping[str, JobHandler]] = MappingProxyType(_JOB_HANDLERS_BY_TYPE)
+
+
+def _job_types_for_process(process_name: str) -> tuple[JobTypeName, ...]:
+    return tuple(
+        handler.job_type_name for handler in JOB_HANDLERS if handler.process_name == process_name
+    )
+
+
+BEGIN_OR_RESUME_ROUTES: Final[tuple[BeginOrResumeRoute, ...]] = (
+    BeginOrResumeRoute(
+        process_name="process_ingest_job",
+        supported_job_types=_job_types_for_process("process_ingest_job"),
+        log_keys=BeginOrResumeLogKeys(
+            unsupported_type="ingest_job_unsupported_type_skipped",
+            terminal_status="ingest_job_cancel_skipped_terminal_status",
+            inactive_source="ingest_job_cancelled_inactive_source",
+            reclaimed_stale_running="ingest_job_reclaimed_stale_running_status",
+            duplicate_delivery="ingest_job_duplicate_delivery_skipped_running_attempt",
+            cancelled="ingest_job_cancelled",
+        ),
+    ),
+    BeginOrResumeRoute(
+        process_name="process_quantity_takeoff_job",
+        supported_job_types=_job_types_for_process("process_quantity_takeoff_job"),
+        log_keys=BeginOrResumeLogKeys(
+            unsupported_type="quantity_takeoff_job_unsupported_type_skipped",
+            terminal_status="quantity_takeoff_job_skipped_terminal_status",
+            inactive_source="quantity_takeoff_job_cancelled_inactive_source",
+            reclaimed_stale_running="quantity_takeoff_job_reclaimed_stale_running_status",
+            duplicate_delivery="quantity_takeoff_job_duplicate_delivery_skipped_running_attempt",
+            cancelled="quantity_takeoff_job_cancelled",
+        ),
+    ),
+    BeginOrResumeRoute(
+        process_name="process_estimate_job",
+        supported_job_types=_job_types_for_process("process_estimate_job"),
+        log_keys=BeginOrResumeLogKeys(
+            unsupported_type="estimate_job_unsupported_type_skipped",
+            terminal_status="estimate_job_skipped_terminal_status",
+            inactive_source="estimate_job_cancelled_inactive_source",
+            reclaimed_stale_running="estimate_job_reclaimed_stale_running_status",
+            duplicate_delivery="estimate_job_duplicate_delivery_skipped_running_attempt",
+            cancelled="estimate_job_cancelled",
+        ),
+    ),
+    BeginOrResumeRoute(
+        process_name="process_export_job",
+        supported_job_types=_job_types_for_process("process_export_job"),
+        log_keys=BeginOrResumeLogKeys(
+            unsupported_type="export_job_unsupported_type_skipped",
+            terminal_status="export_job_skipped_terminal_status",
+            inactive_source="export_job_cancelled_inactive_source",
+            reclaimed_stale_running="export_job_reclaimed_stale_running_status",
+            duplicate_delivery="export_job_duplicate_delivery_skipped_running_attempt",
+            cancelled="export_job_cancelled",
+        ),
+    ),
+)
+
+_BEGIN_OR_RESUME_ROUTES_BY_PROCESS_NAME: Final[dict[str, BeginOrResumeRoute]] = {
+    route.process_name: route for route in BEGIN_OR_RESUME_ROUTES
+}
+
+BEGIN_OR_RESUME_ROUTES_BY_PROCESS_NAME: Final[Mapping[str, BeginOrResumeRoute]] = MappingProxyType(
+    _BEGIN_OR_RESUME_ROUTES_BY_PROCESS_NAME
+)
+
+RECOVERABLE_ENQUEUE_JOB_TYPES: Final[tuple[str, ...]] = tuple(
+    handler.job_type_name for handler in JOB_HANDLERS
+)
+INGEST_WORKER_JOB_TYPES: Final[tuple[str, ...]] = tuple(
+    handler.job_type_name for handler in JOB_HANDLERS if handler.run_task_name == "run_ingest_job"
+)
+JOB_TYPES_WITHOUT_ENQUEUE_PUBLISHER: Final[frozenset[str]] = frozenset(
+    handler.job_type_name for handler in JOB_HANDLERS if handler.enqueue_publisher_name is None
+)
+ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE: Final[Mapping[str, str]] = MappingProxyType(
+    {handler.job_type_name: handler.enqueue_error_message for handler in JOB_HANDLERS}
+)
+
+
+def get_job_handler(job_type: str) -> JobHandler | None:
+    """Return worker metadata for a persisted job type."""
+    return JOB_HANDLERS_BY_TYPE.get(job_type)
+
+
+def get_begin_or_resume_route(process_name: str) -> BeginOrResumeRoute | None:
+    """Return begin/resume routing metadata for a persisted worker process."""
+    return BEGIN_OR_RESUME_ROUTES_BY_PROCESS_NAME.get(process_name)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -24,6 +24,7 @@ from celery.signals import worker_ready
 from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.clock import utcnow as _clock_utcnow
 from app.core.config import settings
 from app.core.errors import ErrorCode
 from app.core.logging import get_logger
@@ -72,6 +73,7 @@ from app.ingestion.debug_overlay import plan_svg_debug_overlay
 from app.ingestion.finalization import IngestFinalizationPayload
 from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
 from app.jobs import lifecycle as job_lifecycle
+from app.jobs import runner as job_runner
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
@@ -94,15 +96,9 @@ from app.storage.keys import build_generated_artifact_storage_key
 
 logger = get_logger(__name__)
 
-_RECOVERABLE_INGEST_JOB_TYPES = (JobType.INGEST.value, JobType.REPROCESS.value)
-_RECOVERABLE_ENQUEUE_JOB_TYPES = (
-    JobType.INGEST.value,
-    JobType.REPROCESS.value,
-    JobType.QUANTITY_TAKEOFF.value,
-    JobType.ESTIMATE.value,
-    JobType.EXPORT.value,
-)
-_KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER: frozenset[str] = frozenset()
+_RECOVERABLE_INGEST_JOB_TYPES = job_runner.INGEST_WORKER_JOB_TYPES
+_RECOVERABLE_ENQUEUE_JOB_TYPES = job_runner.RECOVERABLE_ENQUEUE_JOB_TYPES
+_KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER = job_runner.JOB_TYPES_WITHOUT_ENQUEUE_PUBLISHER
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 _ENQUEUE_STATUS_PENDING = "pending"
 _ENQUEUE_STATUS_PUBLISHING = "publishing"
@@ -112,11 +108,21 @@ _RUNNING_JOB_STALE_AFTER = _DEFAULT_ADAPTER_TIMEOUT * 2
 _ENQUEUE_LEASE_DURATION = timedelta(minutes=1)
 _JOB_CANCELLATION_POLL_INTERVAL_SECONDS = 0.1
 _JOB_CANCELLED_ERROR_CODE = ErrorCode.JOB_CANCELLED.value
-_ENQUEUE_INGEST_JOB_ERROR_MESSAGE = "Failed to enqueue ingest job"
-_ENQUEUE_REPROCESS_JOB_ERROR_MESSAGE = "Failed to enqueue reprocess job"
-_ENQUEUE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to enqueue quantity takeoff job"
-_ENQUEUE_ESTIMATE_JOB_ERROR_MESSAGE = "Failed to enqueue estimate job"
-_ENQUEUE_EXPORT_JOB_ERROR_MESSAGE = "Failed to enqueue export job"
+_ENQUEUE_INGEST_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
+    JobType.INGEST.value
+]
+_ENQUEUE_REPROCESS_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
+    JobType.REPROCESS.value
+]
+_ENQUEUE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
+    JobType.QUANTITY_TAKEOFF.value
+]
+_ENQUEUE_ESTIMATE_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
+    JobType.ESTIMATE.value
+]
+_ENQUEUE_EXPORT_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
+    JobType.EXPORT.value
+]
 _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
 _PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
 _FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to finalize quantity takeoff job"
@@ -189,17 +195,16 @@ def is_recoverable_enqueue_job_type(job_type: JobType | str) -> bool:
 def get_job_enqueue_publisher(job_type: JobType | str) -> Callable[[UUID], None] | None:
     """Return the queue publisher registered for a persisted worker job type."""
     normalized_job_type = job_type.value if isinstance(job_type, JobType) else job_type
-    if normalized_job_type in _KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER:
+    handler = job_runner.get_job_handler(normalized_job_type)
+    if handler is None or normalized_job_type in _KNOWN_ENQUEUE_JOB_TYPES_WITHOUT_PUBLISHER:
         return None
-
-    registry: dict[str, Callable[[UUID], None]] = {
-        JobType.INGEST.value: enqueue_ingest_job,
-        JobType.REPROCESS.value: enqueue_ingest_job,
-        JobType.QUANTITY_TAKEOFF.value: enqueue_quantity_takeoff_job,
-        JobType.ESTIMATE.value: enqueue_estimate_job,
-        JobType.EXPORT.value: enqueue_export_job,
-    }
-    return registry.get(normalized_job_type)
+    publisher_name = handler.enqueue_publisher_name
+    if publisher_name is None:
+        return None
+    publisher = globals().get(publisher_name)
+    if publisher is None:
+        return None
+    return cast(Callable[[UUID], None], publisher)
 
 
 _InactiveSourceError = job_lifecycle._InactiveSourceError
@@ -271,6 +276,110 @@ class _ExportJobInputError(Exception):
 
     def __str__(self) -> str:
         return self.message
+
+
+type _RegisteredJobInputError = (
+    _QuantityTakeoffJobError | _EstimateJobInputError | _ExportJobInputError
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _RegisteredJobAttemptResult:
+    """Deferred finalization kwargs returned by a registered job execution step."""
+
+    finalize_kwargs: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _RegisteredJobProcessSpec:
+    """Shared shell configuration for registered persisted worker jobs."""
+
+    job_type_name: job_runner.JobTypeName
+    input_error_type: type[Exception] | None
+    input_failure_log_event: str | None
+    stale_attempt_log_event: str
+    revision_conflict_log_event: str
+    cancelled_during_execution_log_event: str
+    cancelled_during_finalization_log_event: str
+    process_failed_log_event: str
+    finalization_failed_log_event: str
+    succeeded_log_event: str
+    process_error_message: str
+    finalize_error_message: str
+    execution_result_arg_name: str | None = None
+    execution_error_type: type[Exception] | None = None
+    execution_error_handler_name: str | None = None
+    inactive_source_log_event: str | None = None
+    finalization_exception_log_fields_name: str | None = None
+    reraise_revision_conflict: bool = False
+
+
+_INGEST_PROCESS_SPEC = _RegisteredJobProcessSpec(
+    job_type_name="ingest",
+    input_error_type=None,
+    input_failure_log_event=None,
+    stale_attempt_log_event="ingest_job_stale_attempt_skipped",
+    revision_conflict_log_event="ingest_job_revision_conflict",
+    cancelled_during_execution_log_event="ingest_job_cancelled_during_execution",
+    cancelled_during_finalization_log_event="ingest_job_cancelled_during_finalization",
+    process_failed_log_event="ingest_job_failed",
+    finalization_failed_log_event="ingest_job_finalization_failed",
+    succeeded_log_event="ingest_job_succeeded",
+    process_error_message=_PROCESS_INGEST_JOB_ERROR_MESSAGE,
+    finalize_error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE,
+    execution_result_arg_name="payload",
+    execution_error_type=IngestionRunnerError,
+    execution_error_handler_name="_handle_ingest_runner_error",
+    inactive_source_log_event="ingest_job_cancelled_inactive_source",
+    finalization_exception_log_fields_name="_build_ingest_finalization_error_log_fields",
+    reraise_revision_conflict=True,
+)
+
+
+_QUANTITY_TAKEOFF_PROCESS_SPEC = _RegisteredJobProcessSpec(
+    job_type_name="quantity_takeoff",
+    input_error_type=_QuantityTakeoffJobError,
+    input_failure_log_event="quantity_takeoff_job_input_failed",
+    stale_attempt_log_event="quantity_takeoff_job_stale_attempt_skipped",
+    revision_conflict_log_event="quantity_takeoff_job_revision_conflict",
+    cancelled_during_execution_log_event="quantity_takeoff_job_cancelled_during_execution",
+    cancelled_during_finalization_log_event="quantity_takeoff_job_cancelled_during_finalization",
+    process_failed_log_event="quantity_takeoff_job_failed",
+    finalization_failed_log_event="quantity_takeoff_job_finalization_failed",
+    succeeded_log_event="quantity_takeoff_job_succeeded",
+    process_error_message=_PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+    finalize_error_message=_FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
+)
+
+_ESTIMATE_PROCESS_SPEC = _RegisteredJobProcessSpec(
+    job_type_name="estimate",
+    input_error_type=_EstimateJobInputError,
+    input_failure_log_event="estimate_job_input_failed",
+    stale_attempt_log_event="estimate_job_stale_attempt_skipped",
+    revision_conflict_log_event="estimate_job_revision_conflict",
+    cancelled_during_execution_log_event="estimate_job_cancelled_during_execution",
+    cancelled_during_finalization_log_event="estimate_job_cancelled_during_finalization",
+    process_failed_log_event="estimate_job_failed",
+    finalization_failed_log_event="estimate_job_finalization_failed",
+    succeeded_log_event="estimate_job_succeeded",
+    process_error_message=_PROCESS_ESTIMATE_JOB_ERROR_MESSAGE,
+    finalize_error_message=_FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE,
+)
+
+_EXPORT_PROCESS_SPEC = _RegisteredJobProcessSpec(
+    job_type_name="export",
+    input_error_type=_ExportJobInputError,
+    input_failure_log_event="export_job_input_failed",
+    stale_attempt_log_event="export_job_stale_attempt_skipped",
+    revision_conflict_log_event="export_job_revision_conflict",
+    cancelled_during_execution_log_event="export_job_cancelled_during_execution",
+    cancelled_during_finalization_log_event="export_job_cancelled_during_finalization",
+    process_failed_log_event="export_job_failed",
+    finalization_failed_log_event="export_job_finalization_failed",
+    succeeded_log_event="export_job_succeeded",
+    process_error_message=_PROCESS_EXPORT_JOB_ERROR_MESSAGE,
+    finalize_error_message=_FINALIZE_EXPORT_JOB_ERROR_MESSAGE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -454,7 +563,7 @@ celery_app.autodiscover_tasks(["app.jobs"], force=True)
 
 def _utcnow() -> datetime:
     """Return a timezone-aware UTC timestamp."""
-    return datetime.now(UTC)
+    return _clock_utcnow()
 
 
 def _get_worker_loop_runner() -> asyncio.Runner:
@@ -2497,13 +2606,7 @@ async def _cleanup_failed_storage_writes(
 
 def _get_enqueue_job_error_message(job_type: str) -> str:
     """Return the persisted enqueue failure message for a worker job type."""
-    return {
-        JobType.INGEST.value: _ENQUEUE_INGEST_JOB_ERROR_MESSAGE,
-        JobType.REPROCESS.value: _ENQUEUE_REPROCESS_JOB_ERROR_MESSAGE,
-        JobType.QUANTITY_TAKEOFF.value: _ENQUEUE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
-        JobType.ESTIMATE.value: _ENQUEUE_ESTIMATE_JOB_ERROR_MESSAGE,
-        JobType.EXPORT.value: _ENQUEUE_EXPORT_JOB_ERROR_MESSAGE,
-    }.get(job_type, "Failed to enqueue job")
+    return job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE.get(job_type, "Failed to enqueue job")
 
 
 async def _build_ingestion_run_request(job_id: UUID, *, attempt_token: UUID) -> IngestionRunRequest:
@@ -4583,12 +4686,34 @@ async def _cancel_job_for_inactive_source(
     )
 
 
-async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
-    """Claim, resume, or cancel a persisted ingest job under a row lock."""
-    return await job_lifecycle._begin_or_resume_ingest_job(
+def _get_begin_or_resume_route(process_name: str) -> job_runner.BeginOrResumeRoute:
+    """Return registry-backed begin/resume metadata for a worker process."""
+    route = job_runner.get_begin_or_resume_route(process_name)
+    if route is None:
+        raise LookupError(f"No begin/resume route registered for process '{process_name}'")
+    return route
+
+
+async def _begin_or_resume_registered_job(
+    job_id: UUID,
+    *,
+    process_name: str,
+) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted worker job via registry metadata."""
+    route = _get_begin_or_resume_route(process_name)
+    return await job_lifecycle._begin_or_resume_job(
         job_id,
+        supported_job_types=route.supported_job_types,
         terminal_job_statuses=_TERMINAL_JOB_STATUSES,
         stale_after=_RUNNING_JOB_STALE_AFTER,
+        log_keys=job_lifecycle._BeginOrResumeLogKeys(
+            unsupported_type=route.log_keys.unsupported_type,
+            terminal_status=route.log_keys.terminal_status,
+            inactive_source=route.log_keys.inactive_source,
+            reclaimed_stale_running=route.log_keys.reclaimed_stale_running,
+            duplicate_delivery=route.log_keys.duplicate_delivery,
+            cancelled=route.log_keys.cancelled,
+        ),
         session_maker_factory=get_session_maker,
         lock_job_source_for_terminal_mutation_func=_lock_job_source_for_terminal_mutation,
         cancel_job_for_inactive_source_func=_cancel_job_for_inactive_source,
@@ -4600,55 +4725,27 @@ async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
     )
 
 
+async def _begin_or_resume_ingest_job(job_id: UUID) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted ingest job under a row lock."""
+    return await _begin_or_resume_registered_job(job_id, process_name="process_ingest_job")
+
+
 async def _begin_or_resume_quantity_takeoff_job(job_id: UUID) -> _JobAttemptLease | None:
     """Claim, resume, or cancel a persisted quantity takeoff job under a row lock."""
-    return await job_lifecycle._begin_or_resume_quantity_takeoff_job(
+    return await _begin_or_resume_registered_job(
         job_id,
-        terminal_job_statuses=_TERMINAL_JOB_STATUSES,
-        stale_after=_RUNNING_JOB_STALE_AFTER,
-        session_maker_factory=get_session_maker,
-        lock_job_source_for_terminal_mutation_func=_lock_job_source_for_terminal_mutation,
-        cancel_job_for_inactive_source_func=_cancel_job_for_inactive_source,
-        claim_job_attempt_lease_func=_claim_job_attempt_lease,
-        is_stale_running_job_func=_is_stale_running_job,
-        finalize_job_cancelled_func=_finalize_job_cancelled,
-        emit_job_event_func=emit_job_event,
-        logger_instance=logger,
+        process_name="process_quantity_takeoff_job",
     )
 
 
 async def _begin_or_resume_estimate_job(job_id: UUID) -> _JobAttemptLease | None:
     """Claim, resume, or cancel a persisted estimate job under a row lock."""
-    return await job_lifecycle._begin_or_resume_estimate_job(
-        job_id,
-        terminal_job_statuses=_TERMINAL_JOB_STATUSES,
-        stale_after=_RUNNING_JOB_STALE_AFTER,
-        session_maker_factory=get_session_maker,
-        lock_job_source_for_terminal_mutation_func=_lock_job_source_for_terminal_mutation,
-        cancel_job_for_inactive_source_func=_cancel_job_for_inactive_source,
-        claim_job_attempt_lease_func=_claim_job_attempt_lease,
-        is_stale_running_job_func=_is_stale_running_job,
-        finalize_job_cancelled_func=_finalize_job_cancelled,
-        emit_job_event_func=emit_job_event,
-        logger_instance=logger,
-    )
+    return await _begin_or_resume_registered_job(job_id, process_name="process_estimate_job")
 
 
 async def _begin_or_resume_export_job(job_id: UUID) -> _JobAttemptLease | None:
     """Claim, resume, or cancel a persisted export job under a row lock."""
-    return await job_lifecycle._begin_or_resume_export_job(
-        job_id,
-        terminal_job_statuses=_TERMINAL_JOB_STATUSES,
-        stale_after=_RUNNING_JOB_STALE_AFTER,
-        session_maker_factory=get_session_maker,
-        lock_job_source_for_terminal_mutation_func=_lock_job_source_for_terminal_mutation,
-        cancel_job_for_inactive_source_func=_cancel_job_for_inactive_source,
-        claim_job_attempt_lease_func=_claim_job_attempt_lease,
-        is_stale_running_job_func=_is_stale_running_job,
-        finalize_job_cancelled_func=_finalize_job_cancelled,
-        emit_job_event_func=emit_job_event,
-        logger_instance=logger,
-    )
+    return await _begin_or_resume_registered_job(job_id, process_name="process_export_job")
 
 
 async def _execute_ingest_job_attempt(
@@ -4688,100 +4785,308 @@ async def _execute_ingest_job_attempt(
         )
 
 
-async def process_ingest_job(job_id: UUID) -> None:
-    """Load a persisted ingest job, run ingestion, and persist state transitions."""
+async def _handle_ingest_runner_error(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    exc: IngestionRunnerError,
+) -> None:
+    """Persist and log the expected ingest runner failure contract."""
+    if exc.error_code is ErrorCode.JOB_CANCELLED:
+        await _mark_job_cancelled_with_log(
+            job_id,
+            attempt_token=attempt_token,
+            log_event="ingest_job_cancelled_during_execution",
+            log_fields={"error_code": exc.error_code.value},
+        )
+        return
+
+    await _mark_job_failed(
+        job_id,
+        error_message=exc.message,
+        error_code=exc.error_code,
+        attempt_token=attempt_token,
+    )
+    logger.error("ingest_job_failed", job_id=str(job_id), **_runner_error_log_fields(exc))
+
+
+def _build_ingest_finalization_error_log_fields(exc: Exception) -> dict[str, str]:
+    """Preserve the legacy ingest finalization error log payload."""
+    return {"error": str(exc)}
+
+
+def _get_registered_job_handler(job_type_name: job_runner.JobTypeName) -> job_runner.JobHandler:
+    """Return registered worker metadata for one persisted job type."""
+    handler = job_runner.get_job_handler(job_type_name)
+    if handler is None:
+        raise LookupError(f"No worker handler registered for job type '{job_type_name}'")
+    return handler
+
+
+def _resolve_registered_job_callable(name: str) -> Any:
+    """Late-bind a worker callable by name for monkeypatch-friendly wrappers."""
+    resolved = globals().get(name)
+    if resolved is None:
+        raise LookupError(f"Worker callable '{name}' is not defined")
+    return resolved
+
+
+async def _process_registered_job(job_id: UUID, *, spec: _RegisteredJobProcessSpec) -> None:
+    """Run one registered persisted worker job through the shared execution shell."""
     _ensure_worker_database_configured()
 
-    lease = await _begin_or_resume_ingest_job(job_id)
+    handler = _get_registered_job_handler(spec.job_type_name)
+    execute_name = handler.execute_name
+    finalize_name = handler.finalize_name
+    if execute_name is None:
+        raise LookupError(f"Worker handler '{spec.job_type_name}' is missing execute_name")
+    if finalize_name is None:
+        raise LookupError(f"Worker handler '{spec.job_type_name}' is missing finalize_name")
+
+    lease = await _begin_or_resume_registered_job(job_id, process_name=handler.process_name)
     if lease is None:
         return
 
-    try:
-        payload = await _execute_ingest_job_attempt(job_id, attempt_token=lease.token)
-    except _InactiveSourceError:
-        logger.info("ingest_job_cancelled_inactive_source", job_id=str(job_id))
-        return
-    except _StaleJobAttemptError:
-        logger.info("ingest_job_stale_attempt_skipped", job_id=str(job_id))
-        return
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="ingest_job_revision_conflict",
-            exc=exc,
-        )
-        raise
-    except IngestionRunnerError as exc:
-        if exc.error_code is ErrorCode.JOB_CANCELLED:
-            await _mark_job_cancelled_with_log(
-                job_id,
-                attempt_token=lease.token,
-                log_event="ingest_job_cancelled_during_execution",
-                log_fields={"error_code": exc.error_code.value},
-            )
-        else:
-            await _mark_job_failed(
-                job_id,
-                error_message=exc.message,
-                error_code=exc.error_code,
-                attempt_token=lease.token,
-            )
-            logger.error("ingest_job_failed", job_id=str(job_id), **_runner_error_log_fields(exc))
-        raise
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="ingest_job_cancelled_during_execution",
-        )
-        raise
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_PROCESS_INGEST_JOB_ERROR_MESSAGE,
-            log_event="ingest_job_failed",
-        )
-        raise
+    execute_job = cast(Any, _resolve_registered_job_callable(execute_name))
+    finalize_job = cast(Any, _resolve_registered_job_callable(finalize_name))
 
     try:
-        finalized = await _finalize_ingest_job(
-            job_id,
-            attempt_token=lease.token,
-            payload=payload,
-        )
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="ingest_job_cancelled_during_finalization",
-        )
-        raise
+        execution_result = await execute_job(job_id, attempt_token=lease.token)
+    except _InactiveSourceError:
+        if spec.inactive_source_log_event is None:
+            raise
+        logger.info(spec.inactive_source_log_event, job_id=str(job_id))
+        return
+    except _StaleJobAttemptError:
+        logger.info(spec.stale_attempt_log_event, job_id=str(job_id))
+        return
     except _RevisionConflictError as exc:
         await _mark_job_failed_for_revision_conflict(
             job_id,
             attempt_token=lease.token,
-            log_event="ingest_job_revision_conflict",
+            log_event=spec.revision_conflict_log_event,
             exc=exc,
+        )
+        if spec.reraise_revision_conflict:
+            raise
+        return
+    except asyncio.CancelledError:
+        await _mark_job_cancelled_with_log(
+            job_id,
+            attempt_token=lease.token,
+            log_event=spec.cancelled_during_execution_log_event,
         )
         raise
     except Exception as exc:
+        if spec.input_error_type is not None and isinstance(exc, spec.input_error_type):
+            input_error = cast(_RegisteredJobInputError, exc)
+            failure_details = input_error.details
+            await _mark_job_failed(
+                job_id,
+                error_message=input_error.message,
+                error_code=input_error.error_code,
+                attempt_token=lease.token,
+                error_details=failure_details,
+            )
+            if spec.input_failure_log_event is None:
+                raise AssertionError(
+                    f"Registered job '{spec.job_type_name}' is missing input_failure_log_event"
+                ) from exc
+            logger.warning(
+                spec.input_failure_log_event,
+                job_id=str(job_id),
+                error_code=input_error.error_code.value,
+                **(failure_details or {}),
+            )
+            return
+
+        if spec.execution_error_type is not None and isinstance(exc, spec.execution_error_type):
+            if spec.execution_error_handler_name is None:
+                raise AssertionError(
+                    f"Registered job '{spec.job_type_name}' is missing execution_error_handler_name"
+                ) from exc
+            handle_execution_error = cast(
+                Any,
+                _resolve_registered_job_callable(spec.execution_error_handler_name),
+            )
+            await handle_execution_error(job_id, attempt_token=lease.token, exc=exc)
+            raise
+
         await _mark_job_failed_with_internal_error_log(
             job_id,
             attempt_token=lease.token,
-            error_message=_FINALIZE_INGEST_JOB_ERROR_MESSAGE,
-            log_event="ingest_job_finalization_failed",
-            log_fields={"error": str(exc)},
+            error_message=spec.process_error_message,
+            log_event=spec.process_failed_log_event,
+        )
+        raise
+
+    if execution_result is None:
+        return
+
+    if isinstance(execution_result, _RegisteredJobAttemptResult):
+        finalize_kwargs = execution_result.finalize_kwargs
+    else:
+        if spec.execution_result_arg_name is None:
+            raise TypeError(
+                "Registered job "
+                f"'{spec.job_type_name}' returned a raw execution result without "
+                "execution_result_arg_name"
+            )
+        finalize_kwargs = {spec.execution_result_arg_name: execution_result}
+
+    try:
+        finalized = await finalize_job(
+            job_id,
+            attempt_token=lease.token,
+            **finalize_kwargs,
+        )
+    except asyncio.CancelledError:
+        await _mark_job_cancelled_with_log(
+            job_id,
+            attempt_token=lease.token,
+            log_event=spec.cancelled_during_finalization_log_event,
+        )
+        raise
+    except _RevisionConflictError as exc:
+        await _mark_job_failed_for_revision_conflict(
+            job_id,
+            attempt_token=lease.token,
+            log_event=spec.revision_conflict_log_event,
+            exc=exc,
+        )
+        if spec.reraise_revision_conflict:
+            raise
+        return
+    except Exception as exc:
+        log_fields: dict[str, Any] | None = None
+        if spec.finalization_exception_log_fields_name is not None:
+            build_log_fields = cast(
+                Callable[[Exception], dict[str, Any]],
+                _resolve_registered_job_callable(spec.finalization_exception_log_fields_name),
+            )
+            log_fields = build_log_fields(exc)
+        await _mark_job_failed_with_internal_error_log(
+            job_id,
+            attempt_token=lease.token,
+            error_message=spec.finalize_error_message,
+            log_event=spec.finalization_failed_log_event,
+            log_fields=log_fields,
         )
         raise
 
     if finalized:
-        logger.info("ingest_job_succeeded", job_id=str(job_id))
+        logger.info(spec.succeeded_log_event, job_id=str(job_id))
 
 
-async def recover_incomplete_ingest_jobs() -> list[UUID]:
-    """Requeue incomplete persisted ingest/reprocess/quantity/estimate jobs on worker startup."""
+async def _execute_quantity_takeoff_job_attempt(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> _RegisteredJobAttemptResult | None:
+    """Build quantity inputs, compute deterministic outputs, and defer finalization."""
+    execution = await _build_quantity_takeoff_execution_input(job_id, attempt_token=attempt_token)
+    if execution.quantity_gate in {"review_gated", "blocked"}:
+        error_details = _quantity_gate_details(
+            drawing_revision_id=execution.drawing_revision_id,
+            review_state=execution.review_state,
+            validation_status=execution.validation_status,
+            quantity_gate=execution.quantity_gate,
+        )
+        await _mark_job_failed(
+            job_id,
+            error_message=_QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE,
+            error_code=ErrorCode.INPUT_INVALID,
+            attempt_token=attempt_token,
+            error_details=error_details,
+        )
+        logger.warning(
+            "quantity_takeoff_job_gate_blocked",
+            job_id=str(job_id),
+            error_code=ErrorCode.INPUT_INVALID.value,
+            **error_details,
+        )
+        return None
+
+    result = compute_quantities(execution.gate, execution.entities)
+    if result.conflicts:
+        error_details = {
+            "drawing_revision_id": str(execution.drawing_revision_id),
+            "quantity_gate": execution.quantity_gate,
+            "conflict_count": len(result.conflicts),
+            "conflicts": _build_quantity_conflict_summaries(result.conflicts),
+        }
+        await _mark_job_failed(
+            job_id,
+            error_message=_QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE,
+            error_code=ErrorCode.INPUT_INVALID,
+            attempt_token=attempt_token,
+            error_details=error_details,
+        )
+        logger.warning(
+            "quantity_takeoff_job_conflicts_detected",
+            job_id=str(job_id),
+            error_code=ErrorCode.INPUT_INVALID.value,
+            **error_details,
+        )
+        return None
+
+    return _RegisteredJobAttemptResult(finalize_kwargs={"execution": execution, "result": result})
+
+
+async def _execute_estimate_job_attempt(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> _RegisteredJobAttemptResult:
+    """Build deterministic estimate inputs and defer output persistence."""
+    engine_input = await _build_estimate_engine_input(job_id, attempt_token=attempt_token)
+    try:
+        estimate_output = compose_estimate(engine_input)
+    except EstimateEngineError as exc:
+        raise _EstimateJobInputError(
+            error_code=ErrorCode.INPUT_INVALID,
+            message=_ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE,
+            details={"reason": exc.reason},
+        ) from exc
+
+    logger.info(
+        "estimate_job_composed_pending_finalization",
+        job_id=str(job_id),
+        quantity_entry_count=len(engine_input.quantity_entries),
+        rate_entry_count=len(engine_input.rate_entries),
+        material_entry_count=len(engine_input.material_entries),
+        formula_entry_count=len(engine_input.formula_entries),
+        line_count=len(engine_input.line_inputs),
+    )
+    return _RegisteredJobAttemptResult(finalize_kwargs={"output": estimate_output})
+
+
+async def _execute_export_job(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> _RegisteredJobAttemptResult:
+    """Build export inputs, render deterministic bytes, and defer finalization."""
+    execution = await _build_export_execution_input(job_id, attempt_token=attempt_token)
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        rendered = await _render_export_artifact(session, execution)
+
+    return _RegisteredJobAttemptResult(
+        finalize_kwargs={"execution": execution, "rendered": rendered}
+    )
+
+
+async def process_ingest_job(job_id: UUID) -> None:
+    """Load a persisted ingest job, run ingestion, and persist state transitions."""
+    await _process_registered_job(job_id, spec=_INGEST_PROCESS_SPEC)
+
+
+async def recover_incomplete_jobs() -> list[UUID]:
+    """Requeue incomplete persisted worker jobs on worker startup."""
     session_maker = get_session_maker()
     if session_maker is None:
         raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
@@ -4850,8 +5155,13 @@ async def recover_incomplete_ingest_jobs() -> list[UUID]:
     return enqueued_job_ids
 
 
+async def recover_incomplete_ingest_jobs() -> list[UUID]:
+    """Compatibility alias for incomplete worker job recovery."""
+    return await recover_incomplete_jobs()
+
+
 def recover_incomplete_ingest_jobs_on_worker_start(**_: object) -> None:
-    """Requeue incomplete ingest/reprocess/quantity/estimate jobs when a worker starts."""
+    """Requeue incomplete persisted worker jobs when a worker starts."""
     try:
         recovered_job_ids = _run_worker_loop(recover_incomplete_ingest_jobs)
     except Exception as exc:
@@ -4886,134 +5196,7 @@ def enqueue_ingest_job(job_id: UUID) -> None:
 
 async def process_quantity_takeoff_job(job_id: UUID) -> None:
     """Load a persisted quantity takeoff job and atomically persist its result."""
-    _ensure_worker_database_configured()
-
-    lease = await _begin_or_resume_quantity_takeoff_job(job_id)
-    if lease is None:
-        return
-
-    try:
-        execution = await _build_quantity_takeoff_execution_input(job_id, attempt_token=lease.token)
-        if execution.quantity_gate in {"review_gated", "blocked"}:
-            error_details = _quantity_gate_details(
-                drawing_revision_id=execution.drawing_revision_id,
-                review_state=execution.review_state,
-                validation_status=execution.validation_status,
-                quantity_gate=execution.quantity_gate,
-            )
-            await _mark_job_failed(
-                job_id,
-                error_message=_QUANTITY_TAKEOFF_GATE_BLOCKED_ERROR_MESSAGE,
-                error_code=ErrorCode.INPUT_INVALID,
-                attempt_token=lease.token,
-                error_details=error_details,
-            )
-            logger.warning(
-                "quantity_takeoff_job_gate_blocked",
-                job_id=str(job_id),
-                error_code=ErrorCode.INPUT_INVALID.value,
-                **error_details,
-            )
-            return
-
-        result = compute_quantities(execution.gate, execution.entities)
-        if result.conflicts:
-            error_details = {
-                "drawing_revision_id": str(execution.drawing_revision_id),
-                "quantity_gate": execution.quantity_gate,
-                "conflict_count": len(result.conflicts),
-                "conflicts": _build_quantity_conflict_summaries(result.conflicts),
-            }
-            await _mark_job_failed(
-                job_id,
-                error_message=_QUANTITY_TAKEOFF_CONFLICT_ERROR_MESSAGE,
-                error_code=ErrorCode.INPUT_INVALID,
-                attempt_token=lease.token,
-                error_details=error_details,
-            )
-            logger.warning(
-                "quantity_takeoff_job_conflicts_detected",
-                job_id=str(job_id),
-                error_code=ErrorCode.INPUT_INVALID.value,
-                **error_details,
-            )
-            return
-    except _StaleJobAttemptError:
-        logger.info("quantity_takeoff_job_stale_attempt_skipped", job_id=str(job_id))
-        return
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="quantity_takeoff_job_revision_conflict",
-            exc=exc,
-        )
-        return
-    except _QuantityTakeoffJobError as exc:
-        failure_details: dict[str, Any] | None = exc.details
-        await _mark_job_failed(
-            job_id,
-            error_message=exc.message,
-            error_code=exc.error_code,
-            attempt_token=lease.token,
-            error_details=failure_details,
-        )
-        logger.warning(
-            "quantity_takeoff_job_input_failed",
-            job_id=str(job_id),
-            error_code=exc.error_code.value,
-            **(failure_details or {}),
-        )
-        return
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="quantity_takeoff_job_cancelled_during_execution",
-        )
-        raise
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
-            log_event="quantity_takeoff_job_failed",
-        )
-        raise
-
-    try:
-        finalized = await _finalize_quantity_takeoff_job(
-            job_id,
-            attempt_token=lease.token,
-            execution=execution,
-            result=result,
-        )
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="quantity_takeoff_job_cancelled_during_finalization",
-        )
-        raise
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="quantity_takeoff_job_revision_conflict",
-            exc=exc,
-        )
-        return
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE,
-            log_event="quantity_takeoff_job_finalization_failed",
-        )
-        raise
-
-    if finalized:
-        logger.info("quantity_takeoff_job_succeeded", job_id=str(job_id))
+    await _process_registered_job(job_id, spec=_QUANTITY_TAKEOFF_PROCESS_SPEC)
 
 
 @celery_app.task(
@@ -5034,116 +5217,7 @@ def enqueue_quantity_takeoff_job(job_id: UUID) -> None:
 
 async def process_estimate_job(job_id: UUID) -> None:
     """Load a persisted estimate job and assemble deterministic engine inputs."""
-    _ensure_worker_database_configured()
-
-    lease = await _begin_or_resume_estimate_job(job_id)
-    if lease is None:
-        return
-
-    try:
-        engine_input = await _build_estimate_engine_input(job_id, attempt_token=lease.token)
-        estimate_output = compose_estimate(engine_input)
-    except _StaleJobAttemptError:
-        logger.info("estimate_job_stale_attempt_skipped", job_id=str(job_id))
-        return
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="estimate_job_revision_conflict",
-            exc=exc,
-        )
-        return
-    except _EstimateJobInputError as exc:
-        failure_details = exc.details
-        await _mark_job_failed(
-            job_id,
-            error_message=exc.message,
-            error_code=exc.error_code,
-            attempt_token=lease.token,
-            error_details=failure_details,
-        )
-        logger.warning(
-            "estimate_job_input_failed",
-            job_id=str(job_id),
-            error_code=exc.error_code.value,
-            **(failure_details or {}),
-        )
-        return
-    except EstimateEngineError as exc:
-        failure_details = {"reason": exc.reason}
-        await _mark_job_failed(
-            job_id,
-            error_message=_ESTIMATE_JOB_INPUT_INVALID_ERROR_MESSAGE,
-            error_code=ErrorCode.INPUT_INVALID,
-            attempt_token=lease.token,
-            error_details=failure_details,
-        )
-        logger.warning(
-            "estimate_job_input_failed",
-            job_id=str(job_id),
-            error_code=ErrorCode.INPUT_INVALID.value,
-            **failure_details,
-        )
-        return
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="estimate_job_cancelled_during_execution",
-        )
-        raise
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_PROCESS_ESTIMATE_JOB_ERROR_MESSAGE,
-            log_event="estimate_job_failed",
-        )
-        raise
-
-    logger.info(
-        "estimate_job_composed_pending_finalization",
-        job_id=str(job_id),
-        quantity_entry_count=len(engine_input.quantity_entries),
-        rate_entry_count=len(engine_input.rate_entries),
-        material_entry_count=len(engine_input.material_entries),
-        formula_entry_count=len(engine_input.formula_entries),
-        line_count=len(engine_input.line_inputs),
-    )
-
-    try:
-        finalized = await _finalize_estimate_job(
-            job_id,
-            attempt_token=lease.token,
-            output=estimate_output,
-        )
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="estimate_job_cancelled_during_finalization",
-        )
-        raise
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="estimate_job_revision_conflict",
-            exc=exc,
-        )
-        return
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE,
-            log_event="estimate_job_finalization_failed",
-        )
-        raise
-
-    if finalized:
-        logger.info("estimate_job_succeeded", job_id=str(job_id))
+    await _process_registered_job(job_id, spec=_ESTIMATE_PROCESS_SPEC)
 
 
 @celery_app.task(
@@ -5164,95 +5238,7 @@ def enqueue_estimate_job(job_id: UUID) -> None:
 
 async def process_export_job(job_id: UUID) -> None:
     """Load a persisted export job and atomically persist its generated artifact."""
-    _ensure_worker_database_configured()
-
-    lease = await _begin_or_resume_export_job(job_id)
-    if lease is None:
-        return
-
-    try:
-        execution = await _build_export_execution_input(job_id, attempt_token=lease.token)
-        session_maker = get_session_maker()
-        if session_maker is None:
-            raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
-        async with session_maker() as session:
-            rendered = await _render_export_artifact(session, execution)
-    except _StaleJobAttemptError:
-        logger.info("export_job_stale_attempt_skipped", job_id=str(job_id))
-        return
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="export_job_revision_conflict",
-            exc=exc,
-        )
-        return
-    except _ExportJobInputError as exc:
-        failure_details = exc.details
-        await _mark_job_failed(
-            job_id,
-            error_message=exc.message,
-            error_code=exc.error_code,
-            attempt_token=lease.token,
-            error_details=failure_details,
-        )
-        logger.warning(
-            "export_job_input_failed",
-            job_id=str(job_id),
-            error_code=exc.error_code.value,
-            **(failure_details or {}),
-        )
-        return
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="export_job_cancelled_during_execution",
-        )
-        raise
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_PROCESS_EXPORT_JOB_ERROR_MESSAGE,
-            log_event="export_job_failed",
-        )
-        raise
-
-    try:
-        finalized = await _finalize_export_job(
-            job_id,
-            attempt_token=lease.token,
-            execution=execution,
-            rendered=rendered,
-        )
-    except asyncio.CancelledError:
-        await _mark_job_cancelled_with_log(
-            job_id,
-            attempt_token=lease.token,
-            log_event="export_job_cancelled_during_finalization",
-        )
-        raise
-    except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event="export_job_revision_conflict",
-            exc=exc,
-        )
-        return
-    except Exception:
-        await _mark_job_failed_with_internal_error_log(
-            job_id,
-            attempt_token=lease.token,
-            error_message=_FINALIZE_EXPORT_JOB_ERROR_MESSAGE,
-            log_event="export_job_finalization_failed",
-        )
-        raise
-
-    if finalized:
-        logger.info("export_job_succeeded", job_id=str(job_id))
+    await _process_registered_job(job_id, spec=_EXPORT_PROCESS_SPEC)
 
 
 @celery_app.task(

--- a/tests/test_jobs_worker_estimate.py
+++ b/tests/test_jobs_worker_estimate.py
@@ -2571,3 +2571,61 @@ class TestJobsWorkerEstimate:
         worker_module.run_estimate_job(str(job_id))
 
         assert processed_job_ids == [job_id]
+
+    async def test_process_estimate_job_uses_late_bound_registered_runner_callables(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Estimate wrapper should late-bind registered execution/finalization callables."""
+        _ = self
+
+        job_id = uuid.uuid4()
+        attempt_token = uuid.uuid4()
+        calls: list[tuple[Any, ...]] = []
+
+        monkeypatch.setattr(worker_module, "_ensure_worker_database_configured", lambda: None)
+
+        async def _fake_begin_or_resume_registered_job(
+            job_id_value: uuid.UUID,
+            *,
+            process_name: str,
+        ) -> Any:
+            calls.append(("begin", job_id_value, process_name))
+            return types.SimpleNamespace(token=attempt_token)
+
+        async def _fake_execute_estimate_job_attempt(
+            job_id_value: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+        ) -> Any:
+            calls.append(("execute", job_id_value, attempt_token))
+            return worker_module._RegisteredJobAttemptResult(finalize_kwargs={"output": "output"})
+
+        async def _fake_finalize_estimate_job(
+            job_id_value: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+            output: str,
+        ) -> bool:
+            calls.append(("finalize", job_id_value, attempt_token, output))
+            return True
+
+        monkeypatch.setattr(
+            worker_module,
+            "_begin_or_resume_registered_job",
+            _fake_begin_or_resume_registered_job,
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "_execute_estimate_job_attempt",
+            _fake_execute_estimate_job_attempt,
+        )
+        monkeypatch.setattr(worker_module, "_finalize_estimate_job", _fake_finalize_estimate_job)
+
+        await worker_module.process_estimate_job(job_id)
+
+        assert calls == [
+            ("begin", job_id, "process_estimate_job"),
+            ("execute", job_id, attempt_token),
+            ("finalize", job_id, attempt_token, "output"),
+        ]

--- a/tests/test_jobs_worker_lifecycle.py
+++ b/tests/test_jobs_worker_lifecycle.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 
 import app.api.v1.files as files_api
 import app.db.session as session_module
+import app.jobs.runner as runner_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
 from app.ingestion.contracts import CancellationHandle
@@ -34,6 +35,269 @@ from tests.jobs_test_helpers import (
     _upload_file,
     fake_ingestion_runner,
 )
+
+
+def test_job_handler_registry_explicitly_covers_worker_job_types() -> None:
+    """Runner registry should explicitly describe the persisted worker job types."""
+    expected_recoverable_job_types = (
+        JobType.INGEST.value,
+        JobType.REPROCESS.value,
+        JobType.QUANTITY_TAKEOFF.value,
+        JobType.ESTIMATE.value,
+        JobType.EXPORT.value,
+    )
+    expected_ingest_worker_job_types = (
+        JobType.INGEST.value,
+        JobType.REPROCESS.value,
+    )
+    expected_begin_or_resume_routes = {
+        "process_ingest_job": (
+            JobType.INGEST.value,
+            JobType.REPROCESS.value,
+        ),
+        "process_quantity_takeoff_job": (JobType.QUANTITY_TAKEOFF.value,),
+        "process_estimate_job": (JobType.ESTIMATE.value,),
+        "process_export_job": (JobType.EXPORT.value,),
+    }
+
+    assert [handler.job_type_name for handler in runner_module.JOB_HANDLERS] == [
+        JobType.INGEST.value,
+        JobType.REPROCESS.value,
+        JobType.QUANTITY_TAKEOFF.value,
+        JobType.ESTIMATE.value,
+        JobType.EXPORT.value,
+    ]
+    assert expected_recoverable_job_types == runner_module.RECOVERABLE_ENQUEUE_JOB_TYPES
+    assert expected_ingest_worker_job_types == runner_module.INGEST_WORKER_JOB_TYPES
+    assert {
+        route.process_name: route.supported_job_types
+        for route in runner_module.BEGIN_OR_RESUME_ROUTES
+    } == expected_begin_or_resume_routes
+
+    ingest_handler = runner_module.get_job_handler(JobType.INGEST.value)
+    reprocess_handler = runner_module.get_job_handler(JobType.REPROCESS.value)
+    export_handler = runner_module.get_job_handler(JobType.EXPORT.value)
+    ingest_route = runner_module.get_begin_or_resume_route("process_ingest_job")
+    export_route = runner_module.get_begin_or_resume_route("process_export_job")
+
+    assert ingest_handler is not None
+    assert reprocess_handler is not None
+    assert export_handler is not None
+    assert ingest_route is not None
+    assert export_route is not None
+    assert reprocess_handler.execute_name == ingest_handler.execute_name
+    assert ingest_handler.execute_name == "_execute_ingest_job_attempt"
+    assert reprocess_handler.finalize_name == ingest_handler.finalize_name == "_finalize_ingest_job"
+    assert reprocess_handler.process_name == ingest_handler.process_name == "process_ingest_job"
+    assert reprocess_handler.run_task_name == ingest_handler.run_task_name == "run_ingest_job"
+    assert (
+        reprocess_handler.enqueue_publisher_name
+        == ingest_handler.enqueue_publisher_name
+        == "enqueue_ingest_job"
+    )
+    assert ingest_route.supported_job_types == expected_ingest_worker_job_types
+    assert ingest_route.log_keys.terminal_status == "ingest_job_cancel_skipped_terminal_status"
+    assert reprocess_handler.enqueue_error_message == "Failed to enqueue reprocess job"
+    assert export_handler.execute_name == "_execute_export_job"
+    assert export_handler.finalize_name == "_finalize_export_job"
+    assert export_handler.process_name == "process_export_job"
+    assert export_handler.run_task_name == "run_export_job"
+    assert export_handler.enqueue_publisher_name == "enqueue_export_job"
+    assert export_handler.enqueue_error_message == "Failed to enqueue export job"
+    assert export_route.supported_job_types == (JobType.EXPORT.value,)
+    assert (
+        export_route.log_keys.reclaimed_stale_running == "export_job_reclaimed_stale_running_status"
+    )
+
+
+def test_worker_registry_derived_helpers_preserve_public_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker metadata helpers should remain registry-derived and monkeypatch-friendly."""
+    published_ingest_job_ids: list[uuid.UUID] = []
+    published_export_job_ids: list[uuid.UUID] = []
+
+    def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+        published_ingest_job_ids.append(job_id)
+
+    def _fake_export_enqueue(job_id: uuid.UUID) -> None:
+        published_export_job_ids.append(job_id)
+
+    monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
+    monkeypatch.setattr(worker_module, "enqueue_export_job", _fake_export_enqueue)
+
+    assert worker_module.is_ingest_worker_job_type(JobType.INGEST) is True
+    assert worker_module.is_ingest_worker_job_type(JobType.REPROCESS.value) is True
+    assert worker_module.is_ingest_worker_job_type(JobType.ESTIMATE) is False
+
+    for job_type in (
+        JobType.INGEST,
+        JobType.REPROCESS,
+        JobType.QUANTITY_TAKEOFF,
+        JobType.ESTIMATE,
+        JobType.EXPORT,
+    ):
+        assert worker_module.is_recoverable_enqueue_job_type(job_type) is True
+
+    publisher = worker_module.get_job_enqueue_publisher(JobType.REPROCESS)
+    assert publisher is _fake_recovery_enqueue
+    export_publisher = worker_module.get_job_enqueue_publisher(JobType.EXPORT)
+    assert export_publisher is _fake_export_enqueue
+
+    sample_job_id = uuid.uuid4()
+    assert publisher is not None
+    publisher(sample_job_id)
+    assert published_ingest_job_ids == [sample_job_id]
+
+    sample_export_job_id = uuid.uuid4()
+    assert export_publisher is not None
+    export_publisher(sample_export_job_id)
+    assert published_export_job_ids == [sample_export_job_id]
+
+    assert worker_module._get_enqueue_job_error_message(JobType.REPROCESS.value) == (
+        "Failed to enqueue reprocess job"
+    )
+    assert worker_module._get_enqueue_job_error_message(JobType.EXPORT.value) == (
+        "Failed to enqueue export job"
+    )
+    assert worker_module._get_enqueue_job_error_message("unknown") == "Failed to enqueue job"
+
+
+@pytest.mark.asyncio
+async def test_process_ingest_job_wrapper_late_binds_registered_callables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ingest wrapper should late-bind registered execution/finalization callables."""
+    job_id = uuid.uuid4()
+    attempt_token = uuid.uuid4()
+    payload = _build_fake_ingest_payload(
+        IngestionRunRequest(
+            job_id=job_id,
+            file_id=uuid.uuid4(),
+            checksum_sha256=hashlib.sha256(_TEST_UPLOAD_BODY).hexdigest(),
+            detected_format="pdf",
+            media_type="application/pdf",
+            original_name="plan.pdf",
+            extraction_profile_id=None,
+            initial_job_id=job_id,
+        )
+    )
+    observed_calls: list[tuple[Any, ...]] = []
+
+    async def _fake_begin_or_resume_registered_job(
+        received_job_id: uuid.UUID,
+        *,
+        process_name: str,
+    ) -> types.SimpleNamespace:
+        observed_calls.append(("begin", received_job_id, process_name))
+        return types.SimpleNamespace(token=attempt_token)
+
+    async def _fake_execute_ingest_job_attempt(
+        received_job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> IngestFinalizationPayload:
+        observed_calls.append(("execute", received_job_id, attempt_token))
+        return payload
+
+    async def _fake_finalize_ingest_job(
+        received_job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+        payload: IngestFinalizationPayload,
+    ) -> bool:
+        observed_calls.append(("finalize", received_job_id, attempt_token, payload))
+        return True
+
+    monkeypatch.setattr(worker_module, "_ensure_worker_database_configured", lambda: None)
+    monkeypatch.setattr(
+        worker_module,
+        "_begin_or_resume_registered_job",
+        _fake_begin_or_resume_registered_job,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "_execute_ingest_job_attempt",
+        _fake_execute_ingest_job_attempt,
+    )
+    monkeypatch.setattr(worker_module, "_finalize_ingest_job", _fake_finalize_ingest_job)
+
+    await worker_module.process_ingest_job(job_id)
+
+    assert observed_calls == [
+        ("begin", job_id, "process_ingest_job"),
+        ("execute", job_id, attempt_token),
+        ("finalize", job_id, attempt_token, payload),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_export_job_wrapper_late_binds_registered_callables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Export wrapper should late-bind registered execution/finalization callables."""
+    job_id = uuid.uuid4()
+    attempt_token = uuid.uuid4()
+    observed_calls: list[tuple[Any, ...]] = []
+
+    async def _fake_begin_or_resume_registered_job(
+        received_job_id: uuid.UUID,
+        *,
+        process_name: str,
+    ) -> types.SimpleNamespace:
+        observed_calls.append(("begin", received_job_id, process_name))
+        return types.SimpleNamespace(token=attempt_token)
+
+    async def _fake_execute_export_job(
+        received_job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> worker_module._RegisteredJobAttemptResult:
+        observed_calls.append(("execute", received_job_id, attempt_token))
+        return worker_module._RegisteredJobAttemptResult(
+            finalize_kwargs={"execution": "execution", "rendered": "rendered"}
+        )
+
+    async def _fake_finalize_export_job(
+        received_job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+        execution: str,
+        rendered: str,
+    ) -> bool:
+        observed_calls.append(("finalize", received_job_id, attempt_token, execution, rendered))
+        return True
+
+    monkeypatch.setattr(worker_module, "_ensure_worker_database_configured", lambda: None)
+    monkeypatch.setattr(
+        worker_module,
+        "_begin_or_resume_registered_job",
+        _fake_begin_or_resume_registered_job,
+    )
+    monkeypatch.setattr(worker_module, "_execute_export_job", _fake_execute_export_job)
+    monkeypatch.setattr(worker_module, "_finalize_export_job", _fake_finalize_export_job)
+
+    await worker_module.process_export_job(job_id)
+
+    assert observed_calls == [
+        ("begin", job_id, "process_export_job"),
+        ("execute", job_id, attempt_token),
+        ("finalize", job_id, attempt_token, "execution", "rendered"),
+    ]
+
+
+def test_worker_task_names_preserve_public_compatibility() -> None:
+    """Celery task names should stay aligned with the registered public wrappers."""
+    assert worker_module.run_ingest_job.name == "app.jobs.worker.run_ingest_job"
+    assert worker_module.run_export_job.name == "app.jobs.worker.run_export_job"
+
+    ingest_handler = runner_module.get_job_handler(JobType.INGEST.value)
+    export_handler = runner_module.get_job_handler(JobType.EXPORT.value)
+
+    assert ingest_handler is not None
+    assert export_handler is not None
+    assert ingest_handler.run_task_name == worker_module.run_ingest_job.__name__
+    assert export_handler.run_task_name == worker_module.run_export_job.__name__
 
 
 @pytest.mark.usefixtures(fake_ingestion_runner.__name__)
@@ -184,6 +448,67 @@ class TestJobsWorkerLifecycle:
         assert updated_job.job_type == "reprocess"
         assert updated_job.status == "succeeded"
         assert updated_job.attempts == 1
+
+    async def test_recover_incomplete_jobs_requeues_stranded_pending_export_jobs(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Canonical recovery should requeue pending export jobs through the registry."""
+        _ = self
+        _ = cleanup_projects
+
+        recovered_job_ids: list[str] = []
+
+        def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
+            recovered_job_ids.append(str(job_id))
+
+        async def _skip_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (job_id, publisher, suppress_exceptions, kwargs)
+            return False
+
+        monkeypatch.setattr(files_api, "publish_job_enqueue_intent", _skip_publish)
+        monkeypatch.setattr(worker_module, "enqueue_export_job", _fake_recovery_enqueue)
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        initial_job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(initial_job.id)
+        reprocess_response = await async_client.post(
+            f"/v1/projects/{project['id']}/files/{uploaded['id']}/reprocess",
+            json={"extraction_profile_id": str(initial_job.extraction_profile_id)},
+        )
+        assert reprocess_response.status_code == 202
+        job = await _get_job(uuid.UUID(reprocess_response.json()["id"]))
+        enqueued_job_ids.clear()
+
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        async with session_maker() as session:
+            persisted_job = await session.get(Job, job.id)
+            assert persisted_job is not None
+            persisted_job.job_type = JobType.EXPORT.value
+            persisted_job.extraction_profile_id = None
+            await session.commit()
+
+        requeued = await worker_module.recover_incomplete_jobs()
+
+        assert recovered_job_ids == [str(job.id)]
+        assert requeued == [job.id]
+
+        updated_job = await _get_job(job.id)
+        assert updated_job.job_type == JobType.EXPORT.value
+        assert updated_job.status == "pending"
+        assert updated_job.enqueue_status == "published"
+        assert updated_job.enqueue_attempts == 1
 
     async def test_process_ingest_job_cancels_mid_run_when_project_is_deleted(
         self,

--- a/tests/test_jobs_worker_quantity.py
+++ b/tests/test_jobs_worker_quantity.py
@@ -1,6 +1,7 @@
 """Quantity worker integration tests."""
 
 import json
+import types
 import uuid
 from copy import deepcopy
 from dataclasses import replace
@@ -2013,3 +2014,68 @@ class TestJobsWorkerQuantity:
             "expected_entities": 1,
             "loaded_entities": 0,
         }
+
+    async def test_process_quantity_takeoff_job_uses_late_bound_registered_runner_callables(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Quantity wrapper should late-bind registered execution/finalization callables."""
+        _ = self
+
+        job_id = uuid.uuid4()
+        attempt_token = uuid.uuid4()
+        calls: list[tuple[Any, ...]] = []
+
+        monkeypatch.setattr(worker_module, "_ensure_worker_database_configured", lambda: None)
+
+        async def _fake_begin_or_resume_registered_job(
+            job_id_value: uuid.UUID,
+            *,
+            process_name: str,
+        ) -> Any:
+            calls.append(("begin", job_id_value, process_name))
+            return types.SimpleNamespace(token=attempt_token)
+
+        async def _fake_execute_quantity_takeoff_job_attempt(
+            job_id_value: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+        ) -> Any:
+            calls.append(("execute", job_id_value, attempt_token))
+            return worker_module._RegisteredJobAttemptResult(
+                finalize_kwargs={"execution": "execution", "result": "result"}
+            )
+
+        async def _fake_finalize_quantity_takeoff_job(
+            job_id_value: uuid.UUID,
+            *,
+            attempt_token: uuid.UUID,
+            execution: str,
+            result: str,
+        ) -> bool:
+            calls.append(("finalize", job_id_value, attempt_token, execution, result))
+            return True
+
+        monkeypatch.setattr(
+            worker_module,
+            "_begin_or_resume_registered_job",
+            _fake_begin_or_resume_registered_job,
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "_execute_quantity_takeoff_job_attempt",
+            _fake_execute_quantity_takeoff_job_attempt,
+        )
+        monkeypatch.setattr(
+            worker_module,
+            "_finalize_quantity_takeoff_job",
+            _fake_finalize_quantity_takeoff_job,
+        )
+
+        await worker_module.process_quantity_takeoff_job(job_id)
+
+        assert calls == [
+            ("begin", job_id, "process_quantity_takeoff_job"),
+            ("execute", job_id, attempt_token),
+            ("finalize", job_id, attempt_token, "execution", "result"),
+        ]


### PR DESCRIPTION
Closes #274

## Summary
- replace duplicated worker job shells with a registry-backed runner path while keeping public Celery task names and worker wrappers stable
- centralize shared UTC clock usage and registry-derived begin/resume, recovery, and publisher metadata
- preserve late-bound worker callable resolution and extend lifecycle coverage across ingest, quantity, estimate, and export paths

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_jobs_worker_lifecycle.py tests/test_jobs_worker_ingest.py tests/test_jobs_worker_quantity.py tests/test_jobs_worker_estimate.py tests/test_jobs_worker_exports.py tests/test_jobs_api.py tests/test_jobs.py