### PR TITLE
refactor(exports): extract export artifact base and registry

### DIFF
--- a/app/exports/_base.py
+++ b/app/exports/_base.py
@@ -1,0 +1,145 @@
+"""Shared export renderer helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+type JSONScalar = str | int | float | bool | None
+type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
+
+type JSONScalarNormalizer = Callable[[object], tuple[bool, JSONValue]]
+type JSONMappingKeyNormalizer = Callable[[object], str]
+type JSONUnsupportedValueFactory = Callable[[object], Exception]
+
+
+@dataclass(frozen=True, slots=True)
+class ExportArtifact:
+    """Shared rendered export artifact metadata."""
+
+    content_bytes: bytes
+    checksum_sha256: str
+    size_bytes: int
+    media_type: str
+    generator_name: str
+    generator_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class ExportArtifactWithOptions(ExportArtifact):
+    """Shared rendered export artifact metadata with normalized options."""
+
+    options: dict[str, JSONValue]
+
+
+def build_artifact[T: ExportArtifact](
+    artifact_type: type[T],
+    *,
+    content_bytes: bytes,
+    media_type: str,
+    generator_name: str,
+    generator_version: str,
+    options: dict[str, JSONValue] | None = None,
+) -> T:
+    """Build a typed export artifact with shared checksum and size metadata."""
+
+    artifact = ExportArtifact(
+        content_bytes=content_bytes,
+        checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
+        size_bytes=len(content_bytes),
+        media_type=media_type,
+        generator_name=generator_name,
+        generator_version=generator_version,
+    )
+
+    if issubclass(artifact_type, ExportArtifactWithOptions):
+        if options is None:
+            raise TypeError("Options are required for export artifacts with options.")
+        return artifact_type(
+            content_bytes=artifact.content_bytes,
+            checksum_sha256=artifact.checksum_sha256,
+            size_bytes=artifact.size_bytes,
+            media_type=artifact.media_type,
+            generator_name=artifact.generator_name,
+            generator_version=artifact.generator_version,
+            options=options,
+        )
+
+    if options is not None:
+        raise TypeError("Options are only supported for export artifacts with options.")
+
+    return artifact_type(
+        content_bytes=artifact.content_bytes,
+        checksum_sha256=artifact.checksum_sha256,
+        size_bytes=artifact.size_bytes,
+        media_type=artifact.media_type,
+        generator_name=artifact.generator_name,
+        generator_version=artifact.generator_version,
+    )
+
+
+def canonical_json_bytes(
+    payload: object,
+    *,
+    normalize_value: Callable[[object], JSONValue],
+) -> bytes:
+    """Serialize payload to canonical UTF-8 JSON bytes."""
+
+    return canonical_json_text(normalize_value(payload)).encode("utf-8")
+
+
+def canonical_json_text(value: JSONValue) -> str:
+    """Serialize normalized JSON to canonical text."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def normalize_json_value_tree(
+    value: object,
+    *,
+    normalize_scalar: JSONScalarNormalizer,
+    normalize_mapping_key: JSONMappingKeyNormalizer,
+    unsupported_value: JSONUnsupportedValueFactory,
+) -> JSONValue:
+    """Normalize JSON-compatible trees with module-specific scalar rules."""
+
+    handled, normalized = normalize_scalar(value)
+    if handled:
+        return normalized
+    if isinstance(value, list | tuple):
+        return [
+            normalize_json_value_tree(
+                item,
+                normalize_scalar=normalize_scalar,
+                normalize_mapping_key=normalize_mapping_key,
+                unsupported_value=unsupported_value,
+            )
+            for item in value
+        ]
+    if isinstance(value, Mapping):
+        return {
+            normalize_mapping_key(key): normalize_json_value_tree(
+                item,
+                normalize_scalar=normalize_scalar,
+                normalize_mapping_key=normalize_mapping_key,
+                unsupported_value=unsupported_value,
+            )
+            for key, item in value.items()
+        }
+    raise unsupported_value(value)
+
+
+def normalize_datetime(value: datetime) -> str:
+    """Normalize datetimes to UTC ISO-8601 with Z suffix."""
+
+    normalized = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+    return normalized.isoformat().replace("+00:00", "Z")

--- a/app/exports/csv.py
+++ b/app/exports/csv.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import csv
-import hashlib
-import json
 import math
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import date, datetime
 from decimal import ROUND_HALF_UP, Decimal
 from io import StringIO
 from uuid import UUID
@@ -16,11 +14,16 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.exports._base import (
+    ExportArtifact,
+    JSONValue,
+    build_artifact,
+    canonical_json_text,
+    normalize_datetime,
+    normalize_json_value_tree,
+)
 from app.models.estimate_version import EstimateItem, EstimateVersion
 from app.models.quantity_takeoff import QuantityItem, QuantityTakeoff
-
-type JSONScalar = str | int | float | bool | None
-type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
 
 CSV_EXPORT_MEDIA_TYPE = "text/csv"
 
@@ -91,15 +94,8 @@ class EstimateCsvExportError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
-class CsvExportResult:
+class CsvExportResult(ExportArtifact):
     """Pure rendered CSV export artifact metadata."""
-
-    content_bytes: bytes
-    checksum_sha256: str
-    size_bytes: int
-    media_type: str
-    generator_name: str
-    generator_version: str
 
 
 async def render_quantity_csv_export(
@@ -224,10 +220,9 @@ def _build_result(
     generator_name: str,
     generator_version: str,
 ) -> CsvExportResult:
-    return CsvExportResult(
+    return build_artifact(
+        CsvExportResult,
         content_bytes=content_bytes,
-        checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
-        size_bytes=len(content_bytes),
         media_type=CSV_EXPORT_MEDIA_TYPE,
         generator_name=generator_name,
         generator_version=generator_version,
@@ -285,33 +280,34 @@ def _format_optional_json(value: object) -> str:
     if value is None:
         return ""
     normalized = _normalize_json_value(value)
-    return json.dumps(
-        normalized,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
-    )
+    return canonical_json_text(normalized)
 
 
 def _normalize_json_value(value: object) -> JSONValue:
+    return normalize_json_value_tree(
+        value,
+        normalize_scalar=_normalize_json_scalar,
+        normalize_mapping_key=_normalize_mapping_key,
+        unsupported_value=_unsupported_json_value,
+    )
+
+
+def _normalize_json_scalar(value: object) -> tuple[bool, JSONValue]:
     if isinstance(value, UUID):
-        return str(value)
+        return True, str(value)
     if isinstance(value, datetime):
-        return _normalize_datetime(value)
+        return True, _normalize_datetime(value)
     if isinstance(value, date):
-        return value.isoformat()
+        return True, value.isoformat()
     if isinstance(value, Decimal):
-        return format(value, "f")
+        return True, format(value, "f")
     if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, list | tuple):
-        return [_normalize_json_value(item) for item in value]
-    if isinstance(value, Mapping):
-        return {
-            _normalize_mapping_key(key): _normalize_json_value(item) for key, item in value.items()
-        }
-    raise TypeError(f"Unsupported CSV export JSON value type: {type(value)!r}")
+        return True, value
+    return False, None
+
+
+def _unsupported_json_value(value: object) -> Exception:
+    return TypeError(f"Unsupported CSV export JSON value type: {type(value)!r}")
 
 
 def _normalize_mapping_key(key: object) -> str:
@@ -331,8 +327,7 @@ def _normalize_mapping_key(key: object) -> str:
 
 
 def _normalize_datetime(value: datetime) -> str:
-    normalized = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
-    return normalized.isoformat().replace("+00:00", "Z")
+    return normalize_datetime(value)
 
 
 def _stringify_scalar(value: object) -> str:

--- a/app/exports/estimate_pdf.py
+++ b/app/exports/estimate_pdf.py
@@ -8,7 +8,7 @@ import math
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 from io import BytesIO
 from uuid import UUID
@@ -32,10 +32,14 @@ from reportlab.platypus import (  # type: ignore[import-untyped]
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.exports._base import (
+    ExportArtifactWithOptions,
+    JSONValue,
+    build_artifact,
+    normalize_datetime,
+    normalize_json_value_tree,
+)
 from app.models.estimate_version import EstimateItem, EstimateVersion
-
-type JSONScalar = str | int | float | bool | None
-type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
 
 ESTIMATE_PDF_EXPORT_MEDIA_TYPE = "application/pdf"
 ESTIMATE_PDF_EXPORT_GENERATOR_NAME = "estimate_pdf_export"
@@ -65,16 +69,8 @@ class EstimatePdfExportError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
-class EstimatePdfExportResult:
+class EstimatePdfExportResult(ExportArtifactWithOptions):
     """Pure rendered estimate PDF export artifact metadata."""
-
-    content_bytes: bytes
-    checksum_sha256: str
-    size_bytes: int
-    media_type: str
-    generator_name: str
-    generator_version: str
-    options: dict[str, JSONValue]
 
 
 async def render_estimate_pdf_export(
@@ -93,10 +89,9 @@ async def render_estimate_pdf_export(
 
     items = await _load_estimate_items(db, estimate_version_id)
     content_bytes = _render_estimate_pdf_bytes(estimate_version, items)
-    return EstimatePdfExportResult(
+    return build_artifact(
+        EstimatePdfExportResult,
         content_bytes=content_bytes,
-        checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
-        size_bytes=len(content_bytes),
         media_type=ESTIMATE_PDF_EXPORT_MEDIA_TYPE,
         generator_name=ESTIMATE_PDF_EXPORT_GENERATOR_NAME,
         generator_version=ESTIMATE_PDF_EXPORT_GENERATOR_VERSION,
@@ -423,24 +418,30 @@ def _normalize_options(options: Mapping[str, object] | None) -> dict[str, JSONVa
 
 
 def _normalize_json_value(value: object) -> JSONValue:
+    return normalize_json_value_tree(
+        value,
+        normalize_scalar=_normalize_json_scalar,
+        normalize_mapping_key=_normalize_mapping_key,
+        unsupported_value=_unsupported_json_value,
+    )
+
+
+def _normalize_json_scalar(value: object) -> tuple[bool, JSONValue]:
     if isinstance(value, UUID):
-        return str(value)
+        return True, str(value)
     if isinstance(value, datetime):
-        return _normalize_datetime(value)
+        return True, _normalize_datetime(value)
     if value is None or isinstance(value, (str, int, bool)):
-        return value
+        return True, value
     if isinstance(value, float):
         if not math.isfinite(value):
             raise TypeError("Estimate PDF export options must be finite JSON values.")
-        return value
-    if isinstance(value, list | tuple):
-        return [_normalize_json_value(item) for item in value]
-    if isinstance(value, Mapping):
-        return {
-            _normalize_mapping_key(key): _normalize_json_value(item) for key, item in value.items()
-        }
+        return True, value
+    return False, None
 
-    raise TypeError(f"Unsupported estimate PDF export value type: {type(value)!r}")
+
+def _unsupported_json_value(value: object) -> Exception:
+    return TypeError(f"Unsupported estimate PDF export value type: {type(value)!r}")
 
 
 def _normalize_mapping_key(key: object) -> str:
@@ -461,5 +462,4 @@ def _normalize_mapping_key(key: object) -> str:
 
 
 def _normalize_datetime(value: datetime) -> str:
-    normalized = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
-    return normalized.isoformat().replace("+00:00", "Z")
+    return normalize_datetime(value)

--- a/app/exports/revision_json.py
+++ b/app/exports/revision_json.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.exports._base import (
+    ExportArtifactWithOptions,
+    JSONValue,
+    build_artifact,
+    canonical_json_bytes,
+    normalize_datetime,
+    normalize_json_value_tree,
+)
 from app.models.drawing_revision import DrawingRevision
 from app.models.revision_materialization import (
     RevisionBlock,
@@ -20,9 +26,6 @@ from app.models.revision_materialization import (
     RevisionLayer,
     RevisionLayout,
 )
-
-type JSONScalar = str | int | float | bool | None
-type JSONValue = JSONScalar | list[JSONValue] | dict[str, JSONValue]
 
 REVISION_JSON_EXPORT_SCHEMA_VERSION = "revision-json-export-v1"
 REVISION_JSON_EXPORT_MEDIA_TYPE = "application/json"
@@ -35,16 +38,8 @@ class RevisionJsonExportError(Exception):
 
 
 @dataclass(frozen=True, slots=True)
-class RevisionJsonExportResult:
+class RevisionJsonExportResult(ExportArtifactWithOptions):
     """Pure rendered revision JSON export artifact metadata."""
-
-    content_bytes: bytes
-    checksum_sha256: str
-    size_bytes: int
-    media_type: str
-    generator_name: str
-    generator_version: str
-    options: dict[str, JSONValue]
 
 
 async def render_revision_json_export(
@@ -148,10 +143,9 @@ async def render_revision_json_export(
     }
 
     content_bytes = _canonical_json_bytes(payload)
-    return RevisionJsonExportResult(
+    return build_artifact(
+        RevisionJsonExportResult,
         content_bytes=content_bytes,
-        checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
-        size_bytes=len(content_bytes),
         media_type=REVISION_JSON_EXPORT_MEDIA_TYPE,
         generator_name=REVISION_JSON_EXPORT_GENERATOR_NAME,
         generator_version=REVISION_JSON_EXPORT_GENERATOR_VERSION,
@@ -227,32 +221,33 @@ def _normalize_options(options: Mapping[str, object] | None) -> dict[str, JSONVa
 
 
 def _canonical_json_bytes(payload: Mapping[str, object]) -> bytes:
-    normalized = _normalize_json_value(payload)
-    serialized = json.dumps(
-        normalized,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
+    return canonical_json_bytes(
+        payload,
+        normalize_value=_normalize_json_value,
     )
-    return serialized.encode("utf-8")
 
 
 def _normalize_json_value(value: object) -> JSONValue:
-    if isinstance(value, UUID):
-        return str(value)
-    if isinstance(value, datetime):
-        return _normalize_datetime(value)
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, list | tuple):
-        return [_normalize_json_value(item) for item in value]
-    if isinstance(value, Mapping):
-        return {
-            _normalize_mapping_key(key): _normalize_json_value(item) for key, item in value.items()
-        }
+    return normalize_json_value_tree(
+        value,
+        normalize_scalar=_normalize_json_scalar,
+        normalize_mapping_key=_normalize_mapping_key,
+        unsupported_value=_unsupported_json_value,
+    )
 
-    raise TypeError(f"Unsupported revision JSON export value type: {type(value)!r}")
+
+def _normalize_json_scalar(value: object) -> tuple[bool, JSONValue]:
+    if isinstance(value, UUID):
+        return True, str(value)
+    if isinstance(value, datetime):
+        return True, _normalize_datetime(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True, value
+    return False, None
+
+
+def _unsupported_json_value(value: object) -> Exception:
+    return TypeError(f"Unsupported revision JSON export value type: {type(value)!r}")
 
 
 def _normalize_mapping_key(key: object) -> str:
@@ -269,5 +264,4 @@ def _normalize_mapping_key(key: object) -> str:
 
 
 def _normalize_datetime(value: datetime) -> str:
-    normalized = value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
-    return normalized.isoformat().replace("+00:00", "Z")
+    return normalize_datetime(value)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -51,8 +51,8 @@ from app.estimating.quantities.contracts import (
     RevisionGateMetadata,
 )
 from app.estimating.quantities.engine import compute_quantities
+from app.exports._base import ExportArtifact
 from app.exports.csv import (
-    CsvExportResult,
     EstimateCsvExportError,
     QuantityCsvExportError,
     render_estimate_csv_export,
@@ -60,12 +60,10 @@ from app.exports.csv import (
 )
 from app.exports.estimate_pdf import (
     EstimatePdfExportError,
-    EstimatePdfExportResult,
     render_estimate_pdf_export,
 )
 from app.exports.revision_json import (
     RevisionJsonExportError,
-    RevisionJsonExportResult,
     render_revision_json_export,
 )
 from app.ingestion.contracts import AdapterTimeout, ProgressUpdate
@@ -396,16 +394,140 @@ class _ExportExecutionInput:
     estimate_version_id: UUID | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class _RenderedExportArtifact:
-    """Deterministic rendered artifact bytes and metadata."""
+_ExportRenderFn = Callable[
+    [AsyncSession, _ExportExecutionInput],
+    Coroutine[Any, Any, ExportArtifact],
+]
+_ExportErrorDetailsFn = Callable[[_ExportExecutionInput], dict[str, Any]]
 
-    content_bytes: bytes
-    checksum_sha256: str
-    size_bytes: int
+_EXPORT_LINEAGE_ANCHOR_REVISION = "revision"
+_EXPORT_LINEAGE_ANCHOR_QUANTITY_TAKEOFF = "quantity_takeoff"
+_EXPORT_LINEAGE_ANCHOR_ESTIMATE_VERSION = "estimate_version"
+
+
+@dataclass(frozen=True, slots=True)
+class _ExportKindSpec:
+    """Registry entry for one supported export worker kind."""
+
+    format: str
     media_type: str
-    generator_name: str
-    generator_version: str
+    render_fn: _ExportRenderFn
+    error_type: type[Exception]
+    lineage_anchor: str
+    error_details_fn: _ExportErrorDetailsFn
+
+
+def _export_revision_error_details(execution: _ExportExecutionInput) -> dict[str, Any]:
+    """Build not-found details for revision-scoped exports."""
+    return {"drawing_revision_id": str(execution.drawing_revision_id)}
+
+
+def _export_quantity_error_details(execution: _ExportExecutionInput) -> dict[str, Any]:
+    """Build not-found details for quantity-scoped exports."""
+    assert execution.quantity_takeoff_id is not None
+    return {
+        "drawing_revision_id": str(execution.drawing_revision_id),
+        "quantity_takeoff_id": str(execution.quantity_takeoff_id),
+    }
+
+
+def _export_estimate_error_details(execution: _ExportExecutionInput) -> dict[str, Any]:
+    """Build not-found details for estimate-scoped exports."""
+    assert execution.estimate_version_id is not None
+    return {
+        "drawing_revision_id": str(execution.drawing_revision_id),
+        "estimate_version_id": str(execution.estimate_version_id),
+    }
+
+
+async def _render_revision_json_export_artifact(
+    session: AsyncSession,
+    execution: _ExportExecutionInput,
+) -> ExportArtifact:
+    """Render a revision JSON export artifact."""
+    return await render_revision_json_export(
+        session,
+        execution.drawing_revision_id,
+        options=execution.options_json,
+    )
+
+
+async def _render_quantity_csv_export_artifact(
+    session: AsyncSession,
+    execution: _ExportExecutionInput,
+) -> ExportArtifact:
+    """Render a quantity CSV export artifact."""
+    assert execution.quantity_takeoff_id is not None
+    return await render_quantity_csv_export(session, execution.quantity_takeoff_id)
+
+
+async def _render_estimate_csv_export_artifact(
+    session: AsyncSession,
+    execution: _ExportExecutionInput,
+) -> ExportArtifact:
+    """Render an estimate CSV export artifact."""
+    assert execution.estimate_version_id is not None
+    return await render_estimate_csv_export(session, execution.estimate_version_id)
+
+
+async def _render_estimate_pdf_export_artifact(
+    session: AsyncSession,
+    execution: _ExportExecutionInput,
+) -> ExportArtifact:
+    """Render an estimate PDF export artifact."""
+    assert execution.estimate_version_id is not None
+    return await render_estimate_pdf_export(
+        session,
+        execution.estimate_version_id,
+        options=execution.options_json,
+    )
+
+
+_EXPORT_KIND_SPECS: dict[str, _ExportKindSpec] = {
+    "revision_json": _ExportKindSpec(
+        format="json",
+        media_type="application/json",
+        render_fn=_render_revision_json_export_artifact,
+        error_type=RevisionJsonExportError,
+        lineage_anchor=_EXPORT_LINEAGE_ANCHOR_REVISION,
+        error_details_fn=_export_revision_error_details,
+    ),
+    "quantity_csv": _ExportKindSpec(
+        format="csv",
+        media_type="text/csv",
+        render_fn=_render_quantity_csv_export_artifact,
+        error_type=QuantityCsvExportError,
+        lineage_anchor=_EXPORT_LINEAGE_ANCHOR_QUANTITY_TAKEOFF,
+        error_details_fn=_export_quantity_error_details,
+    ),
+    "estimate_csv": _ExportKindSpec(
+        format="csv",
+        media_type="text/csv",
+        render_fn=_render_estimate_csv_export_artifact,
+        error_type=EstimateCsvExportError,
+        lineage_anchor=_EXPORT_LINEAGE_ANCHOR_ESTIMATE_VERSION,
+        error_details_fn=_export_estimate_error_details,
+    ),
+    "estimate_pdf": _ExportKindSpec(
+        format="pdf",
+        media_type="application/pdf",
+        render_fn=_render_estimate_pdf_export_artifact,
+        error_type=EstimatePdfExportError,
+        lineage_anchor=_EXPORT_LINEAGE_ANCHOR_ESTIMATE_VERSION,
+        error_details_fn=_export_estimate_error_details,
+    ),
+}
+
+
+def _get_export_kind_spec(export_kind: str) -> _ExportKindSpec:
+    """Return the worker registry entry for a supported export kind."""
+    export_spec = _EXPORT_KIND_SPECS.get(export_kind)
+    if export_spec is None:
+        raise _build_export_job_input_error(
+            "Export job kind is not supported by the worker.",
+            details={"export_kind": export_kind},
+        )
+    return export_spec
 
 
 _JobAttemptLease = job_lifecycle._JobAttemptLease
@@ -3252,15 +3374,15 @@ def _build_export_artifact_name(
     estimate_version_id: UUID | None = None,
 ) -> str:
     """Build a deterministic filename for a generated export artifact."""
-    if export_kind == "revision_json":
+    export_spec = _get_export_kind_spec(export_kind)
+    if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_REVISION:
         return f"revision-{drawing_revision_id}.{export_format}"
-    if export_kind == "quantity_csv":
+    if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_QUANTITY_TAKEOFF:
         assert quantity_takeoff_id is not None
         return f"quantity-takeoff-{quantity_takeoff_id}.{export_format}"
-    if export_kind in {"estimate_csv", "estimate_pdf"}:
-        assert estimate_version_id is not None
-        return f"estimate-{estimate_version_id}.{export_format}"
-    return f"export-{drawing_revision_id}.{export_format}"
+    assert export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_ESTIMATE_VERSION
+    assert estimate_version_id is not None
+    return f"estimate-{estimate_version_id}.{export_format}"
 
 
 def _build_export_job_input_error(
@@ -3318,67 +3440,19 @@ def _build_export_artifact_lineage_json(
 async def _render_export_artifact(
     session: AsyncSession,
     execution: _ExportExecutionInput,
-) -> _RenderedExportArtifact:
+) -> ExportArtifact:
     """Render bytes for a supported export job."""
+    export_spec = _get_export_kind_spec(execution.export_kind)
     try:
-        result: RevisionJsonExportResult | CsvExportResult | EstimatePdfExportResult
-        if execution.export_kind == "revision_json":
-            result = await render_revision_json_export(
-                session,
-                execution.drawing_revision_id,
-                options=execution.options_json,
-            )
-        elif execution.export_kind == "quantity_csv":
-            assert execution.quantity_takeoff_id is not None
-            result = await render_quantity_csv_export(session, execution.quantity_takeoff_id)
-        elif execution.export_kind == "estimate_csv":
-            assert execution.estimate_version_id is not None
-            result = await render_estimate_csv_export(session, execution.estimate_version_id)
-        elif execution.export_kind == "estimate_pdf":
-            assert execution.estimate_version_id is not None
-            result = await render_estimate_pdf_export(
-                session,
-                execution.estimate_version_id,
-                options=execution.options_json,
-            )
-        else:
+        result = await export_spec.render_fn(session, execution)
+    except Exception as exc:
+        if isinstance(exc, export_spec.error_type):
             raise _build_export_job_input_error(
-                "Export job kind is not supported by the worker.",
-                details={"export_kind": execution.export_kind},
-            )
-    except RevisionJsonExportError as exc:
-        raise _build_export_job_input_error(
-            str(exc),
-            error_code=ErrorCode.NOT_FOUND,
-            details={"drawing_revision_id": str(execution.drawing_revision_id)},
-        ) from exc
-    except QuantityCsvExportError as exc:
-        raise _build_export_job_input_error(
-            str(exc),
-            error_code=ErrorCode.NOT_FOUND,
-            details={
-                "drawing_revision_id": str(execution.drawing_revision_id),
-                "quantity_takeoff_id": str(execution.quantity_takeoff_id),
-            },
-        ) from exc
-    except EstimateCsvExportError as exc:
-        raise _build_export_job_input_error(
-            str(exc),
-            error_code=ErrorCode.NOT_FOUND,
-            details={
-                "drawing_revision_id": str(execution.drawing_revision_id),
-                "estimate_version_id": str(execution.estimate_version_id),
-            },
-        ) from exc
-    except EstimatePdfExportError as exc:
-        raise _build_export_job_input_error(
-            str(exc),
-            error_code=ErrorCode.NOT_FOUND,
-            details={
-                "drawing_revision_id": str(execution.drawing_revision_id),
-                "estimate_version_id": str(execution.estimate_version_id),
-            },
-        ) from exc
+                str(exc),
+                error_code=ErrorCode.NOT_FOUND,
+                details=export_spec.error_details_fn(execution),
+            ) from exc
+        raise
 
     if result.media_type != execution.media_type:
         raise ValueError("Rendered export media type does not match the persisted export job input")
@@ -3390,14 +3464,7 @@ async def _render_export_artifact(
     if len(result.content_bytes) != result.size_bytes:
         raise ValueError("Rendered export size does not match the generated bytes")
 
-    return _RenderedExportArtifact(
-        content_bytes=result.content_bytes,
-        checksum_sha256=result.checksum_sha256,
-        size_bytes=result.size_bytes,
-        media_type=result.media_type,
-        generator_name=result.generator_name,
-        generator_version=result.generator_version,
-    )
+    return result
 
 
 async def _build_export_execution_input(
@@ -3465,23 +3532,10 @@ async def _build_export_execution_input(
         ):
             raise ValueError("Export job base revision does not belong to the source file")
 
-        supported_exports: dict[str, tuple[str, str]] = {
-            "revision_json": ("json", "application/json"),
-            "quantity_csv": ("csv", "text/csv"),
-            "estimate_csv": ("csv", "text/csv"),
-            "estimate_pdf": ("pdf", "application/pdf"),
-        }
-        expected_export_metadata = supported_exports.get(export_input.export_kind)
-        if expected_export_metadata is None:
-            raise _build_export_job_input_error(
-                "Export job kind is not supported by the worker.",
-                details={"export_kind": export_input.export_kind},
-            )
-
-        expected_format, expected_media_type = expected_export_metadata
+        export_spec = _get_export_kind_spec(export_input.export_kind)
         if (
-            export_input.export_format != expected_format
-            or export_input.media_type != expected_media_type
+            export_input.export_format != export_spec.format
+            or export_input.media_type != export_spec.media_type
         ):
             raise _build_export_job_input_error(
                 "Export job metadata does not match the supported export kind.",
@@ -3493,7 +3547,7 @@ async def _build_export_execution_input(
             )
 
         options_json = deepcopy(export_input.options_json)
-        if export_input.export_kind == "revision_json":
+        if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_REVISION:
             if (
                 export_input.quantity_takeoff_id is not None
                 or export_input.estimate_version_id is not None
@@ -3558,7 +3612,7 @@ async def _build_export_execution_input(
                 },
             )
 
-        if export_input.export_kind == "quantity_csv":
+        if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_QUANTITY_TAKEOFF:
             if export_input.estimate_version_id is not None:
                 raise _build_export_job_input_error(
                     "Quantity CSV export input contains unexpected estimate linkage.",
@@ -3638,7 +3692,7 @@ async def _finalize_export_job(
     *,
     attempt_token: UUID,
     execution: _ExportExecutionInput,
-    rendered: _RenderedExportArtifact,
+    rendered: ExportArtifact,
 ) -> bool:
     """Atomically publish one export artifact and terminal job success."""
     session_maker = get_session_maker()

--- a/tests/test_csv_exports.py
+++ b/tests/test_csv_exports.py
@@ -54,6 +54,10 @@ from tests.conftest import requires_database
 
 pytestmark = [pytest.mark.asyncio, requires_database]
 
+_FIXTURE_UUID_NAMESPACE = uuid.UUID("4b7a71cb-4eb0-4738-b6c6-8b3af08e4e3c")
+_EXPECTED_QUANTITY_CSV_CHECKSUM = "9d06cec6bd7b523c069a1d3f0d1b894a77342bb1ba0534838586db7e50a64f4e"
+_EXPECTED_ESTIMATE_CSV_CHECKSUM = "f054d06bf73f77cf1faa90e5b78efdcf606b7f15fee806641b34cda980e9f48a"
+
 
 @dataclass(frozen=True, slots=True)
 class SeededExportFixture:
@@ -88,6 +92,7 @@ async def test_render_quantity_csv_export_is_deterministic_and_stable(
     assert first.generator_name == QUANTITY_CSV_EXPORT_GENERATOR_NAME
     assert first.generator_version == QUANTITY_CSV_EXPORT_GENERATOR_VERSION
     assert first.checksum_sha256 == hashlib.sha256(first.content_bytes).hexdigest()
+    assert first.checksum_sha256 == _EXPECTED_QUANTITY_CSV_CHECKSUM
 
     rows = _read_csv_rows(first)
     assert rows[0] == list(QUANTITY_CSV_EXPORT_HEADERS)
@@ -123,6 +128,7 @@ async def test_render_estimate_csv_export_is_deterministic_and_stable(
     assert first.generator_name == ESTIMATE_CSV_EXPORT_GENERATOR_NAME
     assert first.generator_version == ESTIMATE_CSV_EXPORT_GENERATOR_VERSION
     assert first.checksum_sha256 == hashlib.sha256(first.content_bytes).hexdigest()
+    assert first.checksum_sha256 == _EXPECTED_ESTIMATE_CSV_CHECKSUM
 
     rows = _read_csv_rows(first)
     assert rows[0] == list(ESTIMATE_CSV_EXPORT_HEADERS)
@@ -232,12 +238,12 @@ def _read_csv_rows(result: CsvExportResult) -> list[list[str]]:
 
 async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
     project = Project(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("project"),
         name="CSV Export Project",
         description="Fixture project",
     )
     source_file = File(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("source_file"),
         project_id=project.id,
         original_filename="fixture.dxf",
         media_type="application/dxf",
@@ -249,7 +255,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 17, 0, tzinfo=UTC),
     )
     extraction_profile = ExtractionProfile(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("extraction_profile"),
         project_id=project.id,
         profile_version="1.0",
         layout_mode="all",
@@ -261,7 +267,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 17, 1, tzinfo=UTC),
     )
     ingest_job = Job(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("ingest_job"),
         project_id=project.id,
         file_id=source_file.id,
         extraction_profile_id=extraction_profile.id,
@@ -278,7 +284,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         finished_at=datetime(2026, 5, 27, 17, 3, tzinfo=UTC),
     )
     adapter_output = AdapterRunOutput(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("adapter_output"),
         project_id=project.id,
         source_file_id=source_file.id,
         extraction_profile_id=extraction_profile.id,
@@ -297,7 +303,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 17, 4, tzinfo=UTC),
     )
     revision = DrawingRevision(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("revision"),
         project_id=project.id,
         source_file_id=source_file.id,
         extraction_profile_id=extraction_profile.id,
@@ -312,7 +318,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 17, 5, tzinfo=UTC),
     )
     quantity_job = Job(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("quantity_job"),
         project_id=project.id,
         file_id=source_file.id,
         extraction_profile_id=None,
@@ -329,7 +335,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         finished_at=datetime(2026, 5, 27, 17, 7, tzinfo=UTC),
     )
     quantity_takeoff = QuantityTakeoff(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("quantity_takeoff"),
         project_id=project.id,
         source_file_id=source_file.id,
         drawing_revision_id=revision.id,
@@ -359,7 +365,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
     await db_session.flush()
 
     quantity_item_first = QuantityItem(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("quantity_item_first"),
         quantity_takeoff_id=quantity_takeoff.id,
         project_id=project.id,
         drawing_revision_id=revision.id,
@@ -375,7 +381,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 18, 0, tzinfo=UTC),
     )
     quantity_item_second = QuantityItem(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("quantity_item_second"),
         quantity_takeoff_id=quantity_takeoff.id,
         project_id=project.id,
         drawing_revision_id=revision.id,
@@ -395,7 +401,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
     await db_session.flush()
 
     estimate_job = Job(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("estimate_job"),
         project_id=project.id,
         file_id=source_file.id,
         extraction_profile_id=None,
@@ -415,7 +421,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
     await db_session.flush()
 
     estimate_version = EstimateVersion(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("estimate_version"),
         project_id=project.id,
         source_file_id=source_file.id,
         drawing_revision_id=revision.id,
@@ -433,7 +439,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
     await db_session.flush()
 
     assumption_snapshot_entry_first = EstimateSnapshotEntry(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("assumption_snapshot_entry_first"),
         estimate_version_id=estimate_version.id,
         project_id=project.id,
         drawing_revision_id=revision.id,
@@ -457,7 +463,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 18, 8, tzinfo=UTC),
     )
     assumption_snapshot_entry_second = EstimateSnapshotEntry(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("assumption_snapshot_entry_second"),
         estimate_version_id=estimate_version.id,
         project_id=project.id,
         drawing_revision_id=revision.id,
@@ -485,7 +491,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
     await db_session.flush()
 
     estimate_item_second = EstimateItem(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("estimate_item_second"),
         estimate_version_id=estimate_version.id,
         project_id=project.id,
         drawing_revision_id=revision.id,
@@ -515,7 +521,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         created_at=datetime(2026, 5, 27, 18, 11, tzinfo=UTC),
     )
     estimate_item_first = EstimateItem(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("estimate_item_first"),
         estimate_version_id=estimate_version.id,
         project_id=project.id,
         drawing_revision_id=revision.id,
@@ -554,3 +560,7 @@ async def _seed_export_fixture(db_session: AsyncSession) -> SeededExportFixture:
         quantity_items=(quantity_item_first, quantity_item_second),
         estimate_items=(estimate_item_first, estimate_item_second),
     )
+
+
+def _fixture_uuid(name: str) -> uuid.UUID:
+    return uuid.uuid5(_FIXTURE_UUID_NAMESPACE, f"csv_export:{name}")

--- a/tests/test_estimate_pdf_export.py
+++ b/tests/test_estimate_pdf_export.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import re
 import uuid
 import zlib
 from collections.abc import AsyncGenerator
@@ -25,6 +24,9 @@ from tests.conftest import requires_database
 from tests.test_csv_exports import _seed_export_fixture
 
 pytestmark = [pytest.mark.asyncio, requires_database]
+
+_EXPECTED_ESTIMATE_PDF_CHECKSUM = "375f6e7c221042ccd545ff16251f4a88078ffcf1358be8cff91a4b7f794155f0"
+_EXPECTED_ESTIMATE_PDF_ID = "c51390cb148e9cbe6dba713ed68dea55"
 
 
 @pytest_asyncio.fixture
@@ -54,12 +56,14 @@ async def test_render_estimate_pdf_export_is_deterministic_and_stable(
     assert first.options == {}
     assert first.size_bytes == len(first.content_bytes)
     assert first.checksum_sha256 == hashlib.sha256(first.content_bytes).hexdigest()
+    assert first.checksum_sha256 == _EXPECTED_ESTIMATE_PDF_CHECKSUM
 
     content = first.content_bytes
     assert content.startswith(b"%PDF-")
     assert b"/CreationDate (D:20000101000000+00'00')" in content
     assert b"/ModDate (D:20000101000000+00'00')" in content
-    assert re.search(rb"/ID\s*\[<[0-9a-f]{32}><[0-9a-f]{32}>\]", content) is not None
+    expected_id_bytes = _EXPECTED_ESTIMATE_PDF_ID.encode("ascii")
+    assert b"/ID [<" + expected_id_bytes + b"><" + expected_id_bytes + b">]" in content
 
 
 async def test_render_estimate_pdf_export_contains_expected_uncompressed_labels(

--- a/tests/test_jobs_worker_exports.py
+++ b/tests/test_jobs_worker_exports.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.errors import ErrorCode
+from app.exports._base import ExportArtifact
 from app.exports.csv import CsvExportResult, render_estimate_csv_export, render_quantity_csv_export
 from app.exports.estimate_pdf import EstimatePdfExportResult, render_estimate_pdf_export
 from app.exports.revision_json import RevisionJsonExportResult, render_revision_json_export
@@ -368,6 +369,40 @@ async def _expected_export_bytes(
     return result.content_bytes, result.generator_name, result.generator_version
 
 
+def _build_export_execution_input(
+    *,
+    lineage: _ExportTestLineage,
+    export_kind: str,
+    export_format: str,
+    media_type: str,
+    options_json: dict[str, object],
+) -> worker_module._ExportExecutionInput:
+    quantity_takeoff_id = (
+        lineage.quantity_takeoff_id
+        if export_kind in {"quantity_csv", "estimate_csv", "estimate_pdf"}
+        else None
+    )
+    estimate_version_id = (
+        lineage.estimate_version_id if export_kind in {"estimate_csv", "estimate_pdf"} else None
+    )
+    return worker_module._ExportExecutionInput(
+        drawing_revision_id=lineage.drawing_revision_id,
+        export_kind=export_kind,
+        export_format=export_format,
+        media_type=media_type,
+        artifact_name=worker_module._build_export_artifact_name(
+            export_kind=export_kind,
+            export_format=export_format,
+            drawing_revision_id=lineage.drawing_revision_id,
+            quantity_takeoff_id=quantity_takeoff_id,
+            estimate_version_id=estimate_version_id,
+        ),
+        options_json=options_json,
+        quantity_takeoff_id=quantity_takeoff_id,
+        estimate_version_id=estimate_version_id,
+    )
+
+
 @pytest.mark.parametrize(
     ("export_kind", "export_format", "media_type", "options_json"),
     [
@@ -455,6 +490,39 @@ async def test_process_export_job_supported_kinds_persist_artifact(
     }
 
 
+@pytest.mark.parametrize(
+    ("export_kind", "export_format", "media_type", "options_json"),
+    [
+        ("revision_json", "json", "application/json", {"include_manifest": True}),
+        ("quantity_csv", "csv", "text/csv", {}),
+        ("estimate_csv", "csv", "text/csv", {}),
+        ("estimate_pdf", "pdf", "application/pdf", {}),
+    ],
+)
+async def test_render_export_artifact_supported_kinds_return_shared_export_artifact(
+    async_client: httpx.AsyncClient,
+    export_kind: str,
+    export_format: str,
+    media_type: str,
+    options_json: dict[str, object],
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    execution = _build_export_execution_input(
+        lineage=lineage,
+        export_kind=export_kind,
+        export_format=export_format,
+        media_type=media_type,
+        options_json=options_json,
+    )
+    session_maker = _get_session_maker()
+
+    async with session_maker() as session:
+        rendered = await worker_module._render_export_artifact(session, execution)
+
+    assert isinstance(rendered, ExportArtifact)
+    assert rendered.media_type == media_type
+
+
 async def test_process_export_job_duplicate_terminal_redelivery_is_noop(
     async_client: httpx.AsyncClient,
 ) -> None:
@@ -477,6 +545,60 @@ async def test_process_export_job_duplicate_terminal_redelivery_is_noop(
         event for event in await _get_job_events(export_job_id) if event.message == "Job succeeded"
     ]
     assert len(success_events) == 1
+
+
+async def test_process_export_job_metadata_mismatch_fails_without_artifact(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+    monkeypatch.setitem(
+        worker_module._EXPORT_KIND_SPECS,
+        "revision_json",
+        replace(
+            worker_module._EXPORT_KIND_SPECS["revision_json"],
+            format="csv",
+            media_type="text/csv",
+        ),
+    )
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INPUT_INVALID.value
+    assert job.error_message == "Export job metadata does not match the supported export kind."
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+
+async def test_process_export_job_unsupported_kind_fails_without_artifact(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revision_json",
+        export_format="json",
+        media_type="application/json",
+        options_json={"include_manifest": True},
+    )
+    monkeypatch.delitem(worker_module._EXPORT_KIND_SPECS, "revision_json")
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INPUT_INVALID.value
+    assert job.error_message == "Export job kind is not supported by the worker."
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
 
 
 async def test_process_export_job_honors_cancel_before_finalization(
@@ -539,10 +661,10 @@ async def test_process_export_job_revision_drift_fails_without_artifact(
     async def _render_without_revision_lookup(
         session: AsyncSession,
         execution: worker_module._ExportExecutionInput,
-    ) -> worker_module._RenderedExportArtifact:
+    ) -> ExportArtifact:
         _ = (session, execution)
         content_bytes = b"stale-rendered-export"
-        return worker_module._RenderedExportArtifact(
+        return ExportArtifact(
             content_bytes=content_bytes,
             checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
             size_bytes=len(content_bytes),

--- a/tests/test_revision_json_export.py
+++ b/tests/test_revision_json_export.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import uuid
 from collections.abc import AsyncGenerator, Mapping
@@ -40,6 +39,11 @@ from app.models.revision_materialization import (
 from tests.conftest import requires_database
 
 pytestmark = [pytest.mark.asyncio, requires_database]
+
+_FIXTURE_UUID_NAMESPACE = uuid.UUID("a6f84dd8-3f4c-4f81-a4f9-2e8a14f7df70")
+_EXPECTED_REVISION_JSON_CHECKSUM = (
+    "5090d3538da96662cef7629a7536507b39b3c3ce2a5d34a524e2f5ae10c60056"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -238,9 +242,10 @@ async def test_render_revision_json_export_is_deterministic_and_canonical(
     expected_bytes = _canonical_json_bytes(expected_payload)
 
     assert first == second
+    assert first.checksum_sha256 == _EXPECTED_REVISION_JSON_CHECKSUM
     assert first == RevisionJsonExportResult(
         content_bytes=expected_bytes,
-        checksum_sha256=hashlib.sha256(expected_bytes).hexdigest(),
+        checksum_sha256=_EXPECTED_REVISION_JSON_CHECKSUM,
         size_bytes=len(expected_bytes),
         media_type=REVISION_JSON_EXPORT_MEDIA_TYPE,
         generator_name=REVISION_JSON_EXPORT_GENERATOR_NAME,
@@ -376,12 +381,12 @@ async def _seed_revision_fixture(
     entities: tuple[Mapping[str, Any], ...] = (),
 ) -> SeededRevisionFixture:
     project = Project(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("project"),
         name="Revision Export Project",
         description="Fixture project",
     )
     source_file = File(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("source_file"),
         project_id=project.id,
         original_filename="fixture.dxf",
         media_type="application/dxf",
@@ -393,7 +398,7 @@ async def _seed_revision_fixture(
         created_at=datetime(2026, 5, 27, 16, 0, tzinfo=UTC),
     )
     extraction_profile = ExtractionProfile(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("extraction_profile"),
         project_id=project.id,
         profile_version="1.0",
         layout_mode="all",
@@ -405,7 +410,7 @@ async def _seed_revision_fixture(
         created_at=datetime(2026, 5, 27, 16, 1, tzinfo=UTC),
     )
     source_job = Job(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("source_job"),
         project_id=project.id,
         file_id=source_file.id,
         extraction_profile_id=extraction_profile.id,
@@ -422,7 +427,7 @@ async def _seed_revision_fixture(
         finished_at=datetime(2026, 5, 27, 16, 8, tzinfo=UTC),
     )
     adapter_output = AdapterRunOutput(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("adapter_output"),
         project_id=project.id,
         source_file_id=source_file.id,
         extraction_profile_id=extraction_profile.id,
@@ -441,7 +446,7 @@ async def _seed_revision_fixture(
         created_at=datetime(2026, 5, 27, 16, 4, tzinfo=UTC),
     )
     revision = DrawingRevision(
-        id=uuid.uuid4(),
+        id=_fixture_uuid("revision"),
         project_id=project.id,
         source_file_id=source_file.id,
         extraction_profile_id=extraction_profile.id,
@@ -471,7 +476,7 @@ async def _seed_revision_fixture(
     manifest: RevisionEntityManifest | None = None
     if with_manifest:
         manifest = RevisionEntityManifest(
-            id=uuid.uuid4(),
+            id=_fixture_uuid("manifest"),
             project_id=project.id,
             source_file_id=source_file.id,
             extraction_profile_id=extraction_profile.id,
@@ -491,9 +496,9 @@ async def _seed_revision_fixture(
         await db_session.flush()
 
     created_layouts: list[RevisionLayout] = []
-    for spec in layouts:
+    for layout_index, spec in enumerate(layouts):
         created_layout = RevisionLayout(
-            id=uuid.uuid4(),
+            id=_fixture_uuid(f"layout:{layout_index}"),
             project_id=project.id,
             source_file_id=source_file.id,
             extraction_profile_id=extraction_profile.id,
@@ -511,9 +516,9 @@ async def _seed_revision_fixture(
     await db_session.flush()
 
     created_layers: list[RevisionLayer] = []
-    for spec in layers:
+    for layer_index, spec in enumerate(layers):
         created_layer = RevisionLayer(
-            id=uuid.uuid4(),
+            id=_fixture_uuid(f"layer:{layer_index}"),
             project_id=project.id,
             source_file_id=source_file.id,
             extraction_profile_id=extraction_profile.id,
@@ -531,9 +536,9 @@ async def _seed_revision_fixture(
     await db_session.flush()
 
     created_blocks: list[RevisionBlock] = []
-    for spec in blocks:
+    for block_index, spec in enumerate(blocks):
         created_block = RevisionBlock(
-            id=uuid.uuid4(),
+            id=_fixture_uuid(f"block:{block_index}"),
             project_id=project.id,
             source_file_id=source_file.id,
             extraction_profile_id=extraction_profile.id,
@@ -555,7 +560,7 @@ async def _seed_revision_fixture(
     block_by_ref = {block.block_ref: block for block in created_blocks}
     entity_by_ref: dict[str, RevisionEntity] = {}
 
-    for spec in entities:
+    for entity_index, spec in enumerate(entities):
         parent_entity_ref_raw = spec.get("parent_entity_ref")
         parent_entity_ref = None if parent_entity_ref_raw is None else str(parent_entity_ref_raw)
         layout_ref_raw = spec.get("layout_ref")
@@ -565,7 +570,7 @@ async def _seed_revision_fixture(
         block_ref_raw = spec.get("block_ref")
         block_ref = None if block_ref_raw is None else str(block_ref_raw)
         entity = RevisionEntity(
-            id=uuid.uuid4(),
+            id=_fixture_uuid(f"entity:{entity_index}"),
             project_id=project.id,
             source_file_id=source_file.id,
             extraction_profile_id=extraction_profile.id,
@@ -634,3 +639,7 @@ def _canonical_json_bytes(payload: Mapping[str, Any]) -> bytes:
         allow_nan=False,
     )
     return serialized.encode("utf-8")
+
+
+def _fixture_uuid(name: str) -> uuid.UUID:
+    return uuid.uuid5(_FIXTURE_UUID_NAMESPACE, f"revision_json_export:{name}")


### PR DESCRIPTION
Closes #275

## Summary
- extract shared export artifact helpers and canonical normalization into `app/exports/_base.py`
- adopt the shared artifact base in CSV, revision JSON, and estimate PDF renderers without changing output bytes
- replace worker export render/error ladders with a registry-driven export kind spec and keep worker finalization behavior intact

## Test plan
- [x] uv run ruff check app/exports/_base.py app/exports/csv.py app/exports/revision_json.py app/exports/estimate_pdf.py app/jobs/worker.py tests/test_revision_json_export.py tests/test_csv_exports.py tests/test_estimate_pdf_export.py tests/test_jobs_worker_exports.py
- [x] uv run mypy app/exports/_base.py app/exports/csv.py app/exports/revision_json.py app/exports/estimate_pdf.py app/jobs/worker.py tests/test_revision_json_export.py tests/test_csv_exports.py tests/test_estimate_pdf_export.py tests/test_jobs_worker_exports.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run alembic upgrade head && DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_revision_json_export.py tests/test_csv_exports.py tests/test_estimate_pdf_export.py tests/test_jobs_worker_exports.py tests/test_export_create_api.py tests/test_export_job_input_contract.py
- [x] git push -u origin refactor/export-artifact-base-registry (pre-push hook ran full pytest)