### PR TITLE
refactor(estimating): centralize money decimal policy

### DIFF
--- a/app/estimating/catalog/api_checksums.py
+++ b/app/estimating/catalog/api_checksums.py
@@ -16,8 +16,9 @@ from app.estimating.formulas import (
     ValueContract,
     validate_formula_definition_json,
 )
+from app.estimating.money import CATALOG_QUANTUM, validate_catalog_money
 
-_SIX_DECIMAL_PLACES = Decimal("0.000001")
+_SIX_DECIMAL_PLACES = CATALOG_QUANTUM
 _ZERO = Decimal("0.000000")
 
 
@@ -225,15 +226,7 @@ def _validate_gbp_currency(currency: str) -> None:
 
 
 def _validate_positive_money(value: Decimal, *, field_name: str) -> None:
-    if not isinstance(value, Decimal):
-        raise ValueError(f"{field_name} must be a Decimal.")
-    if not value.is_finite():
-        raise ValueError(f"{field_name} must be finite.")
-    if value <= Decimal("0"):
-        raise ValueError(f"{field_name} must be greater than zero.")
-    exponent = value.as_tuple().exponent
-    if not isinstance(exponent, int) or exponent < -6:
-        raise ValueError(f"{field_name} must use at most six decimal places.")
+    validate_catalog_money(value, field_name=field_name, require_decimal=True)
 
 
 def _validate_effective_window(effective_from: date, effective_to: date | None) -> None:

--- a/app/estimating/engine/service.py
+++ b/app/estimating/engine/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import date
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
@@ -31,11 +31,11 @@ from app.estimating.formulas import (
     ValueContract,
     evaluate_formula,
 )
+from app.estimating.money import CATALOG_QUANTUM, round_money
 
 type _SnapshotValueType = Literal["quantity_input", "rate", "material", "assumption"]
 
-_MONEY_QUANTUM = Decimal("0.01")
-_CATALOG_QUANTUM = Decimal("0.000001")
+_CATALOG_QUANTUM = CATALOG_QUANTUM
 _CHECKSUM_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -675,7 +675,7 @@ def _apply_formula_rounding(amount: Decimal, rounding_spec: RoundingSpec | None)
 
 
 def _money(value: Decimal) -> Decimal:
-    return value.quantize(_MONEY_QUANTUM, rounding=ROUND_HALF_UP)
+    return round_money(value)
 
 
 def _quantity_decimal(value: Decimal) -> Decimal:

--- a/app/estimating/money.py
+++ b/app/estimating/money.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+GBP_MONEY_QUANTUM = Decimal("0.01")
+CATALOG_QUANTUM = Decimal("0.000001")
+MONEY_QUANTUM = GBP_MONEY_QUANTUM
+_CATALOG_SCALE_EXPONENT = -6
+_ZERO = Decimal("0")
+
+
+def _quantize(value: Decimal, *, quantum: Decimal) -> Decimal:
+    return value.quantize(quantum, rounding=ROUND_HALF_UP)
+
+
+def round_money(value: Decimal) -> Decimal:
+    return _quantize(value, quantum=GBP_MONEY_QUANTUM)
+
+
+def round_catalog_decimal(value: Decimal) -> Decimal:
+    return _quantize(value, quantum=CATALOG_QUANTUM)
+
+
+def format_money(value: Decimal, *, normalize_zero: bool = False) -> str:
+    return _format_decimal(round_money(value), normalize_zero=normalize_zero)
+
+
+def format_catalog_decimal(value: Decimal, *, normalize_zero: bool = False) -> str:
+    return _format_decimal(round_catalog_decimal(value), normalize_zero=normalize_zero)
+
+
+def validate_catalog_money(
+    value: Decimal,
+    *,
+    field_name: str,
+    require_decimal: bool = False,
+) -> Decimal:
+    if require_decimal and not isinstance(value, Decimal):
+        raise ValueError(f"{field_name} must be a Decimal.")
+    if not value.is_finite():
+        raise ValueError(f"{field_name} must be finite.")
+    if value <= _ZERO:
+        raise ValueError(f"{field_name} must be greater than zero.")
+    exponent = value.as_tuple().exponent
+    if not isinstance(exponent, int) or exponent < _CATALOG_SCALE_EXPONENT:
+        raise ValueError(f"{field_name} must use at most six decimal places.")
+    return value
+
+
+def _format_decimal(value: Decimal, *, normalize_zero: bool) -> str:
+    normalized = abs(value) if normalize_zero and value.is_zero() else value
+    return format(normalized, "f")

--- a/app/exports/csv.py
+++ b/app/exports/csv.py
@@ -4,16 +4,22 @@ from __future__ import annotations
 
 import csv
 import math
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from io import StringIO
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.estimating.money import (
+    format_catalog_decimal as shared_format_catalog_decimal,
+)
+from app.estimating.money import (
+    format_money,
+)
 from app.exports._base import (
     ExportArtifact,
     JSONValue,
@@ -80,8 +86,6 @@ ESTIMATE_CSV_EXPORT_HEADERS: tuple[str, ...] = (
     "created_at",
 )
 
-_MONEY_QUANTUM = Decimal("0.01")
-_RATE_QUANTITY_QUANTUM = Decimal("0.000001")
 _SPREADSHEET_FORMULA_PREFIXES = ("=", "+", "-", "@")
 
 
@@ -197,13 +201,13 @@ def _iter_estimate_rows(
             _escape_spreadsheet_text_cell(item.line_type),
             _escape_spreadsheet_text_cell(item.description),
             _escape_spreadsheet_text_cell(item.currency),
-            _format_optional_decimal(item.quantity_value, quantum=_RATE_QUANTITY_QUANTUM),
+            _format_optional_decimal(item.quantity_value, formatter=_format_catalog_decimal),
             _escape_spreadsheet_text_cell(item.quantity_unit or ""),
-            _format_optional_decimal(item.unit_rate_amount, quantum=_RATE_QUANTITY_QUANTUM),
+            _format_optional_decimal(item.unit_rate_amount, formatter=_format_catalog_decimal),
             item.effective_date.isoformat() if item.effective_date is not None else "",
-            _format_decimal(item.subtotal_amount, quantum=_MONEY_QUANTUM),
-            _format_decimal(item.tax_amount, quantum=_MONEY_QUANTUM),
-            _format_decimal(item.total_amount, quantum=_MONEY_QUANTUM),
+            _format_money(item.subtotal_amount),
+            _format_money(item.tax_amount),
+            _format_money(item.total_amount),
             _format_optional_json(item.rounding_json),
             _format_optional_uuid(item.quantity_snapshot_entry_id),
             _format_optional_uuid(item.rate_snapshot_entry_id),
@@ -251,17 +255,22 @@ def _format_quantity_item_value(value: float | None) -> str:
     return format(value, ".15g")
 
 
-def _format_decimal(value: Decimal, *, quantum: Decimal) -> str:
-    normalized = value.quantize(quantum, rounding=ROUND_HALF_UP)
-    if normalized.is_zero():
-        normalized = abs(normalized)
-    return format(normalized, "f")
+def _format_money(value: Decimal) -> str:
+    return format_money(value, normalize_zero=True)
 
 
-def _format_optional_decimal(value: Decimal | None, *, quantum: Decimal) -> str:
+def _format_catalog_decimal(value: Decimal) -> str:
+    return shared_format_catalog_decimal(value, normalize_zero=True)
+
+
+def _format_optional_decimal(
+    value: Decimal | None,
+    *,
+    formatter: Callable[[Decimal], str],
+) -> str:
     if value is None:
         return ""
-    return _format_decimal(value, quantum=quantum)
+    return formatter(value)
 
 
 def _format_optional_uuid(value: UUID | None) -> str:

--- a/app/exports/estimate_pdf.py
+++ b/app/exports/estimate_pdf.py
@@ -6,10 +6,10 @@ import hashlib
 import json
 import math
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from io import BytesIO
 from uuid import UUID
 
@@ -32,6 +32,7 @@ from reportlab.platypus import (  # type: ignore[import-untyped]
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.estimating.money import format_catalog_decimal, format_money
 from app.exports._base import (
     ExportArtifactWithOptions,
     JSONValue,
@@ -47,8 +48,6 @@ ESTIMATE_PDF_EXPORT_GENERATOR_VERSION = "1"
 
 _PAGE_SIZE = A4
 _PAGE_MARGIN = 15 * mm
-_MONEY_QUANTUM = Decimal("0.01")
-_RATE_QUANTITY_QUANTUM = Decimal("0.000001")
 _PDF_INFO_TIMESTAMP = b"D:20000101000000+00'00'"
 _PDF_ID_PLACEHOLDER = b"0" * 32
 _LINE_TABLE_COLUMN_WIDTHS = (
@@ -296,24 +295,29 @@ def _build_items_table(
                 _paragraph(item.line_type, body_style),
                 _paragraph(item.description, body_style),
                 _paragraph(
-                    _format_optional_decimal(item.quantity_value, quantum=_RATE_QUANTITY_QUANTUM),
+                    _format_optional_decimal(
+                        item.quantity_value,
+                        formatter=format_catalog_decimal,
+                    ),
                     body_right_style,
                 ),
                 _paragraph(item.quantity_unit or "", body_style),
                 _paragraph(
-                    _format_optional_decimal(item.unit_rate_amount, quantum=_RATE_QUANTITY_QUANTUM),
+                    _format_optional_decimal(
+                        item.unit_rate_amount, formatter=format_catalog_decimal
+                    ),
                     body_right_style,
                 ),
                 _paragraph(
-                    _format_decimal(item.subtotal_amount, quantum=_MONEY_QUANTUM),
+                    format_money(item.subtotal_amount),
                     body_right_style,
                 ),
                 _paragraph(
-                    _format_decimal(item.tax_amount, quantum=_MONEY_QUANTUM),
+                    format_money(item.tax_amount),
                     body_right_style,
                 ),
                 _paragraph(
-                    _format_decimal(item.total_amount, quantum=_MONEY_QUANTUM),
+                    format_money(item.total_amount),
                     body_right_style,
                 ),
             ]
@@ -359,7 +363,7 @@ def _totals_row(
     return [
         _paragraph(label, body_style),
         "",
-        _paragraph(_format_decimal(amount, quantum=_MONEY_QUANTUM), body_right_style),
+        _paragraph(format_money(amount), body_right_style),
     ]
 
 
@@ -373,15 +377,14 @@ def _escape_paragraph_text(value: str) -> str:
     )
 
 
-def _format_decimal(value: Decimal, *, quantum: Decimal) -> str:
-    normalized = value.quantize(quantum, rounding=ROUND_HALF_UP)
-    return format(normalized, "f")
-
-
-def _format_optional_decimal(value: Decimal | None, *, quantum: Decimal) -> str:
+def _format_optional_decimal(
+    value: Decimal | None,
+    *,
+    formatter: Callable[[Decimal], str],
+) -> str:
     if value is None:
         return ""
-    return _format_decimal(value, quantum=quantum)
+    return formatter(value)
 
 
 def _normalize_pdf_bytes(content_bytes: bytes) -> bytes:

--- a/app/schemas/estimation_catalog.py
+++ b/app/schemas/estimation_catalog.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.estimating.catalog.api_checksums import formula_checksum_sha256
+from app.estimating.money import validate_catalog_money
 
 CatalogScopeType = Literal["global", "project"]
 CatalogCurrencyCode = Literal["GBP"]
@@ -47,14 +48,7 @@ def _require_json_object_array(value: object, *, field_name: str) -> list[dict[s
 
 
 def _validate_positive_money(value: Decimal, *, field_name: str) -> Decimal:
-    if not value.is_finite():
-        raise ValueError(f"{field_name} must be finite.")
-    if value <= Decimal("0"):
-        raise ValueError(f"{field_name} must be greater than zero.")
-    exponent = value.as_tuple().exponent
-    if not isinstance(exponent, int) or exponent < -6:
-        raise ValueError(f"{field_name} must use at most six decimal places.")
-    return value
+    return validate_catalog_money(value, field_name=field_name)
 
 
 def _validate_scope(scope_type: CatalogScopeType, project_id: UUID | None) -> None:

--- a/tests/test_estimate_engine_service.py
+++ b/tests/test_estimate_engine_service.py
@@ -27,10 +27,24 @@ from app.estimating.formulas import (
     RoundingSpec,
     ValueContract,
 )
+from app.estimating.money import round_money
 
 QUANTITY_M = ValueContract(kind="quantity", unit="m")
 RATE_GBP_PER_M = ValueContract(kind="rate", currency="GBP", per_unit="m")
 MONEY_GBP = ValueContract(kind="money", currency="GBP")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (Decimal("0"), Decimal("0.00")),
+        (Decimal("2.225"), Decimal("2.23")),
+        (Decimal("5.555"), Decimal("5.56")),
+        (Decimal("30.864195"), Decimal("30.86")),
+    ],
+)
+def test_round_money_uses_gbp_cent_half_up(value: Decimal, expected: Decimal) -> None:
+    assert round_money(value) == expected
 
 
 def _formula_definition() -> FormulaDefinition:
@@ -566,6 +580,51 @@ def test_compose_estimate_rejects_negative_adjustment_lines() -> None:
         compose_estimate(broken_input)
 
     assert exc_info.value.reason == "negative_adjustment"
+
+
+def test_compose_estimate_rejects_invalid_rate_scale() -> None:
+    engine_input = _valid_engine_input()
+    broken_input = EstimateEngineInput(
+        estimate_job_id=engine_input.estimate_job_id,
+        project_id=engine_input.project_id,
+        file_id=engine_input.file_id,
+        drawing_revision_id=engine_input.drawing_revision_id,
+        quantity_takeoff_id=engine_input.quantity_takeoff_id,
+        source_job_id=engine_input.source_job_id,
+        quantity_gate=engine_input.quantity_gate,
+        trusted_totals=engine_input.trusted_totals,
+        tax_rate=engine_input.tax_rate,
+        quantity_entries=engine_input.quantity_entries,
+        rate_entries=(
+            EstimateRateEntryInput(
+                entry_key="rate:installer",
+                entry_label="Installer labour",
+                sort_order=3,
+                source_rate_id=uuid4(),
+                source_checksum_sha256="c" * 64,
+                unit="m",
+                effective_date=date(2026, 1, 1),
+                unit_amount=Decimal("12.3456789"),
+            ),
+        ),
+        material_entries=(),
+        formula_entries=(),
+        assumption_entries=(),
+        line_inputs=(
+            EstimateLineInputSpec(
+                line_key="line:labour",
+                line_type="rate",
+                description="Installer labour",
+                quantity_entry_key="quantity:labour",
+                rate_entry_key="rate:installer",
+            ),
+        ),
+    )
+
+    with pytest.raises(EstimateEngineError) as exc_info:
+        compose_estimate(broken_input)
+
+    assert exc_info.value.reason == "invalid_rate_scale"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_estimation_catalog_api.py
+++ b/tests/test_estimation_catalog_api.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import UUID, uuid4
 
 import httpx
+import pytest
 from sqlalchemy import select
 
 import app.db.session as session_module
@@ -17,7 +18,9 @@ from app.estimating.catalog.api_checksums import (
     material_checksum_sha256,
     rate_checksum_sha256,
 )
+from app.estimating.money import CATALOG_QUANTUM, GBP_MONEY_QUANTUM, validate_catalog_money
 from app.models.project import Project
+from app.schemas.estimation_catalog import EstimationRateCreate
 from tests.conftest import requires_database
 
 
@@ -189,6 +192,39 @@ def test_formula_checksum_is_deterministic_for_json_key_order_and_changes_with_c
     # Assert
     assert checksum_a == checksum_b
     assert checksum_a != checksum_changed
+
+
+def test_validate_catalog_money_uses_shared_scale_constants_and_returns_original_decimal() -> None:
+    value = Decimal("12.500000")
+
+    assert Decimal("0.01") == GBP_MONEY_QUANTUM
+    assert Decimal("0.000001") == CATALOG_QUANTUM
+    assert validate_catalog_money(value, field_name="amount") is value
+
+
+def test_rate_checksum_requires_decimal_amount_type() -> None:
+    payload = _valid_rate_payload(project_id=str(uuid4()))
+
+    with pytest.raises(ValueError, match="amount must be a Decimal\\."):
+        rate_checksum_sha256(
+            scope_type=payload["scope_type"],
+            project_id=UUID(payload["project_id"]),
+            rate_key=payload["rate_key"],
+            source=payload["source"],
+            metadata_json=payload["metadata_json"],
+            name=payload["name"],
+            item_type=payload["item_type"],
+            per_unit=payload["per_unit"],
+            currency=payload["currency"],
+            amount=payload["amount"],
+            effective_from=date.fromisoformat(payload["effective_from"]),
+            effective_to=None,
+        )
+
+
+def test_estimation_rate_schema_amount_validator_keeps_existing_message() -> None:
+    with pytest.raises(ValueError, match="amount must use at most six decimal places\\."):
+        EstimationRateCreate.validate_amount(Decimal("12.5000001"))
 
 
 def _missing_uuid() -> str:


### PR DESCRIPTION
Closes #276

## Summary
- extract a shared estimating money policy helper for GBP cent rounding, scale-6 decimal formatting, and catalog money validation
- route estimate engine, CSV/PDF exports, and catalog schema/checksum validation through the shared helper without changing export bytes or error semantics
- add focused engine and catalog tests while preserving existing golden export coverage

## Test plan
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_estimate_engine_service.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_csv_exports.py tests/test_estimate_pdf_export.py tests/test_estimation_catalog_api.py
- [x] uv run ruff check app/exports/estimate_pdf.py app/exports/csv.py app/estimating/catalog/api_checksums.py tests/test_estimation_catalog_api.py
- [x] uv run ruff format --check app/exports/estimate_pdf.py app/exports/csv.py app/estimating/catalog/api_checksums.py tests/test_estimation_catalog_api.py