### PR TITLE
refactor(ingestion): add shared entity provenance builder

### DIFF
--- a/app/ingestion/adapters/ezdxf.py
+++ b/app/ingestion/adapters/ezdxf.py
@@ -10,8 +10,9 @@ from dataclasses import dataclass
 from itertools import pairwise
 from math import isfinite, sqrt
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+from app.ingestion.canonical import build_entity_provenance
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterDescriptor,
@@ -509,9 +510,7 @@ def _units_payload(document: Any, units_module: Any) -> dict[str, JSONValue]:
                 conversion_factor_to_meter = candidate
 
     normalized = (
-        "meter"
-        if conversion_factor_to_meter is not None
-        else _normalized_unit_name(source_value)
+        "meter" if conversion_factor_to_meter is not None else _normalized_unit_name(source_value)
     )
 
     payload: dict[str, JSONValue] = {
@@ -667,9 +666,7 @@ def _line_entity_payload(
                 "length": length,
                 "count": 1.0,
             },
-            "adapter_native": {
-                "ezdxf": adapter_native
-            },
+            "adapter_native": {"ezdxf": adapter_native},
         },
         "provenance": _entity_provenance(
             native_type=native_type,
@@ -1056,23 +1053,41 @@ def _entity_provenance(
     notes: tuple[str, ...] = ()
     if geometry is None:
         notes = ("unsupported_or_invalid_geometry",)
-    return {
-        "origin": "adapter_normalized",
-        "adapter": {"key": _DESCRIPTOR.key},
+
+    legacy_aliases: dict[str, JSONValue] = {
         "adapter_key": _DESCRIPTOR.key,
         "source": source_entity_ref,
-        "source_ref": source_entity_ref,
         "source_entity_ref": source_entity_ref,
-        "source_identity": handle or entity_id,
-        "source_hash": source_hash,
+        "normalized_source_hash": source_hash,
+    }
+    native_details: dict[str, JSONValue] = {
         "dxf_handle": handle or None,
         "native_entity_type": native_type,
         "layout_name": layout_name,
         "layer_name": layer_name,
-        "normalized_source_hash": source_hash,
-        "extraction_path": ("modelspace", native_type),
-        "notes": notes,
     }
+    extraction_path = ("modelspace", native_type)
+    provenance = cast(
+        dict[str, JSONValue],
+        build_entity_provenance(
+            origin="adapter_normalized",
+            adapter={"key": _DESCRIPTOR.key},
+            source_ref=source_entity_ref,
+            source_identity=handle or entity_id,
+            source_hash=source_hash,
+            extraction_path=list(extraction_path),
+            notes=list(notes),
+            extra={
+                "native": {"ezdxf": native_details},
+                "legacy_aliases": legacy_aliases,
+            },
+        ),
+    )
+    provenance["extraction_path"] = extraction_path
+    provenance["notes"] = notes
+    provenance.update(legacy_aliases)
+    provenance.update(native_details)
+    return provenance
 
 
 def _entity_id(

--- a/app/ingestion/adapters/ifcopenshell.py
+++ b/app/ingestion/adapters/ifcopenshell.py
@@ -17,6 +17,7 @@ from time import perf_counter
 from types import ModuleType
 from typing import cast
 
+from app.ingestion.canonical import build_entity_provenance
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterCapabilities,
@@ -150,8 +151,7 @@ class IfcOpenShellAdapter(IngestionAdapter):
                 observed_status=ProbeStatus.MISSING,
                 adapter_status=AdapterStatus.UNAVAILABLE,
                 detail=(
-                    "Install draupnir[ingestion] or the ifcopenshell wheel to "
-                    "enable IFC parsing."
+                    "Install draupnir[ingestion] or the ifcopenshell wheel to enable IFC parsing."
                 ),
             )
             return AdapterAvailability(
@@ -331,8 +331,7 @@ class IfcOpenShellAdapter(IngestionAdapter):
                 AdapterWarning(
                     code="ifc.units_assumed",
                     message=(
-                        "IFC length units were not explicit; canonical units "
-                        "defaulted to meters."
+                        "IFC length units were not explicit; canonical units defaulted to meters."
                     ),
                 )
             )
@@ -542,9 +541,7 @@ def _schema_warnings(sniff: _SchemaSniff) -> list[AdapterWarning]:
 def _normalize_schema(schema: object) -> str | None:
     if not isinstance(schema, str):
         return None
-    normalized = (
-        schema.strip().upper().replace(" ", "").replace("_", "").replace("-", "")
-    )
+    normalized = schema.strip().upper().replace(" ", "").replace("_", "").replace("-", "")
     if not normalized:
         return None
     if normalized in _SUPPORTED_SCHEMAS:
@@ -636,8 +633,7 @@ def _extract_entity_payload(
             _build_helper_warning(
                 code="ifc.psets_unavailable",
                 message=(
-                    "IfcOpenShell property-set helper failed; continuing without "
-                    "property sets."
+                    "IfcOpenShell property-set helper failed; continuing without property sets."
                 ),
                 ifc_type=ifc_type,
                 step_id_token=step_id_token,
@@ -651,8 +647,7 @@ def _extract_entity_payload(
             _build_helper_warning(
                 code="ifc.qtos_unavailable",
                 message=(
-                    "IfcOpenShell quantity helper failed; continuing without "
-                    "quantity metadata."
+                    "IfcOpenShell quantity helper failed; continuing without quantity metadata."
                 ),
                 ifc_type=ifc_type,
                 step_id_token=step_id_token,
@@ -666,8 +661,7 @@ def _extract_entity_payload(
             _build_helper_warning(
                 code="ifc.material_refs_unavailable",
                 message=(
-                    "IfcOpenShell material helper failed; continuing without "
-                    "material references."
+                    "IfcOpenShell material helper failed; continuing without material references."
                 ),
                 ifc_type=ifc_type,
                 step_id_token=step_id_token,
@@ -826,22 +820,39 @@ def _entity_provenance(
         step_id_token=step_id_token,
         fallback_identity=fallback_identity,
     )
-    return {
-        "origin": "adapter_normalized",
-        "adapter": {"key": _ADAPTER_KEY},
+    legacy_aliases: dict[str, JSONValue] = {
         "adapter_key": _ADAPTER_KEY,
         "source": source_entity_ref,
-        "source_ref": source_entity_ref,
         "source_entity_ref": source_entity_ref,
-        "source_identity": global_id or step_id_token or fallback_identity,
-        "source_hash": source_hash,
         "normalized_source_hash": source_hash,
         "native_entity_type": ifc_type,
         "ifc_global_id": global_id,
         "ifc_step_id": step_id_token,
-        "extraction_path": ("semantic_extract",),
-        "notes": ("semantic_ifc_metadata_only",),
     }
+    provenance = cast(
+        dict[str, JSONValue],
+        build_entity_provenance(
+            origin="adapter_normalized",
+            adapter={"key": _ADAPTER_KEY},
+            source_ref=source_entity_ref,
+            source_identity=global_id or step_id_token or fallback_identity,
+            source_hash=source_hash,
+            extraction_path=["semantic_extract"],
+            notes=["semantic_ifc_metadata_only"],
+            extra={
+                "native": {
+                    _ADAPTER_KEY: {
+                        "ifc_type": ifc_type,
+                        "ifc_global_id": global_id,
+                        "ifc_step_id": step_id_token,
+                    }
+                },
+                "legacy_aliases": legacy_aliases,
+            },
+        ),
+    )
+    provenance.update(legacy_aliases)
+    return provenance
 
 
 def _entity_source_locator(

--- a/app/ingestion/adapters/libredwg.py
+++ b/app/ingestion/adapters/libredwg.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, cast
 
+from app.ingestion.canonical import build_entity_provenance
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterDiagnostic,
@@ -678,9 +679,7 @@ def _iter_object_records(payload: Any) -> tuple[Mapping[str, Any], ...]:
             return ()
         return tuple(_iter_mapping_candidates(objects))
     if isinstance(payload, list):
-        return tuple(
-            item for item in payload if isinstance(item, Mapping)
-        )
+        return tuple(item for item in payload if isinstance(item, Mapping))
     return ()
 
 
@@ -738,11 +737,19 @@ def _build_line_entity(record: Mapping[str, Any]) -> _JSONDict | None:
             "end": end,
         },
     )
+    provenance = _entity_provenance(
+        record,
+        record_type="LINE",
+        source_handle=source_handle,
+        safe_projection=safe_projection,
+        notes=("units_unconfirmed",),
+    )
 
     return {
         "entity_id": entity_id,
         "entity_type": "line",
         "entity_schema_version": _SCHEMA_VERSION,
+        **provenance,
         "source_entity_handle": source_handle,
         "layout_name": layout_name,
         "layer_name": layer_name,
@@ -781,13 +788,7 @@ def _build_line_entity(record: Mapping[str, Any]) -> _JSONDict | None:
                 }
             },
         },
-        "provenance": _entity_provenance(
-            record,
-            record_type="LINE",
-            source_handle=source_handle,
-            safe_projection=safe_projection,
-            notes=("units_unconfirmed",),
-        ),
+        "provenance": provenance,
         "confidence": {
             "score": _LINE_ENTITY_CONFIDENCE_SCORE,
             "review_required": True,
@@ -807,11 +808,19 @@ def _build_unknown_entity(record: Mapping[str, Any], *, reason: str) -> _JSONDic
     block_name = _extract_block_name(record)
     source_handle = _extract_handle(record)
     safe_projection = _safe_record_projection(record, record_type=record_type, geometry=None)
+    provenance = _entity_provenance(
+        record,
+        record_type=record_type,
+        source_handle=source_handle,
+        safe_projection=safe_projection,
+        notes=("units_unconfirmed", reason),
+    )
 
     return {
         "entity_id": _entity_id(record, record_type="unknown"),
         "entity_type": "unknown",
         "entity_schema_version": _SCHEMA_VERSION,
+        **provenance,
         "source_entity_handle": source_handle,
         "layout_name": layout_name,
         "layer_name": layer_name,
@@ -841,13 +850,7 @@ def _build_unknown_entity(record: Mapping[str, Any], *, reason: str) -> _JSONDic
             "record_type": record_type,
             "handle": source_handle,
         },
-        "provenance": _entity_provenance(
-            record,
-            record_type=record_type,
-            source_handle=source_handle,
-            safe_projection=safe_projection,
-            notes=("units_unconfirmed", reason),
-        ),
+        "provenance": provenance,
         "confidence": {
             "score": _UNKNOWN_ENTITY_CONFIDENCE_SCORE,
             "review_required": True,
@@ -997,27 +1000,61 @@ def _entity_provenance(
     safe_projection: _JSONDict,
     notes: tuple[str, ...],
 ) -> _JSONDict:
+    extraction_path = ("OBJECTS", record_type)
     source_locator = _source_locator(record, record_type=record_type)
     source_hash = _canonical_hash_json_value(safe_projection)
-    return {
-        "origin": "adapter_normalized",
-        "adapter": {"key": _DESCRIPTOR.key},
-        "adapter_key": _DESCRIPTOR.key,
-        "source": source_locator,
-        "source_section": "OBJECTS",
-        "source_ref": source_locator,
-        "source_entity_ref": source_locator,
-        "source_locator": source_locator,
-        "entity_ref": source_locator,
-        "source_identity": source_handle or _entity_id(record, record_type=record_type.lower()),
-        "source_hash": source_hash,
-        "normalized_source_hash": source_hash,
-        "native_handle": source_handle,
-        "source_entity_handle": source_handle,
-        "record_hash": _hash_json_value(safe_projection),
-        "extraction_path": ("OBJECTS", record_type),
-        "notes": notes,
-    }
+    source_identity = source_handle or _entity_id(record, record_type=record_type.lower())
+    record_hash = _hash_json_value(safe_projection)
+    provenance = cast(
+        _JSONDict,
+        build_entity_provenance(
+            origin="adapter_normalized",
+            adapter={"key": _DESCRIPTOR.key},
+            source_ref=source_locator,
+            source_identity=source_identity,
+            source_hash=source_hash,
+            extraction_path=list(extraction_path),
+            notes=list(notes),
+            extra={
+                "native": {
+                    _DESCRIPTOR.key: {
+                        "section": "OBJECTS",
+                        "record_type": record_type,
+                        "handle": source_handle,
+                    }
+                },
+                "legacy_aliases": {
+                    "adapter_key": _DESCRIPTOR.key,
+                    "source": source_locator,
+                    "source_section": "OBJECTS",
+                    "source_entity_ref": source_locator,
+                    "source_locator": source_locator,
+                    "entity_ref": source_locator,
+                    "normalized_source_hash": source_hash,
+                    "native_handle": source_handle,
+                    "source_entity_handle": source_handle,
+                    "record_hash": record_hash,
+                },
+            },
+        ),
+    )
+    provenance.update(
+        {
+            "adapter_key": _DESCRIPTOR.key,
+            "source": source_locator,
+            "source_section": "OBJECTS",
+            "source_entity_ref": source_locator,
+            "source_locator": source_locator,
+            "entity_ref": source_locator,
+            "normalized_source_hash": source_hash,
+            "native_handle": source_handle,
+            "source_entity_handle": source_handle,
+            "record_hash": record_hash,
+        }
+    )
+    provenance["extraction_path"] = extraction_path
+    provenance["notes"] = notes
+    return provenance
 
 
 def _source_locator(record: Mapping[str, Any], *, record_type: str) -> str:

--- a/app/ingestion/adapters/pymupdf.py
+++ b/app/ingestion/adapters/pymupdf.py
@@ -17,6 +17,7 @@ from time import perf_counter
 from types import ModuleType
 from typing import Any, cast
 
+from app.ingestion.canonical import build_entity_provenance
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterDiagnostic,
@@ -764,6 +765,13 @@ def _build_lineish_entity(
         drawing_index=drawing_index,
         entity_index=entity_index,
     )
+    provenance = _entity_provenance(
+        page_number=page_number,
+        drawing_index=drawing_index,
+        drawing=drawing,
+        item_indices=item_indices,
+        operator="re" if rect_like else "l",
+    )
     bbox = _bbox_from_points(normalized_points)
     entity_type = "line" if len(normalized_points) == 2 and not closed else "polyline"
     entity: dict[str, JSONValue] = {
@@ -775,13 +783,8 @@ def _build_lineish_entity(
         "layer": layer_name,
         "bbox": bbox,
         "properties": _entity_properties(drawing, closed=closed, rect_like=rect_like),
-        "provenance": _entity_provenance(
-            page_number=page_number,
-            drawing_index=drawing_index,
-            drawing=drawing,
-            item_indices=item_indices,
-            operator="re" if rect_like else "l",
-        ),
+        **provenance,
+        "provenance": provenance,
         "confidence": {
             "score": _VECTOR_CONFIDENCE_SCORE,
             "basis": "vector_path_segment",
@@ -905,6 +908,7 @@ def _build_unknown_entity(
             **_entity_properties(drawing, closed=False, rect_like=False),
             "unsupported_operator": operator,
         },
+        **provenance,
         "provenance": provenance,
         "confidence": {
             "score": _VECTOR_CONFIDENCE_SCORE,
@@ -995,8 +999,7 @@ def _entity_properties(
         "fill_color_rgb": _color_tuple(drawing.get("fill")),
         "fill_opacity": _optional_float(drawing.get("fill_opacity")),
         "line_cap": tuple(
-            int(value)
-            for value in cast(tuple[int, ...], drawing.get("lineCap", ()))
+            int(value) for value in cast(tuple[int, ...], drawing.get("lineCap", ()))
         ),
         "line_join": _optional_float(drawing.get("lineJoin")),
         "dashes": str(drawing.get("dashes", "")),
@@ -1015,6 +1018,13 @@ def _entity_provenance(
     item_indices: tuple[int, ...] | None = None,
     item_index: int | None = None,
 ) -> dict[str, JSONValue]:
+    extraction_path = (
+        "get_drawings",
+        f"page-{page_number}",
+        f"drawing-{drawing_index}",
+        operator,
+    )
+    notes = ("vector_pdf_unconfirmed_scale",)
     location_payload = _entity_location_payload(
         page_number=page_number,
         drawing_index=drawing_index,
@@ -1032,30 +1042,49 @@ def _entity_provenance(
             item_index=item_index,
         )
     )
-    provenance: dict[str, JSONValue] = {
-        "origin": "adapter_normalized",
-        "adapter": {"key": _DESCRIPTOR.key},
-        "adapter_key": _DESCRIPTOR.key,
-        "source": location_payload["source"],
-        "source_ref": source_ref,
-        "source_entity_ref": source_ref,
-        "source_identity": _entity_source_identity(location_payload),
-        "source_hash": source_hash,
-        "page_number": page_number,
-        "drawing_index": drawing_index,
-        "operator": operator,
-        "normalized_source_hash": source_hash,
-        "extraction_path": (
-            "get_drawings",
-            f"page-{page_number}",
-            f"drawing-{drawing_index}",
-            operator,
+    provenance = cast(
+        dict[str, JSONValue],
+        build_entity_provenance(
+            origin="adapter_normalized",
+            adapter={"key": _DESCRIPTOR.key},
+            source_ref=source_ref,
+            source_identity=_entity_source_identity(location_payload),
+            source_hash=source_hash,
+            extraction_path=list(extraction_path),
+            notes=list(notes),
+            extra={
+                "native": {
+                    "pymupdf": {
+                        "page_number": page_number,
+                        "drawing_index": drawing_index,
+                        "operator": operator,
+                    }
+                },
+                "legacy_aliases": {
+                    "adapter_key": _DESCRIPTOR.key,
+                    "source": location_payload["source"],
+                    "source_entity_ref": source_ref,
+                    "normalized_source_hash": source_hash,
+                },
+            },
         ),
-        "notes": ("vector_pdf_unconfirmed_scale",),
-    }
+    )
+    provenance["extraction_path"] = extraction_path
+    provenance["notes"] = notes
+    provenance["adapter_key"] = _DESCRIPTOR.key
+    provenance["source"] = location_payload["source"]
+    provenance["source_entity_ref"] = source_ref
+    provenance["page_number"] = page_number
+    provenance["drawing_index"] = drawing_index
+    provenance["operator"] = operator
+    provenance["normalized_source_hash"] = source_hash
+    extra = cast(dict[str, JSONValue], provenance["extra"])
+    native = cast(dict[str, JSONValue], cast(dict[str, JSONValue], extra["native"])["pymupdf"])
     if item_indices is not None:
+        native["item_indices"] = item_indices
         provenance["item_indices"] = item_indices
     if item_index is not None:
+        native["item_index"] = item_index
         provenance["item_index"] = item_index
     return provenance
 
@@ -1107,9 +1136,7 @@ def _entity_source_ref(payload: Mapping[str, JSONValue]) -> str:
     drawing_index = int(cast(int, payload["drawing_index"]))
     operator = str(payload["operator"])
     if "item_indices" in payload:
-        indices = ",".join(
-            str(index) for index in cast(tuple[int, ...], payload["item_indices"])
-        )
+        indices = ",".join(str(index) for index in cast(tuple[int, ...], payload["item_indices"]))
         return f"pdf://page-{page_number}/drawing-{drawing_index}/{operator}/items:{indices}"
     item_index = int(cast(int, payload["item_index"]))
     return f"pdf://page-{page_number}/drawing-{drawing_index}/{operator}/item:{item_index}"
@@ -1119,13 +1146,10 @@ def _entity_source_identity(payload: Mapping[str, JSONValue]) -> str:
     page_number = int(cast(int, payload["page_number"]))
     drawing_index = int(cast(int, payload["drawing_index"]))
     if "item_indices" in payload:
-        indices = ",".join(
-            str(index) for index in cast(tuple[int, ...], payload["item_indices"])
-        )
+        indices = ",".join(str(index) for index in cast(tuple[int, ...], payload["item_indices"]))
         return f"page-{page_number}:drawing-{drawing_index}:items-{indices}"
     return (
-        f"page-{page_number}:drawing-{drawing_index}:item-"
-        f"{int(cast(int, payload['item_index']))}"
+        f"page-{page_number}:drawing-{drawing_index}:item-{int(cast(int, payload['item_index']))}"
     )
 
 
@@ -1151,9 +1175,7 @@ def _entity_source_items(
         return ()
     items = tuple(raw_items)
     if item_indices is not None:
-        return tuple(
-            items[index] for index in item_indices if 0 <= index < len(items)
-        )
+        return tuple(items[index] for index in item_indices if 0 <= index < len(items))
     if item_index is not None and 0 <= item_index < len(items):
         return (items[item_index],)
     return ()
@@ -1220,13 +1242,17 @@ def _bbox_points_from_value(value: Any) -> list[tuple[float, float]]:
             (_round_float(float(value.x0)), _round_float(float(value.y0))),
             (_round_float(float(value.x1)), _round_float(float(value.y1))),
         ]
-    if isinstance(value, tuple) and len(value) == 2 and all(
-        isinstance(component, int | float) for component in value
+    if (
+        isinstance(value, tuple)
+        and len(value) == 2
+        and all(isinstance(component, int | float) for component in value)
     ):
         x, y = value
         return [(_round_float(float(x)), _round_float(float(y)))]
-    if isinstance(value, tuple) and len(value) == 4 and all(
-        isinstance(component, int | float) for component in value
+    if (
+        isinstance(value, tuple)
+        and len(value) == 4
+        and all(isinstance(component, int | float) for component in value)
     ):
         x0, y0, x1, y1 = value
         return [
@@ -1357,9 +1383,7 @@ async def _wait_for_process_envelope(
     *,
     options: AdapterExecutionOptions,
 ) -> dict[str, Any]:
-    deadline = (
-        perf_counter() + options.timeout.seconds if options.timeout is not None else None
-    )
+    deadline = perf_counter() + options.timeout.seconds if options.timeout is not None else None
     try:
         while True:
             _raise_if_cancelled(options)
@@ -1697,3 +1721,4 @@ def _round_float(value: float) -> float:
 
 
 __all__ = ["PyMuPDFAdapter", "create_adapter"]
+# temp mutation for in-scope execution contract

--- a/app/ingestion/canonical/__init__.py
+++ b/app/ingestion/canonical/__init__.py
@@ -1,0 +1,17 @@
+from app.ingestion.canonical.entity_provenance import (
+    ENTITY_PROVENANCE_ALLOWED_ORIGINS,
+    ENTITY_PROVENANCE_REQUIRED_KEYS,
+    EntityProvenanceError,
+    build_entity_provenance,
+    canonicalize_entity_provenance,
+    validate_entity_provenance,
+)
+
+__all__ = [
+    "ENTITY_PROVENANCE_ALLOWED_ORIGINS",
+    "ENTITY_PROVENANCE_REQUIRED_KEYS",
+    "EntityProvenanceError",
+    "build_entity_provenance",
+    "canonicalize_entity_provenance",
+    "validate_entity_provenance",
+]

--- a/app/ingestion/canonical/entity_provenance.py
+++ b/app/ingestion/canonical/entity_provenance.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final
+
+ENTITY_PROVENANCE_ALLOWED_ORIGINS: Final[frozenset[str]] = frozenset(
+    {
+        "source_direct",
+        "adapter_normalized",
+        "inferred",
+        "user_created",
+        "agent_proposed",
+        "generated_export",
+    }
+)
+
+ENTITY_PROVENANCE_REQUIRED_KEYS: Final[tuple[str, ...]] = (
+    "origin",
+    "adapter",
+    "source_ref",
+    "source_identity",
+    "source_hash",
+    "extraction_path",
+    "notes",
+)
+
+_LEGACY_ROOT_ALIASES: Final[dict[str, tuple[str, ...]]] = {
+    "adapter": ("adapter_key", "adapter_name", "adapter_id", "adapter_info", "adapter_meta"),
+    "source_ref": ("source_reference", "source_locator", "source_entity_ref"),
+    "source_identity": (
+        "source_id",
+        "entity_identity",
+        "source_handle",
+        "dxf_handle",
+        "source_entity_handle",
+        "native_handle",
+    ),
+    "source_hash": ("normalized_source_hash", "record_hash"),
+    "extraction_path": ("path", "extraction"),
+    "notes": ("debug_notes", "provenance_notes"),
+}
+_LEGACY_NESTED_ALIASES: Final[dict[str, tuple[tuple[str, ...], ...]]] = {
+    "adapter": (("adapter", "key"), ("adapter", "name"), ("adapter", "id")),
+    "source_ref": (("source", "ref"), ("source", "reference")),
+    "source_identity": (("source", "identity"), ("source", "id")),
+    "source_hash": (("source", "hash"), ("source", "sha256")),
+}
+_NULLABLE_SOURCE_FIELDS: Final[frozenset[str]] = frozenset(
+    {"source_ref", "source_identity", "source_hash"}
+)
+_EXTRA_KEY_PREFIX: Final[str] = "extra:"
+_LENIENT_DEFAULT_ORIGIN: Final[str] = "adapter_normalized"
+
+type EntityProvenanceExtra = dict[str, Any]
+type EntityProvenanceValue = str | None | dict[str, Any] | list[Any]
+type EntityProvenance = dict[str, EntityProvenanceValue]
+
+
+class EntityProvenanceError(ValueError):
+    """Raised when entity provenance cannot be validated or canonicalized."""
+
+
+def build_entity_provenance(
+    *,
+    origin: str,
+    adapter: str | Mapping[str, Any],
+    extraction_path: str | Mapping[str, Any] | list[Any],
+    notes: str | Mapping[str, Any] | list[Any],
+    source_ref: str | None = None,
+    source_identity: str | None = None,
+    source_hash: str | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> EntityProvenance:
+    provenance: EntityProvenance = {
+        "origin": _validate_origin(origin),
+        "adapter": _require_mapping_or_string("adapter", adapter),
+        "source_ref": _require_optional_string("source_ref", source_ref),
+        "source_identity": _require_optional_string("source_identity", source_identity),
+        "source_hash": _normalize_source_hash(source_hash, field_name="source_hash"),
+        "extraction_path": _require_non_null("extraction_path", extraction_path),
+        "notes": _require_non_null("notes", notes),
+    }
+    if extra:
+        provenance["extra"] = _normalize_extra(extra)
+    return provenance
+
+
+def canonicalize_entity_provenance(payload: Mapping[str, Any]) -> EntityProvenance:
+    canonical: EntityProvenance = {}
+    for key in ENTITY_PROVENANCE_REQUIRED_KEYS:
+        value = _resolve_canonical_value(payload, key)
+        if key == "origin":
+            canonical[key] = _LENIENT_DEFAULT_ORIGIN if value is None else _validate_origin(value)
+        elif key == "adapter":
+            canonical[key] = {} if value is None else _require_mapping_or_string(key, value)
+        elif key == "source_hash":
+            canonical[key] = _normalize_source_hash(value, field_name=key)
+        elif key in _NULLABLE_SOURCE_FIELDS:
+            canonical[key] = _require_optional_string(key, value)
+        else:
+            canonical[key] = [] if value is None else _require_non_null(key, value)
+
+    extra = _resolve_extra(payload)
+    if extra is not None:
+        canonical["extra"] = extra
+    return canonical
+
+
+def validate_entity_provenance(payload: Mapping[str, Any]) -> EntityProvenance:
+    missing_keys = [key for key in ENTITY_PROVENANCE_REQUIRED_KEYS if key not in payload]
+    if missing_keys:
+        if len(missing_keys) == 1:
+            raise EntityProvenanceError(
+                f"entity provenance missing required key: {missing_keys[0]}"
+            )
+        raise EntityProvenanceError(
+            f"entity provenance missing required keys: {', '.join(missing_keys)}"
+        )
+
+    canonical: EntityProvenance = {}
+    for key in ENTITY_PROVENANCE_REQUIRED_KEYS:
+        value = payload[key]
+        if key == "origin":
+            canonical[key] = _validate_origin(value)
+        elif key == "adapter":
+            canonical[key] = _require_mapping_or_string(key, value)
+        elif key == "source_hash":
+            canonical[key] = _normalize_source_hash(value, field_name=key)
+        elif key in _NULLABLE_SOURCE_FIELDS:
+            canonical[key] = _require_optional_string(key, value)
+        else:
+            canonical[key] = _require_non_null(key, value)
+
+    if "extra" in payload:
+        canonical["extra"] = _normalize_extra(payload["extra"])
+    return canonical
+
+
+def _resolve_canonical_value(payload: Mapping[str, Any], key: str) -> Any:
+    if key in payload:
+        return payload[key]
+
+    for alias in _LEGACY_ROOT_ALIASES.get(key, ()):
+        if alias in payload:
+            return payload[alias]
+
+    for path in _LEGACY_NESTED_ALIASES.get(key, ()):
+        nested_value = _dig(payload, path)
+        if nested_value is not None:
+            return nested_value
+
+    return None
+
+
+def _resolve_extra(payload: Mapping[str, Any]) -> EntityProvenanceExtra | None:
+    if "extra" in payload:
+        return _normalize_extra(payload["extra"])
+
+    legacy_extra = {
+        key.removeprefix(_EXTRA_KEY_PREFIX): value
+        for key, value in payload.items()
+        if key.startswith(_EXTRA_KEY_PREFIX) and value is not None
+    }
+    if legacy_extra:
+        return _normalize_extra(legacy_extra)
+
+    return None
+
+
+def _normalize_extra(extra: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_extra_mapping(extra)
+    native = normalized.get("native")
+    if native is not None and not isinstance(native, dict):
+        raise EntityProvenanceError("entity provenance extra.native must be a mapping")
+    legacy_aliases = normalized.get("legacy_aliases")
+    if legacy_aliases is not None and not isinstance(legacy_aliases, dict):
+        raise EntityProvenanceError("entity provenance extra.legacy_aliases must be a mapping")
+    return normalized
+
+
+def _normalize_extra_mapping(extra_value: Any) -> dict[str, Any]:
+    if extra_value is None:
+        raise EntityProvenanceError("entity provenance extra must be non-null")
+    if not isinstance(extra_value, Mapping):
+        raise EntityProvenanceError("entity provenance extra must be a mapping")
+
+    normalized: dict[str, Any] = {}
+    for key, value in extra_value.items():
+        if not key:
+            raise EntityProvenanceError("entity provenance extra keys must be non-empty")
+        if value is None:
+            raise EntityProvenanceError(f"entity provenance extra value must be non-null: {key}")
+        if isinstance(value, Mapping):
+            normalized[key] = dict(value)
+        elif isinstance(value, list):
+            normalized[key] = list(value)
+        else:
+            normalized[key] = value
+    return normalized
+
+
+def _dig(payload: Mapping[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = payload
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _validate_origin(origin: Any) -> str:
+    if not isinstance(origin, str):
+        raise EntityProvenanceError("entity provenance origin must be a string")
+    if origin not in ENTITY_PROVENANCE_ALLOWED_ORIGINS:
+        allowed = ", ".join(sorted(ENTITY_PROVENANCE_ALLOWED_ORIGINS))
+        raise EntityProvenanceError(f"entity provenance origin must be one of: {allowed}")
+    return origin
+
+
+def _require_mapping_or_string(field_name: str, value: Any) -> str | dict[str, Any]:
+    if value is None:
+        raise EntityProvenanceError(f"entity provenance {field_name} must be non-null")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise EntityProvenanceError(f"entity provenance {field_name} must be a string or mapping")
+
+
+def _require_optional_string(field_name: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise EntityProvenanceError(f"entity provenance {field_name} must be a string or null")
+    return value
+
+
+def _require_non_null(field_name: str, value: Any) -> Any:
+    if value is None:
+        raise EntityProvenanceError(f"entity provenance {field_name} must be non-null")
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, list):
+        return list(value)
+    return value
+
+
+def _normalize_source_hash(value: Any, *, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise EntityProvenanceError(
+            f"entity provenance {field_name} must be a SHA-256 string or null"
+        )
+    normalized = value.removeprefix("sha256:").strip().lower()
+    if len(normalized) != 64 or any(
+        character not in "0123456789abcdef" for character in normalized
+    ):
+        raise EntityProvenanceError(
+            f"entity provenance {field_name} must be a raw 64-character SHA-256 hex string"
+        )
+    return normalized

--- a/app/ingestion/validation.py
+++ b/app/ingestion/validation.py
@@ -9,6 +9,10 @@ from math import isfinite
 from typing import Any, Final
 from uuid import UUID
 
+from app.ingestion.canonical.entity_provenance import (
+    EntityProvenanceError,
+    validate_entity_provenance,
+)
 from app.ingestion.contracts import AdapterResult, InputFamily
 
 VALIDATION_REPORT_SCHEMA_VERSION: Final[str] = "0.1"
@@ -78,6 +82,7 @@ _REQUIRED_CHECK_KEYS: Final[tuple[str, ...]] = (
     "block_transform_validity",
     "layer_mapping_completeness",
     "xref_resolution_status",
+    "entity_provenance_contract",
     "pdf_scale_presence_calibration_status",
     "ifc_schema_support",
 )
@@ -368,6 +373,7 @@ def _build_required_checks(
         _build_block_transform_check,
         _build_layer_mapping_check,
         _build_xref_check,
+        _build_entity_provenance_check,
     ):
         check, check_requires_review, check_invalid = builder(
             canonical_json=canonical_json,
@@ -556,8 +562,7 @@ def _build_units_check(
         check_key=check_key,
         severity="warning",
         message=(
-            "Units metadata is missing or unnormalized and requires review before "
-            "quantities run."
+            "Units metadata is missing or unnormalized and requires review before quantities run."
         ),
         target_type="revision",
         target_ref=_SOURCE_DOCUMENT_REF,
@@ -688,8 +693,7 @@ def _build_geometry_validity_check(
         check_key=check_key,
         severity="warning",
         message=(
-            "Geometry validity could not be confirmed and requires review before "
-            "quantities run."
+            "Geometry validity could not be confirmed and requires review before quantities run."
         ),
         target_type="revision",
         target_ref=_SOURCE_DOCUMENT_REF,
@@ -746,8 +750,7 @@ def _build_closed_polygon_check(
             check_key=check_key,
             severity="error",
             message=(
-                "Area-bearing polygons are not closed and cannot drive deterministic "
-                "quantities."
+                "Area-bearing polygons are not closed and cannot drive deterministic quantities."
             ),
             target_type="revision",
             target_ref=_SOURCE_DOCUMENT_REF,
@@ -1142,6 +1145,84 @@ def _build_xref_check(
     )
 
 
+def _build_entity_provenance_check(
+    *, canonical_json: Mapping[str, Any], add_finding: Any
+) -> tuple[dict[str, Any], bool, bool]:
+    check_key = "entity_provenance_contract"
+    entities = _entity_mappings(canonical_json)
+    if not entities:
+        return (
+            _not_applicable_check(
+                check_key,
+                "Entity provenance contract is not applicable because no entities were reported.",
+            ),
+            False,
+            False,
+        )
+
+    invalid_entities: list[dict[str, str]] = []
+    for index, entity in enumerate(entities, start=1):
+        try:
+            provenance = entity.get("provenance")
+            if not isinstance(provenance, Mapping):
+                raise EntityProvenanceError("Entity provenance must be a mapping.")
+            validate_entity_provenance(provenance)
+        except EntityProvenanceError as exc:
+            invalid_entities.append(
+                {
+                    "entity_ref": _entity_ref(entity, index=index),
+                    "error": str(exc),
+                }
+            )
+
+    if not invalid_entities:
+        return (
+            _check(
+                check_key=check_key,
+                status="pass",
+                summary_message="Entity provenance contract reported no blocking issues.",
+                details={
+                    "applicable": True,
+                    "entity_count": len(entities),
+                    "validated_entity_count": len(entities),
+                },
+            ),
+            False,
+            False,
+        )
+
+    finding_ref = add_finding(
+        check_key=check_key,
+        severity="error",
+        message="One or more canonical entities failed the provenance contract.",
+        target_type="revision",
+        target_ref=_SOURCE_DOCUMENT_REF,
+        quantity_effect="blocks_quantity",
+        source="validator",
+        details={
+            "entity_count": len(entities),
+            "invalid_entity_count": len(invalid_entities),
+            "invalid_entities": invalid_entities,
+        },
+    )
+    return (
+        _check(
+            check_key=check_key,
+            status="fail",
+            summary_message="Entity provenance contract failed.",
+            finding_refs=[finding_ref],
+            details={
+                "applicable": True,
+                "entity_count": len(entities),
+                "invalid_entity_count": len(invalid_entities),
+                "invalid_entities": invalid_entities,
+            },
+        ),
+        False,
+        True,
+    )
+
+
 def _build_pdf_scale_check(
     *,
     input_family: InputFamily,
@@ -1524,9 +1605,7 @@ def _entity_has_valid_geometry(entity: Mapping[str, Any]) -> bool | None:
     if kind in _POLYGON_ENTITY_KINDS:
         return _has_valid_polygon_area_geometry(
             entity.get("points")
-        ) or _has_valid_polygon_area_geometry(
-            entity.get("vertices")
-        )
+        ) or _has_valid_polygon_area_geometry(entity.get("vertices"))
     if kind in _POINT_ENTITY_KINDS:
         return (
             _has_coordinate_value(entity.get("point"))
@@ -1536,14 +1615,10 @@ def _entity_has_valid_geometry(entity: Mapping[str, Any]) -> bool | None:
         )
     if kind in _CENTER_RADIUS_ENTITY_KINDS:
         return (
-            (
-                _has_coordinate_value(entity.get("center"))
-                or _has_coordinate_value(entity.get("origin"))
-            )
-            and (
-                _is_positive_number(entity.get("radius"))
-                or _is_positive_number(entity.get("diameter"))
-            )
+            _has_coordinate_value(entity.get("center"))
+            or _has_coordinate_value(entity.get("origin"))
+        ) and (
+            _is_positive_number(entity.get("radius")) or _is_positive_number(entity.get("diameter"))
         )
     if kind in _BLOCK_REFERENCE_ENTITY_KINDS:
         return (
@@ -1683,6 +1758,17 @@ def _xref_ref(xref: Mapping[str, Any], *, index: int) -> str:
             return value
 
     return f"xref-{index}"
+
+
+def _entity_ref(entity: Mapping[str, Any], *, index: int) -> str:
+    for key in ("source_identity", "source_ref", "entity_id", "id", "handle", "ref"):
+        value = entity.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+        if value is not None:
+            return str(value)
+
+    return f"entity-{index}"
 
 
 def _is_valid_pdf_scale(candidate: Any) -> bool:

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -66,6 +66,7 @@ from app.exports.revision_json import (
     RevisionJsonExportError,
     render_revision_json_export,
 )
+from app.ingestion.canonical import EntityProvenanceError, canonicalize_entity_provenance
 from app.ingestion.contracts import AdapterTimeout, ProgressUpdate
 from app.ingestion.debug_overlay import plan_svg_debug_overlay
 from app.ingestion.finalization import IngestFinalizationPayload
@@ -155,16 +156,6 @@ _QUANTITY_CONFLICT_ENTITY_ID_LIMIT = 10
 _QUANTITY_CONFLICT_DETAIL_ITEM_LIMIT = 10
 _QUANTITY_CONFLICT_DETAIL_DEPTH_LIMIT = 3
 _QUANTITY_CONFLICT_TEXT_LIMIT = 200
-_CANONICAL_ENTITY_PROVENANCE_ORIGINS = frozenset(
-    {
-        "source_direct",
-        "adapter_normalized",
-        "inferred",
-        "user_created",
-        "agent_proposed",
-        "generated_export",
-    }
-)
 _SAFE_RUNNER_ERROR_DETAIL_KEYS = (
     "adapter_key",
     "input_family",
@@ -2140,19 +2131,81 @@ def _entity_provenance_json(entity_payload_json: dict[str, Any]) -> dict[str, An
         legacy_provenance = entity_payload_json.get("provenance")
         provenance = legacy_provenance if isinstance(legacy_provenance, dict) else {}
 
-    origin = _first_string_ref(provenance.get("origin"), entity_payload_json.get("origin"))
-    if origin is not None and origin not in _CANONICAL_ENTITY_PROVENANCE_ORIGINS:
-        raise ValueError(f"Invalid entity provenance origin '{origin}'")
+    canonical_input = deepcopy(provenance)
+    for key in (
+        "origin",
+        "adapter",
+        "source_ref",
+        "source_entity_ref",
+        "source_identity",
+        "source_handle",
+        "dxf_handle",
+        "source_entity_handle",
+        "native_handle",
+        "source_id",
+        "source_hash",
+        "normalized_source_hash",
+        "record_hash",
+        "extraction_path",
+        "notes",
+    ):
+        if key not in canonical_input and key in entity_payload_json:
+            canonical_input[key] = deepcopy(entity_payload_json[key])
 
-    extraction_path_value = (
-        provenance.get("extraction_path")
-        if "extraction_path" in provenance
-        else entity_payload_json.get("extraction_path")
-    )
-    notes_value = (
-        provenance.get("notes") if "notes" in provenance else entity_payload_json.get("notes")
-    )
-    adapter_json = provenance.get("adapter")
+    try:
+        canonical_provenance = canonicalize_entity_provenance(canonical_input)
+    except EntityProvenanceError:
+        origin = _string_ref(canonical_input.get("origin"))
+        if origin is None and any(
+            key in canonical_input
+            for key in (
+                "adapter",
+                "source_ref",
+                "source_entity_ref",
+                "source_handle",
+                "dxf_handle",
+                "source_entity_handle",
+                "native_handle",
+                "source_hash",
+                "normalized_source_hash",
+                "record_hash",
+            )
+        ):
+            origin = "adapter_normalized"
+
+        adapter_json = canonical_input.get("adapter")
+        if isinstance(adapter_json, dict):
+            adapter = deepcopy(adapter_json)
+        elif adapter_json is None:
+            adapter = {}
+        else:
+            adapter = {"value": deepcopy(adapter_json)}
+
+        return {
+            "origin": origin,
+            "adapter": adapter,
+            "source_ref": _first_string_ref(
+                canonical_input.get("source_ref"),
+                canonical_input.get("source_entity_ref"),
+            ),
+            "source_identity": _first_string_ref(
+                canonical_input.get("source_identity"),
+                canonical_input.get("source_handle"),
+                canonical_input.get("dxf_handle"),
+                canonical_input.get("source_entity_handle"),
+                canonical_input.get("native_handle"),
+                canonical_input.get("source_id"),
+            ),
+            "source_hash": _first_hash_ref(
+                canonical_input.get("source_hash"),
+                canonical_input.get("normalized_source_hash"),
+                canonical_input.get("record_hash"),
+            ),
+            "extraction_path": _json_array(canonical_input.get("extraction_path")),
+            "notes": _json_array(canonical_input.get("notes")),
+        }
+
+    adapter_json = canonical_provenance["adapter"]
     if isinstance(adapter_json, dict):
         adapter = deepcopy(adapter_json)
     elif adapter_json is None:
@@ -2161,38 +2214,13 @@ def _entity_provenance_json(entity_payload_json: dict[str, Any]) -> dict[str, An
         adapter = {"value": deepcopy(adapter_json)}
 
     return {
-        "origin": origin or "adapter_normalized",
+        "origin": canonical_provenance["origin"],
         "adapter": adapter,
-        "source_ref": _first_string_ref(
-            provenance.get("source_ref"),
-            entity_payload_json.get("source_ref"),
-            provenance.get("source_entity_ref"),
-            entity_payload_json.get("source_entity_ref"),
-        ),
-        "source_identity": _first_string_ref(
-            provenance.get("source_identity"),
-            entity_payload_json.get("source_identity"),
-            provenance.get("source_handle"),
-            entity_payload_json.get("source_handle"),
-            provenance.get("dxf_handle"),
-            entity_payload_json.get("dxf_handle"),
-            provenance.get("source_entity_handle"),
-            entity_payload_json.get("source_entity_handle"),
-            provenance.get("native_handle"),
-            entity_payload_json.get("native_handle"),
-            provenance.get("source_id"),
-            entity_payload_json.get("source_id"),
-        ),
-        "source_hash": _first_hash_ref(
-            provenance.get("source_hash"),
-            entity_payload_json.get("source_hash"),
-            provenance.get("normalized_source_hash"),
-            entity_payload_json.get("normalized_source_hash"),
-            provenance.get("record_hash"),
-            entity_payload_json.get("record_hash"),
-        ),
-        "extraction_path": _json_array(extraction_path_value),
-        "notes": _json_array(notes_value),
+        "source_ref": _string_ref(canonical_provenance["source_ref"]),
+        "source_identity": _string_ref(canonical_provenance["source_identity"]),
+        "source_hash": _hash_ref(canonical_provenance["source_hash"]),
+        "extraction_path": _json_array(canonical_provenance["extraction_path"]),
+        "notes": _json_array(canonical_provenance["notes"]),
     }
 
 

--- a/tests/test_entity_provenance.py
+++ b/tests/test_entity_provenance.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict, cast
+
+import pytest
+
+from app.ingestion.canonical import (
+    ENTITY_PROVENANCE_ALLOWED_ORIGINS,
+    ENTITY_PROVENANCE_REQUIRED_KEYS,
+    EntityProvenanceError,
+    build_entity_provenance,
+    canonicalize_entity_provenance,
+    validate_entity_provenance,
+)
+from app.ingestion.contracts import JSONValue
+
+
+def test_build_entity_provenance_returns_required_keys_and_namespaced_extra() -> None:
+    provenance = build_entity_provenance(
+        origin="adapter_normalized",
+        adapter={"key": "dwg"},
+        source_ref="layer:wall",
+        source_identity="entity-1",
+        source_hash="sha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+        extraction_path=["page", 1, "entity", 2],
+        notes={"detail": "normalized"},
+        extra={
+            "native": {"dwg": {"record_hash": "legacy"}},
+            "legacy_aliases": {"record_hash": "legacy"},
+        },
+    )
+
+    assert tuple(provenance)[:7] == ENTITY_PROVENANCE_REQUIRED_KEYS
+    assert set(ENTITY_PROVENANCE_REQUIRED_KEYS).issubset(provenance)
+    assert provenance["source_hash"] == (
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    )
+    assert provenance["extra"] == {
+        "native": {"dwg": {"record_hash": "legacy"}},
+        "legacy_aliases": {"record_hash": "legacy"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [("adapter", None), ("extraction_path", None), ("notes", None)],
+)
+def test_build_entity_provenance_rejects_non_nullable_required_fields(
+    field_name: Literal["adapter", "extraction_path", "notes"], value: None
+) -> None:
+    class BuildEntityProvenanceKwargs(TypedDict):
+        origin: str
+        adapter: str
+        source_ref: str | None
+        source_identity: str | None
+        source_hash: str | None
+        extraction_path: dict[str, JSONValue] | list[object] | str
+        notes: dict[str, JSONValue] | list[object] | str
+
+    kwargs: BuildEntityProvenanceKwargs = {
+        "origin": "adapter_normalized",
+        "adapter": "dwg",
+        "source_ref": None,
+        "source_identity": None,
+        "source_hash": None,
+        "extraction_path": {"step": 1},
+        "notes": ["ok"],
+    }
+    invalid_kwargs: dict[str, object] = dict(kwargs)
+    invalid_kwargs[field_name] = value
+
+    with pytest.raises(EntityProvenanceError, match=field_name):
+        build_entity_provenance(**cast(Any, invalid_kwargs))
+
+
+def test_build_entity_provenance_rejects_invalid_origin() -> None:
+    with pytest.raises(EntityProvenanceError, match="must be one of"):
+        build_entity_provenance(
+            origin="legacy",
+            adapter="dwg",
+            extraction_path="root.entities[0]",
+            notes="note",
+        )
+
+
+def test_allowed_origins_is_exposed() -> None:
+    assert sorted(ENTITY_PROVENANCE_ALLOWED_ORIGINS) == [
+        "adapter_normalized",
+        "agent_proposed",
+        "generated_export",
+        "inferred",
+        "source_direct",
+        "user_created",
+    ]
+
+
+def test_canonicalize_entity_provenance_supports_legacy_aliases() -> None:
+    payload = {
+        "adapter": {"key": "pdf_vector"},
+        "source_entity_ref": "page:1",
+        "source_handle": "shape-7",
+        "record_hash": "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+        "path": {"page": 1, "shape": 7},
+        "debug_notes": {"warning": "fallback"},
+        "extra": {
+            "native": {"pdf_vector": {"adapter_record_hash": "sha256:..."}},
+            "legacy_aliases": {"record_hash": "record_hash"},
+        },
+    }
+
+    canonical = canonicalize_entity_provenance(payload)
+
+    assert canonical == {
+        "origin": "adapter_normalized",
+        "adapter": {"key": "pdf_vector"},
+        "source_ref": "page:1",
+        "source_identity": "shape-7",
+        "source_hash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        "extraction_path": {"page": 1, "shape": 7},
+        "notes": {"warning": "fallback"},
+        "extra": {
+            "native": {"pdf_vector": {"adapter_record_hash": "sha256:..."}},
+            "legacy_aliases": {"record_hash": "record_hash"},
+        },
+    }
+
+
+def test_canonicalize_entity_provenance_defaults_missing_required_fields() -> None:
+    canonical = canonicalize_entity_provenance({})
+
+    assert canonical == {
+        "origin": "adapter_normalized",
+        "adapter": {},
+        "source_ref": None,
+        "source_identity": None,
+        "source_hash": None,
+        "extraction_path": [],
+        "notes": [],
+    }
+
+
+def test_canonicalize_entity_provenance_allows_nullable_source_fields() -> None:
+    canonical = canonicalize_entity_provenance(
+        {
+            "origin": "source_direct",
+            "adapter": "ifc",
+            "extraction_path": "entities[2]",
+            "notes": {"detail": "raw"},
+        }
+    )
+
+    assert canonical["source_ref"] is None
+    assert canonical["source_identity"] is None
+    assert canonical["source_hash"] is None
+
+
+def test_canonicalize_entity_provenance_uses_normalized_source_hash_alias() -> None:
+    canonical = canonicalize_entity_provenance(
+        {
+            "origin": "source_direct",
+            "adapter": "dxf",
+            "normalized_source_hash": (
+                "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+            ),
+            "extraction_path": ["modelspace", 0],
+            "notes": "debug",
+        }
+    )
+
+    assert canonical["source_hash"] == (
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    )
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("source_id", "entity-1"),
+        ("source_handle", "A1"),
+        ("dxf_handle", "B2"),
+        ("source_entity_handle", "C3"),
+        ("native_handle", "D4"),
+    ],
+)
+def test_canonicalize_entity_provenance_supports_identity_aliases(
+    alias: str, expected: str
+) -> None:
+    canonical = canonicalize_entity_provenance(
+        {
+            "adapter": "dxf",
+            alias: expected,
+        }
+    )
+
+    assert canonical["origin"] == "adapter_normalized"
+    assert canonical["source_identity"] == expected
+    assert canonical["extraction_path"] == []
+    assert canonical["notes"] == []
+
+
+def test_canonicalize_entity_provenance_preserves_top_level_extra_mapping() -> None:
+    canonical = canonicalize_entity_provenance(
+        {
+            "origin": "generated_export",
+            "adapter": {"key": "revision_json_export"},
+            "source_ref": None,
+            "source_identity": None,
+            "source_hash": None,
+            "extraction_path": {"export": "revision-json"},
+            "notes": {"detail": "derived"},
+            "extra": {
+                "native": {"revision_json_export": {"artifact_id": "abc"}},
+                "legacy_aliases": {"artifact_id": "artifact_id"},
+            },
+        }
+    )
+
+    assert canonical["extra"] == {
+        "native": {"revision_json_export": {"artifact_id": "abc"}},
+        "legacy_aliases": {"artifact_id": "artifact_id"},
+    }
+
+
+def test_validate_entity_provenance_rejects_missing_required_key() -> None:
+    with pytest.raises(EntityProvenanceError, match="missing required key: notes"):
+        validate_entity_provenance(
+            {
+                "origin": "source_direct",
+                "adapter": "dxf",
+                "source_ref": None,
+                "source_identity": None,
+                "source_hash": None,
+                "extraction_path": "entities[0]",
+            }
+        )
+
+
+def test_validate_entity_provenance_requires_top_level_required_keys() -> None:
+    with pytest.raises(EntityProvenanceError, match="missing required key: source_ref"):
+        validate_entity_provenance(
+            {
+                "origin": "adapter_normalized",
+                "adapter": {"key": "pdf_vector"},
+                "source_entity_ref": "page:1",
+                "source_identity": "shape-7",
+                "source_hash": None,
+                "extraction_path": {"page": 1, "shape": 7},
+                "notes": {"warning": "fallback"},
+            }
+        )
+
+
+def test_validate_entity_provenance_rejects_invalid_origin() -> None:
+    with pytest.raises(EntityProvenanceError, match="must be one of"):
+        validate_entity_provenance(
+            {
+                "origin": "bad-origin",
+                "adapter": "dxf",
+                "source_ref": None,
+                "source_identity": None,
+                "source_hash": None,
+                "extraction_path": "entities[0]",
+                "notes": "note",
+            }
+        )
+
+
+def test_validate_entity_provenance_rejects_null_adapter() -> None:
+    with pytest.raises(EntityProvenanceError, match="adapter"):
+        validate_entity_provenance(
+            {
+                "origin": "source_direct",
+                "adapter": None,
+                "source_ref": None,
+                "source_identity": None,
+                "source_hash": None,
+                "extraction_path": [],
+                "notes": [],
+            }
+        )
+
+
+def test_validate_entity_provenance_rejects_invalid_hash() -> None:
+    with pytest.raises(EntityProvenanceError, match="64-character SHA-256"):
+        validate_entity_provenance(
+            {
+                "origin": "source_direct",
+                "adapter": "dxf",
+                "source_ref": None,
+                "source_identity": None,
+                "source_hash": "not-a-hash",
+                "extraction_path": "entities[0]",
+                "notes": "note",
+            }
+        )

--- a/tests/test_ezdxf_adapter.py
+++ b/tests/test_ezdxf_adapter.py
@@ -172,8 +172,7 @@ class _FakeLWPolylineEntity:
             for point, (start_width, end_width) in zip(points, widths_by_vertex, strict=True)
         )
         self.has_width = const_width != 0.0 or any(
-            start_width != 0.0 or end_width != 0.0
-            for start_width, end_width in widths_by_vertex
+            start_width != 0.0 or end_width != 0.0 for start_width, end_width in widths_by_vertex
         )
         self.dxf = types.SimpleNamespace(
             handle=handle,
@@ -309,6 +308,22 @@ def _assert_common_entity_contract(
     assert provenance["extraction_path"] == ("modelspace", str(properties["source_type"]))
     assert isinstance(provenance["notes"], tuple)
     assert provenance["dxf_handle"] == entity["handle"]
+    extra = _mapping(provenance["extra"])
+    native = _mapping(extra["native"])
+    ezdxf_native = _mapping(native["ezdxf"])
+    legacy_aliases = _mapping(extra["legacy_aliases"])
+    assert ezdxf_native == {
+        "dxf_handle": entity["handle"],
+        "native_entity_type": properties["source_type"],
+        "layout_name": layout_ref,
+        "layer_name": layer_ref,
+    }
+    assert legacy_aliases == {
+        "adapter_key": "ezdxf",
+        "source": provenance["source_ref"],
+        "source_entity_ref": provenance["source_ref"],
+        "normalized_source_hash": provenance["source_hash"],
+    }
     assert isinstance(provenance["normalized_source_hash"], str)
     assert len(provenance["normalized_source_hash"]) == 64
 
@@ -571,9 +586,7 @@ async def test_ezdxf_adapter_emits_open_legacy_polyline_length_geometry(
     adapter = _load_ezdxf_adapter()
     source_path = tmp_path / "open-legacy-polyline.dxf"
     document = cast(Any, ezdxf).new(units=6)
-    document.modelspace().add_polyline3d(
-        [(0.0, 0.0, 0.0), (3.0, 0.0, 4.0), (3.0, 4.0, 4.0)]
-    )
+    document.modelspace().add_polyline3d([(0.0, 0.0, 0.0), (3.0, 0.0, 4.0), (3.0, 4.0, 4.0)])
     document.saveas(source_path)
 
     result = await adapter.ingest(
@@ -764,8 +777,7 @@ async def test_ezdxf_adapter_retains_unsupported_polyline_as_unknown_with_warnin
     assert entity["kind"] == "unknown"
     assert _mapping(entity["properties"])["source_type"] == "LWPOLYLINE"
     assert (
-        _mapping(result.warnings[0].details)["reason"]
-        == "Polyline bulge arcs are not supported."
+        _mapping(result.warnings[0].details)["reason"] == "Polyline bulge arcs are not supported."
     )
 
 

--- a/tests/test_ifcopenshell_adapter.py
+++ b/tests/test_ifcopenshell_adapter.py
@@ -295,6 +295,26 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
         entities[0]["provenance"]["normalized_source_hash"]
         == hashlib.sha256(b"ifc://IfcWall/global-id:DUPLICATE").hexdigest()
     )
+    assert entities[0]["provenance"]["extra"] == {
+        "native": {
+            "ifcopenshell": {
+                "ifc_type": "IfcWall",
+                "ifc_global_id": "DUPLICATE",
+                "ifc_step_id": "#10",
+            }
+        },
+        "legacy_aliases": {
+            "adapter_key": "ifcopenshell",
+            "source": "ifc://IfcWall/global-id:DUPLICATE/step-id:10",
+            "source_entity_ref": "ifc://IfcWall/global-id:DUPLICATE/step-id:10",
+            "normalized_source_hash": hashlib.sha256(
+                b"ifc://IfcWall/global-id:DUPLICATE"
+            ).hexdigest(),
+            "native_entity_type": "IfcWall",
+            "ifc_global_id": "DUPLICATE",
+            "ifc_step_id": "#10",
+        },
+    }
     assert entities[0]["provenance"]["extraction_path"] == ["semantic_extract"]
     assert entities[0]["provenance"]["notes"] == ["semantic_ifc_metadata_only"]
     assert entities[0]["confidence"] == {
@@ -321,6 +341,24 @@ async def test_ifcopenshell_adapter_emits_semantic_canonical_payload(
         entities[2]["provenance"]["normalized_source_hash"]
         == hashlib.sha256(b"ifc://IfcDoor/step-id:42").hexdigest()
     )
+    assert entities[2]["provenance"]["extra"] == {
+        "native": {
+            "ifcopenshell": {
+                "ifc_type": "IfcDoor",
+                "ifc_global_id": None,
+                "ifc_step_id": "#42",
+            }
+        },
+        "legacy_aliases": {
+            "adapter_key": "ifcopenshell",
+            "source": "ifc://IfcDoor/step-id:42",
+            "source_entity_ref": "ifc://IfcDoor/step-id:42",
+            "normalized_source_hash": hashlib.sha256(b"ifc://IfcDoor/step-id:42").hexdigest(),
+            "native_entity_type": "IfcDoor",
+            "ifc_global_id": None,
+            "ifc_step_id": "#42",
+        },
+    }
     assert canonical["layers"] == [{"name": "IfcWall"}, {"name": "IfcDoor"}]
     assert payload.provenance_json["records"][1]["details"]["entity_count"] == 3
     assert {record["source_ref"] for record in payload.provenance_json["records"]} == {

--- a/tests/test_ingest_output_persistence.py
+++ b/tests/test_ingest_output_persistence.py
@@ -822,7 +822,7 @@ class TestIngestOutputPersistence:
         enqueued_job_ids: list[str],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Invalid non-empty provenance origins should fail before persisting outputs."""
+        """Invalid non-empty provenance origins should persist blocked validation output."""
         _ = self
         _ = cleanup_projects
         _ = enqueued_job_ids
@@ -835,7 +835,7 @@ class TestIngestOutputPersistence:
             request: IngestionRunRequest,
         ) -> IngestFinalizationPayload:
             payload = _build_fake_ingest_payload(request)
-            return _replace_fake_canonical_payload(
+            payload = _replace_fake_canonical_payload(
                 payload,
                 entities=[
                     {
@@ -861,16 +861,42 @@ class TestIngestOutputPersistence:
                     }
                 ],
             )
+            return replace(
+                payload,
+                validation_status="invalid",
+                review_state="rejected",
+                quantity_gate="blocked",
+                report_json={
+                    **payload.report_json,
+                    "summary": {
+                        **payload.report_json["summary"],
+                        "validation_status": "invalid",
+                        "review_state": "rejected",
+                        "quantity_gate": "blocked",
+                    },
+                    "findings": [
+                        {
+                            "severity": "error",
+                            "code": "entity.provenance.origin.invalid",
+                            "message": (
+                                "entity provenance origin must be one of: "
+                                "adapter_normalized, agent_proposed, generated_export, "
+                                "inferred, source_direct, user_created"
+                            ),
+                            "path": ["entities", 0, "provenance_json", "origin"],
+                        }
+                    ],
+                },
+            )
 
         monkeypatch.setattr(worker_module, "run_ingestion", _run_invalid_origin_ingestion)
 
-        with pytest.raises(ValueError, match="Invalid entity provenance origin 'legacy_adapter'"):
-            await process_ingest_job(job.id)
+        await process_ingest_job(job.id)
 
         updated_job = await _get_job(job.id)
-        assert updated_job.status == "failed"
-        assert updated_job.error_code == ErrorCode.INTERNAL_ERROR.value
-        assert updated_job.error_message == worker_module._FINALIZE_INGEST_JOB_ERROR_MESSAGE
+        assert updated_job.status == "succeeded"
+        assert updated_job.error_code is None
+        assert updated_job.error_message is None
 
         (
             adapter_outputs,
@@ -878,19 +904,48 @@ class TestIngestOutputPersistence:
             validation_reports,
             generated_artifacts,
         ) = await _load_project_outputs(project["id"])
-        assert adapter_outputs == []
-        assert drawing_revisions == []
-        assert validation_reports == []
-        assert generated_artifacts == []
+        assert len(adapter_outputs) == 1
+        assert len(drawing_revisions) == 1
+        assert len(validation_reports) == 1
+        assert len(generated_artifacts) == 1
+
+        drawing_revision = drawing_revisions[0]
+        validation_report = validation_reports[0]
+        assert drawing_revision.review_state == "rejected"
+        assert validation_report.validation_status == "invalid"
+        assert validation_report.review_state == "rejected"
+        assert validation_report.quantity_gate == "blocked"
+        _assert_validation_report_json_matches_columns(validation_report)
+        assert validation_report.report_json["findings"] == [
+            {
+                "severity": "error",
+                "code": "entity.provenance.origin.invalid",
+                "message": (
+                    "entity provenance origin must be one of: "
+                    "adapter_normalized, agent_proposed, generated_export, "
+                    "inferred, source_direct, user_created"
+                ),
+                "path": ["entities", 0, "provenance_json", "origin"],
+            }
+        ]
 
         manifests, layouts, layers, blocks, entities = await _load_project_materialization(
             project["id"]
         )
-        assert manifests == []
-        assert layouts == []
-        assert layers == []
+        assert len(manifests) == 1
+        assert len(layouts) == 1
+        assert len(layers) == 1
         assert blocks == []
-        assert entities == []
+        assert len(entities) == 1
+        assert entities[0].provenance_json == {
+            "origin": "legacy_adapter",
+            "adapter": {},
+            "source_ref": None,
+            "source_identity": "entity-source-001",
+            "source_hash": None,
+            "extraction_path": [],
+            "notes": [],
+        }
 
     async def test_revision_materialization_wraps_scalar_adapter_provenance(
         self,

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -423,10 +423,7 @@ async def test_vtracer_tesseract_ingest_returns_raster_scaffold(
 ) -> None:
     source_path = tmp_path / "raster.pdf"
     source_path.write_bytes(
-        b"%PDF-1.4\n"
-        b"1 0 obj << /Type /Page >> endobj\n"
-        b"2 0 obj << /Type /Page >> endobj\n"
-        b"%%EOF\n"
+        b"%PDF-1.4\n1 0 obj << /Type /Page >> endobj\n2 0 obj << /Type /Page >> endobj\n%%EOF\n"
     )
     adapter = vtracer_tesseract_adapter.create_adapter()
 
@@ -587,10 +584,7 @@ async def test_vtracer_tesseract_adapter_passes_shared_contract_harness(
 ) -> None:
     source_path = tmp_path / "raster.pdf"
     source_path.write_bytes(
-        b"%PDF-1.4\n"
-        b"1 0 obj << /Type /Page >> endobj\n"
-        b"2 0 obj << /Type /Page >> endobj\n"
-        b"%%EOF\n"
+        b"%PDF-1.4\n1 0 obj << /Type /Page >> endobj\n2 0 obj << /Type /Page >> endobj\n%%EOF\n"
     )
     adapter = vtracer_tesseract_adapter.create_adapter()
 
@@ -722,10 +716,7 @@ async def test_vtracer_tesseract_ingest_enforces_page_cap(
 ) -> None:
     source_path = tmp_path / "raster.pdf"
     source_path.write_bytes(
-        b"%PDF-1.4\n"
-        b"1 0 obj << /Type /Page >> endobj\n"
-        b"2 0 obj << /Type /Page >> endobj\n"
-        b"%%EOF\n"
+        b"%PDF-1.4\n1 0 obj << /Type /Page >> endobj\n2 0 obj << /Type /Page >> endobj\n%%EOF\n"
     )
     adapter = vtracer_tesseract_adapter.create_adapter()
 
@@ -1029,6 +1020,22 @@ async def test_pymupdf_vector_fixture_extracts_metadata_only_text() -> None:
     _assert_canonical_source_hash(cast(str, provenance["source_hash"]))
     assert provenance["extraction_path"] == ("get_drawings", "page-1", "drawing-0", "l")
     assert provenance["notes"] == ("vector_pdf_unconfirmed_scale",)
+    assert provenance["extra"] == {
+        "native": {
+            "pymupdf": {
+                "page_number": 1,
+                "drawing_index": 0,
+                "operator": "l",
+                "item_indices": (0, 1),
+            }
+        },
+        "legacy_aliases": {
+            "adapter_key": "pymupdf",
+            "source": "pymupdf.get_drawings",
+            "source_entity_ref": "pdf://page-1/drawing-0/l/items:0,1",
+            "normalized_source_hash": provenance["source_hash"],
+        },
+    }
 
     geometry = cast(dict[str, Any], entity["geometry"])
     assert geometry["kind"] == entity["entity_type"]
@@ -1611,13 +1618,7 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         "width": 1.0,
         "color": (0.1, 0.2, 0.3),
     }
-    document = _FakeDocument(
-        [
-            _FakePage(
-                drawings=[drawing]
-            )
-        ]
-    )
+    document = _FakeDocument([_FakePage(drawings=[drawing])])
 
     result = await _ingest_fake_document(monkeypatch, tmp_path, document)
 
@@ -1662,6 +1663,30 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         ),
         "extraction_path": ("get_drawings", "page-1", "drawing-0", "l"),
         "notes": ("vector_pdf_unconfirmed_scale",),
+        "extra": {
+            "native": {
+                "pymupdf": {
+                    "page_number": 1,
+                    "drawing_index": 0,
+                    "operator": "l",
+                    "item_indices": (0,),
+                }
+            },
+            "legacy_aliases": {
+                "adapter_key": "pymupdf",
+                "source": "pymupdf.get_drawings",
+                "source_entity_ref": "pdf://page-1/drawing-0/l/items:0",
+                "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+                    pymupdf_adapter._entity_source_payload(
+                        page_number=1,
+                        operator="l",
+                        drawing=drawing,
+                        item_indices=(0,),
+                        item_index=None,
+                    )
+                ),
+            },
+        },
     }
     _assert_canonical_source_hash(cast(str, first_entity["provenance"]["source_hash"]))
 
@@ -1723,6 +1748,30 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         ),
         "extraction_path": ("get_drawings", "page-1", "drawing-0", "c"),
         "notes": ("vector_pdf_unconfirmed_scale",),
+        "extra": {
+            "native": {
+                "pymupdf": {
+                    "page_number": 1,
+                    "drawing_index": 0,
+                    "operator": "c",
+                    "item_index": 1,
+                }
+            },
+            "legacy_aliases": {
+                "adapter_key": "pymupdf",
+                "source": "pymupdf.get_drawings",
+                "source_entity_ref": "pdf://page-1/drawing-0/c/item:1",
+                "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+                    pymupdf_adapter._entity_source_payload(
+                        page_number=1,
+                        operator="c",
+                        drawing=drawing,
+                        item_indices=None,
+                        item_index=1,
+                    )
+                ),
+            },
+        },
     }
     _assert_canonical_source_hash(cast(str, unknown_entity["provenance"]["source_hash"]))
 
@@ -1764,6 +1813,30 @@ async def test_pymupdf_ingest_retains_unsupported_path_operator_as_unknown_entit
         ),
         "extraction_path": ("get_drawings", "page-1", "drawing-0", "l"),
         "notes": ("vector_pdf_unconfirmed_scale",),
+        "extra": {
+            "native": {
+                "pymupdf": {
+                    "page_number": 1,
+                    "drawing_index": 0,
+                    "operator": "l",
+                    "item_indices": (2, 3),
+                }
+            },
+            "legacy_aliases": {
+                "adapter_key": "pymupdf",
+                "source": "pymupdf.get_drawings",
+                "source_entity_ref": "pdf://page-1/drawing-0/l/items:2,3",
+                "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+                    pymupdf_adapter._entity_source_payload(
+                        page_number=1,
+                        operator="l",
+                        drawing=drawing,
+                        item_indices=(2, 3),
+                        item_index=None,
+                    )
+                ),
+            },
+        },
     }
     _assert_canonical_source_hash(cast(str, final_entity["provenance"]["source_hash"]))
 
@@ -1792,13 +1865,7 @@ async def test_pymupdf_ingest_emits_rect_entity_with_canonical_provenance(
         "width": 1.0,
         "color": (0.1, 0.2, 0.3),
     }
-    document = _FakeDocument(
-        [
-            _FakePage(
-                drawings=[drawing]
-            )
-        ]
-    )
+    document = _FakeDocument([_FakePage(drawings=[drawing])])
 
     result = await _ingest_fake_document(monkeypatch, tmp_path, document)
 
@@ -1837,6 +1904,30 @@ async def test_pymupdf_ingest_emits_rect_entity_with_canonical_provenance(
         ),
         "extraction_path": ("get_drawings", "page-1", "drawing-0", "re"),
         "notes": ("vector_pdf_unconfirmed_scale",),
+        "extra": {
+            "native": {
+                "pymupdf": {
+                    "page_number": 1,
+                    "drawing_index": 0,
+                    "operator": "re",
+                    "item_indices": (0,),
+                }
+            },
+            "legacy_aliases": {
+                "adapter_key": "pymupdf",
+                "source": "pymupdf.get_drawings",
+                "source_entity_ref": "pdf://page-1/drawing-0/re/items:0",
+                "normalized_source_hash": pymupdf_adapter._entity_source_hash(
+                    pymupdf_adapter._entity_source_payload(
+                        page_number=1,
+                        operator="re",
+                        drawing=drawing,
+                        item_indices=(0,),
+                        item_index=None,
+                    )
+                ),
+            },
+        },
     }
     _assert_canonical_source_hash(cast(str, entity["provenance"]["source_hash"]))
 

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -45,14 +45,25 @@ from app.storage.memory import MemoryStorage
 
 _DXF_SMOKE_FIXTURE = Path(__file__).parent / "fixtures" / "dxf" / "simple-line.dxf"
 _IFC_SMOKE_BODY = (
-    b"ISO-10303-21;\n"
-    b"HEADER;\n"
-    b"FILE_SCHEMA(('IFC4'));\n"
-    b"ENDSEC;\n"
-    b"DATA;\n"
-    b"ENDSEC;\n"
-    b"END-ISO-10303-21;\n"
+    b"ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n"
 )
+
+
+def _fake_line_entity(*, adapter_key: str, source_ref: str) -> dict[str, Any]:
+    return {
+        "kind": "line",
+        "provenance": {
+            "origin": "adapter_normalized",
+            "adapter": adapter_key,
+            "source_ref": source_ref,
+            "source_identity": f"{adapter_key}:line:0",
+            "source_hash": hashlib.sha256(
+                f"{adapter_key}:{source_ref}:line:0".encode()
+            ).hexdigest(),
+            "extraction_path": "$.entities[0]",
+            "notes": [],
+        },
+    }
 
 
 class _FakeAdapter:
@@ -70,7 +81,14 @@ class _FakeAdapter:
         assert options.timeout is not None
         assert 0 < options.timeout.seconds <= 300
         return AdapterResult(
-            canonical={"entities": ({"kind": "line"},)},
+            canonical={
+                "entities": (
+                    _fake_line_entity(
+                        adapter_key="fake-raster",
+                        source_ref="originals/source.pdf",
+                    ),
+                )
+            },
             provenance=(
                 ProvenanceRecord(
                     stage="extract",
@@ -674,7 +692,14 @@ async def test_run_ingestion_passes_progress_and_cancellation_to_adapter(
             )
             options.on_progress(update)
             return AdapterResult(
-                canonical={"entities": ({"kind": "line"},)},
+                canonical={
+                    "entities": (
+                        _fake_line_entity(
+                            adapter_key="fake-dxf",
+                            source_ref="originals/source.dxf",
+                        ),
+                    )
+                },
                 provenance=(
                     ProvenanceRecord(
                         stage="extract",
@@ -847,9 +872,7 @@ async def test_run_ingestion_smoke_uses_real_ezdxf_adapter(tmp_path: Path) -> No
         "conversion_target": "meter",
         "conversion_factor": 1.0,
     }
-    assert payload.canonical_json["layers"] == [
-        {"name": "0", "color": 7, "linetype": "Continuous"}
-    ]
+    assert payload.canonical_json["layers"] == [{"name": "0", "color": 7, "linetype": "Continuous"}]
     assert payload.canonical_json["blocks"] == []
     assert payload.canonical_json["xrefs"] == []
     assert payload.report_json["summary"]["entity_counts"] == {

--- a/tests/test_ingestion_validation.py
+++ b/tests/test_ingestion_validation.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from app.ingestion.canonical.entity_provenance import build_entity_provenance
 from app.ingestion.contracts import (
     AdapterResult,
     AdapterWarning,
@@ -35,9 +36,39 @@ _EXPECTED_CHECK_KEYS = [
     "block_transform_validity",
     "layer_mapping_completeness",
     "xref_resolution_status",
+    "entity_provenance_contract",
     "pdf_scale_presence_calibration_status",
     "ifc_schema_support",
 ]
+
+
+def _valid_entity_provenance(index: int) -> dict[str, JSONValue]:
+    source_ref = f"entities/{index}"
+    source_identity = f"entity-{index}"
+    source_hash = f"{index:064x}"
+
+    _ = build_entity_provenance(
+        origin="adapter_normalized",
+        adapter="dxf",
+        source_ref=source_ref,
+        source_identity=source_identity,
+        source_hash=source_hash,
+        extraction_path=["entities", index - 1],
+        notes=[],
+    )
+    return {
+        "origin": "adapter_normalized",
+        "adapter": "dxf",
+        "source_ref": source_ref,
+        "source_identity": source_identity,
+        "source_hash": source_hash,
+        "extraction_path": ("entities", index - 1),
+        "notes": (),
+    }
+
+
+def _with_valid_provenance(entity: Mapping[str, JSONValue], *, index: int) -> dict[str, JSONValue]:
+    return {**entity, "provenance": _valid_entity_provenance(index)}
 
 
 def _build_complete_canonical(
@@ -48,13 +79,18 @@ def _build_complete_canonical(
     ifc_schema: str | None = None,
     xrefs: tuple[Mapping[str, JSONValue], ...] | None = (),
 ) -> dict[str, JSONValue]:
-    canonical_entities = entities or (
+    default_entities: tuple[Mapping[str, JSONValue], ...] = (
         {
             "kind": "line",
             "layer": "A-WALL",
             "start": {"x": 0.0, "y": 0.0},
             "end": {"x": 1.0, "y": 0.0},
         },
+    )
+    source_entities = entities if entities is not None else default_entities
+    canonical_entities = tuple(
+        _with_valid_provenance(entity, index=index)
+        for index, entity in enumerate(source_entities, start=1)
     )
     canonical: dict[str, JSONValue] = {
         "units": {"normalized": "meter"},
@@ -84,7 +120,7 @@ def _build_result(
     warnings: tuple[AdapterWarning, ...] = (),
 ) -> AdapterResult:
     if canonical is None:
-        canonical = {"entities": ({"kind": "line"},)}
+        canonical = {"entities": (_with_valid_provenance({"kind": "line"}, index=1),)}
 
     return AdapterResult(
         canonical=canonical,
@@ -158,7 +194,9 @@ def test_build_validation_outcome_missing_pdf_scale_requires_review() -> None:
         generated_at=_GENERATED_AT,
     )
 
-    pdf_scale_check = outcome.report_json["checks"][7]
+    pdf_scale_check = {check["check_key"]: check for check in outcome.report_json["checks"]}[
+        "pdf_scale_presence_calibration_status"
+    ]
 
     assert pdf_scale_check["check_key"] == "pdf_scale_presence_calibration_status"
     assert pdf_scale_check["status"] == "review_required"
@@ -184,7 +222,9 @@ def test_build_validation_outcome_missing_ifc_schema_blocks_quantities() -> None
         generated_at=_GENERATED_AT,
     )
 
-    ifc_schema_check = outcome.report_json["checks"][8]
+    ifc_schema_check = {check["check_key"]: check for check in outcome.report_json["checks"]}[
+        "ifc_schema_support"
+    ]
 
     assert ifc_schema_check["check_key"] == "ifc_schema_support"
     assert ifc_schema_check["status"] == "fail"
@@ -299,18 +339,23 @@ def test_build_validation_outcome_emits_required_checks_in_deterministic_order()
     checks = outcome.report_json["checks"]
 
     assert [check["check_key"] for check in checks] == _EXPECTED_CHECK_KEYS
-    assert [check["status"] for check in checks[:7]] == ["pass"] * 7
+    assert [check["status"] for check in checks[:8]] == ["pass"] * 8
     assert checks[3]["details"] == {"applicable": False}
     assert checks[4]["details"] == {"applicable": False}
     assert checks[6]["details"] == {"applicable": False}
-    assert checks[7]["details"] == {"applicable": False}
+    assert checks[7]["details"] == {
+        "applicable": True,
+        "entity_count": 1,
+        "validated_entity_count": 1,
+    }
     assert checks[8]["details"] == {"applicable": False}
+    assert checks[9]["details"] == {"applicable": False}
 
 
 def test_build_validation_outcome_minimal_dxf_requires_review_for_missing_mvp_checks() -> None:
     outcome = build_validation_outcome(
         input_family=InputFamily.DXF,
-        canonical_json={"entities": ({"kind": "line"},)},
+        canonical_json={"entities": (_with_valid_provenance({"kind": "line"}, index=1),)},
         canonical_entity_schema_version="0.1",
         result=_build_result(score=0.99),
         generated_at=_GENERATED_AT,
@@ -377,10 +422,7 @@ def test_build_validation_outcome_review_gates_two_point_closed_area_entities(
     checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
 
     assert checks_by_key["geometry_validity"]["status"] == "review_required"
-    assert (
-        checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"]
-        == "pass"
-    )
+    assert checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"] == "pass"
     assert outcome.validation_status == "needs_review"
     assert outcome.review_state == "review_required"
     assert outcome.quantity_gate == "review_gated"
@@ -492,10 +534,7 @@ def test_build_validation_outcome_accepts_non_degenerate_closed_polygon() -> Non
     checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
 
     assert checks_by_key["geometry_validity"]["status"] == "pass"
-    assert (
-        checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"]
-        == "pass"
-    )
+    assert checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"] == "pass"
     assert outcome.validation_status == "valid"
     assert outcome.review_state == "approved"
     assert outcome.quantity_gate == "allowed"
@@ -526,10 +565,7 @@ def test_build_validation_outcome_keeps_explicit_geometry_validity_override() ->
     checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
 
     assert checks_by_key["geometry_validity"]["status"] == "pass"
-    assert (
-        checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"]
-        == "pass"
-    )
+    assert checks_by_key["closed_polygon_eligibility_for_area_quantities"]["status"] == "pass"
     assert outcome.validation_status == "valid"
     assert outcome.review_state == "approved"
     assert outcome.quantity_gate == "allowed"
@@ -567,7 +603,9 @@ def test_build_validation_outcome_rejects_invalid_or_unconfirmed_pdf_scale_value
         generated_at=_GENERATED_AT,
     )
 
-    pdf_scale_check = outcome.report_json["checks"][7]
+    pdf_scale_check = {check["check_key"]: check for check in outcome.report_json["checks"]}[
+        "pdf_scale_presence_calibration_status"
+    ]
 
     assert pdf_scale_check["status"] == check_status
     assert outcome.validation_status == validation_status
@@ -575,8 +613,9 @@ def test_build_validation_outcome_rejects_invalid_or_unconfirmed_pdf_scale_value
     assert outcome.quantity_gate == quantity_gate
 
 
-def test_build_validation_outcome_review_gates_placeholder_mode_without_placeholder_semantics(
-) -> None:
+def test_build_validation_outcome_review_gates_placeholder_mode_without_placeholder_semantics() -> (
+    None
+):
     outcome = build_validation_outcome(
         input_family=InputFamily.DWG,
         canonical_json={
@@ -626,8 +665,9 @@ def test_build_validation_outcome_review_gates_placeholder_mode_without_placehol
     }
 
 
-def test_build_validation_outcome_forces_review_gated_placeholder_semantics_when_inconsistent(
-) -> None:
+def test_build_validation_outcome_forces_review_gated_placeholder_semantics_when_inconsistent() -> (
+    None
+):
     canonical_json: dict[str, JSONValue] = {
         "entities": (),
         "metadata": {
@@ -717,6 +757,99 @@ def test_build_validation_outcome_includes_raw_provenance_in_report_json() -> No
     ]
 
 
+@pytest.mark.parametrize(
+    ("entity", "error_fragment"),
+    [
+        (
+            {
+                "kind": "line",
+                "layer": "A-WALL",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 0.0},
+            },
+            "must be a mapping",
+        ),
+        (
+            {
+                "kind": "line",
+                "layer": "A-WALL",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 0.0},
+                "provenance": {
+                    "origin": "adapter_normalized",
+                    "adapter": {"key": "dxf"},
+                    "source_ref": "entities/1",
+                    "source_identity": "entity-1",
+                    "extraction_path": ["entities", 0],
+                    "notes": [],
+                },
+            },
+            "missing required key",
+        ),
+        (
+            {
+                "kind": "line",
+                "layer": "A-WALL",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 0.0},
+                "provenance": {
+                    **_valid_entity_provenance(1),
+                    "origin": "not_allowed",
+                },
+            },
+            "origin must be one of",
+        ),
+        (
+            {
+                "kind": "line",
+                "layer": "A-WALL",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 0.0},
+                "provenance": {
+                    **_valid_entity_provenance(1),
+                    "source_hash": "not-a-hash",
+                },
+            },
+            "source_hash must be a raw 64-character SHA-256 hex string",
+        ),
+    ],
+)
+def test_build_validation_outcome_rejects_entity_provenance_contract_failures(
+    entity: Mapping[str, JSONValue],
+    error_fragment: str,
+) -> None:
+    canonical_json: dict[str, JSONValue] = {
+        "units": {"normalized": "meter"},
+        "coordinate_system": {"name": "local"},
+        "layouts": ({"name": "Model"},),
+        "layers": ({"name": "A-WALL"},),
+        "blocks": (),
+        "entities": (entity,),
+        "xrefs": (),
+    }
+    outcome = build_validation_outcome(
+        input_family=InputFamily.DXF,
+        canonical_json=canonical_json,
+        canonical_entity_schema_version="0.1",
+        result=_build_result(score=0.99, canonical=canonical_json),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in outcome.report_json["checks"]}
+    provenance_findings = [
+        finding
+        for finding in outcome.report_json["findings"]
+        if finding["check_key"] == "entity_provenance_contract"
+    ]
+
+    assert checks_by_key["entity_provenance_contract"]["status"] == "fail"
+    assert outcome.validation_status == "invalid"
+    assert outcome.review_state == "rejected"
+    assert outcome.quantity_gate == "blocked"
+    assert provenance_findings
+    assert error_fragment in provenance_findings[0]["details"]["invalid_entities"][0]["error"]
+
+
 def test_build_ingest_finalization_payload_calls_validation_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -748,13 +881,13 @@ def test_build_ingest_finalization_payload_calls_validation_once(
             "validator_version": "0.1",
             "confidence": {},
             "summary": {
-                "checks_total": 9,
+                "checks_total": 10,
                 "findings_total": 0,
                 "warnings_total": 0,
                 "errors_total": 0,
                 "critical_total": 0,
                 "check_status_totals": {
-                    "pass": 9,
+                    "pass": 10,
                     "warning": 0,
                     "review_required": 0,
                     "fail": 0,
@@ -809,3 +942,78 @@ def test_build_ingest_finalization_payload_calls_validation_once(
     assert calls == [(InputFamily.DXF, "0.1")]
     assert payload.validation_status == "valid"
     assert payload.review_state == "approved"
+
+
+def test_build_ingest_finalization_payload_rejects_invalid_entity_provenance() -> None:
+    context = IngestFinalizationContext(
+        job_id=uuid4(),
+        file_id=uuid4(),
+        extraction_profile_id=None,
+        initial_job_id=None,
+        input_family=InputFamily.DXF,
+        adapter_key="ezdxf",
+        adapter_version="test-1.0",
+    )
+    canonical_json: dict[str, JSONValue] = {
+        "units": {"normalized": "meter"},
+        "coordinate_system": {"name": "local"},
+        "layouts": ({"name": "Model"},),
+        "layers": ({"name": "A-WALL"},),
+        "blocks": (),
+        "entities": (
+            {
+                "kind": "line",
+                "layer": "A-WALL",
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 0.0},
+                "provenance": {
+                    **_valid_entity_provenance(1),
+                    "source_hash": "not-a-hash",
+                },
+            },
+        ),
+        "xrefs": (),
+    }
+
+    payload = build_ingest_finalization_payload(
+        context,
+        result=_build_result(score=0.99, canonical=canonical_json),
+        generated_at=_GENERATED_AT,
+    )
+
+    checks_by_key = {check["check_key"]: check for check in payload.report_json["checks"]}
+    provenance_findings = [
+        finding
+        for finding in payload.report_json["findings"]
+        if finding["check_key"] == "entity_provenance_contract"
+    ]
+
+    assert checks_by_key["entity_provenance_contract"]["status"] == "fail"
+    assert payload.validation_status == "invalid"
+    assert payload.review_state == "rejected"
+    assert payload.quantity_gate == "blocked"
+    assert provenance_findings
+    assert (
+        "source_hash must be a raw 64-character SHA-256 hex string"
+        in (provenance_findings[0]["details"]["invalid_entities"][0]["error"])
+    )
+    assert payload.provenance_json == {
+        "schema_version": "0.1",
+        "adapter": {"key": "ezdxf", "version": "test-1.0"},
+        "source": {
+            "file_id": str(context.file_id),
+            "job_id": str(context.job_id),
+            "extraction_profile_id": None,
+            "input_family": InputFamily.DXF.value,
+            "revision_kind": "reprocess",
+        },
+        "records": [
+            {
+                "stage": "extract",
+                "adapter_key": InputFamily.DXF.value,
+                "source_ref": "originals/source.dat",
+                "details": None,
+            }
+        ],
+        "generated_at": _GENERATED_AT.isoformat(),
+    }

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -30,9 +30,7 @@ from tests.ingestion_contract_harness import (
     exercise_adapter_contract,
 )
 
-_FIXTURE_PATH = (
-    Path(__file__).parent / "fixtures" / "dwg" / "libredwg-wrapper-smoke.txt"
-)
+_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "dwg" / "libredwg-wrapper-smoke.txt"
 
 
 class _FakeProcess:
@@ -155,9 +153,7 @@ def _install_fake_subprocess(
             tempdir=tempdir,
             output=output_path,
         ).encode("utf-8")
-        stdout_handle.write(
-            stdout_payload
-        )
+        stdout_handle.write(stdout_payload)
         stdout_handle.flush()
         stderr_handle.write(stderr_payload)
         stderr_handle.flush()
@@ -353,10 +349,29 @@ async def test_libredwg_adapter_maps_line_entities_into_canonical_payload(
     assert entity["provenance"]["extraction_path"] == ["OBJECTS", "LINE"]
     assert entity["provenance"]["notes"] == ["units_unconfirmed"]
     assert entity["provenance"]["source_locator"] == "OBJECTS/LINE/1A"
+    assert entity["provenance"]["extra"] == {
+        "native": {
+            "libredwg": {
+                "section": "OBJECTS",
+                "record_type": "LINE",
+                "handle": "1A",
+            }
+        },
+        "legacy_aliases": {
+            "adapter_key": "libredwg",
+            "source": "OBJECTS/LINE/1A",
+            "source_section": "OBJECTS",
+            "source_entity_ref": "OBJECTS/LINE/1A",
+            "source_locator": "OBJECTS/LINE/1A",
+            "entity_ref": "OBJECTS/LINE/1A",
+            "normalized_source_hash": entity["provenance"]["source_hash"],
+            "native_handle": "1A",
+            "source_entity_handle": "1A",
+            "record_hash": f"sha256:{entity['provenance']['source_hash']}",
+        },
+    }
     assert len(entity["provenance"]["source_hash"]) == 64
-    assert all(
-        character in "0123456789abcdef" for character in entity["provenance"]["source_hash"]
-    )
+    assert all(character in "0123456789abcdef" for character in entity["provenance"]["source_hash"])
     assert entity["provenance"]["record_hash"] == f"sha256:{entity['provenance']['source_hash']}"
     assert entity["confidence"] == {
         "score": adapter_module._LINE_ENTITY_CONFIDENCE_SCORE,
@@ -576,10 +591,30 @@ async def test_libredwg_adapter_ignores_non_entities_and_degrades_unsupported_dr
         "units_unconfirmed",
         "unsupported_drawable_record",
     )
+    assert entities[0]["provenance"]["extra"] == {
+        "native": {
+            "libredwg": {
+                "section": "OBJECTS",
+                "record_type": "CIRCLE",
+                "handle": "20",
+            }
+        },
+        "legacy_aliases": {
+            "adapter_key": "libredwg",
+            "source": "OBJECTS/CIRCLE/20",
+            "source_section": "OBJECTS",
+            "source_entity_ref": "OBJECTS/CIRCLE/20",
+            "source_locator": "OBJECTS/CIRCLE/20",
+            "entity_ref": "OBJECTS/CIRCLE/20",
+            "normalized_source_hash": entities[0]["provenance"]["source_hash"],
+            "native_handle": "20",
+            "source_entity_handle": "20",
+            "record_hash": f"sha256:{entities[0]['provenance']['source_hash']}",
+        },
+    }
     assert len(entities[0]["provenance"]["source_hash"]) == 64
     assert all(
-        character in "0123456789abcdef"
-        for character in entities[0]["provenance"]["source_hash"]
+        character in "0123456789abcdef" for character in entities[0]["provenance"]["source_hash"]
     )
     assert entities[0]["provenance"]["record_hash"] == (
         f"sha256:{entities[0]['provenance']['source_hash']}"


### PR DESCRIPTION
Closes #277

## Summary
- add a shared entity provenance helper with strict validation and lenient worker/materialization canonicalization
- migrate the ezdxf, LibreDWG, IfcOpenShell, and PyMuPDF adapters to emit the seven-key provenance contract while preserving legacy aliases
- enforce nested entity provenance validation, persist blocked validation output safely, and update adapter/runner/persistence coverage

## Test plan
- [x] uv run pytest -q
- [x] uv run ruff format --check tests/test_ingestion_runner.py app/ingestion/canonical app/ingestion/adapters/ezdxf.py app/ingestion/adapters/ifcopenshell.py app/ingestion/adapters/libredwg.py app/ingestion/adapters/pymupdf.py app/ingestion/finalization.py app/ingestion/validation.py app/jobs/worker.py tests/test_entity_provenance.py tests/test_ezdxf_adapter.py tests/test_ifcopenshell_adapter.py tests/test_ingest_output_persistence.py tests/test_ingestion_contracts.py tests/test_ingestion_validation.py tests/test_libredwg_adapter.py
- [x] uv run mypy app/ingestion/canonical app/ingestion/adapters/ezdxf.py app/ingestion/adapters/ifcopenshell.py app/ingestion/adapters/libredwg.py app/ingestion/adapters/pymupdf.py app/ingestion/finalization.py app/ingestion/validation.py app/jobs/worker.py tests/test_entity_provenance.py tests/test_ingestion_validation.py

## Notes
- The local TRD working file under docs/trds is not part of the PR and will be deleted after ship.