### PR TITLE
ci: split DB integration lanes and pre-push gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,23 @@ jobs:
       - name: Run pytest non-integration lane
         run: uv run pytest -m "not integration and not compose_smoke and not smoke"
 
-  test-integration:
-    name: Test integration
+  test-integration-db:
+    name: Test integration (${{ matrix.lane_name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane_name: db_api
+            marker: db_api
+          - lane_name: db_worker
+            marker: db_worker
+          - lane_name: db_estimation_export
+            marker: db_estimation_export
+          - lane_name: db_lineage
+            marker: db_lineage
+          - lane_name: db_migration
+            marker: db_migration
     services:
       postgres:
         image: postgres:18-alpine
@@ -147,6 +161,6 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
 
       - name: Run pytest integration lane
-        run: uv run pytest -m "integration and not compose_smoke"
+        run: uv run pytest --durations=40 --durations-min=0.2 -m "integration and ${{ matrix.marker }} and not compose_smoke"
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,12 @@
 # Lint and typecheck targets will report "no files found" until then.
 #   make test        — Run full pytest suite
 #   make smoke       — Run fast smoke pytest lane
-#   make integration — Run DB-backed integration pytest lane
+#   make integration — Run full DB-backed integration pytest lane
+#   make integration-db-api — Run DB API integration pytest lane
+#   make integration-db-worker — Run DB worker integration pytest lane
+#   make integration-db-estimation-export — Run DB estimation/export integration pytest lane
+#   make integration-db-lineage — Run DB lineage integration pytest lane
+#   make integration-db-migration — Run DB migration integration pytest lane
 #   make compose-smoke — Run opt-in Docker Compose smoke pytest lane
 #   make format      — Run ruff formatter on app/ and tests/
 #   make check       — Run lint + typecheck + test
@@ -29,10 +34,15 @@ PRE_PUSH_HOOK = .git/hooks/pre-push
 PRE_PUSH_HOOK_VERSION = v1
 PYTEST_SMOKE_EXPRESSION = smoke and not integration and not compose_smoke
 PYTEST_INTEGRATION_EXPRESSION = integration and not compose_smoke
+PYTEST_DB_API_EXPRESSION = integration and db_api and not compose_smoke
+PYTEST_DB_WORKER_EXPRESSION = integration and db_worker and not compose_smoke
+PYTEST_DB_ESTIMATION_EXPORT_EXPRESSION = integration and db_estimation_export and not compose_smoke
+PYTEST_DB_LINEAGE_EXPRESSION = integration and db_lineage and not compose_smoke
+PYTEST_DB_MIGRATION_EXPRESSION = integration and db_migration and not compose_smoke
 PYTEST_COMPOSE_SMOKE_EXPRESSION = compose_smoke
 SMOKE_BASE_URL ?= http://localhost:8000
 
-.PHONY: sync lint typecheck test smoke integration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
+.PHONY: sync lint typecheck test smoke integration integration-db-api integration-db-worker integration-db-estimation-export integration-db-lineage integration-db-migration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
 
 sync:
 	uv sync $(UV_SYNC_ARGS)
@@ -90,3 +100,23 @@ shell-worker:
 
 migrate:
 	docker compose exec api alembic upgrade head
+
+integration-db-api:
+	uv run alembic upgrade head
+	uv run pytest -m "$(PYTEST_DB_API_EXPRESSION)"
+
+integration-db-worker:
+	uv run alembic upgrade head
+	uv run pytest -m "$(PYTEST_DB_WORKER_EXPRESSION)"
+
+integration-db-estimation-export:
+	uv run alembic upgrade head
+	uv run pytest -m "$(PYTEST_DB_ESTIMATION_EXPORT_EXPRESSION)"
+
+integration-db-lineage:
+	uv run alembic upgrade head
+	uv run pytest -m "$(PYTEST_DB_LINEAGE_EXPRESSION)"
+
+integration-db-migration:
+	uv run alembic upgrade head
+	uv run pytest -m "$(PYTEST_DB_MIGRATION_EXPRESSION)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,5 +208,10 @@ asyncio_mode = "auto"
 markers = [
     "smoke: fast in-memory smoke lane",
     "integration: tests that require database or integration resources",
+    "db_api: database integration lane for API surface tests",
+    "db_worker: database integration lane for worker/job lifecycle tests",
+    "db_estimation_export: database integration lane for estimation and export persistence tests",
+    "db_lineage: database integration lane for append-only lineage protection tests",
+    "db_migration: database integration lane for DB session and migration contract tests",
     "compose_smoke: compose-backed real-server smoke lane",
 ]

--- a/scripts/pre_push_check.py
+++ b/scripts/pre_push_check.py
@@ -15,6 +15,13 @@ from urllib.parse import urlparse
 
 ZERO_OID = "0" * 40
 EXAMPLE_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test"
+DB_INTEGRATION_PYTEST_ARGS = [
+    "uv",
+    "run",
+    "pytest",
+    "-m",
+    "integration and not compose_smoke",
+]
 SENSITIVE_PREFIXES = (
     "app/api/",
     "app/models/",
@@ -218,9 +225,9 @@ def format_database_url_message(sensitive_paths: Sequence[str]) -> str:
         f"{changed_lines}\n"
         "Set DATABASE_URL and rerun push. Example:\n"
         f"  export DATABASE_URL={EXAMPLE_DATABASE_URL}\n"
-        "This gate mirrors CI with:\n"
+        "This gate runs the DB integration lane with:\n"
         "  uv run alembic upgrade head\n"
-        "  uv run pytest"
+        '  uv run pytest -m "integration and not compose_smoke"'
     )
 
 
@@ -274,8 +281,10 @@ def run_gate(
                 file=stderr,
             )
             return 1
+        db_integration_lane = 'pytest -m "integration and not compose_smoke"'
         print(
-            "pre-push check: DB-sensitive changes detected; running alembic upgrade head.",
+            "pre-push check: DB-sensitive changes detected; running DB integration lane "
+            f"via alembic upgrade head then {db_integration_lane}.",
             file=stderr,
         )
         migration_code = exec_runner(["uv", "run", "alembic", "upgrade", "head"])
@@ -283,7 +292,8 @@ def run_gate(
             return migration_code
     else:
         print("pre-push check: no DB-sensitive changes detected.", file=stderr)
-    return exec_runner(["uv", "run", "pytest"])
+        return exec_runner(["uv", "run", "pytest"])
+    return exec_runner(DB_INTEGRATION_PYTEST_ARGS)
 
 
 def main(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,19 +64,107 @@ _TEST_ONLY_CLEANUP_TABLES: tuple[str, ...] = ("idempotency_keys",)
 
 _DATABASE_REQUIRED_REASON = "DATABASE_URL not set - skipping database tests"
 
+_DB_LANE_MARKERS: frozenset[str] = frozenset(
+    {
+        "db_api",
+        "db_worker",
+        "db_estimation_export",
+        "db_lineage",
+        "db_migration",
+    }
+)
+
+_DB_LANE_BY_TEST_FILE_KEY: dict[str, str] = {
+    "projects": "db_api",
+    "files": "db_api",
+    "idempotency": "db_api",
+    "extraction_profiles": "db_api",
+    "quantity_takeoff_api": "db_api",
+    "estimate_read_api": "db_api",
+    "export_create_api": "db_api",
+    "revision_materialization_api": "db_api",
+    "validation_report_api": "db_api",
+    "revision_quantity_estimate_flow": "db_api",
+    "smoke": "db_api",
+    "jobs": "db_worker",
+    "jobs_api": "db_worker",
+    "jobs_worker_ingest": "db_worker",
+    "jobs_worker_lifecycle": "db_worker",
+    "jobs_worker_quantity": "db_worker",
+    "jobs_worker_estimate": "db_worker",
+    "jobs_worker_exports": "db_worker",
+    "ingest_output_persistence": "db_worker",
+    "csv_exports": "db_estimation_export",
+    "revision_json_export": "db_estimation_export",
+    "estimate_pdf_export": "db_estimation_export",
+    "estimate_engine_persistence_payloads": "db_estimation_export",
+    "estimate_job_input_contract": "db_estimation_export",
+    "estimate_snapshot_item_persistence": "db_estimation_export",
+    "estimate_version_persistence": "db_estimation_export",
+    "estimation_catalog_api": "db_estimation_export",
+    "estimation_catalog_persistence": "db_estimation_export",
+    "estimation_catalog_resolver": "db_estimation_export",
+    "export_job_input_contract": "db_estimation_export",
+    "quantity_takeoff_persistence": "db_estimation_export",
+    "append_only_lineage_tables": "db_lineage",
+    "lineage_delete_restrictions": "db_lineage",
+    "db": "db_migration",
+    "jobs_base_revision_migration": "db_migration",
+    "jobs_revision_scoped_contract_migration": "db_migration",
+}
+
 # Marker for tests that require a running database.
 requires_database = pytest.mark.integration
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Skip integration tests when DATABASE_URL is not configured."""
-    if os.environ.get("DATABASE_URL"):
-        return
+def _item_test_file_key(item: pytest.Item) -> str:
+    """Return normalized `tests/test_*.py` key for lane assignment."""
 
+    item_path = getattr(item, "path", None)
+    path = Path(str(item_path)) if item_path is not None else Path(str(item.fspath))
+    return path.stem.removeprefix("test_")
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Assign DB lanes for integration tests and skip when DB URL is missing."""
+
+    has_database_url = bool(os.environ.get("DATABASE_URL"))
     skip_database = pytest.mark.skip(reason=_DATABASE_REQUIRED_REASON)
+    lane_errors: list[str] = []
+
     for item in items:
-        if "integration" in item.keywords:
+        is_integration = "integration" in item.keywords
+        if not is_integration:
+            continue
+
+        if "compose_smoke" not in item.keywords:
+            file_key = _item_test_file_key(item)
+            expected_lane = _DB_LANE_BY_TEST_FILE_KEY.get(file_key)
+            if expected_lane is None:
+                lane_errors.append(
+                    f"{item.nodeid}: missing DB lane mapping for test file key '{file_key}'"
+                )
+            else:
+                item.add_marker(getattr(pytest.mark, expected_lane))
+
+            assigned_lanes = sorted(
+                marker for marker in _DB_LANE_MARKERS if marker in item.keywords
+            )
+            if len(assigned_lanes) != 1:
+                lane_errors.append(
+                    f"{item.nodeid}: expected exactly one DB lane marker; found {assigned_lanes}"
+                )
+
+        if not has_database_url:
             item.add_marker(skip_database)
+
+    if lane_errors:
+        details = "\n - ".join(lane_errors)
+        raise pytest.UsageError(
+            "DB lane marker assignment failed for integration collection."
+            f"\n - {details}\n"
+            "Update _DB_LANE_BY_TEST_FILE_KEY in tests/conftest.py."
+        )
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,7 +1,6 @@
 """Tests for database connectivity and migrations."""
 
 import asyncio
-import os
 import subprocess
 import sys
 from collections.abc import Generator
@@ -13,12 +12,7 @@ from sqlalchemy import text
 
 from app.core.config import settings
 from app.db.session import close_db, get_engine, get_session_maker, init_db
-
-# Marker for tests that require a running database
-requires_database = pytest.mark.skipif(
-    not os.environ.get("DATABASE_URL"),
-    reason="DATABASE_URL not set - skipping database tests",
-)
+from tests.conftest import requires_database
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pre_push_check.py
+++ b/tests/test_pre_push_check.py
@@ -160,10 +160,12 @@ def test_main_requires_database_url_for_sensitive_changes() -> None:
     error_output = stderr.getvalue()
     assert "DATABASE_URL" in error_output
     assert "uv run alembic upgrade head" in error_output
+    assert 'uv run pytest -m "integration and not compose_smoke"' in error_output
+    assert "DB integration lane" in error_output
     assert "app/db/session.py" in error_output
 
 
-def test_main_runs_migration_before_pytest_for_sensitive_changes() -> None:
+def test_main_runs_migration_before_db_integration_pytest_for_sensitive_changes() -> None:
     query = QueryStub(
         {
             ("git", "diff", "--name-only", "def456..abc123"): (
@@ -188,9 +190,11 @@ def test_main_runs_migration_before_pytest_for_sensitive_changes() -> None:
     assert exit_code == 0
     assert exec_runner.calls == [
         ("uv", "run", "alembic", "upgrade", "head"),
-        ("uv", "run", "pytest"),
+        ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
     ]
-    assert "running alembic upgrade head" in stderr.getvalue()
+    error_output = stderr.getvalue()
+    assert "DB integration lane" in error_output
+    assert 'pytest -m "integration and not compose_smoke"' in error_output
 
 
 def test_main_rejects_non_local_or_non_test_database_url() -> None:


### PR DESCRIPTION
## Summary
- split DB-backed integration tests into five exclusive lanes with collection guards
- add Make and GitHub Actions targets for per-lane integration runs while keeping the full fallback target
- change DB-sensitive pre-push checks to run Alembic plus the DB integration lane instead of the full pytest suite

## Test plan
- uv run pytest -q tests/test_db.py tests/test_pre_push_check.py
- DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q -m "integration and db_migration and not compose_smoke"
- DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q -m "integration and not compose_smoke"
- uv run ruff check pyproject.toml tests/conftest.py tests/test_db.py Makefile .github/workflows/ci.yml scripts/pre_push_check.py tests/test_pre_push_check.py
- uv run ruff format --check pyproject.toml tests/conftest.py tests/test_db.py Makefile .github/workflows/ci.yml scripts/pre_push_check.py tests/test_pre_push_check.py
- uv run mypy tests/conftest.py tests/test_db.py scripts/pre_push_check.py tests/test_pre_push_check.py