### PR TITLE
refactor(api): add shared idempotent mutation orchestrator

### DIFF
--- a/app/api/idempotency.py
+++ b/app/api/idempotency.py
@@ -7,9 +7,10 @@ import hmac
 import json
 import re
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Protocol
 
 from fastapi import Header, HTTPException, status
 from fastapi.responses import JSONResponse, Response
@@ -41,6 +42,72 @@ class IdempotencyReplay:
 
 
 IdempotencyClaim = IdempotencyReservation | IdempotencyReplay
+
+
+@dataclass(frozen=True)
+class IdempotentMutationSuccess[ResultT]:
+    """Successful mutation result awaiting response serialization."""
+
+    value: ResultT
+    status_code: int
+    after_commit: Callable[[], Awaitable[None]] | None = None
+
+
+@dataclass(frozen=True)
+class IdempotentMutationKnownError:
+    """Explicit known-error snapshot that should be finalized and replayed."""
+
+    status_code: int
+    response_body: dict[str, Any] | None
+    after_commit: Callable[[], Awaitable[None]] | None = None
+
+
+class ReplayIdempotencyResponseCallable(Protocol):
+    """Typed replay helper contract for idempotent mutation orchestration."""
+
+    async def __call__(
+        self,
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+    ) -> Response | None: ...
+
+
+class ClaimIdempotencyResponseCallable(Protocol):
+    """Typed claim helper contract for idempotent mutation orchestration."""
+
+    async def __call__(
+        self,
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None: ...
+
+
+class CompleteIdempotencyResponseCallable(Protocol):
+    """Typed completion helper contract for idempotent mutation orchestration."""
+
+    async def __call__(
+        self,
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response: ...
+
+
+@dataclass(frozen=True)
+class IdempotentMutationOps:
+    """Injectable idempotency helper operations for mutation orchestration."""
+
+    replay: ReplayIdempotencyResponseCallable
+    claim: ClaimIdempotencyResponseCallable
+    complete: CompleteIdempotencyResponseCallable
 
 
 def _resolve_hash_secret() -> str:
@@ -292,3 +359,77 @@ async def complete_idempotency_response(
     if status_code == status.HTTP_204_NO_CONTENT:
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     return JSONResponse(status_code=status_code, content=response_body)
+
+
+DEFAULT_IDEMPOTENT_MUTATION_OPS = IdempotentMutationOps(
+    replay=replay_idempotency_response,
+    claim=claim_idempotency_response,
+    complete=complete_idempotency_response,
+)
+
+
+async def run_idempotent_mutation[ResultT](
+    db: AsyncSession,
+    *,
+    key: str | None,
+    fingerprint: str,
+    method: str,
+    path: str,
+    mutate: Callable[
+        [],
+        Awaitable[IdempotentMutationSuccess[ResultT] | IdempotentMutationKnownError],
+    ],
+    serialize_result: Callable[[ResultT], dict[str, Any] | None],
+    preclaim: Callable[[], Awaitable[Response | None]] | None = None,
+    reload_after_claim: Callable[[], Awaitable[None]] | None = None,
+    ops: IdempotentMutationOps | None = None,
+) -> Response:
+    """Run the shared replay/claim/mutate/complete/commit mutation flow."""
+
+    resolved_ops = ops or DEFAULT_IDEMPOTENT_MUTATION_OPS
+    replay_response = await resolved_ops.replay(
+        db,
+        key=key,
+        fingerprint=fingerprint,
+    )
+    if replay_response is not None:
+        return replay_response
+
+    if preclaim is not None:
+        preclaim_response = await preclaim()
+        if preclaim_response is not None:
+            return preclaim_response
+
+    reservation_or_response = await resolved_ops.claim(
+        db,
+        key=key,
+        fingerprint=fingerprint,
+        method=method,
+        path=path,
+    )
+    if isinstance(reservation_or_response, Response):
+        return reservation_or_response
+
+    if reservation_or_response is not None and reload_after_claim is not None:
+        await reload_after_claim()
+
+    mutation_result = await mutate()
+    if isinstance(mutation_result, IdempotentMutationKnownError):
+        response_body = mutation_result.response_body
+        after_commit = mutation_result.after_commit
+        status_code = mutation_result.status_code
+    else:
+        response_body = serialize_result(mutation_result.value)
+        after_commit = mutation_result.after_commit
+        status_code = mutation_result.status_code
+
+    response = await resolved_ops.complete(
+        db,
+        reservation_or_response,
+        status_code=status_code,
+        response_body=response_body,
+    )
+    await db.commit()
+    if after_commit is not None:
+        await after_commit()
+    return response

--- a/app/api/v1/estimation.py
+++ b/app/api/v1/estimation.py
@@ -16,12 +16,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.api.idempotency import (
-    IdempotencyReservation,
+    IdempotentMutationKnownError,
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
     build_idempotency_fingerprint,
     claim_idempotency_response,
     complete_idempotency_response,
     get_idempotency_key,
     replay_idempotency_response,
+    run_idempotent_mutation,
 )
 from app.api.pagination import decode_cursor_payload, encode_cursor_payload, raise_invalid_cursor
 from app.core.errors import ErrorCode
@@ -56,6 +59,12 @@ from app.schemas.estimation_catalog import (
 )
 
 estimation_router = APIRouter()
+
+_IDEMPOTENT_MUTATION_OPS = IdempotentMutationOps(
+    replay=replay_idempotency_response,
+    claim=claim_idempotency_response,
+    complete=complete_idempotency_response,
+)
 
 
 class _TimestampCursor(BaseModel):
@@ -111,22 +120,11 @@ def _catalog_conflict_body(kind: str) -> dict[str, Any]:
     )
 
 
-async def _raise_catalog_conflict(
-    db: AsyncSession,
-    reservation: IdempotencyReservation | None,
-    *,
-    kind: str,
-) -> None:
-    error_body = _catalog_conflict_body(kind)
-    if reservation is not None:
-        await complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_409_CONFLICT,
-            response_body=error_body,
-        )
-        await db.commit()
-    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error_body)
+def _catalog_conflict_result(kind: str) -> IdempotentMutationKnownError:
+    return IdempotentMutationKnownError(
+        status_code=status.HTTP_409_CONFLICT,
+        response_body=_catalog_conflict_body(kind),
+    )
 
 
 def _raise_input_invalid(message: str) -> None:
@@ -203,73 +201,57 @@ async def _create_catalog_entry[
     build_supersession: Callable[[CatalogPredecessorT, CatalogEntryT], Any] | None,
     serialize_created: Callable[[CatalogEntryT, UUID | None], CatalogReadT],
 ) -> CatalogReadT | Response:
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            fingerprint_namespace,
-            payload.model_dump(mode="json"),
-        )
-        replay = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay is not None:
-            return replay
-
-    if project_id is not None:
-        await _get_active_project_or_404(db, project_id)
-
+    fingerprint = build_idempotency_fingerprint(
+        fingerprint_namespace,
+        payload.model_dump(mode="json"),
+    )
     predecessor: CatalogPredecessorT | None = None
-    if supersedes_id is not None:
-        predecessor = await get_predecessor(db, supersedes_id)
-        validate_predecessor(payload, predecessor)
-        if validate_effective_window is not None:
-            validate_effective_window(payload, predecessor)
 
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=path,
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
+    async def _preclaim() -> Response | None:
+        nonlocal predecessor
+        if project_id is not None:
+            await _get_active_project_or_404(db, project_id)
+        predecessor = None
+        if supersedes_id is not None:
+            predecessor = await get_predecessor(db, supersedes_id)
+            validate_predecessor(payload, predecessor)
+            if validate_effective_window is not None:
+                validate_effective_window(payload, predecessor)
+        return None
 
-    entry = build_entry(payload)
-    db.add(entry)
+    async def _reload_after_claim() -> None:
+        await _preclaim()
 
-    try:
-        await db.flush()
-        if predecessor is not None and build_supersession is not None:
-            db.add(build_supersession(predecessor, entry))
+    async def _mutate() -> IdempotentMutationSuccess[CatalogReadT] | IdempotentMutationKnownError:
+        entry = build_entry(payload)
+        db.add(entry)
+        try:
             await db.flush()
-        await db.refresh(entry)
-    except IntegrityError:
-        await db.rollback()
-        await _raise_catalog_conflict(db, reservation, kind=conflict_kind)
+            if predecessor is not None and build_supersession is not None:
+                db.add(build_supersession(predecessor, entry))
+                await db.flush()
+            await db.refresh(entry)
+        except IntegrityError:
+            await db.rollback()
+            return _catalog_conflict_result(conflict_kind)
 
-    body = serialize_created(entry, supersedes_id)
-    response_body = body.model_dump(mode="json")
-    idempotent_response: Response | None = None
-    if reservation is not None:
-        idempotent_response = await complete_idempotency_response(
-            db,
-            reservation,
+        return IdempotentMutationSuccess(
+            value=serialize_created(entry, supersedes_id),
             status_code=status.HTTP_201_CREATED,
-            response_body=response_body,
         )
-    await db.commit()
 
-    if idempotent_response is not None:
-        return idempotent_response
-    return body
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path=path,
+        preclaim=_preclaim,
+        reload_after_claim=_reload_after_claim,
+        mutate=_mutate,
+        serialize_result=lambda body: body.model_dump(mode="json"),
+        ops=_IDEMPOTENT_MUTATION_OPS,
+    )
 
 
 async def _get_catalog_entry_or_404[CatalogReadT: BaseModel](

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -16,12 +16,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReservation,
+    IdempotentMutationKnownError,
+    IdempotentMutationSuccess,
     build_idempotency_fingerprint,
-    claim_idempotency_response,
-    complete_idempotency_response,
     get_idempotency_key,
-    replay_idempotency_response,
+    run_idempotent_mutation,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -326,38 +325,57 @@ def _raise_reprocess_base_revision_conflict() -> None:
     )
 
 
-async def _raise_upload_storage_failure(
-    db: AsyncSession,
-    reservation: IdempotencyReservation | None,
-    *,
-    message: str,
-    cause: Exception | None = None,
-) -> None:
-    """Raise a sanitized storage error and finalize idempotency when reserved."""
+def _upload_storage_failure_response_body(message: str) -> dict[str, Any]:
+    """Build a sanitized known upload storage failure response body."""
 
-    error_body = create_error_response(
+    return create_error_response(
         code=ErrorCode.STORAGE_FAILED,
         message=message,
         details=None,
     )
-    if reservation is not None:
-        await complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            response_body=error_body,
-        )
-        await db.commit()
 
-    if cause is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_body,
-        )
+
+def _known_upload_storage_failure(message: str) -> IdempotentMutationKnownError:
+    """Build an explicit replay-safe upload storage failure snapshot."""
+
+    return IdempotentMutationKnownError(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        response_body=_upload_storage_failure_response_body(message),
+    )
+
+
+def _raise_upload_storage_failure(message: str, *, cause: Exception | None = None) -> None:
+    """Raise a sanitized upload storage failure response."""
+
+    error_body = _upload_storage_failure_response_body(message)
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail=error_body,
     ) from cause
+
+
+def _serialize_uploaded_file(file_row: FileModel) -> dict[str, Any]:
+    """Serialize a file row using the public upload response contract."""
+
+    return FileRead.model_validate(_attach_initial_upload_metadata(file_row)).model_dump(
+        mode="json"
+    )
+
+
+def _serialize_job(job: Job) -> dict[str, Any]:
+    """Serialize a job row using the public jobs response contract."""
+
+    return JobRead.model_validate(job).model_dump(mode="json")
+
+
+async def _publish_ingest_job_after_commit(job_id: UUID) -> None:
+    """Best-effort publish of a committed ingest/reprocess enqueue intent."""
+
+    await publish_job_enqueue_intent(
+        job_id,
+        publisher=enqueue_ingest_job,
+        suppress_exceptions=True,
+    )
 
 
 def _attach_initial_upload_metadata(file_row: FileModel) -> FileModel:
@@ -394,12 +412,14 @@ async def upload_project_file(
 ) -> FileModel | Response:
     """Upload immutable source file bytes for a project and create ingest job."""
     if idempotency_key is None:
-        await _get_active_project_or_404(db, project_id)
+        try:
+            await _get_active_project_or_404(db, project_id)
+        except BaseException:
+            await file.close()
+            raise
 
     original_filename = file.filename or "upload.bin"
     media_type = file.content_type or "application/octet-stream"
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
 
     if len(original_filename) > _MAX_ORIGINAL_FILENAME_LENGTH:
         await _raise_input_invalid_for_upload_metadata(
@@ -414,8 +434,6 @@ async def upload_project_file(
 
     file_id = uuid.uuid4()
     staging_path = _staging_path(file_id)
-    storage_key: str | None = None
-    storage_uri: str | None = None
     detected_format: str | None = None
     upload_root = _upload_root()
     _ensure_private_directory(upload_root)
@@ -471,6 +489,52 @@ async def upload_project_file(
 
         checksum = checksum_builder.hexdigest()
         storage_key = build_original_storage_key(file_id, checksum)
+        assert detected_format is not None
+
+        async def _finalize_upload(persisted_storage_uri: str) -> FileModel:
+            try:
+                await _get_active_project_or_404(db, project_id, for_update=True)
+            except Exception:
+                await db.rollback()
+                await _cleanup_persisted_upload(storage, storage_key, persisted_storage_uri)
+                raise
+
+            extraction_profile = _build_extraction_profile(project_id)
+            db.add(extraction_profile)
+
+            ingest_job = Job(
+                id=uuid.uuid4(),
+                project_id=project_id,
+                file_id=file_id,
+                extraction_profile_id=extraction_profile.id,
+                job_type="ingest",
+                status="pending",
+                attempts=0,
+                max_attempts=3,
+                cancel_requested=False,
+            )
+
+            file_row = FileModel(
+                id=file_id,
+                project_id=project_id,
+                original_filename=original_filename,
+                media_type=media_type,
+                detected_format=detected_format,
+                storage_uri=persisted_storage_uri,
+                size_bytes=total_bytes,
+                checksum_sha256=checksum,
+                immutable=True,
+                initial_job_id=ingest_job.id,
+                initial_extraction_profile_id=extraction_profile.id,
+            )
+            db.add(file_row)
+            db.add(ingest_job)
+            prepare_job_enqueue_intent(ingest_job)
+            await db.flush()
+            await db.refresh(file_row)
+            await db.refresh(ingest_job)
+
+            return _attach_initial_upload_metadata(file_row)
 
         if idempotency_key is not None:
             fingerprint = build_idempotency_fingerprint(
@@ -484,50 +548,68 @@ async def upload_project_file(
                     "checksum_sha256": checksum,
                 },
             )
-            replay = await replay_idempotency_response(
-                db,
-                key=idempotency_key,
-                fingerprint=fingerprint,
-            )
-            if replay is not None:
-                return replay
-            await _get_active_project_or_404(db, project_id)
-            claim = await claim_idempotency_response(
+
+            async def _preclaim_upload() -> Response | None:
+                await _get_active_project_or_404(db, project_id)
+                return None
+
+            async def _mutate_upload() -> (
+                IdempotentMutationSuccess[FileModel] | IdempotentMutationKnownError
+            ):
+                try:
+                    stored_object = await storage.put(storage_key, staging_path, immutable=True)
+                except FileExistsError:
+                    return _known_upload_storage_failure(
+                        "Storage collision occurred during upload."
+                    )
+                except OSError:
+                    return _known_upload_storage_failure("Failed to persist uploaded file.")
+
+                if stored_object.checksum_sha256 != checksum:
+                    await _cleanup_persisted_upload(storage, storage_key, stored_object.storage_uri)
+                    return _known_upload_storage_failure("Stored file checksum mismatch detected.")
+
+                file_row = await _finalize_upload(stored_object.storage_uri)
+                return IdempotentMutationSuccess(
+                    value=file_row,
+                    status_code=status.HTTP_201_CREATED,
+                    after_commit=lambda: _publish_ingest_job_after_commit(
+                        cast(UUID, file_row.initial_job_id)
+                    ),
+                )
+
+            return await run_idempotent_mutation(
                 db,
                 key=idempotency_key,
                 fingerprint=fingerprint,
                 method="POST",
                 path=f"/projects/{project_id}/files",
+                preclaim=_preclaim_upload,
+                mutate=_mutate_upload,
+                serialize_result=_serialize_uploaded_file,
             )
-            if isinstance(claim, Response):
-                return claim
-            assert claim is not None
-            reservation = claim
 
         try:
             stored_object = await storage.put(storage_key, staging_path, immutable=True)
             if stored_object.checksum_sha256 != checksum:
                 await _cleanup_persisted_upload(storage, storage_key, stored_object.storage_uri)
-                await _raise_upload_storage_failure(
-                    db,
-                    reservation,
-                    message="Stored file checksum mismatch detected.",
-                )
+                _raise_upload_storage_failure("Stored file checksum mismatch detected.")
             storage_uri = stored_object.storage_uri
         except FileExistsError as exc:
-            await _raise_upload_storage_failure(
-                db,
-                reservation,
-                message="Storage collision occurred during upload.",
+            _raise_upload_storage_failure(
+                "Storage collision occurred during upload.",
                 cause=exc,
             )
         except OSError as exc:
-            await _raise_upload_storage_failure(
-                db,
-                reservation,
-                message="Failed to persist uploaded file.",
+            _raise_upload_storage_failure(
+                "Failed to persist uploaded file.",
                 cause=exc,
             )
+
+        file_row = await _finalize_upload(storage_uri)
+        await db.commit()
+        await _publish_ingest_job_after_commit(cast(UUID, file_row.initial_job_id))
+        return file_row
     except HTTPException:
         _cleanup_uploaded_path(staging_path)
         raise
@@ -537,77 +619,6 @@ async def upload_project_file(
     finally:
         _cleanup_uploaded_path(staging_path)
         await file.close()
-
-    assert detected_format is not None
-    assert storage_key is not None
-    assert storage_uri is not None
-
-    try:
-        await _get_active_project_or_404(db, project_id, for_update=True)
-    except Exception:
-        await db.rollback()
-        await _cleanup_persisted_upload(storage, storage_key, storage_uri)
-        raise
-
-    extraction_profile = _build_extraction_profile(project_id)
-    db.add(extraction_profile)
-
-    ingest_job = Job(
-        id=uuid.uuid4(),
-        project_id=project_id,
-        file_id=file_id,
-        extraction_profile_id=extraction_profile.id,
-        job_type="ingest",
-        status="pending",
-        attempts=0,
-        max_attempts=3,
-        cancel_requested=False,
-    )
-
-    file_row = FileModel(
-        id=file_id,
-        project_id=project_id,
-        original_filename=original_filename,
-        media_type=media_type,
-        detected_format=detected_format,
-        storage_uri=storage_uri,
-        size_bytes=total_bytes,
-        checksum_sha256=checksum,
-        immutable=True,
-        initial_job_id=ingest_job.id,
-        initial_extraction_profile_id=extraction_profile.id,
-    )
-    db.add(file_row)
-    db.add(ingest_job)
-    prepare_job_enqueue_intent(ingest_job)
-    await db.flush()
-    await db.refresh(file_row)
-    await db.refresh(ingest_job)
-
-    success_body: dict[str, Any] | None = None
-    idempotent_response: Response | None = None
-    if reservation is not None:
-        success_body = FileRead.model_validate(
-            _attach_initial_upload_metadata(file_row)
-        ).model_dump(mode="json")
-        idempotent_response = await complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_201_CREATED,
-            response_body=success_body,
-        )
-
-    await db.commit()
-    await publish_job_enqueue_intent(
-        ingest_job.id,
-        publisher=enqueue_ingest_job,
-        suppress_exceptions=True,
-    )
-
-    if idempotent_response is not None:
-        return idempotent_response
-
-    return _attach_initial_upload_metadata(file_row)
 
 
 @files_router.post(
@@ -623,50 +634,83 @@ async def reprocess_project_file(
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> Job | Response:
     """Create a new pending reprocess job for an existing file and profile selection."""
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
+    if idempotency_key is None:
+        await _get_active_project_or_404(db, project_id)
+        await _get_project_file_or_404(db, project_id, file_id)
+        if request.extraction_profile_id is not None:
+            await _get_existing_project_extraction_profile_or_404(
+                db,
+                project_id,
+                request.extraction_profile_id,
+            )
+
     if idempotency_key is not None:
         fingerprint = build_idempotency_fingerprint(
             f"files.reprocess:{project_id}:{file_id}",
             request.model_dump(mode="json"),
         )
-        replay = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay is not None:
-            return replay
 
-    await _get_active_project_or_404(db, project_id)
-    await _get_project_file_or_404(db, project_id, file_id)
-    if request.extraction_profile_id is not None:
-        await _get_existing_project_extraction_profile_or_404(
-            db,
-            project_id,
-            request.extraction_profile_id,
-        )
+        async def _preclaim_reprocess() -> Response | None:
+            await _get_active_project_or_404(db, project_id)
+            await _get_project_file_or_404(db, project_id, file_id)
+            if request.extraction_profile_id is not None:
+                await _get_existing_project_extraction_profile_or_404(
+                    db,
+                    project_id,
+                    request.extraction_profile_id,
+                )
 
-    if idempotency_key is not None:
-        await _get_active_project_or_404(db, project_id, for_update=True)
-        await _get_project_file_or_404(db, project_id, file_id, for_update=True)
-        if await _get_latest_finalized_revision(db, project_id, file_id) is None:
-            await db.rollback()
-            _raise_reprocess_base_revision_conflict()
+            await _get_active_project_or_404(db, project_id, for_update=True)
+            await _get_project_file_or_404(db, project_id, file_id, for_update=True)
+            if await _get_latest_finalized_revision(db, project_id, file_id) is None:
+                await db.rollback()
+                _raise_reprocess_base_revision_conflict()
+            return None
 
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
+        async def _mutate_reprocess() -> IdempotentMutationSuccess[Job]:
+            await _get_active_project_or_404(db, project_id, for_update=True)
+            await _get_project_file_or_404(db, project_id, file_id, for_update=True)
+            base_revision = await _get_latest_finalized_revision(db, project_id, file_id)
+            if base_revision is None:
+                await db.rollback()
+                _raise_reprocess_base_revision_conflict()
+            assert base_revision is not None
+
+            extraction_profile = await _resolve_project_extraction_profile(db, project_id, request)
+
+            ingest_job = Job(
+                project_id=project_id,
+                file_id=file_id,
+                extraction_profile_id=extraction_profile.id,
+                base_revision_id=base_revision.id,
+                job_type="reprocess",
+                status="pending",
+                attempts=0,
+                max_attempts=3,
+                cancel_requested=False,
+            )
+            db.add(ingest_job)
+            prepare_job_enqueue_intent(ingest_job)
+            await db.flush()
+            await db.refresh(ingest_job)
+
+            return IdempotentMutationSuccess(
+                value=ingest_job,
+                status_code=status.HTTP_202_ACCEPTED,
+                after_commit=lambda: _publish_ingest_job_after_commit(ingest_job.id),
+            )
+
+        return await run_idempotent_mutation(
             db,
             key=idempotency_key,
             fingerprint=fingerprint,
             method="POST",
             path=f"/projects/{project_id}/files/{file_id}/reprocess",
+            preclaim=_preclaim_reprocess,
+            mutate=_mutate_reprocess,
+            serialize_result=_serialize_job,
         )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
+
     await _get_active_project_or_404(db, project_id, for_update=True)
     await _get_project_file_or_404(db, project_id, file_id, for_update=True)
     base_revision = await _get_latest_finalized_revision(db, project_id, file_id)
@@ -693,26 +737,8 @@ async def reprocess_project_file(
     await db.flush()
     await db.refresh(ingest_job)
 
-    success_body: dict[str, Any] | None = None
-    idempotent_response: Response | None = None
-    if reservation is not None:
-        success_body = JobRead.model_validate(ingest_job).model_dump(mode="json")
-        idempotent_response = await complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=success_body,
-        )
-
     await db.commit()
-    await publish_job_enqueue_intent(
-        ingest_job.id,
-        publisher=enqueue_ingest_job,
-        suppress_exceptions=True,
-    )
-
-    if idempotent_response is not None:
-        return idempotent_response
+    await _publish_ingest_job_after_commit(ingest_job.id)
 
     return ingest_job
 

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -1,7 +1,7 @@
 """Job status endpoints."""
 
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
@@ -10,12 +10,14 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReservation,
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
     build_idempotency_fingerprint,
     claim_idempotency_response,
     complete_idempotency_response,
     get_idempotency_key,
     replay_idempotency_response,
+    run_idempotent_mutation,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -41,6 +43,12 @@ jobs_router = APIRouter()
 _DEFAULT_EVENTS_LIMIT = 50
 _MAX_EVENTS_LIMIT = 200
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
+
+_IDEMPOTENT_MUTATION_OPS = IdempotentMutationOps(
+    replay=replay_idempotency_response,
+    claim=claim_idempotency_response,
+    complete=complete_idempotency_response,
+)
 
 
 async def _get_job_or_404(db: AsyncSession, job_id: UUID) -> Job:
@@ -196,6 +204,11 @@ def _decode_job_events_cursor(cursor: str) -> tuple[datetime, int | None, UUID]:
     return created_at.astimezone(UTC), sequence_id, cursor_id
 
 
+def _serialize_job(job: Job) -> dict[str, Any]:
+    """Serialize a job row for idempotent mutation snapshots."""
+    return JobRead.model_validate(job).model_dump(mode="json")
+
+
 @jobs_router.get(
     "/jobs/{job_id}",
     response_model=JobRead,
@@ -277,75 +290,54 @@ async def cancel_job(
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> Job | Response:
     """Request cancellation for a persisted job."""
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            f"jobs.cancel:{job_id}",
-            {"job_id": str(job_id)},
-        )
-        replay = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay is not None:
-            return replay
-
-    project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
-
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/jobs/{job_id}/cancel",
-        )
-        if isinstance(claim, Response):
-            return claim
-        reservation = claim
-
-    await _get_project_for_job_update_or_404(
-        db,
-        job_id=job_id,
-        project_id=project_id,
+    fingerprint = build_idempotency_fingerprint(
+        f"jobs.cancel:{job_id}",
+        {"job_id": str(job_id)},
     )
-    job = await _get_job_for_update_or_404(
-        db,
-        job_id,
-        expected_project_id=project_id,
-        expected_file_id=file_id,
-    )
-    if job.status in _TERMINAL_JOB_STATUSES:
-        if reservation is not None:
-            response = await complete_idempotency_response(
-                db,
-                reservation,
-                status_code=status.HTTP_202_ACCEPTED,
-                response_body=JobRead.model_validate(job).model_dump(mode="json"),
-            )
-            await db.commit()
-            return response
-        return job
+    project_id: UUID | None = None
+    file_id: UUID | None = None
 
-    job.cancel_requested = True
-    if reservation is not None:
-        await db.flush()
-        await db.refresh(job)
-        response = await complete_idempotency_response(
+    async def _preclaim_cancel() -> Response | None:
+        nonlocal project_id, file_id
+        project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
+        return None
+
+    async def _mutate_cancel() -> IdempotentMutationSuccess[Job]:
+        assert project_id is not None
+        assert file_id is not None
+
+        await _get_project_for_job_update_or_404(
             db,
-            reservation,
+            job_id=job_id,
+            project_id=project_id,
+        )
+        job = await _get_job_for_update_or_404(
+            db,
+            job_id,
+            expected_project_id=project_id,
+            expected_file_id=file_id,
+        )
+        if job.status not in _TERMINAL_JOB_STATUSES:
+            job.cancel_requested = True
+            await db.flush()
+            await db.refresh(job)
+
+        return IdempotentMutationSuccess(
+            value=job,
             status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(job).model_dump(mode="json"),
         )
-        await db.commit()
-        return response
 
-    await db.commit()
-    await db.refresh(job)
-    return job
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path=f"/jobs/{job_id}/cancel",
+        preclaim=_preclaim_cancel,
+        mutate=_mutate_cancel,
+        serialize_result=_serialize_job,
+        ops=_IDEMPOTENT_MUTATION_OPS,
+    )
 
 
 @jobs_router.post(
@@ -359,102 +351,73 @@ async def retry_job(
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> Job | Response:
     """Requeue a failed persisted job when attempts remain."""
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            f"jobs.retry:{job_id}",
-            {"job_id": str(job_id)},
-        )
-        replay = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay is not None:
-            return replay
-
-    project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
-
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/jobs/{job_id}/retry",
-        )
-        if isinstance(claim, Response):
-            return claim
-        reservation = claim
-
-    job = await _lock_retry_source_or_404(
-        db,
-        job_id,
-        project_id=project_id,
-        file_id=file_id,
+    fingerprint = build_idempotency_fingerprint(
+        f"jobs.retry:{job_id}",
+        {"job_id": str(job_id)},
     )
-    if job.status != "failed" or job.attempts >= job.max_attempts:
-        if reservation is not None:
-            response = await complete_idempotency_response(
-                db,
-                reservation,
-                status_code=status.HTTP_202_ACCEPTED,
-                response_body=JobRead.model_validate(job).model_dump(mode="json"),
-            )
-            await db.commit()
-            return response
-        return job
+    project_id: UUID | None = None
+    file_id: UUID | None = None
 
-    if job.error_code == ErrorCode.REVISION_CONFLICT.value:
-        if reservation is not None:
-            response = await complete_idempotency_response(
-                db,
-                reservation,
-                status_code=status.HTTP_202_ACCEPTED,
-                response_body=JobRead.model_validate(job).model_dump(mode="json"),
-            )
-            await db.commit()
-            return response
-        return job
+    async def _preclaim_retry() -> Response | None:
+        nonlocal project_id, file_id
+        project_id, file_id = await _get_job_lock_metadata_or_404(db, job_id)
+        return None
 
-    if not is_recoverable_enqueue_job_type(job.job_type):
-        if reservation is not None:
-            response = await complete_idempotency_response(
-                db,
-                reservation,
-                status_code=status.HTTP_202_ACCEPTED,
-                response_body=JobRead.model_validate(job).model_dump(mode="json"),
-            )
-            await db.commit()
-            return response
-        return job
+    async def _mutate_retry() -> IdempotentMutationSuccess[Job]:
+        assert project_id is not None
+        assert file_id is not None
 
-    job.status = "pending"
-    job.cancel_requested = False
-    job.error_code = None
-    job.error_message = None
-    job.started_at = None
-    job.finished_at = None
-    prepare_job_enqueue_intent(job)
-    await db.flush()
-    await db.refresh(job)
-
-    retry_response: Response | None = None
-    if reservation is not None:
-        retry_response = await complete_idempotency_response(
+        job = await _lock_retry_source_or_404(
             db,
-            reservation,
+            job_id,
+            project_id=project_id,
+            file_id=file_id,
+        )
+        if job.status != "failed" or job.attempts >= job.max_attempts:
+            return IdempotentMutationSuccess(
+                value=job,
+                status_code=status.HTTP_202_ACCEPTED,
+            )
+
+        if job.error_code == ErrorCode.REVISION_CONFLICT.value:
+            return IdempotentMutationSuccess(
+                value=job,
+                status_code=status.HTTP_202_ACCEPTED,
+            )
+
+        if not is_recoverable_enqueue_job_type(job.job_type):
+            return IdempotentMutationSuccess(
+                value=job,
+                status_code=status.HTTP_202_ACCEPTED,
+            )
+
+        job.status = "pending"
+        job.cancel_requested = False
+        job.error_code = None
+        job.error_message = None
+        job.started_at = None
+        job.finished_at = None
+        prepare_job_enqueue_intent(job)
+        await db.flush()
+        await db.refresh(job)
+
+        async def _publish_retry_after_commit() -> None:
+            await publish_job_enqueue_intent(job.id, suppress_exceptions=True)
+
+        return IdempotentMutationSuccess(
+            value=job,
             status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(job).model_dump(mode="json"),
+            after_commit=_publish_retry_after_commit,
         )
 
-    await db.commit()
-    await publish_job_enqueue_intent(job.id, suppress_exceptions=True)
-
-    if reservation is not None:
-        assert retry_response is not None
-        return retry_response
-
-    return job
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path=f"/jobs/{job_id}/retry",
+        preclaim=_preclaim_retry,
+        mutate=_mutate_retry,
+        serialize_result=_serialize_job,
+        ops=_IDEMPOTENT_MUTATION_OPS,
+    )

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -1,7 +1,7 @@
 """Project CRUD endpoints."""
 
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
@@ -10,12 +10,14 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
-    IdempotencyReservation,
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
     build_idempotency_fingerprint,
     claim_idempotency_response,
     complete_idempotency_response,
     get_idempotency_key,
     replay_idempotency_response,
+    run_idempotent_mutation,
 )
 from app.api.pagination import (
     decode_cursor_payload,
@@ -37,6 +39,12 @@ from app.schemas.project import (
 )
 
 project_router = APIRouter()
+
+_IDEMPOTENT_MUTATION_OPS = IdempotentMutationOps(
+    replay=replay_idempotency_response,
+    claim=claim_idempotency_response,
+    complete=complete_idempotency_response,
+)
 
 
 async def _get_active_project_or_404(
@@ -85,44 +93,41 @@ async def create_project(
     project_in: ProjectCreate,
     db: Annotated[AsyncSession, Depends(get_db)],
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
-) -> Project | Response:
+) -> Response:
     """Create a new project."""
-    claim = await claim_idempotency_response(
-        db,
-        key=idempotency_key,
-        fingerprint=build_idempotency_fingerprint(
-            "projects.create",
-            project_in.model_dump(mode="json", exclude_unset=True),
-        ),
-        method="POST",
-        path="/projects",
+    fingerprint = build_idempotency_fingerprint(
+        "projects.create",
+        project_in.model_dump(mode="json", exclude_unset=True),
     )
-    if isinstance(claim, Response):
-        return claim
-    reservation = claim
 
-    project = Project(
-        name=project_in.name,
-        description=project_in.description,
-        default_unit_system=project_in.default_unit_system,
-        default_currency=project_in.default_currency,
-    )
-    db.add(project)
-    if reservation is not None:
+    async def _mutate() -> IdempotentMutationSuccess[Project]:
+        project = Project(
+            name=project_in.name,
+            description=project_in.description,
+            default_unit_system=project_in.default_unit_system,
+            default_currency=project_in.default_currency,
+        )
+        db.add(project)
         await db.flush()
         await db.refresh(project)
-        response = await complete_idempotency_response(
-            db,
-            reservation,
+        return IdempotentMutationSuccess(
+            value=project,
             status_code=status.HTTP_201_CREATED,
-            response_body=ProjectRead.model_validate(project).model_dump(mode="json"),
         )
-        await db.commit()
-        return response
 
-    await db.commit()
-    await db.refresh(project)
-    return project
+    def _serialize_project(project: Project) -> dict[str, Any]:
+        return ProjectRead.model_validate(project).model_dump(mode="json")
+
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path="/projects",
+        mutate=_mutate,
+        serialize_result=_serialize_project,
+        ops=_IDEMPOTENT_MUTATION_OPS,
+    )
 
 
 @project_router.get(
@@ -195,58 +200,53 @@ async def update_project(
     project_in: ProjectUpdate,
     db: Annotated[AsyncSession, Depends(get_db)],
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
-) -> Project | Response:
+) -> Response:
     """Update an existing project."""
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            f"projects.update:{project_id}",
-            project_in.model_dump(mode="json", exclude_unset=True),
-        )
-        replay = await replay_idempotency_response(
-            db,
-            fingerprint=fingerprint,
-            key=idempotency_key,
-        )
-        if replay is not None:
-            return replay
+    fingerprint = build_idempotency_fingerprint(
+        f"projects.update:{project_id}",
+        project_in.model_dump(mode="json", exclude_unset=True),
+    )
+    project: Project | None = None
 
-    project = await _get_active_project_or_404(db, project_id)
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="PATCH",
-            path=f"/projects/{project_id}",
-        )
-        if isinstance(claim, Response):
-            return claim
-        reservation = claim
+    async def _preclaim() -> Response | None:
+        nonlocal project
+        project = await _get_active_project_or_404(db, project_id)
+        return None
+
+    async def _reload_after_claim() -> None:
+        nonlocal project
         project = await _get_active_project_or_404(db, project_id)
 
-    # Update only provided fields
-    update_data = project_in.model_dump(exclude_unset=True)
-    for field, value in update_data.items():
-        setattr(project, field, value)
-
-    if reservation is not None:
+    async def _mutate() -> IdempotentMutationSuccess[Project]:
+        nonlocal project
+        if project is None:
+            project = await _get_active_project_or_404(db, project_id)
+        assert project is not None
+        update_data = project_in.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(project, field, value)
         await db.flush()
         await db.refresh(project)
-        response = await complete_idempotency_response(
-            db,
-            reservation,
+        return IdempotentMutationSuccess(
+            value=project,
             status_code=status.HTTP_200_OK,
-            response_body=ProjectRead.model_validate(project).model_dump(mode="json"),
         )
-        await db.commit()
-        return response
 
-    await db.commit()
-    await db.refresh(project)
-    return project
+    def _serialize_project(project: Project) -> dict[str, Any]:
+        return ProjectRead.model_validate(project).model_dump(mode="json")
+
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="PATCH",
+        path=f"/projects/{project_id}",
+        preclaim=_preclaim,
+        reload_after_claim=_reload_after_claim,
+        mutate=_mutate,
+        serialize_result=_serialize_project,
+        ops=_IDEMPOTENT_MUTATION_OPS,
+    )
 
 
 @project_router.delete(
@@ -259,79 +259,79 @@ async def delete_project(
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> Response:
     """Delete a project."""
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = build_idempotency_fingerprint(
-            f"projects.delete:{project_id}",
-            {"project_id": str(project_id)},
-        )
-        replay = await replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay is not None:
-            return replay
+    fingerprint = build_idempotency_fingerprint(
+        f"projects.delete:{project_id}",
+        {"project_id": str(project_id)},
+    )
+    project: Project | None = None
 
-    await _get_active_project_or_404(db, project_id)
+    async def _preclaim() -> Response | None:
+        await _get_active_project_or_404(db, project_id)
+        return None
 
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="DELETE",
-            path=f"/projects/{project_id}",
-        )
-        if isinstance(claim, Response):
-            return claim
-        reservation = claim
+    async def _reload_after_claim() -> None:
+        nonlocal project
+        project = await _get_active_project_or_404(db, project_id, for_update=True)
 
-    project = await _get_active_project_or_404(db, project_id, for_update=True)
-    locked_jobs = (
-        (
-            await db.execute(
-                select(Job)
-                .where((Job.project_id == project_id) & (Job.status.in_(("pending", "running"))))
-                .order_by(Job.created_at.asc(), Job.id.asc())
-                .with_for_update(of=Job)
+    async def _mutate() -> IdempotentMutationSuccess[None]:
+        nonlocal project
+        if project is None:
+            project = await _get_active_project_or_404(db, project_id, for_update=True)
+        assert project is not None
+        locked_jobs = (
+            (
+                await db.execute(
+                    select(Job)
+                    .where(
+                        (Job.project_id == project_id) & (Job.status.in_(("pending", "running")))
+                    )
+                    .order_by(Job.created_at.asc(), Job.id.asc())
+                    .with_for_update(of=Job)
+                )
             )
+            .scalars()
+            .all()
         )
-        .scalars()
-        .all()
-    )
-    deleted_at = datetime.now(UTC)
-    project.deleted_at = deleted_at
-    for job in locked_jobs:
-        job.status = "cancelled"
-        job.cancel_requested = True
-        job.error_code = ErrorCode.JOB_CANCELLED.value
-        job.error_message = None
-        job.finished_at = deleted_at
-        job.attempt_token = None
-        job.attempt_lease_expires_at = None
-    await db.execute(
-        update(File)
-        .where((File.project_id == project_id) & (File.deleted_at.is_(None)))
-        .values(deleted_at=deleted_at)
-    )
-    await db.execute(
-        update(GeneratedArtifact)
-        .where(
-            (GeneratedArtifact.project_id == project_id) & (GeneratedArtifact.deleted_at.is_(None))
+        deleted_at = datetime.now(UTC)
+        project.deleted_at = deleted_at
+        for job in locked_jobs:
+            job.status = "cancelled"
+            job.cancel_requested = True
+            job.error_code = ErrorCode.JOB_CANCELLED.value
+            job.error_message = None
+            job.finished_at = deleted_at
+            job.attempt_token = None
+            job.attempt_lease_expires_at = None
+        await db.execute(
+            update(File)
+            .where((File.project_id == project_id) & (File.deleted_at.is_(None)))
+            .values(deleted_at=deleted_at)
         )
-        .values(deleted_at=deleted_at)
-    )
-    if reservation is not None:
-        response = await complete_idempotency_response(
-            db,
-            reservation,
+        await db.execute(
+            update(GeneratedArtifact)
+            .where(
+                (GeneratedArtifact.project_id == project_id)
+                & (GeneratedArtifact.deleted_at.is_(None))
+            )
+            .values(deleted_at=deleted_at)
+        )
+        return IdempotentMutationSuccess(
+            value=None,
             status_code=status.HTTP_204_NO_CONTENT,
-            response_body=None,
         )
-        await db.commit()
-        return response
-    await db.commit()
-    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    def _serialize_deleted(_: None) -> None:
+        return None
+
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="DELETE",
+        path=f"/projects/{project_id}",
+        preclaim=_preclaim,
+        reload_after_claim=_reload_after_claim,
+        mutate=_mutate,
+        serialize_result=_serialize_deleted,
+        ops=_IDEMPOTENT_MUTATION_OPS,
+    )

--- a/app/api/v1/revision_routes/estimates.py
+++ b/app/api/v1/revision_routes/estimates.py
@@ -6,13 +6,17 @@ from typing import Annotated, Any, cast
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, Query, status
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
     IdempotencyReservation,
+    IdempotentMutationKnownError,
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
     get_idempotency_key,
+    run_idempotent_mutation,
 )
 from app.api.idempotency import (
     build_idempotency_fingerprint as _build_idempotency_fingerprint_direct,
@@ -257,6 +261,36 @@ async def _complete_idempotency_response(*args: Any, **kwargs: Any) -> Response:
         ),
     )
     return await helper(*args, **kwargs)
+
+
+async def _complete_mutation_response(
+    db: AsyncSession,
+    reservation: IdempotencyReservation | None,
+    *,
+    status_code: int,
+    response_body: dict[str, Any] | None,
+) -> Response:
+    """Finalize create responses while preserving non-idempotent behavior."""
+
+    if reservation is None:
+        return JSONResponse(status_code=status_code, content=response_body)
+
+    return await _complete_idempotency_response(
+        db,
+        reservation,
+        status_code=status_code,
+        response_body=response_body,
+    )
+
+
+def _idempotent_mutation_ops() -> IdempotentMutationOps:
+    """Return compatibility-aware idempotency operations for mutation helpers."""
+
+    return IdempotentMutationOps(
+        replay=_replay_idempotency_response,
+        claim=_claim_idempotency_response,
+        complete=_complete_mutation_response,
+    )
 
 
 def _prepare_job_enqueue_intent(job: Job) -> None:
@@ -647,134 +681,127 @@ async def create_revision_estimate_version(
         )
 
     normalized_body = _normalize_estimate_request_body(request)
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = _build_idempotency_fingerprint(
-            f"revisions.quantity_takeoffs.estimate_versions:{revision_id}:{takeoff_id}",
-            {
-                "revision_id": str(revision_id),
-                "takeoff_id": str(takeoff_id),
-                "body": normalized_body,
-            },
-        )
-        replay_response = await _replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert revision is not None
-
-    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
-    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
-        _raise_estimate_takeoff_gate_invalid(takeoff)
-
-    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
-    if locked_revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert locked_revision is not None
-    revision = locked_revision
-    takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
-    if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
-        _raise_estimate_takeoff_gate_invalid(takeoff)
-
-    job_created_at = _utc_now()
-    pricing_mode, pricing_effective_date = _resolve_estimate_pricing_contract(
-        request,
-        job_created_at=job_created_at,
+    fingerprint = _build_idempotency_fingerprint(
+        f"revisions.quantity_takeoffs.estimate_versions:{revision_id}:{takeoff_id}",
+        {
+            "revision_id": str(revision_id),
+            "takeoff_id": str(takeoff_id),
+            "body": normalized_body,
+        },
     )
-    normalized_refs = await _resolve_estimate_catalog_refs(
-        revision,
-        takeoff,
-        request.catalog_refs,
-        pricing_effective_date,
+    job_created_at: datetime | None = None
+    pricing_mode: str | None = None
+    pricing_effective_date: date | None = None
+    normalized_refs: list[_NormalizedEstimateCatalogRef] | None = None
+
+    async def _preclaim() -> Response | None:
+        nonlocal job_created_at, pricing_mode, pricing_effective_date, normalized_refs
+
+        revision = await _get_active_revision(revision_id, db)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+
+        takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+        if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
+            _raise_estimate_takeoff_gate_invalid(takeoff)
+
+        job_created_at = _utc_now()
+        pricing_mode, pricing_effective_date = _resolve_estimate_pricing_contract(
+            request,
+            job_created_at=job_created_at,
+        )
+        normalized_refs = await _resolve_estimate_catalog_refs(
+            revision,
+            takeoff,
+            request.catalog_refs,
+            pricing_effective_date,
+            db,
+        )
+        return None
+
+    async def _mutate() -> IdempotentMutationSuccess[Job] | IdempotentMutationKnownError:
+        revision = await _get_active_revision(revision_id, db, for_update=True)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+
+        takeoff = await _get_revision_quantity_takeoff_or_404(revision_id, takeoff_id, db)
+        if takeoff.quantity_gate != QuantityGate.ALLOWED.value or not takeoff.trusted_totals:
+            _raise_estimate_takeoff_gate_invalid(takeoff)
+        assert job_created_at is not None
+        assert pricing_mode is not None
+        assert pricing_effective_date is not None
+        assert normalized_refs is not None
+
+        estimate_job = Job(
+            id=uuid4(),
+            project_id=revision.project_id,
+            file_id=revision.source_file_id,
+            extraction_profile_id=None,
+            base_revision_id=revision.id,
+            parent_job_id=(
+                takeoff.source_job_id
+                if takeoff.project_id == revision.project_id
+                and takeoff.source_file_id == revision.source_file_id
+                else None
+            ),
+            job_type=JobType.ESTIMATE.value,
+            status="pending",
+            attempts=0,
+            max_attempts=3,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+            error_code=None,
+            error_message=None,
+            started_at=None,
+            finished_at=None,
+            created_at=job_created_at,
+        )
+        db.add(estimate_job)
+        _prepare_job_enqueue_intent(estimate_job)
+        await db.flush()
+        await db.refresh(estimate_job)
+
+        estimate_job_input_model, estimate_job_input_ref_model = (
+            _resolve_estimate_job_model_classes()
+        )
+        input_payload, ref_payloads = _build_estimate_job_input_payload(
+            estimate_job,
+            revision,
+            takeoff,
+            request,
+            normalized_refs,
+            pricing_mode=pricing_mode,
+            pricing_effective_date=pricing_effective_date,
+        )
+        db.add(_build_mapped_instance(estimate_job_input_model, input_payload))
+        for ref_payload in ref_payloads:
+            db.add(_build_mapped_instance(estimate_job_input_ref_model, ref_payload))
+
+        async def _after_commit() -> None:
+            await _publish_job_enqueue_intent(
+                estimate_job.id,
+                publisher=_revisions_module().enqueue_estimate_job,
+                suppress_exceptions=True,
+            )
+
+        return IdempotentMutationSuccess(
+            estimate_job,
+            status.HTTP_202_ACCEPTED,
+            after_commit=_after_commit,
+        )
+
+    return await run_idempotent_mutation(
         db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path=f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
+        preclaim=_preclaim,
+        mutate=_mutate,
+        serialize_result=lambda job: JobRead.model_validate(job).model_dump(mode="json"),
+        ops=_idempotent_mutation_ops(),
     )
-
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await _claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/estimate-versions",
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
-
-    estimate_job = Job(
-        id=uuid4(),
-        project_id=revision.project_id,
-        file_id=revision.source_file_id,
-        extraction_profile_id=None,
-        base_revision_id=revision.id,
-        parent_job_id=(
-            takeoff.source_job_id
-            if takeoff.project_id == revision.project_id
-            and takeoff.source_file_id == revision.source_file_id
-            else None
-        ),
-        job_type=JobType.ESTIMATE.value,
-        status="pending",
-        attempts=0,
-        max_attempts=3,
-        enqueue_status="pending",
-        enqueue_attempts=0,
-        cancel_requested=False,
-        error_code=None,
-        error_message=None,
-        started_at=None,
-        finished_at=None,
-        created_at=job_created_at,
-    )
-    db.add(estimate_job)
-    _prepare_job_enqueue_intent(estimate_job)
-    await db.flush()
-    await db.refresh(estimate_job)
-
-    estimate_job_input_model, estimate_job_input_ref_model = _resolve_estimate_job_model_classes()
-    input_payload, ref_payloads = _build_estimate_job_input_payload(
-        estimate_job,
-        revision,
-        takeoff,
-        request,
-        normalized_refs,
-        pricing_mode=pricing_mode,
-        pricing_effective_date=pricing_effective_date,
-    )
-    db.add(_build_mapped_instance(estimate_job_input_model, input_payload))
-    for ref_payload in ref_payloads:
-        db.add(_build_mapped_instance(estimate_job_input_ref_model, ref_payload))
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await _complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(estimate_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await _publish_job_enqueue_intent(
-        estimate_job.id,
-        publisher=_revisions_module().enqueue_estimate_job,
-        suppress_exceptions=True,
-    )
-
-    if success_response is not None:
-        return success_response
-
-    return estimate_job
 
 
 @estimates_router.get(

--- a/app/api/v1/revision_routes/exports.py
+++ b/app/api/v1/revision_routes/exports.py
@@ -8,7 +8,12 @@ from fastapi import APIRouter, Depends, status
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.idempotency import IdempotencyReservation, get_idempotency_key
+from app.api.idempotency import (
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
+    get_idempotency_key,
+    run_idempotent_mutation,
+)
 from app.api.idempotency import (
     build_idempotency_fingerprint as _build_idempotency_fingerprint_direct,
 )
@@ -60,6 +65,8 @@ type _JobEnqueuePublisher = Callable[[UUID], None]
 type _PublishJobEnqueueIntent = Callable[..., Awaitable[bool]]
 type _ReplayIdempotencyResponse = Callable[..., Awaitable[Response | None]]
 type _CompleteIdempotencyResponse = Callable[..., Awaitable[Response]]
+type _ExportPreclaimLoader = Callable[[], Awaitable[None]]
+type _ExportJobCreator = Callable[[], Awaitable[Job]]
 
 
 def _compat_attr(*names: str, default: Any = _MISSING) -> Any:
@@ -398,6 +405,112 @@ async def _get_exportable_estimate_or_404(
     return takeoff, estimate_version
 
 
+def _export_create_idempotency_ops() -> IdempotentMutationOps:
+    """Return shared export-route idempotency ops via local compat wrappers."""
+
+    return IdempotentMutationOps(
+        replay=_replay_idempotency_response,
+        claim=_claim_idempotency_response,
+        complete=_complete_idempotency_response,
+    )
+
+
+async def _publish_export_enqueue(job_id: UUID) -> None:
+    """Publish the export job after the enclosing transaction commits."""
+
+    await _publish_job_enqueue_intent(
+        job_id,
+        publisher=_enqueue_export_job,
+        suppress_exceptions=True,
+    )
+
+
+async def _persist_export_job(
+    db: AsyncSession,
+    revision: DrawingRevision,
+    *,
+    parent_job_id: UUID | None,
+    export_kind: ExportKind,
+    options_json: dict[str, Any],
+    quantity_takeoff: QuantityTakeoff | None = None,
+    estimate_version: EstimateVersion | None = None,
+) -> Job:
+    """Create and stage a pending export job plus immutable input row."""
+
+    export_job = _build_export_job(
+        revision,
+        parent_job_id=parent_job_id,
+    )
+    db.add(export_job)
+    _prepare_job_enqueue_intent(export_job)
+    await db.flush()
+    await db.refresh(export_job)
+
+    db.add(
+        _build_export_job_input(
+            export_job,
+            revision,
+            export_kind=export_kind,
+            options_json=options_json,
+            quantity_takeoff=quantity_takeoff,
+            estimate_version=estimate_version,
+        )
+    )
+    return export_job
+
+
+async def _create_export_route_job(
+    db: AsyncSession,
+    *,
+    idempotency_key: str | None,
+    fingerprint: str | None,
+    path: str,
+    load_before_claim: _ExportPreclaimLoader,
+    create_export_job: _ExportJobCreator,
+) -> Job | Response:
+    """Run the shared export-create flow with optional idempotency helpers."""
+
+    if idempotency_key is None:
+        await load_before_claim()
+        export_job = await create_export_job()
+        await db.commit()
+        await _publish_export_enqueue(export_job.id)
+        return export_job
+
+    assert fingerprint is not None
+
+    async def preclaim() -> Response | None:
+        await load_before_claim()
+        return None
+
+    async def mutate() -> IdempotentMutationSuccess[Job]:
+        export_job = await create_export_job()
+
+        async def after_commit() -> None:
+            await _publish_export_enqueue(export_job.id)
+
+        return IdempotentMutationSuccess(
+            value=export_job,
+            status_code=status.HTTP_202_ACCEPTED,
+            after_commit=after_commit,
+        )
+
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path=path,
+        mutate=mutate,
+        serialize_result=lambda export_job: JobRead.model_validate(export_job).model_dump(
+            mode="json"
+        ),
+        preclaim=preclaim,
+        reload_after_claim=load_before_claim,
+        ops=_export_create_idempotency_ops(),
+    )
+
+
 @exports_router.post(
     "/revisions/{revision_id}/exports/revision-json",
     response_model=JobRead,
@@ -412,11 +525,11 @@ async def create_revision_json_export(
     """Create a pending revision JSON export job for an active drawing revision."""
 
     export_kind = ExportKind.REVISION_JSON
+    path = f"/revisions/{revision_id}/exports/revision-json"
     normalized_body = _build_export_request_body(
         export_kind,
         options=request.options,
     )
-    reservation: IdempotencyReservation | None = None
     fingerprint: str | None = None
     if idempotency_key is not None:
         fingerprint = _build_idempotency_fingerprint(
@@ -426,68 +539,31 @@ async def create_revision_json_export(
                 "body": normalized_body,
             },
         )
-        replay_response = await _replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
 
-    revision = await _get_locked_active_revision_or_404(revision_id, db)
+    revision: DrawingRevision | None = None
 
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await _claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/revisions/{revision_id}/exports/revision-json",
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
+    async def load_before_claim() -> None:
+        nonlocal revision
         revision = await _get_locked_active_revision_or_404(revision_id, db)
 
-    export_job = _build_export_job(
-        revision,
-        parent_job_id=_parent_job_id_for_revision(revision),
-    )
-    db.add(export_job)
-    _prepare_job_enqueue_intent(export_job)
-    await db.flush()
-    await db.refresh(export_job)
-
-    db.add(
-        _build_export_job_input(
-            export_job,
+    async def create_export_job() -> Job:
+        assert revision is not None
+        return await _persist_export_job(
+            db,
             revision,
+            parent_job_id=_parent_job_id_for_revision(revision),
             export_kind=export_kind,
             options_json=request.options,
         )
+
+    return await _create_export_route_job(
+        db,
+        idempotency_key=idempotency_key,
+        fingerprint=fingerprint,
+        path=path,
+        load_before_claim=load_before_claim,
+        create_export_job=create_export_job,
     )
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await _complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(export_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await _publish_job_enqueue_intent(
-        export_job.id,
-        publisher=_enqueue_export_job,
-        suppress_exceptions=True,
-    )
-
-    if success_response is not None:
-        return success_response
-    return export_job
 
 
 @exports_router.post(
@@ -505,11 +581,11 @@ async def create_revision_quantity_csv_export(
     """Create a pending quantity CSV export job for a trusted revision takeoff."""
 
     export_kind = ExportKind.QUANTITY_CSV
+    path = f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/exports/quantity-csv"
     normalized_body = _build_export_request_body(
         export_kind,
         options=request.options,
     )
-    reservation: IdempotencyReservation | None = None
     fingerprint: str | None = None
     if idempotency_key is not None:
         fingerprint = _build_idempotency_fingerprint(
@@ -520,71 +596,35 @@ async def create_revision_quantity_csv_export(
                 "body": normalized_body,
             },
         )
-        replay_response = await _replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
 
-    revision = await _get_locked_active_revision_or_404(revision_id, db)
-    takeoff = await _get_exportable_takeoff_or_404(revision_id, takeoff_id, db)
+    revision: DrawingRevision | None = None
+    takeoff: QuantityTakeoff | None = None
 
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await _claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=(f"/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/exports/quantity-csv"),
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
+    async def load_before_claim() -> None:
+        nonlocal revision, takeoff
         revision = await _get_locked_active_revision_or_404(revision_id, db)
         takeoff = await _get_exportable_takeoff_or_404(revision_id, takeoff_id, db)
 
-    export_job = _build_export_job(
-        revision,
-        parent_job_id=_parent_job_id_for_takeoff(revision, takeoff),
-    )
-    db.add(export_job)
-    _prepare_job_enqueue_intent(export_job)
-    await db.flush()
-    await db.refresh(export_job)
-
-    db.add(
-        _build_export_job_input(
-            export_job,
+    async def create_export_job() -> Job:
+        assert revision is not None
+        assert takeoff is not None
+        return await _persist_export_job(
+            db,
             revision,
+            parent_job_id=_parent_job_id_for_takeoff(revision, takeoff),
             export_kind=export_kind,
             options_json=request.options,
             quantity_takeoff=takeoff,
         )
+
+    return await _create_export_route_job(
+        db,
+        idempotency_key=idempotency_key,
+        fingerprint=fingerprint,
+        path=path,
+        load_before_claim=load_before_claim,
+        create_export_job=create_export_job,
     )
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await _complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(export_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await _publish_job_enqueue_intent(
-        export_job.id,
-        publisher=_enqueue_export_job,
-        suppress_exceptions=True,
-    )
-
-    if success_response is not None:
-        return success_response
-    return export_job
 
 
 @exports_router.post(
@@ -603,7 +643,11 @@ async def create_revision_estimate_export(
     """Create a pending estimate CSV/PDF export job for a trusted takeoff."""
 
     normalized_body = request.model_dump(mode="json")
-    reservation: IdempotencyReservation | None = None
+    path = (
+        "/revisions/"
+        f"{revision_id}/quantity-takeoffs/{takeoff_id}/estimates/"
+        f"{estimate_version_id}/exports"
+    )
     fingerprint: str | None = None
     if idempotency_key is not None:
         fingerprint = _build_idempotency_fingerprint(
@@ -618,39 +662,13 @@ async def create_revision_estimate_export(
                 "body": normalized_body,
             },
         )
-        replay_response = await _replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
 
-    revision = await _get_locked_active_revision_or_404(revision_id, db)
-    takeoff, estimate_version = await _get_exportable_estimate_or_404(
-        revision_id,
-        takeoff_id,
-        estimate_version_id,
-        db,
-    )
+    revision: DrawingRevision | None = None
+    takeoff: QuantityTakeoff | None = None
+    estimate_version: EstimateVersion | None = None
 
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await _claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=(
-                "/revisions/"
-                f"{revision_id}/quantity-takeoffs/{takeoff_id}/estimates/"
-                f"{estimate_version_id}/exports"
-            ),
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
+    async def load_before_claim() -> None:
+        nonlocal revision, takeoff, estimate_version
         revision = await _get_locked_active_revision_or_404(revision_id, db)
         takeoff, estimate_version = await _get_exportable_estimate_or_404(
             revision_id,
@@ -659,42 +677,25 @@ async def create_revision_estimate_export(
             db,
         )
 
-    export_job = _build_export_job(
-        revision,
-        parent_job_id=_parent_job_id_for_estimate(revision, estimate_version),
-    )
-    db.add(export_job)
-    _prepare_job_enqueue_intent(export_job)
-    await db.flush()
-    await db.refresh(export_job)
-
-    db.add(
-        _build_export_job_input(
-            export_job,
+    async def create_export_job() -> Job:
+        assert revision is not None
+        assert takeoff is not None
+        assert estimate_version is not None
+        return await _persist_export_job(
+            db,
             revision,
+            parent_job_id=_parent_job_id_for_estimate(revision, estimate_version),
             export_kind=request.export_kind,
             options_json=request.options,
             quantity_takeoff=takeoff,
             estimate_version=estimate_version,
         )
+
+    return await _create_export_route_job(
+        db,
+        idempotency_key=idempotency_key,
+        fingerprint=fingerprint,
+        path=path,
+        load_before_claim=load_before_claim,
+        create_export_job=create_export_job,
     )
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await _complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(export_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await _publish_job_enqueue_intent(
-        export_job.id,
-        publisher=_enqueue_export_job,
-        suppress_exceptions=True,
-    )
-
-    if success_response is not None:
-        return success_response
-    return export_job

--- a/app/api/v1/revision_routes/quantity_takeoffs.py
+++ b/app/api/v1/revision_routes/quantity_takeoffs.py
@@ -5,13 +5,17 @@ from typing import Annotated, Any, cast
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
     IdempotencyReservation,
+    IdempotentMutationKnownError,
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
     get_idempotency_key,
+    run_idempotent_mutation,
 )
 from app.api.idempotency import (
     build_idempotency_fingerprint as _build_idempotency_fingerprint_direct,
@@ -236,6 +240,36 @@ async def _complete_idempotency_response(*args: Any, **kwargs: Any) -> Response:
     return await helper(*args, **kwargs)
 
 
+async def _complete_mutation_response(
+    db: AsyncSession,
+    reservation: IdempotencyReservation | None,
+    *,
+    status_code: int,
+    response_body: dict[str, Any] | None,
+) -> Response:
+    """Finalize create responses while preserving non-idempotent behavior."""
+
+    if reservation is None:
+        return JSONResponse(status_code=status_code, content=response_body)
+
+    return await _complete_idempotency_response(
+        db,
+        reservation,
+        status_code=status_code,
+        response_body=response_body,
+    )
+
+
+def _idempotent_mutation_ops() -> IdempotentMutationOps:
+    """Return compatibility-aware idempotency operations for mutation helpers."""
+
+    return IdempotentMutationOps(
+        replay=_replay_idempotency_response,
+        claim=_claim_idempotency_response,
+        complete=_complete_mutation_response,
+    )
+
+
 def _prepare_job_enqueue_intent(job: Job) -> None:
     """Compatibility wrapper for enqueue intent staging."""
 
@@ -450,94 +484,75 @@ async def create_revision_quantity_takeoff(
 ) -> Job | Response:
     """Create a pending quantity takeoff job for an active drawing revision."""
 
-    reservation: IdempotencyReservation | None = None
-    fingerprint: str | None = None
-    if idempotency_key is not None:
-        fingerprint = _build_idempotency_fingerprint(
-            f"revisions.quantity_takeoffs:{revision_id}",
-            {"revision_id": str(revision_id)},
-        )
-        replay_response = await _replay_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-        )
-        if replay_response is not None:
-            return replay_response
-
-    revision = await _get_active_revision(revision_id, db)
-    if revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    assert revision is not None
-    await _get_active_revision_manifest_or_409(revision_id, db)
-    report = await _get_active_validation_report_or_404(revision_id, db)
-    if report.quantity_gate in {
-        QuantityGate.REVIEW_GATED.value,
-        QuantityGate.BLOCKED.value,
-    }:
-        _raise_quantity_takeoff_gate_invalid(report)
-
-    locked_revision = await _get_active_revision(revision_id, db, for_update=True)
-    if locked_revision is None:
-        raise_not_found("Drawing revision", str(revision_id))
-    revision = locked_revision
-    assert revision is not None
-
-    if idempotency_key is not None:
-        assert fingerprint is not None
-        claim = await _claim_idempotency_response(
-            db,
-            key=idempotency_key,
-            fingerprint=fingerprint,
-            method="POST",
-            path=f"/revisions/{revision_id}/quantity-takeoffs",
-        )
-        if isinstance(claim, Response):
-            return claim
-        assert claim is not None
-        reservation = claim
-
-    quantity_job = Job(
-        id=uuid4(),
-        project_id=revision.project_id,
-        file_id=revision.source_file_id,
-        extraction_profile_id=None,
-        base_revision_id=revision.id,
-        parent_job_id=None,
-        job_type=JobType.QUANTITY_TAKEOFF.value,
-        status="pending",
-        attempts=0,
-        max_attempts=3,
-        enqueue_status="pending",
-        enqueue_attempts=0,
-        cancel_requested=False,
-        error_code=None,
-        error_message=None,
-        started_at=None,
-        finished_at=None,
-    )
-    db.add(quantity_job)
-    _prepare_job_enqueue_intent(quantity_job)
-    await db.flush()
-    await db.refresh(quantity_job)
-
-    success_response: Response | None = None
-    if reservation is not None:
-        success_response = await _complete_idempotency_response(
-            db,
-            reservation,
-            status_code=status.HTTP_202_ACCEPTED,
-            response_body=JobRead.model_validate(quantity_job).model_dump(mode="json"),
-        )
-
-    await db.commit()
-    await _publish_job_enqueue_intent(
-        quantity_job.id,
-        publisher=_revisions_module().enqueue_quantity_takeoff_job,
-        suppress_exceptions=True,
+    fingerprint = _build_idempotency_fingerprint(
+        f"revisions.quantity_takeoffs:{revision_id}",
+        {"revision_id": str(revision_id)},
     )
 
-    if success_response is not None:
-        return success_response
+    async def _preclaim() -> Response | None:
+        revision = await _get_active_revision(revision_id, db)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
 
-    return quantity_job
+        await _get_active_revision_manifest_or_409(revision_id, db)
+        report = await _get_active_validation_report_or_404(revision_id, db)
+        if report.quantity_gate in {
+            QuantityGate.REVIEW_GATED.value,
+            QuantityGate.BLOCKED.value,
+        }:
+            _raise_quantity_takeoff_gate_invalid(report)
+        return None
+
+    async def _mutate() -> IdempotentMutationSuccess[Job] | IdempotentMutationKnownError:
+        revision = await _get_active_revision(revision_id, db, for_update=True)
+        if revision is None:
+            raise_not_found("Drawing revision", str(revision_id))
+
+        quantity_job = Job(
+            id=uuid4(),
+            project_id=revision.project_id,
+            file_id=revision.source_file_id,
+            extraction_profile_id=None,
+            base_revision_id=revision.id,
+            parent_job_id=None,
+            job_type=JobType.QUANTITY_TAKEOFF.value,
+            status="pending",
+            attempts=0,
+            max_attempts=3,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+            error_code=None,
+            error_message=None,
+            started_at=None,
+            finished_at=None,
+        )
+        db.add(quantity_job)
+        _prepare_job_enqueue_intent(quantity_job)
+        await db.flush()
+        await db.refresh(quantity_job)
+
+        async def _after_commit() -> None:
+            await _publish_job_enqueue_intent(
+                quantity_job.id,
+                publisher=_revisions_module().enqueue_quantity_takeoff_job,
+                suppress_exceptions=True,
+            )
+
+        return IdempotentMutationSuccess(
+            quantity_job,
+            status.HTTP_202_ACCEPTED,
+            after_commit=_after_commit,
+        )
+
+    return await run_idempotent_mutation(
+        db,
+        key=idempotency_key,
+        fingerprint=fingerprint,
+        method="POST",
+        path=f"/revisions/{revision_id}/quantity-takeoffs",
+        preclaim=_preclaim,
+        mutate=_mutate,
+        serialize_result=lambda job: JobRead.model_validate(job).model_dump(mode="json"),
+        ops=_idempotent_mutation_ops(),
+    )

--- a/tests/test_estimation_catalog_api.py
+++ b/tests/test_estimation_catalog_api.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 from sqlalchemy import select
 
+import app.api.v1.estimation as estimation_api
 import app.db.session as session_module
 from app.estimating.catalog.api_checksums import (
     formula_checksum_sha256,
@@ -689,6 +690,62 @@ class TestEstimationCatalogApiRateIdempotency:
         assert second_conflict_response.status_code == 409
         assert first_conflict_response.json() == second_conflict_response.json()
         assert first_conflict_response.json()["error"]["code"] == "DB_CONFLICT"
+
+    async def test_create_rate_revalidates_project_after_idempotency_claim(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Idempotency Revalidation Project")
+        payload = _valid_rate_payload(project_id=project_id)
+        headers = {"Idempotency-Key": "rate-create-revalidate-project-key"}
+        callback_order: list[str] = []
+
+        async def fake_run_idempotent_mutation(
+            db: Any,
+            *,
+            key: str | None,
+            fingerprint: str,
+            method: str,
+            path: str,
+            preclaim: Any,
+            mutate: Any,
+            serialize_result: Any,
+            ops: Any,
+            reload_after_claim: Any = None,
+        ) -> Any:
+            _ = (db, fingerprint, method, path, mutate, serialize_result, ops)
+            assert key == headers["Idempotency-Key"]
+
+            callback_order.append("preclaim")
+            await preclaim()
+            project = (
+                await db.execute(select(Project).where(Project.id == UUID(project_id)))
+            ).scalar_one()
+            project.deleted_at = project.updated_at
+            await db.flush()
+
+            assert reload_after_claim is not None
+            callback_order.append("reload_after_claim")
+            await reload_after_claim()
+
+            pytest.fail("reload_after_claim should raise before mutate")
+
+        monkeypatch.setattr(estimation_api, "run_idempotent_mutation", fake_run_idempotent_mutation)
+
+        response = await async_client.post(
+            "/v1/estimation/catalog/rates",
+            json=payload,
+            headers=headers,
+        )
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "NOT_FOUND"
+        assert callback_order == ["preclaim", "reload_after_claim"]
 
 
 @requires_database

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -6,12 +6,12 @@ import uuid
 from collections.abc import AsyncGenerator, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 
 import httpx
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from sqlalchemy import select
 
 import app.api.v1.files as files_api
@@ -911,6 +911,79 @@ class TestProjectFiles:
         data = response.json()
         assert data["error"]["code"] == "NOT_FOUND"
         assert "Project" in data["error"]["message"]
+
+    async def test_upload_file_missing_project_precedes_body_validation(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POST should return Project 404 before no-key upload body validation runs."""
+        _ = self
+        _ = cleanup_projects
+        monkeypatch.setattr(settings, "max_upload_mb", 1)
+
+        payload = b"x" * ((settings.max_upload_mb * 1024 * 1024) + 1)
+        response = await async_client.post(
+            f"/v1/projects/{uuid.uuid4()}/files",
+            files={"file": ("missing.xyz", payload, "application/octet-stream")},
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["error"]["code"] == "NOT_FOUND"
+        assert "Project" in data["error"]["message"]
+        assert data["error"]["details"] is None
+
+    async def test_upload_file_missing_project_closes_upload_on_early_validation_error(
+        self,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Early missing-project validation should still close the upload handle."""
+        _ = self
+        _ = cleanup_projects
+
+        class StubUploadFile:
+            filename = "missing.pdf"
+            content_type = "application/pdf"
+
+            def __init__(self) -> None:
+                self.close_calls = 0
+                self.read_calls = 0
+
+            async def close(self) -> None:
+                self.close_calls += 1
+
+            async def read(self, _size: int = -1) -> bytes:
+                self.read_calls += 1
+                raise AssertionError("upload body should not be read")
+
+        async def _missing_project(
+            db: Any,
+            project_id: uuid.UUID,
+            *,
+            for_update: bool = False,
+        ) -> NoReturn:
+            _ = (db, for_update)
+            raise_not_found("Project", str(project_id))
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(files_api, "_get_active_project_or_404", _missing_project)
+        upload = cast(Any, StubUploadFile())
+
+        with pytest.raises(HTTPException) as exc_info:
+            await files_api.upload_project_file(
+                uuid.uuid4(),
+                upload,
+                cast(Any, object()),
+                cast(Any, object()),
+                idempotency_key=None,
+            )
+
+        assert exc_info.value.status_code == 404
+        assert upload.close_calls == 1
+        assert upload.read_calls == 0
 
     async def test_upload_file_soft_deleted_project_returns_not_found(
         self,

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -12,15 +12,14 @@ import pytest
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-import app.api.idempotency as idempotency_api
-import app.api.v1.files as files_api
-import app.api.v1.jobs as jobs_api
-import app.db.session as session_module
-import app.jobs.worker as worker_module
 from app.api.idempotency import (
     IdempotencyReplay,
     IdempotencyReservation,
+    IdempotentMutationKnownError,
+    IdempotentMutationOps,
+    IdempotentMutationSuccess,
     build_idempotency_fingerprint,
     claim_idempotency_response,
     complete_idempotency_response,
@@ -29,9 +28,14 @@ from app.api.idempotency import (
     mark_idempotency_completed,
     replay_idempotency,
     replay_idempotency_response,
+    run_idempotent_mutation,
 )
+from app.api.v1 import files as files_api
+from app.api.v1 import jobs as jobs_api
 from app.core.config import settings
 from app.core.errors import ErrorCode
+from app.db import session as session_module
+from app.jobs import worker as worker_module
 from app.jobs.worker import process_ingest_job
 from app.models.drawing_revision import DrawingRevision
 from app.models.idempotency_key import IdempotencyKey, IdempotencyStatus
@@ -147,7 +151,7 @@ async def test_replay_idempotency_response_unwraps_replay(monkeypatch: pytest.Mo
         assert fingerprint == "fingerprint-2"
         return IdempotencyReplay(response=replay_response)
 
-    monkeypatch.setattr(idempotency_api, "replay_idempotency", _fake_replay_idempotency)
+    monkeypatch.setattr("app.api.idempotency.replay_idempotency", _fake_replay_idempotency)
 
     result = await replay_idempotency_response(
         cast(Any, object()),
@@ -195,7 +199,7 @@ async def test_claim_idempotency_response_unwraps_replay(monkeypatch: pytest.Mon
         )
         return IdempotencyReplay(response=replay_response)
 
-    monkeypatch.setattr(idempotency_api, "claim_idempotency", _fake_claim_idempotency)
+    monkeypatch.setattr("app.api.idempotency.claim_idempotency", _fake_claim_idempotency)
 
     result = await claim_idempotency_response(
         cast(Any, object()),
@@ -230,6 +234,464 @@ class _FakeIdempotencySession:
 
     async def commit(self) -> None:
         self.commit_calls += 1
+
+
+class _CommitTrackingSession:
+    """Minimal session double that records commit ordering for orchestration tests."""
+
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.commit_calls = 0
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+        self._events.append("commit")
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_mutation_supports_no_key_execution() -> None:
+    """Shared orchestration should no-op idempotency helpers when the key is absent."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert key is None
+        assert fingerprint == "fingerprint-7"
+        return None
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = db
+        events.append("claim")
+        assert key is None
+        assert (fingerprint, method, path) == ("fingerprint-7", "POST", "/v1/projects")
+        return None
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = db
+        events.append("complete")
+        assert reservation is None
+        assert status_code == 201
+        assert response_body == {"id": "project-1"}
+        return JSONResponse(status_code=status_code, content=response_body)
+
+    async def _preclaim() -> Response | None:
+        events.append("preclaim")
+        return None
+
+    async def _mutate() -> IdempotentMutationSuccess[str]:
+        events.append("mutate")
+        return IdempotentMutationSuccess(value="project-1", status_code=201)
+
+    def _serialize(value: str) -> dict[str, Any]:
+        events.append("serialize")
+        return {"id": value}
+
+    response = await run_idempotent_mutation(
+        cast(Any, session),
+        key=None,
+        fingerprint="fingerprint-7",
+        method="POST",
+        path="/v1/projects",
+        preclaim=_preclaim,
+        mutate=_mutate,
+        serialize_result=_serialize,
+        ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+    )
+
+    assert response.status_code == 201
+    assert json.loads(bytes(response.body)) == {"id": "project-1"}
+    assert session.commit_calls == 1
+    assert events == ["replay", "preclaim", "claim", "mutate", "serialize", "complete", "commit"]
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_mutation_short_circuits_replay_response() -> None:
+    """Replay responses should return before preclaim, claim, mutation, or commit."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+    replay_response = Response(status_code=204)
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert (key, fingerprint) == ("replay-key-2", "fingerprint-8")
+        return replay_response
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = (db, key, fingerprint, method, path)
+        raise AssertionError("claim should not run after replay short-circuit")
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = (db, reservation, status_code, response_body)
+        raise AssertionError("complete should not run after replay short-circuit")
+
+    async def _mutate() -> IdempotentMutationSuccess[dict[str, Any]]:
+        raise AssertionError("mutate should not run after replay short-circuit")
+
+    def _serialize(_: dict[str, Any]) -> dict[str, Any]:
+        raise AssertionError("serialize should not run after replay short-circuit")
+
+    response = await run_idempotent_mutation(
+        cast(Any, session),
+        key="replay-key-2",
+        fingerprint="fingerprint-8",
+        method="POST",
+        path="/v1/projects",
+        mutate=_mutate,
+        serialize_result=_serialize,
+        ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+    )
+
+    assert response is replay_response
+    assert session.commit_calls == 0
+    assert events == ["replay"]
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_mutation_short_circuits_claim_response() -> None:
+    """Claim responses should return before reload, mutation, completion, or commit."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+    claim_response = JSONResponse(status_code=409, content={"error": {"code": "conflict"}})
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert (key, fingerprint) == ("claim-key-2", "fingerprint-9")
+        return None
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = db
+        events.append("claim")
+        assert (key, fingerprint, method, path) == (
+            "claim-key-2",
+            "fingerprint-9",
+            "PATCH",
+            "/v1/projects/project-1",
+        )
+        return claim_response
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = (db, reservation, status_code, response_body)
+        raise AssertionError("complete should not run after claim short-circuit")
+
+    async def _preclaim() -> Response | None:
+        events.append("preclaim")
+        return None
+
+    async def _reload_after_claim() -> None:
+        raise AssertionError("reload should not run after claim short-circuit")
+
+    async def _mutate() -> IdempotentMutationSuccess[dict[str, Any]]:
+        raise AssertionError("mutate should not run after claim short-circuit")
+
+    def _serialize(_: dict[str, Any]) -> dict[str, Any]:
+        raise AssertionError("serialize should not run after claim short-circuit")
+
+    response = await run_idempotent_mutation(
+        cast(Any, session),
+        key="claim-key-2",
+        fingerprint="fingerprint-9",
+        method="PATCH",
+        path="/v1/projects/project-1",
+        preclaim=_preclaim,
+        reload_after_claim=_reload_after_claim,
+        mutate=_mutate,
+        serialize_result=_serialize,
+        ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+    )
+
+    assert response is claim_response
+    assert session.commit_calls == 0
+    assert events == ["replay", "preclaim", "claim"]
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_mutation_reloads_serializes_and_runs_after_commit() -> None:
+    """Successful orchestration should reload after claim and run hooks after commit."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+    expected_reservation = IdempotencyReservation(record_id=uuid.uuid4())
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert (key, fingerprint) == ("success-key-1", "fingerprint-10")
+        return None
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = db
+        events.append("claim")
+        assert (key, fingerprint, method, path) == (
+            "success-key-1",
+            "fingerprint-10",
+            "POST",
+            "/v1/projects",
+        )
+        return expected_reservation
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = db
+        events.append("complete")
+        assert reservation == expected_reservation
+        assert status_code == 201
+        assert response_body == {"id": "project-2"}
+        return JSONResponse(status_code=status_code, content=response_body)
+
+    async def _preclaim() -> Response | None:
+        events.append("preclaim")
+        return None
+
+    async def _reload_after_claim() -> None:
+        events.append("reload")
+
+    async def _after_commit() -> None:
+        events.append("after_commit")
+
+    async def _mutate() -> IdempotentMutationSuccess[str]:
+        events.append("mutate")
+        return IdempotentMutationSuccess(
+            value="project-2",
+            status_code=201,
+            after_commit=_after_commit,
+        )
+
+    def _serialize(value: str) -> dict[str, Any]:
+        events.append("serialize")
+        return {"id": value}
+
+    response = await run_idempotent_mutation(
+        cast(Any, session),
+        key="success-key-1",
+        fingerprint="fingerprint-10",
+        method="POST",
+        path="/v1/projects",
+        preclaim=_preclaim,
+        reload_after_claim=_reload_after_claim,
+        mutate=_mutate,
+        serialize_result=_serialize,
+        ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+    )
+
+    assert response.status_code == 201
+    assert json.loads(bytes(response.body)) == {"id": "project-2"}
+    assert session.commit_calls == 1
+    assert events == [
+        "replay",
+        "preclaim",
+        "claim",
+        "reload",
+        "mutate",
+        "serialize",
+        "complete",
+        "commit",
+        "after_commit",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_mutation_completes_known_error_snapshot() -> None:
+    """Known local errors should snapshot and commit without calling the serializer."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+    expected_reservation = IdempotencyReservation(record_id=uuid.uuid4())
+    response_body = {
+        "error": {
+            "code": "STORAGE_FAILED",
+            "message": "Failed to persist uploaded file.",
+            "details": None,
+        }
+    }
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert (key, fingerprint) == ("known-error-key-1", "fingerprint-11")
+        return None
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = db
+        events.append("claim")
+        assert (key, fingerprint, method, path) == (
+            "known-error-key-1",
+            "fingerprint-11",
+            "POST",
+            "/v1/projects/project-1/files",
+        )
+        return expected_reservation
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = db
+        events.append("complete")
+        assert reservation == expected_reservation
+        assert status_code == 500
+        assert response_body == {
+            "error": {
+                "code": "STORAGE_FAILED",
+                "message": "Failed to persist uploaded file.",
+                "details": None,
+            }
+        }
+        return JSONResponse(status_code=status_code, content=response_body)
+
+    async def _mutate() -> IdempotentMutationKnownError:
+        events.append("mutate")
+        return IdempotentMutationKnownError(status_code=500, response_body=response_body)
+
+    def _serialize(_: str) -> dict[str, Any]:
+        raise AssertionError("serialize should not run for known-error snapshots")
+
+    response = await run_idempotent_mutation(
+        cast(Any, session),
+        key="known-error-key-1",
+        fingerprint="fingerprint-11",
+        method="POST",
+        path="/v1/projects/project-1/files",
+        mutate=_mutate,
+        serialize_result=_serialize,
+        ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+    )
+
+    assert response.status_code == 500
+    assert json.loads(bytes(response.body)) == response_body
+    assert session.commit_calls == 1
+    assert events == ["replay", "claim", "mutate", "complete", "commit"]
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent_mutation_propagates_arbitrary_exceptions() -> None:
+    """Unexpected exceptions should escape without completion snapshots or commits."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert (key, fingerprint) == ("exception-key-1", "fingerprint-12")
+        return None
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = db
+        events.append("claim")
+        assert (key, fingerprint, method, path) == (
+            "exception-key-1",
+            "fingerprint-12",
+            "DELETE",
+            "/v1/projects/project-2",
+        )
+        return IdempotencyReservation(record_id=uuid.uuid4())
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = (db, reservation, status_code, response_body)
+        raise AssertionError("complete should not run for arbitrary exceptions")
+
+    async def _mutate() -> IdempotentMutationSuccess[str]:
+        events.append("mutate")
+        raise RuntimeError("boom")
+
+    def _serialize(_: str) -> dict[str, Any]:
+        raise AssertionError("serialize should not run for arbitrary exceptions")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await run_idempotent_mutation(
+            cast(Any, session),
+            key="exception-key-1",
+            fingerprint="fingerprint-12",
+            method="DELETE",
+            path="/v1/projects/project-2",
+            mutate=_mutate,
+            serialize_result=_serialize,
+            ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+        )
+
+    assert session.commit_calls == 0
+    assert events == ["replay", "claim", "mutate"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_idempotent_mutation_inventory.py
+++ b/tests/test_idempotent_mutation_inventory.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import inspect
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+
+def _load_callable(module_paths: tuple[str, ...], attr_name: str) -> Any:
+    last_error: Exception | None = None
+    for module_path in module_paths:
+        try:
+            module = import_module(module_path)
+            return getattr(module, attr_name)
+        except (ImportError, AttributeError) as exc:
+            last_error = exc
+
+    joined_paths = ", ".join(module_paths)
+    raise AssertionError(
+        f"Could not resolve callable '{attr_name}' from modules: {joined_paths}"
+    ) from last_error
+
+
+@pytest.mark.parametrize(
+    ("module_paths", "attr_name", "label"),
+    [
+        (("app.api.v1.projects",), "create_project", "projects.create_project"),
+        (("app.api.v1.projects",), "update_project", "projects.update_project"),
+        (("app.api.v1.projects",), "delete_project", "projects.delete_project"),
+        (("app.api.v1.files",), "upload_project_file", "files.upload_project_file"),
+        (
+            ("app.api.v1.files",),
+            "reprocess_project_file",
+            "files.reprocess_project_file",
+        ),
+        (("app.api.v1.jobs",), "cancel_job", "jobs.cancel_job"),
+        (("app.api.v1.jobs",), "retry_job", "jobs.retry_job"),
+        (("app.api.v1.estimation",), "_create_catalog_entry", "estimation._create_catalog_entry"),
+        (
+            ("app.api.v1.revision_routes.exports", "app.api.v1.exports"),
+            "_create_export_route_job",
+            "exports._create_export_route_job",
+        ),
+        (
+            (
+                "app.api.v1.revision_routes.quantity_takeoffs",
+                "app.api.v1.quantity_takeoffs",
+            ),
+            "create_revision_quantity_takeoff",
+            "quantity_takeoffs.create_revision_quantity_takeoff",
+        ),
+        (
+            ("app.api.v1.revision_routes.estimates", "app.api.v1.estimates"),
+            "create_revision_estimate_version",
+            "estimates.create_revision_estimate_version",
+        ),
+    ],
+)
+def test_mutating_routes_use_run_idempotent_mutation(
+    module_paths: tuple[str, ...], attr_name: str, label: str
+) -> None:
+    callable_obj = _load_callable(module_paths, attr_name)
+
+    source = inspect.getsource(callable_obj)
+
+    assert "run_idempotent_mutation" in source, (
+        f"{label} must be wired through run_idempotent_mutation"
+    )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1522,6 +1522,33 @@ class TestJobs:
         assert unchanged.cancel_requested is False
         assert unchanged.attempts == 1
 
+    async def test_cancel_job_replays_terminal_no_op_with_idempotency_key(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+    ) -> None:
+        """Cancel should snapshot and replay terminal no-op responses."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await worker_module.process_ingest_job(job.id)
+
+        headers = {"Idempotency-Key": "cancel-terminal-replay"}
+        first = await async_client.post(f"/v1/jobs/{job.id}/cancel", headers=headers)
+        second = await async_client.post(f"/v1/jobs/{job.id}/cancel", headers=headers)
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json() == first.json()
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "succeeded"
+        assert unchanged.cancel_requested is False
+
     async def test_retry_job_requeues_failed_job_below_max_attempts(
         self,
         async_client: httpx.AsyncClient,
@@ -1573,6 +1600,59 @@ class TestJobs:
         assert updated.status == "pending"
         assert updated.error_code is None
         assert updated.error_message is None
+
+    async def test_retry_job_publishes_only_after_commit(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry publish should observe committed state only after mutation commit."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        observed_publish_states: list[tuple[str, str]] = []
+
+        async def _observe_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
+            persisted = await _get_job(job_id)
+            observed_publish_states.append((persisted.status, persisted.enqueue_status))
+            assert persisted.cancel_requested is False
+            assert persisted.error_code is None
+            assert persisted.error_message is None
+            return True
+
+        monkeypatch.setattr(
+            jobs_api,
+            "publish_job_enqueue_intent",
+            _observe_retry_publish,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+            cancel_requested=True,
+            error_message="previous failure",
+        )
+
+        response = await async_client.post(f"/v1/jobs/{job.id}/retry")
+
+        assert response.status_code == 202
+        assert observed_publish_states == [("pending", "pending")]
 
     async def test_retry_job_succeeds_when_publish_is_deferred(
         self,
@@ -2084,6 +2164,62 @@ class TestJobs:
         unchanged = await _get_job(job.id)
         assert unchanged.status == "cancelled"
         assert unchanged.attempts == 1
+
+    async def test_retry_job_replays_attempt_limit_no_op_with_idempotency_key(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        enqueued_job_ids: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Retry should snapshot and replay attempt-limit no-op responses."""
+        _ = self
+        _ = cleanup_projects
+        _ = enqueued_job_ids
+
+        retried_job_ids: list[str] = []
+
+        async def _fake_retry_publish(
+            job_id: uuid.UUID,
+            *,
+            publisher: Any | None = None,
+            suppress_exceptions: bool = False,
+            **kwargs: Any,
+        ) -> bool:
+            _ = (publisher, suppress_exceptions, kwargs)
+            retried_job_ids.append(str(job_id))
+            return True
+
+        monkeypatch.setattr(
+            jobs_api,
+            "publish_job_enqueue_intent",
+            _fake_retry_publish,
+            raising=False,
+        )
+
+        project = await _create_project(async_client)
+        uploaded = await _upload_file(async_client, project["id"])
+        job = await _get_job_for_file(str(uploaded["id"]))
+        await _update_job(
+            job.id,
+            status="failed",
+            attempts=3,
+            max_attempts=3,
+            error_message="maxed out",
+        )
+
+        headers = {"Idempotency-Key": "retry-attempt-limit-replay"}
+        first = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=headers)
+        second = await async_client.post(f"/v1/jobs/{job.id}/retry", headers=headers)
+
+        assert first.status_code == 202
+        assert second.status_code == 202
+        assert second.json() == first.json()
+        assert retried_job_ids == []
+        unchanged = await _get_job(job.id)
+        assert unchanged.status == "failed"
+        assert unchanged.attempts == 3
+        assert unchanged.max_attempts == 3
 
     @pytest.mark.parametrize(
         ("status", "attempts", "max_attempts", "error_code", "error_message"),

--- a/tests/test_quantity_takeoff_api.py
+++ b/tests/test_quantity_takeoff_api.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import IdempotencyReservation
 from app.api.v1 import revisions as revisions_module
+from app.api.v1.revision_routes import estimates as estimates_routes_module
 from app.api.v1.revisions import revisions_router
 from app.db import session as session_module
 from app.db.session import get_db
@@ -810,6 +811,8 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
     idempotency_state: dict[str, dict[str, Any]] = {}
     enqueued_job_ids: list[UUID] = []
     pricing_effective_dates: list[date] = []
+    utc_now_calls = 0
+    pricing_contract_calls: list[datetime] = []
 
     class _EstimateJobInputRecord:
         pass
@@ -929,13 +932,22 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
     def fake_enqueue_estimate_job(job_id: UUID) -> None:
         enqueued_job_ids.append(job_id)
 
-    class _AppClock(datetime):
-        @classmethod
-        def now(cls, tz: Any = None) -> _AppClock:
-            app_now = job_created_at
-            if tz is None:
-                return cls.fromtimestamp(app_now.timestamp(), UTC)
-            return cls.fromtimestamp(app_now.astimezone(tz).timestamp(), tz)
+    def fake_utc_now() -> datetime:
+        nonlocal utc_now_calls
+        utc_now_calls += 1
+        return job_created_at
+
+    def fake_resolve_estimate_pricing_contract(
+        request_value: Any,
+        *,
+        job_created_at: datetime | None = None,
+    ) -> tuple[str, date]:
+        assert request_value.pricing.currency == request_body["pricing"]["currency"]
+        assert request_value.assumptions == request_body["assumptions"]
+        assert len(request_value.catalog_refs) == len(request_body["catalog_refs"])
+        assert job_created_at is not None
+        pricing_contract_calls.append(job_created_at)
+        return ("derived_from_job_created_at_utc", job_created_at.date())
 
     monkeypatch.setattr(revisions_module, "_get_active_revision", fake_get_active_revision)
     monkeypatch.setattr(
@@ -974,7 +986,12 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
         fake_publish_job_enqueue_intent,
     )
     monkeypatch.setattr(revisions_module, "enqueue_estimate_job", fake_enqueue_estimate_job)
-    monkeypatch.setattr(revisions_module, "datetime", _AppClock)
+    monkeypatch.setattr(estimates_routes_module, "_utc_now", fake_utc_now)
+    monkeypatch.setattr(
+        estimates_routes_module,
+        "_resolve_estimate_pricing_contract",
+        fake_resolve_estimate_pricing_contract,
+    )
     monkeypatch.setattr(
         revisions_module,
         "_resolve_estimate_job_model_classes",
@@ -1008,6 +1025,8 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
     assert estimate_input.pricing_mode == "derived_from_job_created_at_utc"
     assert estimate_input.pricing_effective_date == estimate_job.created_at.date()
     assert estimate_input.assumptions_json == {"crew": "default"}
+    assert utc_now_calls == 1
+    assert pricing_contract_calls == [job_created_at]
     first_ref = session.added[2]
     second_ref = session.added[3]
     assert first_ref.ref_order == 1
@@ -1031,6 +1050,8 @@ def test_create_revision_estimate_version_replays_idempotent_response(monkeypatc
     assert replay_response.status_code == 202
     assert replay_response.json() == first_body
     assert len(session.added) == 4
+    assert utc_now_calls == 1
+    assert pricing_contract_calls == [job_created_at]
 
 
 def test_create_revision_estimate_version_returns_job_without_idempotency_key(


### PR DESCRIPTION
Closes #278

## Summary
- add `run_idempotent_mutation` and shared idempotent mutation result/ops helpers
- refactor mutating API routes to use the shared orchestration while preserving replay, post-claim revalidation, and after-commit enqueue behavior
- expand regression coverage for orchestrator routing, upload ordering/cleanup, and estimate replay/pricing timing

## Test plan
- [x] `uv run ruff check app tests`
- [x] `uv run mypy app`
- [x] `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_idempotency.py tests/test_idempotent_mutation_inventory.py tests/test_export_create_api.py tests/test_estimation_catalog_api.py tests/test_files.py tests/test_jobs.py tests/test_jobs_api.py tests/test_quantity_takeoff_api.py tests/test_revision_quantity_estimate_flow.py tests/test_jobs_worker_exports.py tests/test_revision_router_contract.py`
- [x] pre-push hook `uv run pytest` on push