### PR TITLE
test(tooling): profile integration lane runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,6 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
 
       - name: Run pytest integration lane
-        run: uv run pytest --durations=40 --durations-min=0.2 -m "integration and ${{ matrix.marker }} and not compose_smoke"
+        run: uv run python scripts/profile_integration_lane.py --marker "integration and ${{ matrix.marker }} and not compose_smoke" --durations 50 --durations-min 0.2
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 #   make test        — Run full pytest suite
 #   make smoke       — Run fast smoke pytest lane
 #   make integration — Run full DB-backed integration pytest lane
+#   make profile-integration — Profile DB-backed integration lane timing
 #   make integration-db-api — Run DB API integration pytest lane
 #   make integration-db-worker — Run DB worker integration pytest lane
 #   make integration-db-estimation-export — Run DB estimation/export integration pytest lane
@@ -20,6 +21,12 @@
 #   make format      — Run ruff formatter on app/ and tests/
 #   make check       — Run lint + typecheck + test
 #   make hooks       — Install pre-commit + adaptive pre-push hooks
+#
+# profile-integration overrides:
+#   PROFILE_INTEGRATION_MARKER      — pytest -m expression (default: integration lane)
+#   PROFILE_INTEGRATION_DURATIONS   — slow test count for --durations output
+#   PROFILE_INTEGRATION_DURATIONS_MIN — minimum seconds for --durations-min
+#   PROFILE_INTEGRATION_PYTEST_ARGS — extra pytest args passed through to the runner
 #   make up          — Start Docker Compose stack
 #   make down        — Stop Docker Compose stack
 #   make logs        — Follow Docker Compose logs
@@ -32,6 +39,10 @@
 UV_SYNC_ARGS = --extra db --extra jobs --extra ingestion --extra dev --extra test
 PRE_PUSH_HOOK = .git/hooks/pre-push
 PRE_PUSH_HOOK_VERSION = v1
+PROFILE_INTEGRATION_MARKER ?= $(PYTEST_INTEGRATION_EXPRESSION)
+PROFILE_INTEGRATION_DURATIONS ?= 50
+PROFILE_INTEGRATION_DURATIONS_MIN ?= 0.2
+PROFILE_INTEGRATION_PYTEST_ARGS ?=
 PYTEST_SMOKE_EXPRESSION = smoke and not integration and not compose_smoke
 PYTEST_INTEGRATION_EXPRESSION = integration and not compose_smoke
 PYTEST_DB_API_EXPRESSION = integration and db_api and not compose_smoke
@@ -42,7 +53,7 @@ PYTEST_DB_MIGRATION_EXPRESSION = integration and db_migration and not compose_sm
 PYTEST_COMPOSE_SMOKE_EXPRESSION = compose_smoke
 SMOKE_BASE_URL ?= http://localhost:8000
 
-.PHONY: sync lint typecheck test smoke integration integration-db-api integration-db-worker integration-db-estimation-export integration-db-lineage integration-db-migration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
+.PHONY: sync lint typecheck test smoke integration profile-integration integration-db-api integration-db-worker integration-db-estimation-export integration-db-lineage integration-db-migration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
 
 sync:
 	uv sync $(UV_SYNC_ARGS)
@@ -62,6 +73,10 @@ smoke:
 integration:
 	uv run alembic upgrade head
 	uv run pytest -m "$(PYTEST_INTEGRATION_EXPRESSION)"
+
+profile-integration:
+	uv run alembic upgrade head
+	uv run python scripts/profile_integration_lane.py --marker "$(PROFILE_INTEGRATION_MARKER)" --durations $(PROFILE_INTEGRATION_DURATIONS) --durations-min $(PROFILE_INTEGRATION_DURATIONS_MIN) $(PROFILE_INTEGRATION_PYTEST_ARGS)
 
 compose-smoke:
 	COMPOSE_SMOKE=1 SMOKE_BASE_URL="$(SMOKE_BASE_URL)" uv run pytest -m "$(PYTEST_COMPOSE_SMOKE_EXPRESSION)"

--- a/docs/integration-lane-profiling.md
+++ b/docs/integration-lane-profiling.md
@@ -1,0 +1,6 @@
+# Issue #297 profiling note
+
+- Repro command (local snapshot, not a permanent benchmark): `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke" PROFILE_INTEGRATION_DURATIONS=50 PROFILE_INTEGRATION_DURATIONS_MIN=0.2`
+- Timing snapshot: collect-only preflight `1.718s`, full pytest run (includes normal collection) `73.203s`, combined wall clock `74.921s`; results `161 passed, 814 deselected, 8 warnings`.
+- Top runtime contributors in the `db_api` lane: six export-create API cases at `6.10s`-`6.14s` each — idempotency different-payload rejection, `estimate_csv` persistence, `estimate_pdf` persistence, replay idempotent request, `revision_json` persistence, and `quantity_csv` persistence; file upload size/format setup phases at roughly `0.36s`-`0.42s`; one revision quantity→estimate flow call at `0.39s`; one revision materialization filter call at `0.24s`; one project update setup at `0.23s`.
+- Follow-up recommendations: profile the export-create tests together first (likely shared fixture/setup or repeated DB/app startup cost), then trim file-upload fixture overhead, and finally review the quantity→estimate/materialization paths for avoidable setup duplication or unnecessary DB work.

--- a/scripts/profile_integration_lane.py
+++ b/scripts/profile_integration_lane.py
@@ -1,0 +1,178 @@
+"""Profile pytest DB integration lanes with collect-only preflight timing."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TextIO
+
+DEFAULT_DURATIONS = 50
+DEFAULT_DURATIONS_MIN = 0.2
+BASE_PYTEST_COMMAND = ("uv", "run", "pytest")
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    marker: str
+    durations: int
+    durations_min: float
+    pytest_args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+CommandRunner = Callable[[Sequence[str], bool], CommandResult]
+Clock = Callable[[], float]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> ProfileConfig:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--marker", required=True)
+    parser.add_argument("--durations", type=int, default=DEFAULT_DURATIONS)
+    parser.add_argument("--durations-min", type=float, default=DEFAULT_DURATIONS_MIN)
+    namespace, pytest_args = parser.parse_known_args(argv)
+    return ProfileConfig(
+        marker=namespace.marker,
+        durations=namespace.durations,
+        durations_min=namespace.durations_min,
+        pytest_args=tuple(normalize_pytest_args(pytest_args)),
+    )
+
+
+def normalize_pytest_args(args: Sequence[str]) -> list[str]:
+    if args and args[0] == "--":
+        return list(args[1:])
+    return list(args)
+
+
+def build_collection_command(config: ProfileConfig) -> list[str]:
+    return [
+        *BASE_PYTEST_COMMAND,
+        "-m",
+        config.marker,
+        "--collect-only",
+        "-q",
+        *config.pytest_args,
+    ]
+
+
+def build_execution_command(config: ProfileConfig) -> list[str]:
+    return [
+        *BASE_PYTEST_COMMAND,
+        "-m",
+        config.marker,
+        f"--durations={config.durations}",
+        f"--durations-min={config.durations_min:g}",
+        *config.pytest_args,
+    ]
+
+
+def default_runner(command: Sequence[str], capture_output: bool) -> CommandResult:
+    result = subprocess.run(
+        list(command),
+        check=False,
+        capture_output=capture_output,
+        text=capture_output,
+    )
+    return CommandResult(
+        returncode=result.returncode,
+        stdout=result.stdout or "",
+        stderr=result.stderr or "",
+    )
+
+
+def format_command(command: Sequence[str]) -> str:
+    return shlex.join(command)
+
+
+def print_command_start(label: str, command: Sequence[str], stream: TextIO) -> None:
+    print(f"[profile] {label} command: {format_command(command)}", file=stream)
+
+
+def print_command_finish(
+    label: str,
+    elapsed_seconds: float,
+    returncode: int,
+    stream: TextIO,
+) -> None:
+    print(
+        f"[profile] {label} elapsed: {elapsed_seconds:.3f}s (exit {returncode})",
+        file=stream,
+    )
+
+
+def relay_captured_output(result: CommandResult, stdout: TextIO, stderr: TextIO) -> None:
+    if result.stdout:
+        print(result.stdout, end="", file=stdout)
+    if result.stderr:
+        print(result.stderr, end="", file=stderr)
+
+
+def run_profile(
+    config: ProfileConfig,
+    *,
+    runner: CommandRunner = default_runner,
+    clock: Clock = time.perf_counter,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    collection_command = build_collection_command(config)
+    execution_command = build_execution_command(config)
+
+    print_command_start("collect-only", collection_command, stderr)
+    collection_started = clock()
+    collection_result = runner(collection_command, True)
+    collection_elapsed = clock() - collection_started
+    print_command_finish("collect-only", collection_elapsed, collection_result.returncode, stderr)
+    if collection_result.returncode != 0:
+        relay_captured_output(collection_result, stdout, stderr)
+        print("[profile] full pytest run skipped after collect-only failure.", file=stderr)
+        return collection_result.returncode
+
+    print_command_start("full pytest run", execution_command, stderr)
+    execution_started = clock()
+    execution_result = runner(execution_command, False)
+    execution_elapsed = clock() - execution_started
+    print_command_finish("full pytest run", execution_elapsed, execution_result.returncode, stderr)
+    print(
+        "[profile] summary: "
+        f"collect-only={collection_elapsed:.3f}s "
+        f"full-pytest-run={execution_elapsed:.3f}s "
+        f"combined-wall={collection_elapsed + execution_elapsed:.3f}s",
+        file=stderr,
+    )
+    return execution_result.returncode
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    runner: CommandRunner = default_runner,
+    clock: Clock = time.perf_counter,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    config = parse_args(argv)
+    output_stream = sys.stdout if stdout is None else stdout
+    error_stream = sys.stderr if stderr is None else stderr
+    return run_profile(
+        config,
+        runner=runner,
+        clock=clock,
+        stdout=output_stream,
+        stderr=error_stream,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_profile_integration_lane.py
+++ b/tests/test_profile_integration_lane.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from types import ModuleType
+
+
+def load_profile_integration_lane_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "profile_integration_lane.py"
+    spec = importlib.util.spec_from_file_location("profile_integration_lane", module_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("failed to load profile_integration_lane module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+profile_integration_lane = load_profile_integration_lane_module()
+
+
+class RunnerStub:
+    def __init__(self, results: Sequence[object]) -> None:
+        self._results = list(results)
+        self.calls: list[tuple[tuple[str, ...], bool]] = []
+
+    def __call__(self, command: Sequence[str], capture_output: bool) -> object:
+        self.calls.append((tuple(command), capture_output))
+        if not self._results:
+            raise AssertionError("unexpected runner call")
+        return self._results.pop(0)
+
+
+class ClockStub:
+    def __init__(self, values: Sequence[float]) -> None:
+        self._values = list(values)
+
+    def __call__(self) -> float:
+        if not self._values:
+            raise AssertionError("unexpected clock call")
+        return self._values.pop(0)
+
+
+def test_parse_args_supports_marker_durations_and_passthrough() -> None:
+    config = profile_integration_lane.parse_args(
+        [
+            "--marker",
+            "integration and db_api and not compose_smoke",
+            "--durations",
+            "25",
+            "--durations-min",
+            "0.5",
+            "--",
+            "--maxfail=1",
+            "tests/test_jobs_api.py",
+        ]
+    )
+
+    assert config.marker == "integration and db_api and not compose_smoke"
+    assert config.durations == 25
+    assert config.durations_min == 0.5
+    assert config.pytest_args == ("--maxfail=1", "tests/test_jobs_api.py")
+
+
+def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() -> None:
+    runner = RunnerStub(
+        [
+            profile_integration_lane.CommandResult(returncode=0),
+            profile_integration_lane.CommandResult(returncode=0),
+        ]
+    )
+    clock = ClockStub([10.0, 10.25, 20.0, 21.75])
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    exit_code = profile_integration_lane.main(
+        [
+            "--marker",
+            "integration and db_worker and not compose_smoke",
+            "--durations",
+            "50",
+            "--durations-min",
+            "0.2",
+            "--maxfail=1",
+        ],
+        runner=runner,
+        clock=clock,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert runner.calls == [
+        (
+            (
+                "uv",
+                "run",
+                "pytest",
+                "-m",
+                "integration and db_worker and not compose_smoke",
+                "--collect-only",
+                "-q",
+                "--maxfail=1",
+            ),
+            True,
+        ),
+        (
+            (
+                "uv",
+                "run",
+                "pytest",
+                "-m",
+                "integration and db_worker and not compose_smoke",
+                "--durations=50",
+                "--durations-min=0.2",
+                "--maxfail=1",
+            ),
+            False,
+        ),
+    ]
+    assert stdout.getvalue() == ""
+    error_output = stderr.getvalue()
+    assert "[profile] collect-only command:" in error_output
+    assert "[profile] full pytest run command:" in error_output
+    assert "[profile] collect-only elapsed: 0.250s (exit 0)" in error_output
+    assert "[profile] full pytest run elapsed: 1.750s (exit 0)" in error_output
+    assert (
+        "[profile] summary: collect-only=0.250s full-pytest-run=1.750s combined-wall=2.000s"
+        in error_output
+    )
+
+
+def test_main_returns_collection_failure_and_skips_execution() -> None:
+    runner = RunnerStub(
+        [
+            profile_integration_lane.CommandResult(
+                returncode=2,
+                stdout="collection stdout\n",
+                stderr="collection stderr\n",
+            )
+        ]
+    )
+    clock = ClockStub([1.0, 1.1])
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    exit_code = profile_integration_lane.main(
+        ["--marker", "integration and db_api and not compose_smoke"],
+        runner=runner,
+        clock=clock,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert exit_code == 2
+    assert runner.calls == [
+        (
+            (
+                "uv",
+                "run",
+                "pytest",
+                "-m",
+                "integration and db_api and not compose_smoke",
+                "--collect-only",
+                "-q",
+            ),
+            True,
+        )
+    ]
+    assert stdout.getvalue() == "collection stdout\n"
+    error_output = stderr.getvalue()
+    assert "collection stderr\n" in error_output
+    assert "[profile] full pytest run skipped after collect-only failure." in error_output


### PR DESCRIPTION
Closes #297

## Summary
- add a dependency-free integration-lane profiling runner with separate collect-only preflight and full pytest timing labels
- add a `make profile-integration` target and switch CI integration lanes to use the profiling runner
- document a local profiling snapshot, top contributors, and follow-up recommendations

## Test plan
- [x] uv run ruff check scripts tests/test_profile_integration_lane.py
- [x] uv run mypy scripts tests/test_profile_integration_lane.py
- [x] uv run pytest -q tests/test_profile_integration_lane.py tests/test_pre_push_check.py
- [x] DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke" PROFILE_INTEGRATION_DURATIONS=50 PROFILE_INTEGRATION_DURATIONS_MIN=0.2