### PR TITLE
test(tooling): optimize integration DB setup lifecycle #298

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
 
-      - name: Run Alembic migrations
-        run: uv run alembic upgrade head
-        env:
-          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
-
       - name: Run pytest integration lane
         run: uv run python scripts/profile_integration_lane.py --marker "integration and ${{ matrix.marker }} and not compose_smoke" --durations 50 --durations-min 0.2
         env:

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ integration:
 	uv run pytest -m "$(PYTEST_INTEGRATION_EXPRESSION)"
 
 profile-integration:
-	uv run alembic upgrade head
 	uv run python scripts/profile_integration_lane.py --marker "$(PROFILE_INTEGRATION_MARKER)" --durations $(PROFILE_INTEGRATION_DURATIONS) --durations-min $(PROFILE_INTEGRATION_DURATIONS_MIN) $(PROFILE_INTEGRATION_PYTEST_ARGS)
 
 compose-smoke:

--- a/docs/integration-lane-profiling.md
+++ b/docs/integration-lane-profiling.md
@@ -1,6 +1,38 @@
-# Issue #297 profiling note
+# Integration lane profiling notes
+
+## Local usage
+
+- Use a local PostgreSQL test database only: `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test"`.
+- Keep the existing `_test` guardrails intact when profiling locally: localhost-only Postgres, database name ending in `_test`, and no shared dev/prod database targets.
+- Repro commands (local snapshots, not permanent benchmarks):
+  - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke"`
+  - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_worker and not compose_smoke"`
+- The profiler owns `uv run alembic upgrade head`, the collect-only preflight, and the full pytest pass; do not pre-run Alembic before `make profile-integration`.
+
+## CI behavior
+
+- CI integration matrix lanes run against a fresh `postgres:18-alpine` service per lane.
+- The profiled lane invokes `scripts/profile_integration_lane.py` directly with `DATABASE_URL` set on that step.
+- CI does not run a separate pre-profile `uv run alembic upgrade head`; the profiler performs the single migration timing pass so local and CI behavior stay aligned and profiled lanes do not double-run migrations.
+
+## Timing evidence
+
+### Issue #297 baseline (`db_api`)
 
 - Repro command (local snapshot, not a permanent benchmark): `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke" PROFILE_INTEGRATION_DURATIONS=50 PROFILE_INTEGRATION_DURATIONS_MIN=0.2`
 - Timing snapshot: collect-only preflight `1.718s`, full pytest run (includes normal collection) `73.203s`, combined wall clock `74.921s`; results `161 passed, 814 deselected, 8 warnings`.
 - Top runtime contributors in the `db_api` lane: six export-create API cases at `6.10s`-`6.14s` each — idempotency different-payload rejection, `estimate_csv` persistence, `estimate_pdf` persistence, replay idempotent request, `revision_json` persistence, and `quantity_csv` persistence; file upload size/format setup phases at roughly `0.36s`-`0.42s`; one revision quantity→estimate flow call at `0.39s`; one revision materialization filter call at `0.24s`; one project update setup at `0.23s`.
 - Follow-up recommendations: profile the export-create tests together first (likely shared fixture/setup or repeated DB/app startup cost), then trim file-upload fixture overhead, and finally review the quantity→estimate/materialization paths for avoidable setup duplication or unnecessary DB work.
+
+### Issue #298 Phase 2 snapshots
+
+- `db_api` timing snapshot: migration `0.322s`, collect-only `1.186s`, full pytest run `70.025s`, combined wall `71.533s`; result `161 passed, 815 deselected, 8 warnings`.
+- `db_api` runtime concentration: full pytest runtime dominates over migration plus collect-only; slowest calls were six export-create API cases at `6.09s`-`6.12s` each, while the only visible setup at/above the reporting threshold was one project update setup at `0.20s`.
+- `db_worker` timing snapshot: migration `0.316s`, collect-only `1.151s`, full pytest run `186.241s`, combined wall `187.708s`; result `178 passed, 798 deselected, 7 warnings`.
+- `db_worker` runtime concentration: full pytest runtime dominates over migration plus collect-only; slowest calls were worker export storage/readback cases at `12.22s`-`12.26s` and multiple export worker calls at `6.14s`-`6.28s`, while the only visible setup at/above the reporting threshold was one quantity recovery setup at `0.24s`.
+
+## Decision
+
+- No DB lifecycle optimization was adopted.
+- Why: Phase 2 showed migration plus collect-only staying under roughly `1.5s` in both `db_api` and `db_worker`, while the meaningful cost remains inside the full pytest run itself.
+- Result: keep the current fresh-database flow for both local profiling and CI, avoid template DB or other lifecycle complexity, and use the retained hotspot evidence for later test-specific optimization work.

--- a/scripts/profile_integration_lane.py
+++ b/scripts/profile_integration_lane.py
@@ -1,4 +1,4 @@
-"""Profile pytest DB integration lanes with collect-only preflight timing."""
+"""Profile DB integration lanes across migration, collect-only, and pytest run."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from typing import TextIO
 
 DEFAULT_DURATIONS = 50
 DEFAULT_DURATIONS_MIN = 0.2
+BASE_MIGRATION_COMMAND = ("uv", "run", "alembic", "upgrade", "head")
 BASE_PYTEST_COMMAND = ("uv", "run", "pytest")
 
 
@@ -64,6 +65,10 @@ def build_collection_command(config: ProfileConfig) -> list[str]:
         "-q",
         *config.pytest_args,
     ]
+
+
+def build_migration_command() -> list[str]:
+    return [*BASE_MIGRATION_COMMAND]
 
 
 def build_execution_command(config: ProfileConfig) -> list[str]:
@@ -126,8 +131,20 @@ def run_profile(
     stdout: TextIO,
     stderr: TextIO,
 ) -> int:
+    migration_command = build_migration_command()
     collection_command = build_collection_command(config)
     execution_command = build_execution_command(config)
+
+    print_command_start("migration", migration_command, stderr)
+    migration_started = clock()
+    migration_result = runner(migration_command, True)
+    migration_elapsed = clock() - migration_started
+    print_command_finish("migration", migration_elapsed, migration_result.returncode, stderr)
+    if migration_result.returncode != 0:
+        relay_captured_output(migration_result, stdout, stderr)
+        print("[profile] collect-only skipped after migration failure.", file=stderr)
+        print("[profile] full pytest run skipped after migration failure.", file=stderr)
+        return migration_result.returncode
 
     print_command_start("collect-only", collection_command, stderr)
     collection_started = clock()
@@ -146,9 +163,10 @@ def run_profile(
     print_command_finish("full pytest run", execution_elapsed, execution_result.returncode, stderr)
     print(
         "[profile] summary: "
+        f"migration={migration_elapsed:.3f}s "
         f"collect-only={collection_elapsed:.3f}s "
         f"full-pytest-run={execution_elapsed:.3f}s "
-        f"combined-wall={collection_elapsed + execution_elapsed:.3f}s",
+        f"combined-wall={migration_elapsed + collection_elapsed + execution_elapsed:.3f}s",
         file=stderr,
     )
     return execution_result.returncode

--- a/tests/test_profile_integration_lane.py
+++ b/tests/test_profile_integration_lane.py
@@ -70,9 +70,10 @@ def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() ->
         [
             profile_integration_lane.CommandResult(returncode=0),
             profile_integration_lane.CommandResult(returncode=0),
+            profile_integration_lane.CommandResult(returncode=0),
         ]
     )
-    clock = ClockStub([10.0, 10.25, 20.0, 21.75])
+    clock = ClockStub([1.0, 1.5, 10.0, 10.25, 20.0, 21.75])
     stdout = io.StringIO()
     stderr = io.StringIO()
 
@@ -94,6 +95,16 @@ def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() ->
 
     assert exit_code == 0
     assert runner.calls == [
+        (
+            (
+                "uv",
+                "run",
+                "alembic",
+                "upgrade",
+                "head",
+            ),
+            True,
+        ),
         (
             (
                 "uv",
@@ -123,27 +134,72 @@ def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() ->
     ]
     assert stdout.getvalue() == ""
     error_output = stderr.getvalue()
+    assert "[profile] migration command:" in error_output
     assert "[profile] collect-only command:" in error_output
     assert "[profile] full pytest run command:" in error_output
+    assert "[profile] migration elapsed: 0.500s (exit 0)" in error_output
     assert "[profile] collect-only elapsed: 0.250s (exit 0)" in error_output
     assert "[profile] full pytest run elapsed: 1.750s (exit 0)" in error_output
     assert (
-        "[profile] summary: collect-only=0.250s full-pytest-run=1.750s combined-wall=2.000s"
-        in error_output
+        "[profile] summary: migration=0.500s collect-only=0.250s "
+        "full-pytest-run=1.750s combined-wall=2.500s" in error_output
     )
+
+
+def test_main_returns_migration_failure_and_skips_collect_only_and_execution() -> None:
+    runner = RunnerStub(
+        [
+            profile_integration_lane.CommandResult(
+                returncode=1,
+                stdout="migration stdout\n",
+                stderr="migration stderr\n",
+            )
+        ]
+    )
+    clock = ClockStub([1.0, 1.2])
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    exit_code = profile_integration_lane.main(
+        ["--marker", "integration and db_api and not compose_smoke"],
+        runner=runner,
+        clock=clock,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+    assert exit_code == 1
+    assert runner.calls == [
+        (
+            (
+                "uv",
+                "run",
+                "alembic",
+                "upgrade",
+                "head",
+            ),
+            True,
+        )
+    ]
+    assert stdout.getvalue() == "migration stdout\n"
+    error_output = stderr.getvalue()
+    assert "migration stderr\n" in error_output
+    assert "[profile] collect-only skipped after migration failure." in error_output
+    assert "[profile] full pytest run skipped after migration failure." in error_output
 
 
 def test_main_returns_collection_failure_and_skips_execution() -> None:
     runner = RunnerStub(
         [
+            profile_integration_lane.CommandResult(returncode=0),
             profile_integration_lane.CommandResult(
                 returncode=2,
                 stdout="collection stdout\n",
                 stderr="collection stderr\n",
-            )
+            ),
         ]
     )
-    clock = ClockStub([1.0, 1.1])
+    clock = ClockStub([1.0, 1.2, 2.0, 2.1])
     stdout = io.StringIO()
     stderr = io.StringIO()
 
@@ -161,6 +217,16 @@ def test_main_returns_collection_failure_and_skips_execution() -> None:
             (
                 "uv",
                 "run",
+                "alembic",
+                "upgrade",
+                "head",
+            ),
+            True,
+        ),
+        (
+            (
+                "uv",
+                "run",
                 "pytest",
                 "-m",
                 "integration and db_api and not compose_smoke",
@@ -168,9 +234,10 @@ def test_main_returns_collection_failure_and_skips_execution() -> None:
                 "-q",
             ),
             True,
-        )
+        ),
     ]
     assert stdout.getvalue() == "collection stdout\n"
     error_output = stderr.getvalue()
+    assert "[profile] migration elapsed: 0.200s (exit 0)" in error_output
     assert "collection stderr\n" in error_output
     assert "[profile] full pytest run skipped after collect-only failure." in error_output


### PR DESCRIPTION
Closes #298

## Summary
- add migration timing and failure short-circuiting to the integration lane profiler
- align local and CI profile-integration flows so the profiler owns the single Alembic run
- document measured db_api/db_worker timings and record the decision to keep current DB lifecycle defaults

## Test plan
- [x] uv run ruff check app tests scripts
- [x] uv run mypy app tests scripts
- [x] uv run pytest -q tests/test_profile_integration_lane.py tests/test_pre_push_check.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test make integration-db-migration
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test make integration-db-api
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke"

## Notes
- phase 2 measurements showed full pytest runtime dominates, so no template DB or broader DB lifecycle optimization was adopted