### PR TITLE
test(tooling): support parallel DB integration workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@
 #   PROFILE_INTEGRATION_MARKER      — pytest -m expression (default: integration lane)
 #   PROFILE_INTEGRATION_DURATIONS   — slow test count for --durations output
 #   PROFILE_INTEGRATION_DURATIONS_MIN — minimum seconds for --durations-min
+#   PROFILE_INTEGRATION_XDIST_WORKERS — optional local xdist worker count (default: serial)
 #   PROFILE_INTEGRATION_PYTEST_ARGS — extra pytest args passed through to the runner
 #   make up          — Start Docker Compose stack
 #   make down        — Stop Docker Compose stack
@@ -42,7 +43,9 @@ PRE_PUSH_HOOK_VERSION = v1
 PROFILE_INTEGRATION_MARKER ?= $(PYTEST_INTEGRATION_EXPRESSION)
 PROFILE_INTEGRATION_DURATIONS ?= 50
 PROFILE_INTEGRATION_DURATIONS_MIN ?= 0.2
+PROFILE_INTEGRATION_XDIST_WORKERS ?=
 PROFILE_INTEGRATION_PYTEST_ARGS ?=
+PROFILE_INTEGRATION_XDIST_ARGS = $(if $(strip $(PROFILE_INTEGRATION_XDIST_WORKERS)),--xdist-workers $(PROFILE_INTEGRATION_XDIST_WORKERS),)
 PYTEST_SMOKE_EXPRESSION = smoke and not integration and not compose_smoke
 PYTEST_INTEGRATION_EXPRESSION = integration and not compose_smoke
 PYTEST_DB_API_EXPRESSION = integration and db_api and not compose_smoke
@@ -75,7 +78,7 @@ integration:
 	uv run pytest -m "$(PYTEST_INTEGRATION_EXPRESSION)"
 
 profile-integration:
-	uv run python scripts/profile_integration_lane.py --marker "$(PROFILE_INTEGRATION_MARKER)" --durations $(PROFILE_INTEGRATION_DURATIONS) --durations-min $(PROFILE_INTEGRATION_DURATIONS_MIN) $(PROFILE_INTEGRATION_PYTEST_ARGS)
+	uv run python scripts/profile_integration_lane.py --marker "$(PROFILE_INTEGRATION_MARKER)" --durations $(PROFILE_INTEGRATION_DURATIONS) --durations-min $(PROFILE_INTEGRATION_DURATIONS_MIN) $(PROFILE_INTEGRATION_XDIST_ARGS) $(PROFILE_INTEGRATION_PYTEST_ARGS)
 
 compose-smoke:
 	COMPOSE_SMOKE=1 SMOKE_BASE_URL="$(SMOKE_BASE_URL)" uv run pytest -m "$(PYTEST_COMPOSE_SMOKE_EXPRESSION)"

--- a/docs/integration-lane-profiling.md
+++ b/docs/integration-lane-profiling.md
@@ -4,10 +4,16 @@
 
 - Use a local PostgreSQL test database only: `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test"`.
 - Keep the existing `_test` guardrails intact when profiling locally: localhost-only Postgres, database name ending in `_test`, and no shared dev/prod database targets.
+- Optional xdist mode is local-only and opt-in: set `PROFILE_INTEGRATION_XDIST_WORKERS=<count>` to pass `-n <count> --dist loadfile` through the profiling runner.
 - Repro commands (local snapshots, not permanent benchmarks):
   - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke"`
   - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_worker and not compose_smoke"`
+- Repro commands with xdist enabled (local snapshots, not permanent benchmarks):
+  - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke" PROFILE_INTEGRATION_XDIST_WORKERS=4`
+  - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_worker and not compose_smoke" PROFILE_INTEGRATION_XDIST_WORKERS=4`
 - The profiler owns `uv run alembic upgrade head`, the collect-only preflight, and the full pytest pass; do not pre-run Alembic before `make profile-integration`.
+- Per-worker DB safety constraints: keep the base `DATABASE_URL` local and `_test`-suffixed; worker databases are derived from that base URL and created/migrated per worker, so never point profiling at shared or non-test databases.
+- Trade-off framing: xdist can reduce wall clock when tests parallelize cleanly, but can increase setup/load and contention. Treat any speedup as evidence-to-collect per lane (serial vs xdist snapshots on the same machine), not a guaranteed benchmark claim.
 
 ## CI behavior
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ test = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
+    "pytest-xdist>=3.6",
     "factory-boy>=3.3",
 ]
 

--- a/scripts/profile_integration_lane.py
+++ b/scripts/profile_integration_lane.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import shlex
 import subprocess
 import sys
@@ -15,6 +16,7 @@ DEFAULT_DURATIONS = 50
 DEFAULT_DURATIONS_MIN = 0.2
 BASE_MIGRATION_COMMAND = ("uv", "run", "alembic", "upgrade", "head")
 BASE_PYTEST_COMMAND = ("uv", "run", "pytest")
+XDIST_WORKERS_ENV = "PROFILE_INTEGRATION_XDIST_WORKERS"
 
 
 @dataclass(frozen=True)
@@ -22,6 +24,7 @@ class ProfileConfig:
     marker: str
     durations: int
     durations_min: float
+    xdist_workers: int | None
     pytest_args: tuple[str, ...]
 
 
@@ -41,11 +44,17 @@ def parse_args(argv: Sequence[str] | None = None) -> ProfileConfig:
     parser.add_argument("--marker", required=True)
     parser.add_argument("--durations", type=int, default=DEFAULT_DURATIONS)
     parser.add_argument("--durations-min", type=float, default=DEFAULT_DURATIONS_MIN)
+    parser.add_argument(
+        "--xdist-workers",
+        type=parse_positive_int,
+        default=default_xdist_workers(parser),
+    )
     namespace, pytest_args = parser.parse_known_args(argv)
     return ProfileConfig(
         marker=namespace.marker,
         durations=namespace.durations,
         durations_min=namespace.durations_min,
+        xdist_workers=namespace.xdist_workers,
         pytest_args=tuple(normalize_pytest_args(pytest_args)),
     )
 
@@ -54,6 +63,33 @@ def normalize_pytest_args(args: Sequence[str]) -> list[str]:
     if args and args[0] == "--":
         return list(args[1:])
     return list(args)
+
+
+def parse_positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def default_xdist_workers(parser: argparse.ArgumentParser) -> int | None:
+    raw = os.getenv(XDIST_WORKERS_ENV)
+    if raw is None or raw == "":
+        return None
+    try:
+        return parse_positive_int(raw)
+    except argparse.ArgumentTypeError as exc:
+        parser.error(f"{XDIST_WORKERS_ENV} must be a positive integer: {exc}")
+    return None
+
+
+def build_xdist_command_args(xdist_workers: int | None) -> list[str]:
+    if xdist_workers is None:
+        return []
+    return ["-n", str(xdist_workers), "--dist", "loadfile"]
 
 
 def build_collection_command(config: ProfileConfig) -> list[str]:
@@ -78,6 +114,7 @@ def build_execution_command(config: ProfileConfig) -> list[str]:
         config.marker,
         f"--durations={config.durations}",
         f"--durations-min={config.durations_min:g}",
+        *build_xdist_command_args(config.xdist_workers),
         *config.pytest_args,
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 """Shared fixtures for integration tests."""
 
+import asyncio
 import os
+import re
 import shutil
-from collections.abc import AsyncGenerator, Generator
+import subprocess
+from collections.abc import AsyncGenerator, Callable, Generator, Mapping, MutableMapping
 from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import parse_qsl, quote, unquote, urlparse, urlunparse
 
 import httpx
 import pytest
@@ -13,12 +18,214 @@ from httpx import ASGITransport
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-import app.api.v1.files as files_api
-import app.jobs.worker as worker_module
-from app.core.config import settings
-from app.db.session import get_db
-from app.main import app as fastapi_app
-from app.storage.dependencies import _get_default_storage
+_LOCAL_DATABASE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_XDIST_WORKER_ID_RE = re.compile(r"^gw[0-9]+$")
+_XDIST_BLOCKED_QUERY_PARAMS = frozenset(
+    {
+        "host",
+        "hostaddr",
+        "port",
+        "database",
+        "dbname",
+        "user",
+        "password",
+        "service",
+    }
+)
+_POSTGRES_IDENTIFIER_MAX_BYTES = 63
+
+
+class XdistDatabaseConfig(NamedTuple):
+    """Derived database URLs for one pytest-xdist worker process."""
+
+    worker_id: str
+    worker_database_name: str
+    worker_database_url: str
+    maintenance_database_url: str
+
+
+def _xdist_worker_id(environ: Mapping[str, str]) -> str | None:
+    """Return the active xdist worker id, excluding serial/master collection."""
+
+    worker_id = environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is None or worker_id == "master":
+        return None
+    return worker_id
+
+
+def _xdist_testrun_uid(environ: Mapping[str, str]) -> str | None:
+    """Return the xdist test-run uid when present."""
+
+    testrun_uid = environ.get("PYTEST_XDIST_TESTRUNUID")
+    if testrun_uid is None:
+        return None
+    normalized = testrun_uid.strip()
+    return normalized or None
+
+
+def _derive_database_identity(database_url: str) -> str:
+    """Return a sanitized host/database identity for error messages."""
+
+    parsed = urlparse(database_url)
+    host = parsed.hostname or "<unknown-host>"
+    database_name = unquote(parsed.path.lstrip("/")) or "<unknown-database>"
+    if parsed.port is None:
+        return f"{host}/{database_name}"
+    return f"{host}:{parsed.port}/{database_name}"
+
+
+def _derive_xdist_database_config(
+    database_url: str,
+    worker_id: str,
+    *,
+    testrun_uid: str | None = None,
+) -> XdistDatabaseConfig:
+    """Derive a safe physical database URL for one xdist worker."""
+
+    parsed = urlparse(database_url)
+    if not parsed.scheme.startswith("postgresql"):
+        raise ValueError("DATABASE_URL must use a PostgreSQL URL for xdist DB isolation.")
+    if parsed.hostname not in _LOCAL_DATABASE_HOSTS:
+        raise ValueError(
+            "DATABASE_URL must point to localhost, 127.0.0.1, or ::1 for xdist DB isolation."
+        )
+
+    unsafe_query_params = sorted(
+        {
+            key.casefold()
+            for key, _ in parse_qsl(parsed.query, keep_blank_values=True)
+            if key.casefold() in _XDIST_BLOCKED_QUERY_PARAMS
+        }
+    )
+    if unsafe_query_params:
+        raise ValueError(
+            "DATABASE_URL contains unsupported query parameter(s) for xdist DB isolation: "
+            + ", ".join(unsafe_query_params)
+        )
+
+    database_name = unquote(parsed.path.lstrip("/"))
+    if not database_name.endswith("_test"):
+        raise ValueError(
+            "DATABASE_URL must use a dedicated test database name ending in '_test' for "
+            "xdist DB isolation."
+        )
+    if _XDIST_WORKER_ID_RE.fullmatch(worker_id) is None:
+        raise ValueError(f"unsupported pytest-xdist worker id for DB isolation: {worker_id!r}")
+
+    worker_suffix = worker_id if testrun_uid is None else f"{testrun_uid}_{worker_id}"
+    worker_database_name = f"{database_name}_{worker_suffix}"
+    if len(worker_database_name.encode("utf-8")) > _POSTGRES_IDENTIFIER_MAX_BYTES:
+        raise ValueError(
+            "Derived worker database name exceeds PostgreSQL identifier limit "
+            f"({_POSTGRES_IDENTIFIER_MAX_BYTES} bytes): {worker_database_name!r}"
+        )
+
+    worker_database_url = urlunparse(parsed._replace(path=f"/{quote(worker_database_name)}"))
+    maintenance_database_url = urlunparse(parsed._replace(path="/postgres"))
+    return XdistDatabaseConfig(
+        worker_id=worker_id,
+        worker_database_name=worker_database_name,
+        worker_database_url=worker_database_url,
+        maintenance_database_url=maintenance_database_url,
+    )
+
+
+def _asyncpg_dsn(database_url: str) -> str:
+    """Return an asyncpg-compatible DSN from the SQLAlchemy async URL."""
+
+    parsed = urlparse(database_url)
+    scheme = parsed.scheme.split("+", maxsplit=1)[0]
+    return urlunparse(parsed._replace(scheme=scheme))
+
+
+def _quote_postgres_identifier(value: str) -> str:
+    """Quote a PostgreSQL identifier for CREATE DATABASE."""
+
+    return '"' + value.replace('"', '""') + '"'
+
+
+async def _create_xdist_worker_database_async(config: XdistDatabaseConfig) -> None:
+    """Create the worker database if it does not already exist."""
+
+    import asyncpg  # type: ignore[import-untyped]
+
+    connection = await asyncpg.connect(_asyncpg_dsn(config.maintenance_database_url))
+    try:
+        exists = await connection.fetchval(
+            "SELECT 1 FROM pg_database WHERE datname = $1",
+            config.worker_database_name,
+        )
+        if exists is None:
+            await connection.execute(
+                f"CREATE DATABASE {_quote_postgres_identifier(config.worker_database_name)}"
+            )
+    finally:
+        await connection.close()
+
+
+def _create_xdist_worker_database(config: XdistDatabaseConfig) -> None:
+    """Synchronously ensure the worker database exists before app imports."""
+
+    asyncio.run(_create_xdist_worker_database_async(config))
+
+
+def _run_xdist_worker_migrations(
+    worker_database_url: str,
+    environ: Mapping[str, str],
+) -> None:
+    """Run Alembic migrations against the isolated worker database."""
+
+    migration_env = {**environ, "DATABASE_URL": worker_database_url}
+    result = subprocess.run(
+        ["uv", "run", "alembic", "upgrade", "head"],
+        check=False,
+        env=migration_env,
+    )
+    if result.returncode != 0:
+        worker_database_identity = _derive_database_identity(worker_database_url)
+        raise pytest.UsageError(
+            "pytest-xdist worker database migration failed for "
+            f"{worker_database_identity!r} with exit code {result.returncode}."
+        )
+
+
+def _configure_xdist_worker_database(
+    environ: MutableMapping[str, str] = os.environ,
+    *,
+    create_database: Callable[[XdistDatabaseConfig], None] = _create_xdist_worker_database,
+    run_migrations: Callable[[str, Mapping[str, str]], None] = _run_xdist_worker_migrations,
+) -> str | None:
+    """Configure this xdist worker process to use its own physical database."""
+
+    worker_id = _xdist_worker_id(environ)
+    testrun_uid = _xdist_testrun_uid(environ)
+    base_database_url = environ.get("DATABASE_URL")
+    if worker_id is None or not base_database_url:
+        return None
+
+    try:
+        config = _derive_xdist_database_config(
+            base_database_url,
+            worker_id,
+            testrun_uid=testrun_uid,
+        )
+    except ValueError as exc:
+        raise pytest.UsageError(str(exc)) from exc
+
+    create_database(config)
+    environ["DATABASE_URL"] = config.worker_database_url
+    run_migrations(config.worker_database_url, environ)
+    return config.worker_database_url
+
+
+_configure_xdist_worker_database()
+
+import app.api.v1.files as files_api  # noqa: E402
+import app.jobs.worker as worker_module  # noqa: E402
+from app.core.config import settings  # noqa: E402
+from app.db.session import get_db  # noqa: E402
+from app.main import app as fastapi_app  # noqa: E402
+from app.storage.dependencies import _get_default_storage  # noqa: E402
 
 APPEND_ONLY_PROTECTED_TABLES: tuple[str, ...] = (
     "files",

--- a/tests/test_profile_integration_lane.py
+++ b/tests/test_profile_integration_lane.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 
 def load_profile_integration_lane_module() -> ModuleType:
     module_path = Path(__file__).resolve().parents[1] / "scripts" / "profile_integration_lane.py"
@@ -62,7 +64,35 @@ def test_parse_args_supports_marker_durations_and_passthrough() -> None:
     assert config.marker == "integration and db_api and not compose_smoke"
     assert config.durations == 25
     assert config.durations_min == 0.5
+    assert config.xdist_workers is None
     assert config.pytest_args == ("--maxfail=1", "tests/test_jobs_api.py")
+
+
+def test_parse_args_supports_xdist_workers_flag_and_passthrough() -> None:
+    config = profile_integration_lane.parse_args(
+        [
+            "--marker",
+            "integration and db_api and not compose_smoke",
+            "--xdist-workers",
+            "3",
+            "--",
+            "--maxfail=1",
+            "tests/test_jobs_api.py",
+        ]
+    )
+
+    assert config.xdist_workers == 3
+    assert config.pytest_args == ("--maxfail=1", "tests/test_jobs_api.py")
+
+
+def test_parse_args_supports_xdist_workers_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROFILE_INTEGRATION_XDIST_WORKERS", "4")
+
+    config = profile_integration_lane.parse_args(
+        ["--marker", "integration and db_api and not compose_smoke"]
+    )
+
+    assert config.xdist_workers == 4
 
 
 def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() -> None:
@@ -85,6 +115,8 @@ def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() ->
             "50",
             "--durations-min",
             "0.2",
+            "--xdist-workers",
+            "2",
             "--maxfail=1",
         ],
         runner=runner,
@@ -127,6 +159,10 @@ def test_main_profiles_collect_only_and_full_pytest_run_with_summary_output() ->
                 "integration and db_worker and not compose_smoke",
                 "--durations=50",
                 "--durations-min=0.2",
+                "-n",
+                "2",
+                "--dist",
+                "loadfile",
                 "--maxfail=1",
             ),
             False,

--- a/tests/test_xdist_database_isolation.py
+++ b/tests/test_xdist_database_isolation.py
@@ -1,0 +1,212 @@
+"""Tests for pytest-xdist database isolation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from tests import conftest
+
+BASE_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test"
+
+
+def test_derive_xdist_database_config_uses_physical_worker_database() -> None:
+    config = conftest._derive_xdist_database_config(
+        f"{BASE_DATABASE_URL}?ssl=disable",
+        "gw1",
+    )
+
+    assert config.worker_id == "gw1"
+    assert config.worker_database_name == "draupnir_test_gw1"
+    assert (
+        config.worker_database_url
+        == "postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test_gw1?ssl=disable"
+    )
+    assert (
+        config.maintenance_database_url
+        == "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres?ssl=disable"
+    )
+
+
+def test_derive_xdist_database_config_includes_testrun_uid_in_worker_database_name() -> None:
+    config = conftest._derive_xdist_database_config(
+        BASE_DATABASE_URL,
+        "gw3",
+        testrun_uid="run-123",
+    )
+
+    assert config.worker_database_name == "draupnir_test_run-123_gw3"
+    assert config.worker_database_url == f"{BASE_DATABASE_URL}_run-123_gw3"
+
+
+def test_configure_xdist_worker_database_updates_environment_after_create() -> None:
+    environ = {
+        "DATABASE_URL": BASE_DATABASE_URL,
+        "PYTEST_XDIST_WORKER": "gw0",
+    }
+    created: list[conftest.XdistDatabaseConfig] = []
+    migrated: list[tuple[str, str]] = []
+
+    def create_database(config: conftest.XdistDatabaseConfig) -> None:
+        created.append(config)
+
+    def run_migrations(worker_database_url: str, migration_env: Mapping[str, str]) -> None:
+        migrated.append((worker_database_url, migration_env["DATABASE_URL"]))
+
+    worker_url = conftest._configure_xdist_worker_database(
+        environ,
+        create_database=create_database,
+        run_migrations=run_migrations,
+    )
+
+    assert worker_url == f"{BASE_DATABASE_URL}_gw0"
+    assert environ["DATABASE_URL"] == f"{BASE_DATABASE_URL}_gw0"
+    assert [config.worker_database_name for config in created] == ["draupnir_test_gw0"]
+    assert migrated == [(f"{BASE_DATABASE_URL}_gw0", f"{BASE_DATABASE_URL}_gw0")]
+
+
+def test_configure_xdist_worker_database_uses_testrun_uid_when_available() -> None:
+    environ = {
+        "DATABASE_URL": BASE_DATABASE_URL,
+        "PYTEST_XDIST_WORKER": "gw1",
+        "PYTEST_XDIST_TESTRUNUID": "run_abc",
+    }
+    created: list[conftest.XdistDatabaseConfig] = []
+    migrated: list[str] = []
+
+    def run_migrations(worker_database_url: str, _migration_env: Mapping[str, str]) -> None:
+        migrated.append(worker_database_url)
+
+    worker_url = conftest._configure_xdist_worker_database(
+        environ,
+        create_database=lambda config: created.append(config),
+        run_migrations=run_migrations,
+    )
+
+    assert worker_url == f"{BASE_DATABASE_URL}_run_abc_gw1"
+    assert environ["DATABASE_URL"] == f"{BASE_DATABASE_URL}_run_abc_gw1"
+    assert [config.worker_database_name for config in created] == ["draupnir_test_run_abc_gw1"]
+    assert migrated == [f"{BASE_DATABASE_URL}_run_abc_gw1"]
+
+
+@pytest.mark.parametrize(
+    ("environ", "expected_url"),
+    [
+        ({}, None),
+        ({"DATABASE_URL": BASE_DATABASE_URL}, None),
+        ({"DATABASE_URL": BASE_DATABASE_URL, "PYTEST_XDIST_WORKER": "master"}, None),
+    ],
+)
+def test_configure_xdist_worker_database_keeps_serial_behavior_unchanged(
+    environ: dict[str, str],
+    expected_url: str | None,
+) -> None:
+    worker_url = conftest._configure_xdist_worker_database(
+        environ,
+        create_database=lambda config: pytest.fail(f"unexpected create for {config!r}"),
+        run_migrations=lambda worker_database_url, migration_env: pytest.fail(
+            f"unexpected migration for {worker_database_url!r} with {migration_env!r}"
+        ),
+    )
+
+    assert worker_url == expected_url
+
+
+@pytest.mark.parametrize(
+    ("database_url", "worker_id", "message"),
+    [
+        ("sqlite:///tmp/test.db", "gw0", "PostgreSQL"),
+        (
+            "postgresql+asyncpg://postgres:postgres@db.internal:5432/draupnir_test",
+            "gw0",
+            "localhost",
+        ),
+        (
+            "postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir",
+            "gw0",
+            "ending in '_test'",
+        ),
+        (BASE_DATABASE_URL, "worker-0", "unsupported pytest-xdist worker id"),
+        (
+            f"{BASE_DATABASE_URL}?database=override",
+            "gw0",
+            "unsupported query parameter",
+        ),
+        (
+            f"{BASE_DATABASE_URL}?Host=db.internal",
+            "gw0",
+            "unsupported query parameter",
+        ),
+        (
+            f"{BASE_DATABASE_URL}?user=postgres",
+            "gw0",
+            "unsupported query parameter",
+        ),
+        (
+            f"{BASE_DATABASE_URL}?PASSWORD=secret",
+            "gw0",
+            "unsupported query parameter",
+        ),
+        (
+            f"{BASE_DATABASE_URL}?service=readonly",
+            "gw0",
+            "unsupported query parameter",
+        ),
+        (
+            f"postgresql+asyncpg://postgres:postgres@localhost:5432/{'a' * 58}_test",
+            "gw0",
+            "identifier limit",
+        ),
+    ],
+)
+def test_derive_xdist_database_config_rejects_unsafe_inputs(
+    database_url: str,
+    worker_id: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        conftest._derive_xdist_database_config(database_url, worker_id)
+
+
+def test_configure_xdist_worker_database_raises_usage_error_for_unsafe_base_url() -> None:
+    environ = {
+        "DATABASE_URL": "postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir",
+        "PYTEST_XDIST_WORKER": "gw0",
+    }
+
+    with pytest.raises(pytest.UsageError, match="ending in '_test'"):
+        conftest._configure_xdist_worker_database(
+            environ,
+            create_database=lambda config: pytest.fail(f"unexpected create for {config!r}"),
+            run_migrations=lambda worker_database_url, migration_env: pytest.fail(
+                f"unexpected migration for {worker_database_url!r} with {migration_env!r}"
+            ),
+        )
+
+
+def test_run_xdist_worker_migrations_usage_error_redacts_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worker_database_url = (
+        "postgresql+asyncpg://postgres:super-secret@localhost:5432/draupnir_test_run_abc_gw2"
+    )
+
+    class _Result:
+        returncode = 19
+
+    def fake_subprocess_run(*_args: object, **_kwargs: object) -> _Result:
+        return _Result()
+
+    monkeypatch.setattr("tests.conftest.subprocess.run", fake_subprocess_run)
+
+    with pytest.raises(pytest.UsageError) as exc_info:
+        conftest._run_xdist_worker_migrations(
+            worker_database_url,
+            {"DATABASE_URL": worker_database_url},
+        )
+
+    message = str(exc_info.value)
+    assert "localhost:5432/draupnir_test_run_abc_gw2" in message
+    assert "super-secret" not in message
+    assert worker_database_url not in message

--- a/uv.lock
+++ b/uv.lock
@@ -600,6 +600,7 @@ all = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "redis" },
     { name = "ruff" },
     { name = "scikit-image" },
@@ -643,6 +644,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -672,6 +674,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "redis", marker = "extra == 'jobs'", specifier = ">=5.0" },
@@ -696,6 +699,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1773,6 +1785,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #299

## Summary
- add opt-in pytest-xdist worker support to the integration profiling lane
- isolate xdist workers onto derived local PostgreSQL _test databases with query-param and identifier guardrails
- document local profiling commands, safety constraints, and trade-offs

## Test plan
- [x] uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
- [x] uv run ruff check scripts tests pyproject.toml
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_profile_integration_lane.py tests/test_xdist_database_isolation.py tests/test_pre_push_check.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke" PROFILE_INTEGRATION_XDIST_WORKERS=2 PROFILE_INTEGRATION_DURATIONS=5 PROFILE_INTEGRATION_DURATIONS_MIN=0.2

## Notes
- serial execution remains the default path; xdist is local opt-in only