### PR TITLE
ci: tune PR and extended DB lane boundaries #300

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -106,7 +109,49 @@ jobs:
       - name: Run pytest non-integration lane
         run: uv run pytest -m "not integration and not compose_smoke and not smoke"
 
-  test-integration-db:
+  test-integration-db-pr:
+    if: github.event_name == 'pull_request'
+    name: Test integration (db_api)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: draupnir_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.8"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked --extra db --extra jobs --extra ingestion --extra dev --extra test
+
+      - name: Run pytest integration lane
+        run: uv run python scripts/profile_integration_lane.py --marker "integration and db_api and not compose_smoke" --durations 50 --durations-min 0.2
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test
+
+  test-integration-db-extended:
+    if: github.event_name != 'pull_request'
     name: Test integration (${{ matrix.lane_name }})
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 #   make smoke       — Run fast smoke pytest lane
 #   make integration — Run full DB-backed integration pytest lane
 #   make profile-integration — Profile DB-backed integration lane timing
+#   make ci-db-pr-fast — Run CI-equivalent PR DB fast gate (db_api only)
+#   make ci-db-extended — Run CI-equivalent extended DB coverage (all DB lanes)
 #   make integration-db-api — Run DB API integration pytest lane
 #   make integration-db-worker — Run DB worker integration pytest lane
 #   make integration-db-estimation-export — Run DB estimation/export integration pytest lane
@@ -56,7 +58,7 @@ PYTEST_DB_MIGRATION_EXPRESSION = integration and db_migration and not compose_sm
 PYTEST_COMPOSE_SMOKE_EXPRESSION = compose_smoke
 SMOKE_BASE_URL ?= http://localhost:8000
 
-.PHONY: sync lint typecheck test smoke integration profile-integration integration-db-api integration-db-worker integration-db-estimation-export integration-db-lineage integration-db-migration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
+.PHONY: sync lint typecheck test smoke integration profile-integration ci-db-pr-fast ci-db-extended integration-db-api integration-db-worker integration-db-estimation-export integration-db-lineage integration-db-migration compose-smoke format check hooks up down logs ps shell-api shell-worker migrate
 
 sync:
 	uv sync $(UV_SYNC_ARGS)
@@ -79,6 +81,18 @@ integration:
 
 profile-integration:
 	uv run python scripts/profile_integration_lane.py --marker "$(PROFILE_INTEGRATION_MARKER)" --durations $(PROFILE_INTEGRATION_DURATIONS) --durations-min $(PROFILE_INTEGRATION_DURATIONS_MIN) $(PROFILE_INTEGRATION_XDIST_ARGS) $(PROFILE_INTEGRATION_PYTEST_ARGS)
+
+ci-db-pr-fast:
+	$(MAKE) profile-integration PROFILE_INTEGRATION_MARKER="$(PYTEST_DB_API_EXPRESSION)"
+
+ci-db-extended:
+	@status=0; \
+	$(MAKE) profile-integration PROFILE_INTEGRATION_MARKER="$(PYTEST_DB_API_EXPRESSION)" || status=$$?; \
+	$(MAKE) profile-integration PROFILE_INTEGRATION_MARKER="$(PYTEST_DB_WORKER_EXPRESSION)" || status=$$?; \
+	$(MAKE) profile-integration PROFILE_INTEGRATION_MARKER="$(PYTEST_DB_ESTIMATION_EXPORT_EXPRESSION)" || status=$$?; \
+	$(MAKE) profile-integration PROFILE_INTEGRATION_MARKER="$(PYTEST_DB_LINEAGE_EXPRESSION)" || status=$$?; \
+	$(MAKE) profile-integration PROFILE_INTEGRATION_MARKER="$(PYTEST_DB_MIGRATION_EXPRESSION)" || status=$$?; \
+	exit $$status
 
 compose-smoke:
 	COMPOSE_SMOKE=1 SMOKE_BASE_URL="$(SMOKE_BASE_URL)" uv run pytest -m "$(PYTEST_COMPOSE_SMOKE_EXPRESSION)"

--- a/README.md
+++ b/README.md
@@ -104,11 +104,32 @@ make down -v        # Stop and remove volumes (destructive)
 
 ### Pytest Lanes
 
-The repository keeps three explicit pytest lanes with non-overlapping marker expressions:
+The repository keeps three top-level pytest lanes with non-overlapping marker expressions:
 
 - `make smoke` runs the fast smoke lane: `smoke and not integration and not compose_smoke`
 - `make integration` runs the database-backed integration lane: `integration and not compose_smoke`
 - `make compose-smoke` runs the opt-in Docker Compose lane: `compose_smoke`
+
+The database-backed integration lane is also split into five non-overlapping DB sub-lanes for targeted local runs and CI policy:
+
+- `make integration-db-api` runs `integration and db_api and not compose_smoke`
+- `make integration-db-worker` runs `integration and db_worker and not compose_smoke`
+- `make integration-db-estimation-export` runs `integration and db_estimation_export and not compose_smoke`
+- `make integration-db-lineage` runs `integration and db_lineage and not compose_smoke`
+- `make integration-db-migration` runs `integration and db_migration and not compose_smoke`
+
+CI now uses two DB coverage modes:
+
+- Pull requests run only the fast DB API gate: `Test integration (db_api)`
+- Pushes to `main`, the weekly scheduled run, and manual `workflow_dispatch` run the full five-lane DB matrix
+
+For local CI-equivalent runs, use:
+
+- `make ci-db-pr-fast` to mirror the pull-request DB fast gate via the profiling runner
+- `make ci-db-extended` to mirror the extended DB matrix via the profiling runner
+
+> [!IMPORTANT]
+> If GitHub branch protection still requires `Test integration (db_worker)`, `Test integration (db_estimation_export)`, `Test integration (db_lineage)`, or `Test integration (db_migration)` on pull requests, update the required checks. Pull requests now publish only `Test integration (db_api)` for DB-backed CI.
 
 #### Smoke
 
@@ -142,7 +163,9 @@ make integration
 # or: uv run alembic upgrade head && uv run pytest -m "integration and not compose_smoke"
 ```
 
-CI keeps this lane separate from smoke and preserves the PostgreSQL service plus Alembic migration step before pytest.
+CI keeps this lane separate from smoke and preserves the PostgreSQL service. CI-parity DB targets route through `scripts/profile_integration_lane.py`, which owns the migration timing pass plus pytest execution.
+
+For CI-parity runs, prefer `make ci-db-pr-fast` for the pull-request fast gate and `make ci-db-extended` for the extended non-PR coverage, because those targets route through `scripts/profile_integration_lane.py` just like GitHub Actions.
 
 #### Compose smoke
 

--- a/docs/integration-lane-profiling.md
+++ b/docs/integration-lane-profiling.md
@@ -8,6 +8,9 @@
 - Repro commands (local snapshots, not permanent benchmarks):
   - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke"`
   - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_worker and not compose_smoke"`
+- CI-equivalent helper targets:
+  - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make ci-db-pr-fast`
+  - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make ci-db-extended`
 - Repro commands with xdist enabled (local snapshots, not permanent benchmarks):
   - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke" PROFILE_INTEGRATION_XDIST_WORKERS=4`
   - `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test" make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_worker and not compose_smoke" PROFILE_INTEGRATION_XDIST_WORKERS=4`
@@ -17,9 +20,11 @@
 
 ## CI behavior
 
-- CI integration matrix lanes run against a fresh `postgres:18-alpine` service per lane.
-- The profiled lane invokes `scripts/profile_integration_lane.py` directly with `DATABASE_URL` set on that step.
+- Pull requests run only `Test integration (db_api)` as the DB fast gate.
+- Pushes to `main`, the weekly scheduled run, and manual `workflow_dispatch` run the full five-lane DB matrix against a fresh `postgres:18-alpine` service per lane.
+- Each profiled lane invokes `scripts/profile_integration_lane.py` directly with `DATABASE_URL` set on that step.
 - CI does not run a separate pre-profile `uv run alembic upgrade head`; the profiler performs the single migration timing pass so local and CI behavior stay aligned and profiled lanes do not double-run migrations.
+- Branch-protection implication: pull requests no longer publish `Test integration (db_worker)`, `Test integration (db_estimation_export)`, `Test integration (db_lineage)`, or `Test integration (db_migration)`. If any of those are configured as required PR checks, update branch protection to require `Test integration (db_api)` instead.
 
 ## Timing evidence
 
@@ -39,6 +44,6 @@
 
 ## Decision
 
-- No DB lifecycle optimization was adopted.
+- No DB lifecycle optimization was adopted, and pull requests now stay on the `db_api` fast gate while non-PR triggers keep the full DB matrix.
 - Why: Phase 2 showed migration plus collect-only staying under roughly `1.5s` in both `db_api` and `db_worker`, while the meaningful cost remains inside the full pytest run itself.
-- Result: keep the current fresh-database flow for both local profiling and CI, avoid template DB or other lifecycle complexity, and use the retained hotspot evidence for later test-specific optimization work.
+- Result: keep the current fresh-database flow for both local profiling and CI, avoid template DB or other lifecycle complexity, use `db_api` for PR turnaround, and retain the full five-lane matrix on push-to-main/scheduled/manual coverage for later test-specific optimization work.


### PR DESCRIPTION
Closes #300

## Summary
- run only the  DB integration fast gate on pull requests while keeping the full five-lane DB matrix on push to , weekly schedule, and manual dispatch
- add /Applications/Xcode.app/Contents/Developer/usr/bin/make profile-integration PROFILE_INTEGRATION_MARKER="integration and db_api and not compose_smoke"
uv run python scripts/profile_integration_lane.py --marker "integration and db_api and not compose_smoke" --durations 50 --durations-min 0.2  
2026-05-31 09:30:08 [info     ] database_engine_created        url=postgres:5432/draupnir and uv run python scripts/profile_integration_lane.py --marker "integration and db_api and not compose_smoke" --durations 50 --durations-min 0.2  
2026-05-31 09:30:09 [info     ] database_engine_created        url=postgres:5432/draupnir
uv run python scripts/profile_integration_lane.py --marker "integration and db_worker and not compose_smoke" --durations 50 --durations-min 0.2  
2026-05-31 09:30:09 [info     ] database_engine_created        url=postgres:5432/draupnir
uv run python scripts/profile_integration_lane.py --marker "integration and db_estimation_export and not compose_smoke" --durations 50 --durations-min 0.2  
2026-05-31 09:30:09 [info     ] database_engine_created        url=postgres:5432/draupnir
uv run python scripts/profile_integration_lane.py --marker "integration and db_lineage and not compose_smoke" --durations 50 --durations-min 0.2  
2026-05-31 09:30:10 [info     ] database_engine_created        url=postgres:5432/draupnir
uv run python scripts/profile_integration_lane.py --marker "integration and db_migration and not compose_smoke" --durations 50 --durations-min 0.2  
2026-05-31 09:30:10 [info     ] database_engine_created        url=postgres:5432/draupnir so local CI-parity runs mirror the workflow split
- document DB sub-lanes, CI coverage modes, and the required-check follow-up for removed slow PR checks

## Test plan
- [x] uv run ruff check scripts tests
- [x] uv run mypy app tests
- [x] make -n ci-db-pr-fast ci-db-extended
- [x] uv run pytest -q tests/test_profile_integration_lane.py tests/test_pre_push_check.py

## Notes
- pull requests keep the existing visible DB check name 
- if branch protection still requires the removed slow DB PR checks, update it to require  instead