### PR TITLE
ci(tooling): narrow pre-push DB test selection

### DIFF
--- a/docs/integration-lane-profiling.md
+++ b/docs/integration-lane-profiling.md
@@ -25,6 +25,7 @@
 - Each profiled lane invokes `scripts/profile_integration_lane.py` directly with `DATABASE_URL` set on that step.
 - CI does not run a separate pre-profile `uv run alembic upgrade head`; the profiler performs the single migration timing pass so local and CI behavior stay aligned and profiled lanes do not double-run migrations.
 - Branch-protection implication: pull requests no longer publish `Test integration (db_worker)`, `Test integration (db_estimation_export)`, `Test integration (db_lineage)`, or `Test integration (db_migration)`. If any of those are configured as required PR checks, update branch protection to require `Test integration (db_api)` instead.
+- The local pre-push gate is narrower than CI: clean single-lane source changes run one DB marker, known mapped DB test-file edits can run just those files, and same-lane source+test mixes stay on that lane marker; API schema changes under `app/schemas/` and selector/test-config paths such as `Makefile`, `pyproject.toml`, `scripts/pre_push_check.py`, `tests/conftest.py`, and test helpers still force full fallback to `integration and not compose_smoke`, as do schema/model/migration/new-deleted-renamed/unmapped or mixed-lane changes; every DB pre-push path still runs `uv run alembic upgrade head` first.
 
 ## Timing evidence
 

--- a/scripts/pre_push_check.py
+++ b/scripts/pre_push_check.py
@@ -22,8 +22,47 @@ DB_INTEGRATION_PYTEST_ARGS = [
     "-m",
     "integration and not compose_smoke",
 ]
+DB_API_PYTEST_ARGS = [
+    "uv",
+    "run",
+    "pytest",
+    "-m",
+    "integration and db_api and not compose_smoke",
+]
+DB_WORKER_PYTEST_ARGS = [
+    "uv",
+    "run",
+    "pytest",
+    "-m",
+    "integration and db_worker and not compose_smoke",
+]
+DB_ESTIMATION_EXPORT_PYTEST_ARGS = [
+    "uv",
+    "run",
+    "pytest",
+    "-m",
+    "integration and db_estimation_export and not compose_smoke",
+]
+DB_LINEAGE_PYTEST_ARGS = [
+    "uv",
+    "run",
+    "pytest",
+    "-m",
+    "integration and db_lineage and not compose_smoke",
+]
+DB_MIGRATION_PYTEST_ARGS = [
+    "uv",
+    "run",
+    "pytest",
+    "-m",
+    "integration and db_migration and not compose_smoke",
+]
 SENSITIVE_PREFIXES = (
     "app/api/",
+    "app/schemas/",
+    "app/jobs/",
+    "app/estimating/",
+    "app/exports/",
     "app/models/",
     "app/db/",
     "alembic/",
@@ -40,6 +79,71 @@ SENSITIVE_TEST_CONTENT_MARKERS = frozenset(
         "async_sessionmaker",
     }
 )
+UNSAFE_FALLBACK_PATHS = frozenset(
+    {
+        "Makefile",
+        "pyproject.toml",
+        "scripts/pre_push_check.py",
+        "tests/conftest.py",
+        "tests/jobs_test_helpers.py",
+    }
+)
+SAFE_SOURCE_LANE_ARGS = {
+    "app/api/": DB_API_PYTEST_ARGS,
+    "app/jobs/": DB_WORKER_PYTEST_ARGS,
+    "app/estimating/": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "app/exports/": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+}
+DB_TEST_FILE_KEY_LANE_ARGS = {
+    "projects": DB_API_PYTEST_ARGS,
+    "files": DB_API_PYTEST_ARGS,
+    "idempotency": DB_API_PYTEST_ARGS,
+    "extraction_profiles": DB_API_PYTEST_ARGS,
+    "quantity_takeoff_api": DB_API_PYTEST_ARGS,
+    "estimate_read_api": DB_API_PYTEST_ARGS,
+    "export_create_api": DB_API_PYTEST_ARGS,
+    "revision_materialization_api": DB_API_PYTEST_ARGS,
+    "validation_report_api": DB_API_PYTEST_ARGS,
+    "revision_quantity_estimate_flow": DB_API_PYTEST_ARGS,
+    "smoke": DB_API_PYTEST_ARGS,
+    "jobs": DB_WORKER_PYTEST_ARGS,
+    "jobs_api": DB_WORKER_PYTEST_ARGS,
+    "jobs_worker_ingest": DB_WORKER_PYTEST_ARGS,
+    "jobs_worker_lifecycle": DB_WORKER_PYTEST_ARGS,
+    "jobs_worker_quantity": DB_WORKER_PYTEST_ARGS,
+    "jobs_worker_estimate": DB_WORKER_PYTEST_ARGS,
+    "jobs_worker_exports": DB_WORKER_PYTEST_ARGS,
+    "ingest_output_persistence": DB_WORKER_PYTEST_ARGS,
+    "csv_exports": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "revision_json_export": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimate_pdf_export": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimate_engine_persistence_payloads": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimate_job_input_contract": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimate_snapshot_item_persistence": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimate_version_persistence": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimation_catalog_api": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimation_catalog_persistence": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "estimation_catalog_resolver": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "export_job_input_contract": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "quantity_takeoff_persistence": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "append_only_lineage_tables": DB_LINEAGE_PYTEST_ARGS,
+    "lineage_delete_restrictions": DB_LINEAGE_PYTEST_ARGS,
+    "db": DB_MIGRATION_PYTEST_ARGS,
+    "jobs_base_revision_migration": DB_MIGRATION_PYTEST_ARGS,
+    "jobs_revision_scoped_contract_migration": DB_MIGRATION_PYTEST_ARGS,
+}
+SAFE_DB_TEST_FILE_LANE_ARGS = {
+    f"tests/test_{file_key}.py": lane_args
+    for file_key, lane_args in DB_TEST_FILE_KEY_LANE_ARGS.items()
+}
+DB_LANE_PYTEST_ARGS = (
+    tuple(DB_API_PYTEST_ARGS),
+    tuple(DB_WORKER_PYTEST_ARGS),
+    tuple(DB_ESTIMATION_EXPORT_PYTEST_ARGS),
+    tuple(DB_LINEAGE_PYTEST_ARGS),
+    tuple(DB_MIGRATION_PYTEST_ARGS),
+    tuple(DB_INTEGRATION_PYTEST_ARGS),
+)
 LOCAL_DATABASE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
@@ -53,6 +157,18 @@ class RefUpdate:
     local_sha: str
     remote_ref: str
     remote_sha: str
+
+
+@dataclass(frozen=True)
+class ChangedPath:
+    path: str
+    status: str
+
+
+@dataclass(frozen=True)
+class DbPytestSelection:
+    pytest_args: tuple[str, ...]
+    description: str
 
 
 QueryRunner = Callable[[Sequence[str]], str]
@@ -117,14 +233,57 @@ def unique_paths(paths: Iterable[str]) -> list[str]:
     return ordered
 
 
-def list_diff_files(left: str, right: str, query_runner: QueryRunner) -> list[str]:
-    output = query_runner(["git", "diff", "--name-only", f"{left}..{right}"])
-    return unique_paths(output.splitlines())
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./")
 
 
-def current_head_files(query_runner: QueryRunner) -> list[str]:
-    output = query_runner(["git", "diff", "--name-only", "HEAD"])
-    return unique_paths(output.splitlines())
+def unique_changed_paths(paths: Iterable[ChangedPath]) -> list[ChangedPath]:
+    seen: set[str] = set()
+    ordered: list[ChangedPath] = []
+    for changed_path in paths:
+        normalized = normalize_path(changed_path.path)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(ChangedPath(path=normalized, status=changed_path.status))
+    return ordered
+
+
+def parse_name_status_output(lines: Iterable[str]) -> list[ChangedPath]:
+    parsed: list[ChangedPath] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = raw_line.rstrip("\n").split("\t")
+        if len(parts) < 2:
+            raise ValueError(f"invalid name-status line: {raw_line!r}")
+        status = parts[0].strip().upper()
+        if status.startswith(("R", "C")):
+            if len(parts) < 3:
+                raise ValueError(f"invalid rename/copy line: {raw_line!r}")
+            changed_file_paths = parts[1:3]
+        else:
+            changed_file_paths = parts[1:2]
+        for path in changed_file_paths:
+            normalized = normalize_path(path)
+            if normalized:
+                parsed.append(ChangedPath(path=normalized, status=status))
+    return unique_changed_paths(parsed)
+
+
+def list_diff_changed_paths(
+    left: str,
+    right: str,
+    query_runner: QueryRunner,
+) -> list[ChangedPath]:
+    output = query_runner(["git", "diff", "--name-status", "--find-renames", f"{left}..{right}"])
+    return parse_name_status_output(output.splitlines())
+
+
+def current_head_changed_paths(query_runner: QueryRunner) -> list[ChangedPath]:
+    output = query_runner(["git", "diff", "--name-status", "--find-renames", "HEAD"])
+    return parse_name_status_output(output.splitlines())
 
 
 def resolve_merge_base(
@@ -155,15 +314,15 @@ def resolve_merge_base(
     return None
 
 
-def changed_files_for_update(
+def changed_paths_for_update(
     update: RefUpdate,
     remote_name: str,
     query_runner: QueryRunner,
-) -> list[str]:
+) -> list[ChangedPath]:
     if update.local_sha == ZERO_OID:
         return []
     if update.remote_sha != ZERO_OID:
-        return list_diff_files(update.remote_sha, update.local_sha, query_runner)
+        return list_diff_changed_paths(update.remote_sha, update.local_sha, query_runner)
     merge_base = resolve_merge_base(
         local_ref=update.local_ref,
         local_sha=update.local_sha,
@@ -171,11 +330,32 @@ def changed_files_for_update(
         query_runner=query_runner,
     )
     if merge_base is not None:
-        return list_diff_files(merge_base, update.local_sha, query_runner)
+        return list_diff_changed_paths(merge_base, update.local_sha, query_runner)
     output = query_runner(
-        ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", update.local_sha]
+        [
+            "git",
+            "diff-tree",
+            "--no-commit-id",
+            "--name-status",
+            "--find-renames",
+            "-r",
+            update.local_sha,
+        ]
     )
-    return unique_paths(output.splitlines())
+    return parse_name_status_output(output.splitlines())
+
+
+def determine_changed_paths(
+    updates: Sequence[RefUpdate],
+    remote_name: str,
+    query_runner: QueryRunner,
+) -> list[ChangedPath]:
+    if not updates:
+        return current_head_changed_paths(query_runner)
+    paths: list[ChangedPath] = []
+    for update in updates:
+        paths.extend(changed_paths_for_update(update, remote_name, query_runner))
+    return unique_changed_paths(paths)
 
 
 def determine_changed_files(
@@ -183,12 +363,8 @@ def determine_changed_files(
     remote_name: str,
     query_runner: QueryRunner,
 ) -> list[str]:
-    if not updates:
-        return current_head_files(query_runner)
-    paths: list[str] = []
-    for update in updates:
-        paths.extend(changed_files_for_update(update, remote_name, query_runner))
-    return unique_paths(paths)
+    changed_paths = determine_changed_paths(updates, remote_name, query_runner)
+    return [changed_path.path for changed_path in changed_paths]
 
 
 def test_file_uses_database(path: str) -> bool:
@@ -204,7 +380,11 @@ def test_file_uses_database(path: str) -> bool:
 
 
 def is_sensitive_path(path: str) -> bool:
-    normalized = path.replace("\\", "/").lstrip("./")
+    normalized = normalize_path(path)
+    if normalized in UNSAFE_FALLBACK_PATHS:
+        return True
+    if normalized in SAFE_DB_TEST_FILE_LANE_ARGS:
+        return True
     if any(normalized.startswith(prefix) for prefix in SENSITIVE_PREFIXES):
         return True
     pure_path = PurePosixPath(normalized)
@@ -217,7 +397,16 @@ def is_sensitive_path(path: str) -> bool:
     return test_file_uses_database(normalized)
 
 
-def format_database_url_message(sensitive_paths: Sequence[str]) -> str:
+def format_pytest_command(args: Sequence[str]) -> str:
+    if len(args) >= 5 and list(args[:4]) == ["uv", "run", "pytest", "-m"]:
+        return f'uv run pytest -m "{args[4]}"'
+    return " ".join(args)
+
+
+def format_database_url_message(
+    sensitive_paths: Sequence[str],
+    pytest_args: Sequence[str],
+) -> str:
     changed_lines = "\n".join(f"  - {path}" for path in sensitive_paths)
     return (
         "pre-push check failed: DB-sensitive changes require DATABASE_URL.\n"
@@ -225,9 +414,10 @@ def format_database_url_message(sensitive_paths: Sequence[str]) -> str:
         f"{changed_lines}\n"
         "Set DATABASE_URL and rerun push. Example:\n"
         f"  export DATABASE_URL={EXAMPLE_DATABASE_URL}\n"
-        "This gate runs the DB integration lane with:\n"
+        "This gate runs the selected DB pytest command "
+        "(DB integration lane fallback when needed) with:\n"
         "  uv run alembic upgrade head\n"
-        '  uv run pytest -m "integration and not compose_smoke"'
+        f"  {format_pytest_command(pytest_args)}"
     )
 
 
@@ -262,17 +452,91 @@ def format_invalid_database_url_message(
     )
 
 
+def classify_db_change(changed_path: ChangedPath) -> DbPytestSelection | None:
+    if changed_path.status[:1] != "M":
+        return DbPytestSelection(tuple(DB_INTEGRATION_PYTEST_ARGS), "DB integration lane")
+
+    path = normalize_path(changed_path.path)
+    if path in UNSAFE_FALLBACK_PATHS:
+        return DbPytestSelection(tuple(DB_INTEGRATION_PYTEST_ARGS), "DB integration lane")
+
+    for prefix, pytest_args in SAFE_SOURCE_LANE_ARGS.items():
+        if path.startswith(prefix):
+            return DbPytestSelection(tuple(pytest_args), "single-source DB lane")
+
+    if any(path.startswith(prefix) for prefix in ("app/models/", "app/db/", "alembic/")):
+        return DbPytestSelection(tuple(DB_INTEGRATION_PYTEST_ARGS), "DB integration lane")
+
+    if not path.startswith("tests/"):
+        return DbPytestSelection(tuple(DB_INTEGRATION_PYTEST_ARGS), "DB integration lane")
+
+    mapped_pytest_args = SAFE_DB_TEST_FILE_LANE_ARGS.get(path)
+    if mapped_pytest_args is None or not Path(path).is_file():
+        return DbPytestSelection(tuple(DB_INTEGRATION_PYTEST_ARGS), "DB integration lane")
+    return DbPytestSelection(tuple(mapped_pytest_args), "focused DB test files")
+
+
+def select_db_pytest_selection(changed_paths: Sequence[ChangedPath]) -> DbPytestSelection | None:
+    sensitive_changes = [
+        changed_path for changed_path in changed_paths if is_sensitive_path(changed_path.path)
+    ]
+    if not sensitive_changes:
+        return None
+
+    lane_args: tuple[str, ...] | None = None
+    focused_test_paths: list[str] = []
+    saw_source_change = False
+    saw_test_change = False
+    fallback_selection = DbPytestSelection(tuple(DB_INTEGRATION_PYTEST_ARGS), "DB integration lane")
+
+    for changed_path in sensitive_changes:
+        selection = classify_db_change(changed_path)
+        if selection is None:
+            continue
+        if selection.pytest_args == tuple(DB_INTEGRATION_PYTEST_ARGS):
+            return fallback_selection
+
+        current_path = normalize_path(changed_path.path)
+        if current_path.startswith("tests/"):
+            saw_test_change = True
+            focused_test_paths.append(current_path)
+        else:
+            saw_source_change = True
+
+        if lane_args is None:
+            lane_args = selection.pytest_args
+            continue
+        if selection.pytest_args != lane_args:
+            return fallback_selection
+
+    if lane_args is None:
+        return fallback_selection
+    if saw_test_change:
+        if saw_source_change:
+            return DbPytestSelection(pytest_args=lane_args, description="single-source DB lane")
+        return DbPytestSelection(
+            pytest_args=("uv", "run", "pytest", *focused_test_paths),
+            description="focused DB test files",
+        )
+    return DbPytestSelection(pytest_args=lane_args, description="single-source DB lane")
+
+
 def run_gate(
-    changed_files: Sequence[str],
+    changed_paths: Sequence[ChangedPath],
     env: Mapping[str, str],
     exec_runner: ExecRunner,
     stderr: TextIO,
 ) -> int:
-    sensitive_paths = [path for path in changed_files if is_sensitive_path(path)]
-    if sensitive_paths:
+    selection = select_db_pytest_selection(changed_paths)
+    if selection is not None:
+        sensitive_paths = [
+            changed_path.path
+            for changed_path in changed_paths
+            if is_sensitive_path(changed_path.path)
+        ]
         database_url = env.get("DATABASE_URL")
         if not database_url:
-            print(format_database_url_message(sensitive_paths), file=stderr)
+            print(format_database_url_message(sensitive_paths, selection.pytest_args), file=stderr)
             return 1
         validation_error = validate_database_url(database_url)
         if validation_error is not None:
@@ -281,10 +545,10 @@ def run_gate(
                 file=stderr,
             )
             return 1
-        db_integration_lane = 'pytest -m "integration and not compose_smoke"'
         print(
-            "pre-push check: DB-sensitive changes detected; running DB integration lane "
-            f"via alembic upgrade head then {db_integration_lane}.",
+            "pre-push check: DB-sensitive changes detected; running "
+            f"{selection.description} via alembic upgrade head then "
+            f"{format_pytest_command(selection.pytest_args)}.",
             file=stderr,
         )
         migration_code = exec_runner(["uv", "run", "alembic", "upgrade", "head"])
@@ -293,7 +557,7 @@ def run_gate(
     else:
         print("pre-push check: no DB-sensitive changes detected.", file=stderr)
         return exec_runner(["uv", "run", "pytest"])
-    return exec_runner(DB_INTEGRATION_PYTEST_ARGS)
+    return exec_runner(selection.pytest_args)
 
 
 def main(
@@ -311,11 +575,11 @@ def main(
     active_env = os.environ if env is None else env
     try:
         updates = parse_ref_updates(input_stream)
-        changed_files = determine_changed_files(updates, args.remote_name, query_runner)
+        changed_paths = determine_changed_paths(updates, args.remote_name, query_runner)
     except (CommandError, ValueError) as error:
         print(f"pre-push check failed: {error}", file=output_stream)
         return 1
-    return run_gate(changed_files, active_env, exec_runner, output_stream)
+    return run_gate(changed_paths, active_env, exec_runner, output_stream)
 
 
 if __name__ == "__main__":

--- a/tests/test_pre_push_check.py
+++ b/tests/test_pre_push_check.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import ast
 import importlib.util
 import io
+import re
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -20,6 +22,38 @@ def load_pre_push_check_module() -> ModuleType:
 
 
 pre_push_check = load_pre_push_check_module()
+
+
+def read_repo_text(relative_path: str) -> str:
+    return (Path(__file__).resolve().parents[1] / relative_path).read_text(encoding="utf-8")
+
+
+def extract_makefile_lane_markers() -> set[str]:
+    makefile_text = read_repo_text("Makefile")
+    return set(re.findall(r"integration and db_[a-z_]+ and not compose_smoke", makefile_text))
+
+
+def extract_conftest_db_lane_mapping() -> dict[str, str]:
+    module = ast.parse(read_repo_text("tests/conftest.py"))
+    for statement in module.body:
+        value: ast.expr | None
+        if isinstance(statement, ast.Assign):
+            targets = statement.targets
+            value = statement.value
+        elif isinstance(statement, ast.AnnAssign):
+            targets = [statement.target]
+            value = statement.value
+        else:
+            continue
+        if value is None:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == "_DB_LANE_BY_TEST_FILE_KEY":
+                parsed = ast.literal_eval(value)
+                if not isinstance(parsed, dict):
+                    raise AssertionError("_DB_LANE_BY_TEST_FILE_KEY must stay a dict literal")
+                return {str(key): str(value) for key, value in parsed.items()}
+    raise AssertionError("failed to find _DB_LANE_BY_TEST_FILE_KEY in tests/conftest.py")
 
 
 class QueryStub:
@@ -56,9 +90,16 @@ class ExecStub:
 
 def test_is_sensitive_path_detects_expected_paths() -> None:
     assert pre_push_check.is_sensitive_path("app/api/v1/revisions.py")
+    assert pre_push_check.is_sensitive_path("app/schemas/file.py")
+    assert pre_push_check.is_sensitive_path("app/jobs/worker.py")
+    assert pre_push_check.is_sensitive_path("app/exports/csv.py")
+    assert pre_push_check.is_sensitive_path("app/estimating/money.py")
     assert pre_push_check.is_sensitive_path("app/models/job.py")
     assert pre_push_check.is_sensitive_path("app/db/session.py")
     assert pre_push_check.is_sensitive_path("alembic/versions/0001_init.py")
+    assert pre_push_check.is_sensitive_path("Makefile")
+    assert pre_push_check.is_sensitive_path("pyproject.toml")
+    assert pre_push_check.is_sensitive_path("scripts/pre_push_check.py")
     assert pre_push_check.is_sensitive_path("tests/api/test_revisions.py")
     assert pre_push_check.is_sensitive_path("tests/test_files.py")
     assert pre_push_check.is_sensitive_path("tests/test_revision_api.py")
@@ -84,9 +125,13 @@ def test_determine_changed_files_uses_merge_base_for_new_branch_push() -> None:
                 "refs/remotes/origin/HEAD",
             ): "origin/main",
             ("git", "merge-base", "abc123", "origin/main"): "base123",
-            ("git", "diff", "--name-only", "base123..abc123"): (
-                "app/api/v1/revisions.py\ntests/test_revision_api.py\n"
-            ),
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "base123..abc123",
+            ): ("M\tapp/api/v1/revisions.py\nM\ttests/test_revision_api.py\n"),
         },
     )
     updates = [
@@ -106,12 +151,41 @@ def test_determine_changed_files_uses_merge_base_for_new_branch_push() -> None:
     ]
 
 
+def test_makefile_lane_markers_match_script_constants() -> None:
+    assert extract_makefile_lane_markers() == {
+        pre_push_check.DB_API_PYTEST_ARGS[4],
+        pre_push_check.DB_WORKER_PYTEST_ARGS[4],
+        pre_push_check.DB_ESTIMATION_EXPORT_PYTEST_ARGS[4],
+        pre_push_check.DB_LINEAGE_PYTEST_ARGS[4],
+        pre_push_check.DB_MIGRATION_PYTEST_ARGS[4],
+    }
+
+
+def test_conftest_db_test_file_lane_keys_match_script_mapping() -> None:
+    lane_name_by_args = {
+        tuple(pre_push_check.DB_API_PYTEST_ARGS): "db_api",
+        tuple(pre_push_check.DB_WORKER_PYTEST_ARGS): "db_worker",
+        tuple(pre_push_check.DB_ESTIMATION_EXPORT_PYTEST_ARGS): "db_estimation_export",
+        tuple(pre_push_check.DB_LINEAGE_PYTEST_ARGS): "db_lineage",
+        tuple(pre_push_check.DB_MIGRATION_PYTEST_ARGS): "db_migration",
+    }
+
+    assert {
+        file_key: lane_name_by_args[tuple(pytest_args)]
+        for file_key, pytest_args in pre_push_check.DB_TEST_FILE_KEY_LANE_ARGS.items()
+    } == extract_conftest_db_lane_mapping()
+
+
 def test_main_runs_pytest_only_for_non_sensitive_changes() -> None:
     query = QueryStub(
         {
-            ("git", "diff", "--name-only", "def456..abc123"): (
-                "docs/runbook.md\nscripts/pre_push_check.py\n"
-            )
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tdocs/runbook.md\n")
         }
     )
     exec_runner = ExecStub()
@@ -136,9 +210,13 @@ def test_main_runs_pytest_only_for_non_sensitive_changes() -> None:
 def test_main_requires_database_url_for_sensitive_changes() -> None:
     query = QueryStub(
         {
-            ("git", "diff", "--name-only", "def456..abc123"): (
-                "app/db/session.py\ntests/test_storage.py\n"
-            )
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tapp/db/session.py\nM\ttests/test_storage.py\n")
         }
     )
     exec_runner = ExecStub()
@@ -165,12 +243,169 @@ def test_main_requires_database_url_for_sensitive_changes() -> None:
     assert "app/db/session.py" in error_output
 
 
-def test_main_runs_migration_before_db_integration_pytest_for_sensitive_changes() -> None:
+def test_main_runs_migration_before_single_source_db_lane() -> None:
     query = QueryStub(
         {
-            ("git", "diff", "--name-only", "def456..abc123"): (
-                "app/models/job.py\ntests/persistence/test_catalog.py\n"
-            )
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tapp/api/v1/revisions.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and db_api and not compose_smoke"),
+    ]
+    error_output = stderr.getvalue()
+    assert "single-source DB lane" in error_output
+    assert 'pytest -m "integration and db_api and not compose_smoke"' in error_output
+
+
+def test_main_runs_migration_before_same_lane_mixed_source_and_test_changes() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tapp/api/v1/revisions.py\nM\ttests/test_files.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and db_api and not compose_smoke"),
+    ]
+    error_output = stderr.getvalue()
+    assert "single-source DB lane" in error_output
+    assert 'pytest -m "integration and db_api and not compose_smoke"' in error_output
+
+
+def test_main_runs_migration_before_focused_db_test_files() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\ttests/test_jobs_worker_ingest.py\nM\ttests/test_jobs_worker_quantity.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        (
+            "uv",
+            "run",
+            "pytest",
+            "tests/test_jobs_worker_ingest.py",
+            "tests/test_jobs_worker_quantity.py",
+        ),
+    ]
+    error_output = stderr.getvalue()
+    assert "focused DB test files" in error_output
+    assert (
+        "uv run pytest tests/test_jobs_worker_ingest.py "
+        "tests/test_jobs_worker_quantity.py" in error_output
+    )
+
+
+def test_main_runs_migration_before_focused_db_api_test_file() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\ttests/test_files.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "tests/test_files.py"),
+    ]
+    error_output = stderr.getvalue()
+    assert "focused DB test files" in error_output
+    assert "uv run pytest tests/test_files.py" in error_output
+
+
+def test_main_falls_back_to_full_integration_for_mixed_sensitive_lanes() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tapp/api/v1/revisions.py\nM\tapp/jobs/worker.py\n")
         }
     )
     exec_runner = ExecStub()
@@ -192,13 +427,191 @@ def test_main_runs_migration_before_db_integration_pytest_for_sensitive_changes(
         ("uv", "run", "alembic", "upgrade", "head"),
         ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
     ]
-    error_output = stderr.getvalue()
-    assert "DB integration lane" in error_output
-    assert 'pytest -m "integration and not compose_smoke"' in error_output
+    assert "DB integration lane" in stderr.getvalue()
+
+
+def test_main_falls_back_to_full_integration_for_selector_changes() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tscripts/pre_push_check.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
+    ]
+    assert "DB integration lane" in stderr.getvalue()
+
+
+def test_main_falls_back_to_full_integration_for_makefile_and_pyproject_changes() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tMakefile\nM\tpyproject.toml\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
+    ]
+    assert "DB integration lane" in stderr.getvalue()
+
+
+def test_main_falls_back_to_full_integration_for_added_db_test_files() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("A\ttests/test_jobs_worker_ingest.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
+    ]
+    assert "DB integration lane" in stderr.getvalue()
+
+
+def test_main_falls_back_to_full_integration_for_schema_changes() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\tapp/schemas/files.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
+    ]
+    assert "DB integration lane" in stderr.getvalue()
+
+
+def test_main_falls_back_to_full_integration_for_deleted_mapped_db_test_files() -> None:
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("D\ttests/test_files.py\n")
+        }
+    )
+    exec_runner = ExecStub()
+    stderr = io.StringIO()
+
+    exit_code = pre_push_check.main(
+        ["origin", "git@github.com:momoshell/draupnir.git"],
+        stdin=io.StringIO(
+            "refs/heads/feature/pre-push abc123 refs/heads/feature/pre-push def456\n"
+        ),
+        env={"DATABASE_URL": pre_push_check.EXAMPLE_DATABASE_URL},
+        query_runner=query,
+        exec_runner=exec_runner,
+        stderr=stderr,
+    )
+
+    assert exit_code == 0
+    assert exec_runner.calls == [
+        ("uv", "run", "alembic", "upgrade", "head"),
+        ("uv", "run", "pytest", "-m", "integration and not compose_smoke"),
+    ]
+    assert "DB integration lane" in stderr.getvalue()
 
 
 def test_main_rejects_non_local_or_non_test_database_url() -> None:
-    query = QueryStub({("git", "diff", "--name-only", "def456..abc123"): ("tests/test_files.py\n")})
+    query = QueryStub(
+        {
+            (
+                "git",
+                "diff",
+                "--name-status",
+                "--find-renames",
+                "def456..abc123",
+            ): ("M\ttests/test_files.py\n")
+        }
+    )
     exec_runner = ExecStub()
     stderr = io.StringIO()
 


### PR DESCRIPTION
Closes #301

## Summary
- narrow local pre-push DB selection to safe single-lane source changes and mapped DB test file edits
- preserve full DB fallback for schema, model, migration, selector, test-infra, mixed-lane, and unmapped changes
- add parity and regression coverage for lane mappings, fallback boundaries, and selected pytest commands

## Test plan
- [x] uv run pytest -q tests/test_pre_push_check.py
- [x] uv run ruff check scripts/pre_push_check.py tests/test_pre_push_check.py
- [x] uv run mypy app tests scripts/pre_push_check.py
- [x] uv build