### PR TITLE
refactor(ingestion): reshape adapter registry for write capability #272

### DIFF
--- a/app/ingestion/contracts.py
+++ b/app/ingestion/contracts.py
@@ -242,6 +242,35 @@ class AdapterResult:
 
 
 @dataclass(frozen=True, slots=True)
+class AdapterExportRequest:
+    """Canonical export request passed into write-capable adapters."""
+
+    canonical: Mapping[str, JSONValue]
+    output_format: str
+
+    def __post_init__(self) -> None:
+        if not self.output_format:
+            raise ValueError("Adapter export output format cannot be empty.")
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterExportResult:
+    """Opaque export payload returned by a write-capable adapter."""
+
+    output_format: str
+    media_type: str
+    content: bytes
+    warnings: tuple[AdapterWarning, ...] = ()
+    diagnostics: tuple[AdapterDiagnostic, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.output_format:
+            raise ValueError("Adapter export output format cannot be empty.")
+        if not self.media_type:
+            raise ValueError("Adapter export media type cannot be empty.")
+
+
+@dataclass(frozen=True, slots=True)
 class AdapterSource:
     """Immutable source reference handed to an adapter implementation."""
 
@@ -411,6 +440,19 @@ class AdapterDescriptor:
             raise ValueError("Adapter key must use stable lowercase slug semantics.")
         if not self.output_formats:
             raise ValueError("Adapter descriptor must declare at least one output format.")
+        seen_output_formats: set[str] = set()
+        for output_format in self.output_formats:
+            canonical_output_format = output_format.strip().lower()
+            if not canonical_output_format:
+                raise ValueError("Adapter output format cannot be empty.")
+            if output_format != canonical_output_format:
+                raise ValueError(
+                    "Adapter output format must use canonical lowercase semantics without"
+                    " surrounding whitespace."
+                )
+            if output_format in seen_output_formats:
+                raise ValueError(f"Duplicate adapter output format '{output_format}'.")
+            seen_output_formats.add(output_format)
         if self.bounded_probe_ms <= 0:
             raise ValueError("Bounded probe time must be greater than zero.")
         if self.confidence_range is not None:
@@ -446,3 +488,19 @@ class IngestionAdapter(Protocol):
         options: AdapterExecutionOptions,
     ) -> AdapterResult:
         """Transform a source file into canonical output."""
+
+
+class ExportAdapter(Protocol):
+    """Protocol that concrete export-capable adapters must implement."""
+
+    descriptor: AdapterDescriptor
+
+    def probe(self) -> AdapterAvailability:
+        """Return current availability without importing optional peers."""
+
+    async def export(
+        self,
+        request: AdapterExportRequest,
+        options: AdapterExecutionOptions,
+    ) -> AdapterExportResult:
+        """Transform canonical payloads into an adapter-owned export artifact."""

--- a/app/ingestion/loader.py
+++ b/app/ingestion/loader.py
@@ -6,26 +6,50 @@ import importlib
 from collections.abc import Callable
 from typing import cast
 
-from app.ingestion.contracts import AdapterDescriptor, IngestionAdapter
+from app.ingestion.contracts import AdapterDescriptor, ExportAdapter, IngestionAdapter
 
-_FACTORY_NAME = "create_adapter"
+_READ_FACTORY_NAME = "create_adapter"
+_EXPORT_FACTORY_NAME = "create_export_adapter"
 
 
-def load_adapter(descriptor: AdapterDescriptor) -> IngestionAdapter:
-    """Import an adapter module and call its standard factory."""
+def _load_factory(descriptor: AdapterDescriptor, factory_name: str) -> Callable[[], object]:
     module = importlib.import_module(descriptor.module)
 
     try:
-        factory = getattr(module, _FACTORY_NAME)
+        factory = getattr(module, factory_name)
     except AttributeError as exc:
         raise AttributeError(
-            f"Adapter module '{descriptor.module}' does not define '{_FACTORY_NAME}'."
+            f"Adapter module '{descriptor.module}' does not define '{factory_name}'."
         ) from exc
 
     if not callable(factory):
         raise TypeError(
-            f"Adapter module '{descriptor.module}' exposes non-callable '{_FACTORY_NAME}'."
+            f"Adapter module '{descriptor.module}' exposes non-callable '{factory_name}'."
         )
 
-    adapter_factory = cast(Callable[[], IngestionAdapter], factory)
+    return cast(Callable[[], object], factory)
+
+
+def load_adapter(descriptor: AdapterDescriptor) -> IngestionAdapter:
+    """Import an adapter module and call its standard factory."""
+    if not descriptor.capabilities.can_read:
+        raise ValueError(f"Adapter '{descriptor.key}' does not support read ingestion.")
+
+    adapter_factory = cast(
+        Callable[[], IngestionAdapter],
+        _load_factory(descriptor, _READ_FACTORY_NAME),
+    )
     return adapter_factory()
+
+
+def load_export_adapter(descriptor: AdapterDescriptor) -> ExportAdapter:
+    """Import an adapter module and call its export-capable factory."""
+
+    if not descriptor.capabilities.can_write or not descriptor.capabilities.supports_exports:
+        raise ValueError(f"Adapter '{descriptor.key}' does not support exports.")
+
+    export_factory = cast(
+        Callable[[], ExportAdapter],
+        _load_factory(descriptor, _EXPORT_FACTORY_NAME),
+    )
+    return export_factory()

--- a/app/ingestion/registry.py
+++ b/app/ingestion/registry.py
@@ -46,8 +46,7 @@ _ADAPTER_DESCRIPTORS: tuple[AdapterDescriptor, ...] = (
         display_name="LibreDWG",
         module="app.ingestion.adapters.libredwg",
         license_name="GPL-3.0-or-later",
-        capabilities=AdapterCapabilities(
-        ),
+        capabilities=AdapterCapabilities(),
         confidence_range=(0.2, 0.72),
         probes=(
             ProbeRequirement(
@@ -227,13 +226,58 @@ def list_descriptors() -> tuple[AdapterDescriptor, ...]:
     return _ADAPTER_DESCRIPTORS
 
 
+def _register_unique[IndexKey](
+    registry: dict[IndexKey, AdapterDescriptor],
+    index_key: IndexKey,
+    descriptor: AdapterDescriptor,
+    *,
+    index_name: str,
+) -> None:
+    existing = registry.get(index_key)
+    if existing is not None:
+        raise ValueError(
+            f"Duplicate {index_name} '{index_key}' declared by adapters "
+            f"'{existing.key}' and '{descriptor.key}'."
+        )
+    registry[index_key] = descriptor
+
+
+@lru_cache(maxsize=1)
+def get_registry_by_key() -> Mapping[str, AdapterDescriptor]:
+    """Return registry descriptors keyed by stable adapter key."""
+
+    registry: dict[str, AdapterDescriptor] = {}
+    for descriptor in list_descriptors():
+        _register_unique(
+            registry,
+            descriptor.key,
+            descriptor,
+            index_name="adapter key",
+        )
+    return MappingProxyType(registry)
+
+
+def get_descriptor_by_key(key: str) -> AdapterDescriptor:
+    """Return the descriptor registered for a stable adapter key."""
+
+    return get_registry_by_key()[key]
+
+
 @lru_cache(maxsize=1)
 def get_registry() -> Mapping[InputFamily, AdapterDescriptor]:
     """Return registry descriptors keyed by normalized input family."""
 
-    return MappingProxyType(
-        {descriptor.family: descriptor for descriptor in list_descriptors()}
-    )
+    registry: dict[InputFamily, AdapterDescriptor] = {}
+    for descriptor in list_descriptors():
+        if not descriptor.capabilities.can_read:
+            continue
+        _register_unique(
+            registry,
+            descriptor.family,
+            descriptor,
+            index_name="read adapter family",
+        )
+    return MappingProxyType(registry)
 
 
 def get_descriptor(family: InputFamily) -> AdapterDescriptor:
@@ -242,12 +286,44 @@ def get_descriptor(family: InputFamily) -> AdapterDescriptor:
     return get_registry()[family]
 
 
+@lru_cache(maxsize=1)
+def get_export_registry() -> Mapping[str, tuple[AdapterDescriptor, ...]]:
+    """Return export-capable descriptors keyed by declared output format."""
+
+    registry: dict[str, list[AdapterDescriptor]] = {}
+    for descriptor in list_descriptors():
+        if not (descriptor.capabilities.can_write and descriptor.capabilities.supports_exports):
+            continue
+        for output_format in descriptor.output_formats:
+            registry.setdefault(output_format, []).append(descriptor)
+    return MappingProxyType(
+        {output_format: tuple(descriptors) for output_format, descriptors in registry.items()}
+    )
+
+
+def get_export_descriptors(output_format: str) -> tuple[AdapterDescriptor, ...]:
+    """Return ordered export-capable descriptors for a requested output format."""
+
+    return get_export_registry()[output_format]
+
+
+def get_export_descriptor(output_format: str) -> AdapterDescriptor:
+    """Return the single export-capable descriptor registered for an output format."""
+
+    descriptors = get_export_descriptors(output_format)
+    if len(descriptors) > 1:
+        descriptor_keys = ", ".join(descriptor.key for descriptor in descriptors)
+        raise ValueError(
+            f"Multiple export adapters registered for '{output_format}': {descriptor_keys}."
+        )
+    return descriptors[0]
+
+
 def descriptors_for_upload_format(upload_format: UploadFormat) -> tuple[AdapterDescriptor, ...]:
     """Return candidate descriptors for a top-level upload format."""
 
     return tuple(
-        get_descriptor(family)
-        for family in input_families_for_upload_format(upload_format)
+        get_descriptor(family) for family in input_families_for_upload_format(upload_format)
     )
 
 
@@ -335,6 +411,10 @@ __all__ = [
     "descriptors_for_upload_format",
     "evaluate_availability",
     "get_descriptor",
+    "get_descriptor_by_key",
+    "get_export_descriptor",
+    "get_export_registry",
     "get_registry",
+    "get_registry_by_key",
     "list_descriptors",
 ]

--- a/app/ingestion/selection.py
+++ b/app/ingestion/selection.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from app.ingestion.contracts import AdapterDescriptor, InputFamily, UploadFormat
-from app.ingestion.registry import descriptors_for_upload_format, get_descriptor
+from app.ingestion.registry import (
+    descriptors_for_upload_format,
+    get_descriptor,
+    get_export_descriptor,
+    get_export_descriptors,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,6 +42,33 @@ def select_adapter_candidates(
         AdapterCandidate(upload_format, descriptor.family, descriptor)
         for descriptor in descriptors_for_upload_format(upload_format)
     )
+
+
+def _normalize_export_format(output_format: str) -> str:
+    normalized = output_format.strip().lower()
+    if not normalized:
+        raise ValueError("Unsupported export format for ingestion.")
+    return normalized
+
+
+def select_export_candidates(output_format: str) -> tuple[AdapterDescriptor, ...]:
+    """Resolve ordered export-capable adapter descriptors for a requested format."""
+
+    normalized_output_format = _normalize_export_format(output_format)
+    try:
+        return get_export_descriptors(normalized_output_format)
+    except KeyError as exc:
+        raise ValueError("Unsupported export format for ingestion.") from exc
+
+
+def select_export_descriptor(output_format: str) -> AdapterDescriptor:
+    """Resolve a single export-capable adapter descriptor for a requested format."""
+
+    normalized_output_format = _normalize_export_format(output_format)
+    try:
+        return get_export_descriptor(normalized_output_format)
+    except KeyError as exc:
+        raise ValueError("Unsupported export format for ingestion.") from exc
 
 
 def resolve_input_family(

--- a/tests/test_ingestion_contracts.py
+++ b/tests/test_ingestion_contracts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import fields
 from datetime import UTC, datetime
 from pathlib import Path
@@ -14,6 +14,7 @@ import pytest
 
 import app.ingestion.adapters.pymupdf as pymupdf_adapter
 import app.ingestion.adapters.vtracer_tesseract as vtracer_tesseract_adapter
+import app.ingestion.registry as registry_module
 from app.core.errors import ErrorCode
 from app.ingestion.contracts import (
     AdapterAvailability,
@@ -45,7 +46,9 @@ from app.ingestion.contracts import (
 from app.ingestion.registry import (
     descriptors_for_upload_format,
     evaluate_availability,
+    get_export_registry,
     get_registry,
+    get_registry_by_key,
     list_descriptors,
 )
 from app.ingestion.validation import build_validation_outcome
@@ -126,6 +129,88 @@ class _FakeDocument:
 
     def close(self) -> None:
         self.closed = True
+
+
+def _clear_registry_caches() -> None:
+    cast(Any, list_descriptors).cache_clear()
+    cast(Any, get_registry_by_key).cache_clear()
+    cast(Any, get_registry).cache_clear()
+    cast(Any, get_export_registry).cache_clear()
+
+
+@pytest.fixture
+def clear_registry_caches() -> Iterator[None]:
+    _clear_registry_caches()
+    try:
+        yield
+    finally:
+        _clear_registry_caches()
+
+
+def _build_descriptor(
+    *,
+    key: str,
+    family: InputFamily,
+    upload_formats: tuple[UploadFormat, ...],
+    can_read: bool,
+    can_write: bool,
+    supports_exports: bool,
+    output_formats: tuple[str, ...] = ("canonical_json",),
+) -> AdapterDescriptor:
+    return AdapterDescriptor(
+        key=key,
+        family=family,
+        upload_formats=upload_formats,
+        output_formats=output_formats,
+        display_name=key,
+        module=f"tests.synthetic.{key}",
+        license_name="MIT",
+        capabilities=AdapterCapabilities(
+            can_read=can_read,
+            can_write=can_write,
+            supports_exports=supports_exports,
+        ),
+        confidence_range=(0.95, 1.0),
+        probes=(),
+    )
+
+
+@pytest.mark.parametrize(
+    "output_formats",
+    [
+        ("",),
+        ("   ",),
+        ("Canonical_JSON",),
+        (" canonical_json",),
+        ("canonical_json ",),
+    ],
+)
+def test_adapter_descriptor_rejects_non_canonical_output_formats(
+    output_formats: tuple[str, ...],
+) -> None:
+    with pytest.raises(ValueError, match="Adapter output format"):
+        _build_descriptor(
+            key="synthetic-output-format",
+            family=InputFamily.DXF,
+            upload_formats=(UploadFormat.DXF,),
+            can_read=False,
+            can_write=True,
+            supports_exports=True,
+            output_formats=output_formats,
+        )
+
+
+def test_adapter_descriptor_rejects_duplicate_output_formats() -> None:
+    with pytest.raises(ValueError, match="Duplicate adapter output format 'revised_dxf'"):
+        _build_descriptor(
+            key="synthetic-duplicate-output-format",
+            family=InputFamily.DXF,
+            upload_formats=(UploadFormat.DXF,),
+            can_read=False,
+            can_write=True,
+            supports_exports=True,
+            output_formats=("revised_dxf", "revised_dxf"),
+        )
 
 
 def _assert_no_nonfinite_numbers(value: object) -> None:
@@ -286,6 +371,141 @@ def test_registry_is_static_and_covers_every_family() -> None:
     assert dwg_license_probe.failure_status is AdapterStatus.UNAVAILABLE
     assert pdf_vector_license_probe.failure_status is AdapterStatus.UNAVAILABLE
     assert pdf_raster_binary_probe.failure_status is AdapterStatus.DEGRADED
+
+
+def test_registry_by_key_rejects_duplicate_adapter_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    duplicate_key = "synthetic-dxf-export"
+    first = _build_descriptor(
+        key=duplicate_key,
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=False,
+        can_write=True,
+        supports_exports=True,
+        output_formats=("revised_dxf",),
+    )
+    second = _build_descriptor(
+        key=duplicate_key,
+        family=InputFamily.DWG,
+        upload_formats=(UploadFormat.DWG,),
+        can_read=False,
+        can_write=True,
+        supports_exports=True,
+        output_formats=("revised_dxf",),
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*list_descriptors(), first, second),
+    )
+    _clear_registry_caches()
+
+    with pytest.raises(ValueError, match="Duplicate adapter key 'synthetic-dxf-export'"):
+        get_registry_by_key()
+
+
+def test_registry_rejects_duplicate_read_families(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    duplicate_reader = _build_descriptor(
+        key="synthetic-dxf-reader",
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=True,
+        can_write=False,
+        supports_exports=False,
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*list_descriptors(), duplicate_reader),
+    )
+    _clear_registry_caches()
+
+    with pytest.raises(ValueError, match="Duplicate read adapter family"):
+        get_registry()
+
+
+def test_export_registry_indexes_synthetic_dxf_writers_without_changing_read_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    first = _build_descriptor(
+        key="synthetic-dxf-export-a",
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=False,
+        can_write=True,
+        supports_exports=True,
+        output_formats=("revised_dxf",),
+    )
+    second = _build_descriptor(
+        key="synthetic-dxf-export-b",
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=False,
+        can_write=True,
+        supports_exports=True,
+        output_formats=("revised_dxf",),
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*list_descriptors(), first, second),
+    )
+    _clear_registry_caches()
+
+    assert get_registry()[InputFamily.DXF].key == "ezdxf"
+    assert get_export_registry()["revised_dxf"] == (first, second)
+
+
+def test_export_registry_requires_write_and_export_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    read_only = _build_descriptor(
+        key="synthetic-read-only-export",
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=False,
+        can_write=False,
+        supports_exports=True,
+        output_formats=("revised_dxf",),
+    )
+    write_only = _build_descriptor(
+        key="synthetic-write-only-export",
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=False,
+        can_write=True,
+        supports_exports=False,
+        output_formats=("revised_dxf",),
+    )
+    eligible = _build_descriptor(
+        key="synthetic-dxf-export",
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        can_read=False,
+        can_write=True,
+        supports_exports=True,
+        output_formats=("revised_dxf",),
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*list_descriptors(), read_only, write_only, eligible),
+    )
+    _clear_registry_caches()
+
+    assert get_export_registry()["revised_dxf"] == (eligible,)
 
 
 def test_ifc_registry_metadata_stays_semantic_only() -> None:

--- a/tests/test_ingestion_runner.py
+++ b/tests/test_ingestion_runner.py
@@ -6,7 +6,7 @@ import asyncio
 import hashlib
 import importlib.machinery
 import types
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, BinaryIO, Literal, cast
@@ -15,11 +15,14 @@ from uuid import uuid4
 import ezdxf
 import pytest
 
+import app.ingestion.registry as registry_module
 from app.core.errors import ErrorCode
 from app.ingestion.adapters import ifcopenshell as ifcopenshell_adapter_module
 from app.ingestion.adapters import pymupdf as pymupdf_adapter_module
 from app.ingestion.contracts import (
     AdapterAvailability,
+    AdapterCapabilities,
+    AdapterDescriptor,
     AdapterResult,
     AdapterStatus,
     AdapterTimeout,
@@ -31,8 +34,13 @@ from app.ingestion.contracts import (
     ProvenanceRecord,
     UploadFormat,
 )
+from app.ingestion.loader import load_export_adapter
 from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_ingestion
-from app.ingestion.selection import select_adapter_candidates
+from app.ingestion.selection import (
+    select_adapter_candidates,
+    select_export_candidates,
+    select_export_descriptor,
+)
 from app.ingestion.source import (
     OriginalSourceMaterialization,
     OriginalSourceReadError,
@@ -47,6 +55,46 @@ _DXF_SMOKE_FIXTURE = Path(__file__).parent / "fixtures" / "dxf" / "simple-line.d
 _IFC_SMOKE_BODY = (
     b"ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n"
 )
+
+
+def _clear_registry_caches() -> None:
+    cast(Any, registry_module.list_descriptors).cache_clear()
+    cast(Any, registry_module.get_registry_by_key).cache_clear()
+    cast(Any, registry_module.get_registry).cache_clear()
+    cast(Any, registry_module.get_export_registry).cache_clear()
+
+
+@pytest.fixture
+def clear_registry_caches() -> Iterator[None]:
+    _clear_registry_caches()
+    try:
+        yield
+    finally:
+        _clear_registry_caches()
+
+
+def _build_export_descriptor(
+    *,
+    key: str,
+    can_write: bool,
+    supports_exports: bool,
+) -> AdapterDescriptor:
+    return AdapterDescriptor(
+        key=key,
+        family=InputFamily.DXF,
+        upload_formats=(UploadFormat.DXF,),
+        output_formats=("revised_dxf",),
+        display_name=key,
+        module=f"tests.synthetic.{key}",
+        license_name="MIT",
+        capabilities=AdapterCapabilities(
+            can_read=False,
+            can_write=can_write,
+            supports_exports=supports_exports,
+        ),
+        confidence_range=(0.95, 1.0),
+        probes=(),
+    )
 
 
 def _fake_line_entity(*, adapter_key: str, source_ref: str) -> dict[str, Any]:
@@ -346,6 +394,169 @@ def test_select_adapter_candidates_keeps_pdf_vector_then_raster_order() -> None:
         (UploadFormat.PDF, InputFamily.PDF_VECTOR),
         (UploadFormat.PDF, InputFamily.PDF_RASTER),
     ]
+
+
+def test_select_export_candidates_keep_registered_order_and_filter_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    read_only = _build_export_descriptor(
+        key="synthetic-read-only-export",
+        can_write=False,
+        supports_exports=True,
+    )
+    first = _build_export_descriptor(
+        key="synthetic-dxf-export-a",
+        can_write=True,
+        supports_exports=True,
+    )
+    write_only = _build_export_descriptor(
+        key="synthetic-write-only-export",
+        can_write=True,
+        supports_exports=False,
+    )
+    second = _build_export_descriptor(
+        key="synthetic-dxf-export-b",
+        can_write=True,
+        supports_exports=True,
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*registry_module.list_descriptors(), read_only, first, write_only, second),
+    )
+    _clear_registry_caches()
+
+    assert select_export_candidates("revised_dxf") == (first, second)
+
+
+def test_select_export_descriptor_returns_single_registered_writer(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    descriptor = _build_export_descriptor(
+        key="synthetic-dxf-export",
+        can_write=True,
+        supports_exports=True,
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*registry_module.list_descriptors(), descriptor),
+    )
+    _clear_registry_caches()
+
+    assert select_export_descriptor("revised_dxf") is descriptor
+
+
+def test_select_export_descriptor_rejects_ambiguous_registered_writers(
+    monkeypatch: pytest.MonkeyPatch,
+    clear_registry_caches: None,
+) -> None:
+    first = _build_export_descriptor(
+        key="synthetic-dxf-export-a",
+        can_write=True,
+        supports_exports=True,
+    )
+    second = _build_export_descriptor(
+        key="synthetic-dxf-export-b",
+        can_write=True,
+        supports_exports=True,
+    )
+
+    monkeypatch.setattr(
+        registry_module,
+        "_ADAPTER_DESCRIPTORS",
+        (*registry_module.list_descriptors(), first, second),
+    )
+    _clear_registry_caches()
+
+    with pytest.raises(
+        ValueError,
+        match="Multiple export adapters registered for 'revised_dxf'",
+    ):
+        select_export_descriptor("revised_dxf")
+
+
+def test_select_export_helpers_reject_unsupported_export_formats() -> None:
+    with pytest.raises(ValueError, match=r"Unsupported export format for ingestion\."):
+        select_export_candidates("revised_svg")
+
+    with pytest.raises(ValueError, match=r"Unsupported export format for ingestion\."):
+        select_export_descriptor("revised_svg")
+
+
+def test_load_export_adapter_uses_create_export_adapter_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    descriptor = _build_export_descriptor(
+        key="synthetic-export-factory",
+        can_write=True,
+        supports_exports=True,
+    )
+    sentinel = object()
+    module = types.ModuleType("synthetic_export_factory_module")
+    module.create_export_adapter = lambda: sentinel  # type: ignore[attr-defined]
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        assert module_name == descriptor.module
+        return module
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    assert load_export_adapter(descriptor) is sentinel
+
+
+def test_load_export_adapter_rejects_missing_export_capabilities() -> None:
+    descriptor = _build_export_descriptor(
+        key="synthetic-export-disabled",
+        can_write=True,
+        supports_exports=False,
+    )
+
+    with pytest.raises(ValueError, match="does not support exports"):
+        load_export_adapter(descriptor)
+
+
+def test_load_export_adapter_rejects_missing_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    descriptor = _build_export_descriptor(
+        key="synthetic-export-missing-factory",
+        can_write=True,
+        supports_exports=True,
+    )
+    module = types.ModuleType("synthetic_export_missing_factory_module")
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        assert module_name == descriptor.module
+        return module
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    with pytest.raises(AttributeError, match="does not define 'create_export_adapter'"):
+        load_export_adapter(descriptor)
+
+
+def test_load_export_adapter_rejects_non_callable_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    descriptor = _build_export_descriptor(
+        key="synthetic-export-non-callable-factory",
+        can_write=True,
+        supports_exports=True,
+    )
+    module = types.ModuleType("synthetic_export_non_callable_factory_module")
+    module.create_export_adapter = object()  # type: ignore[attr-defined]
+
+    def fake_import_module(module_name: str) -> types.ModuleType:
+        assert module_name == descriptor.module
+        return module
+
+    monkeypatch.setattr("app.ingestion.loader.importlib.import_module", fake_import_module)
+
+    with pytest.raises(TypeError, match="exposes non-callable 'create_export_adapter'"):
+        load_export_adapter(descriptor)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #272

## Summary
- rework the ingestion adapter registry around unique adapter keys while preserving read-family compatibility APIs
- add export adapter contracts, selection helpers, and loader boundaries for future write-capable adapters
- cover duplicate/canonical output-format validation and synthetic DXF export selection/loader cases in focused tests

## Test plan
- [x] uv run ruff check
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_ingestion_contracts.py tests/test_ingestion_runner.py tests/test_system_endpoints.py tests/test_ezdxf_adapter.py

## Notes
- no production DXF writer or DXF emit logic is included in this change