### PR TITLE
refactor: extract shared canonical helpers

### DIFF
--- a/app/estimating/engine/_decimal.py
+++ b/app/estimating/engine/_decimal.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def _decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"

--- a/app/estimating/engine/contracts.py
+++ b/app/estimating/engine/contracts.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Literal
 from uuid import NAMESPACE_URL, UUID, uuid5
 
+from app.estimating.engine._decimal import _decimal_text
 from app.estimating.formulas import (
     FormulaDefinition,
     FormulaInputDefinition,
@@ -400,10 +401,3 @@ def _rounding_json(rounding: RoundingSpec | None) -> dict[str, JSONValue] | None
     if rounding is None:
         return None
     return {"scale": rounding.scale, "mode": rounding.mode}
-
-
-def _decimal_text(value: Decimal) -> str:
-    text = format(value.normalize(), "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    return text or "0"

--- a/app/estimating/engine/service.py
+++ b/app/estimating/engine/service.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
+from app.estimating.engine._decimal import _decimal_text
 from app.estimating.engine.contracts import (
     EstimateAssumptionEntryInput,
     EstimateEngineInput,
@@ -793,10 +794,3 @@ def _resolve_adjustment_anchor(
         expected_type="assumption",
     )
     return None, assumption_value.snapshot.id
-
-
-def _decimal_text(value: Decimal) -> str:
-    text = format(value.normalize(), "f")
-    if "." in text:
-        text = text.rstrip("0").rstrip(".")
-    return text or "0"

--- a/app/ingestion/adapters/ezdxf.py
+++ b/app/ingestion/adapters/ezdxf.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from app.ingestion.canonical import build_entity_provenance
+from app.ingestion.canonical.geometry import canonical_bbox_from_points
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterDescriptor,
@@ -982,21 +983,17 @@ def _scaled_points_payload(
 
 
 def _points_bbox_payload(points: tuple[dict[str, JSONValue], ...]) -> dict[str, JSONValue]:
-    x_values = tuple(_point_component(point, "x") for point in points)
-    y_values = tuple(_point_component(point, "y") for point in points)
-    z_values = tuple(_point_component(point, "z") for point in points)
-    return {
-        "min": {
-            "x": min(x_values),
-            "y": min(y_values),
-            "z": min(z_values),
-        },
-        "max": {
-            "x": max(x_values),
-            "y": max(y_values),
-            "z": max(z_values),
-        },
-    }
+    return cast(
+        dict[str, JSONValue],
+        canonical_bbox_from_points(
+            {
+                "x": _point_component(point, "x"),
+                "y": _point_component(point, "y"),
+                "z": _point_component(point, "z"),
+            }
+            for point in points
+        ),
+    )
 
 
 def _polyline_measure(
@@ -1133,18 +1130,23 @@ def _bbox_payload(
     start: dict[str, JSONValue],
     end: dict[str, JSONValue],
 ) -> dict[str, JSONValue]:
-    return {
-        "min": {
-            "x": min(_point_component(start, "x"), _point_component(end, "x")),
-            "y": min(_point_component(start, "y"), _point_component(end, "y")),
-            "z": min(_point_component(start, "z"), _point_component(end, "z")),
-        },
-        "max": {
-            "x": max(_point_component(start, "x"), _point_component(end, "x")),
-            "y": max(_point_component(start, "y"), _point_component(end, "y")),
-            "z": max(_point_component(start, "z"), _point_component(end, "z")),
-        },
-    }
+    return cast(
+        dict[str, JSONValue],
+        canonical_bbox_from_points(
+            (
+                {
+                    "x": _point_component(start, "x"),
+                    "y": _point_component(start, "y"),
+                    "z": _point_component(start, "z"),
+                },
+                {
+                    "x": _point_component(end, "x"),
+                    "y": _point_component(end, "y"),
+                    "z": _point_component(end, "z"),
+                },
+            )
+        ),
+    )
 
 
 def _line_length(start: dict[str, JSONValue], end: dict[str, JSONValue]) -> float:

--- a/app/ingestion/adapters/libredwg.py
+++ b/app/ingestion/adapters/libredwg.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import math
 import resource
@@ -16,7 +15,12 @@ from pathlib import Path
 from time import perf_counter
 from typing import Any, cast
 
-from app.ingestion.canonical import build_entity_provenance
+from app.ingestion.canonical.entity_provenance import build_entity_provenance
+from app.ingestion.canonical.hashing import (
+    sha256_canonical_json_hex,
+    sha256_canonical_json_prefixed,
+    sha256_text_hex,
+)
 from app.ingestion.contracts import (
     AdapterAvailability,
     AdapterDiagnostic,
@@ -1143,16 +1147,15 @@ def _safe_record_projection(
 
 
 def _hash_json_value(value: JSONValue) -> str:
-    return f"sha256:{_canonical_hash_json_value(value)}"
+    return sha256_canonical_json_prefixed(value)
 
 
 def _canonical_hash_json_value(value: JSONValue) -> str:
-    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-    return _hash_text(payload)
+    return sha256_canonical_json_hex(value)
 
 
 def _hash_text(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return sha256_text_hex(value)
 
 
 def _source_ref(source: AdapterSource) -> str:

--- a/app/ingestion/canonical/entity_provenance.py
+++ b/app/ingestion/canonical/entity_provenance.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Final
 
+from app.ingestion.canonical.hashing import normalize_sha256_hex
+
 ENTITY_PROVENANCE_ALLOWED_ORIGINS: Final[frozenset[str]] = frozenset(
     {
         "source_direct",
@@ -252,11 +254,10 @@ def _normalize_source_hash(value: Any, *, field_name: str) -> str | None:
         raise EntityProvenanceError(
             f"entity provenance {field_name} must be a SHA-256 string or null"
         )
-    normalized = value.removeprefix("sha256:").strip().lower()
-    if len(normalized) != 64 or any(
-        character not in "0123456789abcdef" for character in normalized
-    ):
+    normalized = value.strip().lower()
+    try:
+        return normalize_sha256_hex(normalized, allow_prefix=True)
+    except ValueError as exc:
         raise EntityProvenanceError(
             f"entity provenance {field_name} must be a raw 64-character SHA-256 hex string"
-        )
-    return normalized
+        ) from exc

--- a/app/ingestion/canonical/geometry.py
+++ b/app/ingestion/canonical/geometry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+type Point3DMapping = Mapping[str, float]
+type BBox3DMapping = dict[str, dict[str, float]]
+
+
+def canonical_bbox_from_points(points: Iterable[Point3DMapping]) -> BBox3DMapping:
+    iterator = iter(points)
+    first_point = next(iterator)
+
+    min_x = max_x = first_point["x"]
+    min_y = max_y = first_point["y"]
+    min_z = max_z = first_point["z"]
+
+    for point in iterator:
+        x = point["x"]
+        y = point["y"]
+        z = point["z"]
+
+        if x < min_x:
+            min_x = x
+        if x > max_x:
+            max_x = x
+        if y < min_y:
+            min_y = y
+        if y > max_y:
+            max_y = y
+        if z < min_z:
+            min_z = z
+        if z > max_z:
+            max_z = z
+
+    return {
+        "min": {"x": min_x, "y": min_y, "z": min_z},
+        "max": {"x": max_x, "y": max_y, "z": max_z},
+    }

--- a/app/ingestion/canonical/hashing.py
+++ b/app/ingestion/canonical/hashing.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def sha256_text_hex(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_text_prefixed(value: str) -> str:
+    return f"sha256:{sha256_text_hex(value)}"
+
+
+def sha256_canonical_json_hex(payload: Any) -> str:
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return sha256_text_hex(canonical)
+
+
+def sha256_canonical_json_prefixed(payload: Any) -> str:
+    return f"sha256:{sha256_canonical_json_hex(payload)}"
+
+
+def normalize_sha256_hex(value: str, *, allow_prefix: bool = False) -> str:
+    normalized = value.removeprefix("sha256:") if allow_prefix else value
+    if not _SHA256_HEX_RE.fullmatch(normalized):
+        raise ValueError("expected SHA-256 hex digest")
+    return normalized

--- a/tests/test_entity_provenance.py
+++ b/tests/test_entity_provenance.py
@@ -293,3 +293,23 @@ def test_validate_entity_provenance_rejects_invalid_hash() -> None:
                 "notes": "note",
             }
         )
+
+
+def test_validate_entity_provenance_normalizes_prefixed_hash_with_whitespace() -> None:
+    canonical = validate_entity_provenance(
+        {
+            "origin": "source_direct",
+            "adapter": "dxf",
+            "source_ref": None,
+            "source_identity": None,
+            "source_hash": (
+                "  sha256:ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789\n"
+            ),
+            "extraction_path": "entities[0]",
+            "notes": "note",
+        }
+    )
+
+    assert canonical["source_hash"] == (
+        "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    )

--- a/tests/test_estimate_engine_contracts.py
+++ b/tests/test_estimate_engine_contracts.py
@@ -20,6 +20,7 @@ from app.estimating.engine import (
     formula_definition_from_json,
     formula_definition_from_selected_formula,
 )
+from app.estimating.engine._decimal import _decimal_text
 from app.estimating.formulas import (
     FormulaDefinition,
     FormulaInputDefinition,
@@ -32,6 +33,22 @@ SCALAR = ValueContract(kind="scalar")
 MONEY_GBP = ValueContract(kind="money", currency="GBP")
 QUANTITY_M = ValueContract(kind="quantity", unit="m")
 RATE_GBP_PER_M = ValueContract(kind="rate", currency="GBP", per_unit="m")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (Decimal("12.3400"), "12.34"),
+        (Decimal("1.2000"), "1.2"),
+        (Decimal("5.000"), "5"),
+        (Decimal("0.000"), "0"),
+    ],
+)
+def test_decimal_text_normalizes_estimate_engine_decimal_strings(
+    value: Decimal,
+    expected: str,
+) -> None:
+    assert _decimal_text(value) == expected
 
 
 def test_engine_contracts_expose_deterministic_ids_and_frozen_specs() -> None:

--- a/tests/test_ezdxf_adapter.py
+++ b/tests/test_ezdxf_adapter.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import types
 from collections.abc import Iterator
 from math import isfinite
@@ -12,12 +14,15 @@ from typing import Any, NoReturn, cast
 import ezdxf
 import pytest
 
+from app.ingestion.adapters import ezdxf as ezdxf_adapter_module
 from app.ingestion.adapters.ezdxf import EzdxfAdapter
+from app.ingestion.canonical.geometry import canonical_bbox_from_points
 from app.ingestion.contracts import (
     AdapterExecutionOptions,
     AdapterTimeout,
     IngestionAdapter,
     InputFamily,
+    JSONValue,
     ProgressUpdate,
 )
 from app.ingestion.loader import load_adapter
@@ -334,6 +339,84 @@ def _load_ezdxf_adapter() -> IngestionAdapter:
 
 def input_family() -> InputFamily:
     return InputFamily.DXF
+
+
+def test_ezdxf_entity_fingerprint_hashes_canonical_json_payload() -> None:
+    geometry: dict[str, JSONValue] = {
+        "end": {"z": 4.0, "y": -3.0, "x": 7.5},
+        "start": {"z": 1.0, "y": 2.5, "x": -1.25},
+    }
+    expected_geometry: dict[str, JSONValue] = {
+        "start": {"x": -1.25, "y": 2.5, "z": 1.0},
+        "end": {"x": 7.5, "y": -3.0, "z": 4.0},
+    }
+    expected_payload: dict[str, JSONValue] = {
+        "native_type": "LINE",
+        "handle": "",
+        "layout_name": "Model",
+        "layer_name": "Walls",
+        "geometry": expected_geometry,
+    }
+    expected_hash = hashlib.sha256(
+        json.dumps(expected_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+    assert (
+        ezdxf_adapter_module._entity_fingerprint(
+            native_type="LINE",
+            handle="",
+            layout_name="Model",
+            layer_name="Walls",
+            geometry=geometry,
+        )
+        == expected_hash
+    )
+    assert (
+        ezdxf_adapter_module._entity_fingerprint(
+            native_type="LINE",
+            handle="",
+            layout_name="Model",
+            layer_name="Walls",
+            geometry=expected_geometry,
+        )
+        == expected_hash
+    )
+
+
+def test_ezdxf_line_bbox_payload_uses_coordinate_min_max() -> None:
+    start: dict[str, JSONValue] = {"x": 7.5, "y": 2.5, "z": 4.0}
+    end: dict[str, JSONValue] = {"x": -1.25, "y": -3.0, "z": 1.0}
+
+    assert ezdxf_adapter_module._bbox_payload(start, end) == {
+        "min": {"x": -1.25, "y": -3.0, "z": 1.0},
+        "max": {"x": 7.5, "y": 2.5, "z": 4.0},
+    }
+
+
+def test_canonical_bbox_from_points_uses_coordinate_min_max() -> None:
+    points = (
+        {"x": 7.5, "y": 2.5, "z": 4.0},
+        {"x": -1.25, "y": -3.0, "z": 1.0},
+        {"x": 0.0, "y": 9.0, "z": -2.0},
+    )
+
+    assert canonical_bbox_from_points(points) == {
+        "min": {"x": -1.25, "y": -3.0, "z": -2.0},
+        "max": {"x": 7.5, "y": 9.0, "z": 4.0},
+    }
+
+
+def test_ezdxf_polyline_bbox_payload_uses_pointwise_coordinate_min_max() -> None:
+    points: tuple[dict[str, JSONValue], ...] = (
+        {"x": 7.5, "y": 2.5, "z": 4.0},
+        {"x": -1.25, "y": -3.0, "z": 1.0},
+        {"x": 0.0, "y": 9.0, "z": -2.0},
+    )
+
+    assert ezdxf_adapter_module._points_bbox_payload(points) == {
+        "min": {"x": -1.25, "y": -3.0, "z": -2.0},
+        "max": {"x": 7.5, "y": 9.0, "z": 4.0},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_libredwg_adapter.py
+++ b/tests/test_libredwg_adapter.py
@@ -1105,3 +1105,23 @@ async def test_libredwg_adapter_terminates_and_kills_process_on_cancellation(
 
     assert process.terminate_calls == 1
     assert process.kill_calls == 1
+
+
+def test_libredwg_hash_helpers_preserve_raw_and_prefixed_forms() -> None:
+    value = {
+        "record_type": "LINE",
+        "handle": "1A",
+        "layer_name": "Walls",
+        "layout_name": "Model",
+        "block_name": None,
+        "geometry": {
+            "start": {"x": 1.0, "y": 2.0, "z": 0.0},
+            "end": {"x": 4.0, "y": 6.0, "z": 0.0},
+        },
+    }
+    canonical_payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    expected_raw_hash = adapter_module._hash_text(canonical_payload)
+
+    assert adapter_module._canonical_hash_json_value(value) == expected_raw_hash
+    assert adapter_module._hash_json_value(value) == f"sha256:{expected_raw_hash}"
+    assert adapter_module._hash_json_value(value) != expected_raw_hash


### PR DESCRIPTION
Closes #280

## Summary
- extract shared canonical SHA-256 hashing helpers and reuse them in provenance and LibreDWG paths
- extract a shared canonical 3D bbox helper and reuse it from the ezdxf adapter while keeping adapter-local coercion and validation
- dedupe the estimating engine decimal text helper and add characterization coverage for preserved hash, bbox, provenance, and decimal semantics

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_entity_provenance.py tests/test_libredwg_adapter.py tests/test_ezdxf_adapter.py tests/test_estimate_engine_service.py tests/test_estimate_engine_contracts.py tests/test_estimate_engine_persistence_payloads.py
- [x] uv run pytest

## Notes
- no shared units helper was extracted because DXF and IFC unit handling remain intentionally different