### PR TITLE
refactor(db): introduce declarative model mixins

### DIFF
--- a/app/db/mixins.py
+++ b/app/db/mixins.py
@@ -1,0 +1,140 @@
+"""Shared declarative SQLAlchemy mixins/helpers."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, ClassVar, cast
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, MappedColumn, declarative_mixin, declared_attr, mapped_column
+
+
+def _require_str_config(model_cls: type[Any], attribute_name: str) -> str:
+    value = getattr(model_cls, attribute_name, None)
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{model_cls.__name__} must define a non-empty {attribute_name}")
+    return value
+
+
+def _table_name(model_cls: type[Any]) -> str:
+    table_name = getattr(model_cls, "__tablename__", None)
+    if not isinstance(table_name, str) or not table_name:
+        raise TypeError(f"{model_cls.__name__} must define a non-empty __tablename__")
+    return table_name
+
+
+def _fk_name(model_cls: type[Any], local_column: str, remote_table: str) -> str:
+    return f"fk_{_table_name(model_cls)}_{local_column}_{remote_table}"
+
+
+@declarative_mixin
+class TimestampMixin:
+    """Adds a created_at timestamp column with subclass-owned comment text."""
+
+    __created_at_comment__: ClassVar[str]
+
+    @declared_attr
+    def created_at(cls) -> Mapped[datetime]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            DateTime(timezone=True),
+            default=func.now(),
+            nullable=False,
+            comment=_require_str_config(model_cls, "__created_at_comment__"),
+        )
+
+
+@declarative_mixin
+class ProjectScopedMixin:
+    """Adds the project ownership column used by scoped lineage tables."""
+
+    @declared_attr
+    def project_id(cls) -> Mapped[uuid.UUID]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            ForeignKey(
+                "projects.id",
+                name=_fk_name(model_cls, "project_id", "projects"),
+                ondelete="RESTRICT",
+            ),
+            nullable=False,
+            index=True,
+            comment="Owning project identifier",
+        )
+
+
+@declarative_mixin
+class RevisionLineageMixin:
+    """Adds the repeated revision materialization lineage columns only."""
+
+    __source_file_comment__: ClassVar[str]
+    __extraction_profile_comment__: ClassVar[str]
+    __source_job_comment__: ClassVar[str]
+    __drawing_revision_comment__: ClassVar[str]
+    __adapter_run_output_comment__: ClassVar[str]
+    __canonical_entity_schema_version_comment__: ClassVar[str]
+
+    @declared_attr
+    def source_file_id(cls) -> Mapped[uuid.UUID]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            nullable=False,
+            index=True,
+            comment=_require_str_config(model_cls, "__source_file_comment__"),
+        )
+
+    @declared_attr
+    def extraction_profile_id(cls) -> Mapped[uuid.UUID | None]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            nullable=True,
+            index=True,
+            comment=_require_str_config(model_cls, "__extraction_profile_comment__"),
+        )
+
+    @declared_attr
+    def source_job_id(cls) -> Mapped[uuid.UUID]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            ForeignKey(
+                "jobs.id",
+                name=_fk_name(model_cls, "source_job_id", "jobs"),
+                ondelete="RESTRICT",
+            ),
+            nullable=False,
+            index=True,
+            comment=_require_str_config(model_cls, "__source_job_comment__"),
+        )
+
+    @declared_attr
+    def drawing_revision_id(cls) -> Mapped[uuid.UUID]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            nullable=False,
+            comment=_require_str_config(model_cls, "__drawing_revision_comment__"),
+        )
+
+    @declared_attr
+    def adapter_run_output_id(cls) -> Mapped[uuid.UUID | None]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            nullable=True,
+            index=True,
+            comment=_require_str_config(model_cls, "__adapter_run_output_comment__"),
+        )
+
+    @declared_attr
+    def canonical_entity_schema_version(cls) -> Mapped[str]:  # noqa: N805
+        model_cls = cast(type[Any], cls)
+        return mapped_column(
+            String(16),
+            nullable=False,
+            comment=_require_str_config(model_cls, "__canonical_entity_schema_version_comment__"),
+        )
+
+
+def sha256_column(*, nullable: bool, index: bool, comment: str) -> MappedColumn[Any]:
+    """Return the standard nullable/non-nullable SHA-256 text column shape."""
+
+    return mapped_column(String(64), nullable=nullable, index=index, comment=comment)

--- a/app/models/revision_materialization.py
+++ b/app/models/revision_materialization.py
@@ -3,28 +3,45 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from sqlalchemy import (
     JSON,
     CheckConstraint,
-    DateTime,
-    ForeignKey,
     ForeignKeyConstraint,
     Index,
     Integer,
     String,
     UniqueConstraint,
-    func,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
+from app.db.mixins import ProjectScopedMixin, RevisionLineageMixin, TimestampMixin, sha256_column
 
 
-class RevisionEntityManifest(Base):
+class RevisionEntityManifest(RevisionLineageMixin, ProjectScopedMixin, TimestampMixin, Base):
     """Manifest row recording whether revision entities were materialized."""
+
+    __source_file_comment__: ClassVar[str] = (
+        "Immutable source file identifier for the materialized revision"
+    )
+    __extraction_profile_comment__: ClassVar[str] = (
+        "Immutable extraction profile identifier used for materialization"
+    )
+    __source_job_comment__: ClassVar[str] = (
+        "Job identifier that materialized normalized revision entities"
+    )
+    __drawing_revision_comment__: ClassVar[str] = (
+        "Drawing revision identifier whose normalized entities were materialized"
+    )
+    __adapter_run_output_comment__: ClassVar[str] = (
+        "Adapter run output identifier materialized into revision-scoped entity tables"
+    )
+    __canonical_entity_schema_version_comment__: ClassVar[str] = (
+        "Canonical entity schema version for the materialized revision payloads"
+    )
+    __created_at_comment__: ClassVar[str] = "Manifest creation timestamp"
 
     __tablename__ = "revision_entity_manifests"
     __table_args__ = (
@@ -76,67 +93,33 @@ class RevisionEntityManifest(Base):
         default=uuid.uuid4,
         comment="Unique revision entity materialization manifest identifier (UUID v4)",
     )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "projects.id",
-            name="fk_revision_entity_manifests_project_id_projects",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Owning project identifier",
-    )
-    source_file_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        index=True,
-        comment="Immutable source file identifier for the materialized revision",
-    )
-    extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional extraction profile identifier used for materialization",
-    )
-    source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "jobs.id",
-            name="fk_revision_entity_manifests_source_job_id_jobs",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Job identifier that materialized normalized revision entities",
-    )
-    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        comment="Drawing revision identifier whose normalized entities were materialized",
-    )
-    adapter_run_output_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment=(
-            "Optional adapter run output identifier materialized into revision-scoped entity tables"
-        ),
-    )
-    canonical_entity_schema_version: Mapped[str] = mapped_column(
-        String(16),
-        nullable=False,
-        comment="Canonical entity schema version for the materialized revision payloads",
-    )
     counts_json: Mapped[dict[str, int]] = mapped_column(
         JSON,
         nullable=False,
         comment="Materialized normalized row counts keyed by layouts, layers, blocks, and entities",
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        default=func.now(),
-        nullable=False,
-        comment="Manifest creation timestamp",
-    )
 
 
-class RevisionLayout(Base):
+class RevisionLayout(RevisionLineageMixin, ProjectScopedMixin, TimestampMixin, Base):
     """Materialized layout payload rows scoped to a drawing revision."""
+
+    __source_file_comment__: ClassVar[str] = (
+        "Immutable source file identifier for this materialized layout row"
+    )
+    __extraction_profile_comment__: ClassVar[str] = (
+        "Immutable extraction profile identifier used for this layout row"
+    )
+    __source_job_comment__: ClassVar[str] = "Job identifier that materialized this layout row"
+    __drawing_revision_comment__: ClassVar[str] = (
+        "Drawing revision identifier that owns this layout row"
+    )
+    __adapter_run_output_comment__: ClassVar[str] = (
+        "Adapter run output identifier that produced this layout row"
+    )
+    __canonical_entity_schema_version_comment__: ClassVar[str] = (
+        "Canonical entity schema version for this layout row payload"
+    )
+    __created_at_comment__: ClassVar[str] = "Revision layout materialization timestamp"
 
     __tablename__ = "revision_layouts"
     __table_args__ = (
@@ -188,50 +171,6 @@ class RevisionLayout(Base):
         default=uuid.uuid4,
         comment="Unique materialized revision layout row identifier (UUID v4)",
     )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "projects.id",
-            name="fk_revision_layouts_project_id_projects",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Owning project identifier",
-    )
-    source_file_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        index=True,
-        comment="Immutable source file identifier for this materialized layout row",
-    )
-    extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional extraction profile identifier used for this layout row",
-    )
-    source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "jobs.id",
-            name="fk_revision_layouts_source_job_id_jobs",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Job identifier that materialized this layout row",
-    )
-    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        comment="Drawing revision identifier that owns this layout row",
-    )
-    adapter_run_output_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional adapter run output identifier that produced this layout row",
-    )
-    canonical_entity_schema_version: Mapped[str] = mapped_column(
-        String(16),
-        nullable=False,
-        comment="Canonical entity schema version for this layout row payload",
-    )
     sequence_index: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
@@ -248,16 +187,28 @@ class RevisionLayout(Base):
         index=True,
         comment="Stable non-null layout reference extracted from the canonical layout payload",
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        default=func.now(),
-        nullable=False,
-        comment="Revision layout materialization timestamp",
-    )
 
 
-class RevisionLayer(Base):
+class RevisionLayer(RevisionLineageMixin, ProjectScopedMixin, TimestampMixin, Base):
     """Materialized layer payload rows scoped to a drawing revision."""
+
+    __source_file_comment__: ClassVar[str] = (
+        "Immutable source file identifier for this materialized layer row"
+    )
+    __extraction_profile_comment__: ClassVar[str] = (
+        "Immutable extraction profile identifier used for this layer row"
+    )
+    __source_job_comment__: ClassVar[str] = "Job identifier that materialized this layer row"
+    __drawing_revision_comment__: ClassVar[str] = (
+        "Drawing revision identifier that owns this layer row"
+    )
+    __adapter_run_output_comment__: ClassVar[str] = (
+        "Adapter run output identifier that produced this layer row"
+    )
+    __canonical_entity_schema_version_comment__: ClassVar[str] = (
+        "Canonical entity schema version for this layer row payload"
+    )
+    __created_at_comment__: ClassVar[str] = "Revision layer materialization timestamp"
 
     __tablename__ = "revision_layers"
     __table_args__ = (
@@ -309,50 +260,6 @@ class RevisionLayer(Base):
         default=uuid.uuid4,
         comment="Unique materialized revision layer row identifier (UUID v4)",
     )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "projects.id",
-            name="fk_revision_layers_project_id_projects",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Owning project identifier",
-    )
-    source_file_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        index=True,
-        comment="Immutable source file identifier for this materialized layer row",
-    )
-    extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional extraction profile identifier used for this layer row",
-    )
-    source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "jobs.id",
-            name="fk_revision_layers_source_job_id_jobs",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Job identifier that materialized this layer row",
-    )
-    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        comment="Drawing revision identifier that owns this layer row",
-    )
-    adapter_run_output_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional adapter run output identifier that produced this layer row",
-    )
-    canonical_entity_schema_version: Mapped[str] = mapped_column(
-        String(16),
-        nullable=False,
-        comment="Canonical entity schema version for this layer row payload",
-    )
     sequence_index: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
@@ -369,16 +276,28 @@ class RevisionLayer(Base):
         index=True,
         comment="Stable non-null layer reference extracted from the canonical layer payload",
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        default=func.now(),
-        nullable=False,
-        comment="Revision layer materialization timestamp",
-    )
 
 
-class RevisionBlock(Base):
+class RevisionBlock(RevisionLineageMixin, ProjectScopedMixin, TimestampMixin, Base):
     """Materialized block payload rows scoped to a drawing revision."""
+
+    __source_file_comment__: ClassVar[str] = (
+        "Immutable source file identifier for this materialized block row"
+    )
+    __extraction_profile_comment__: ClassVar[str] = (
+        "Immutable extraction profile identifier used for this block row"
+    )
+    __source_job_comment__: ClassVar[str] = "Job identifier that materialized this block row"
+    __drawing_revision_comment__: ClassVar[str] = (
+        "Drawing revision identifier that owns this block row"
+    )
+    __adapter_run_output_comment__: ClassVar[str] = (
+        "Adapter run output identifier that produced this block row"
+    )
+    __canonical_entity_schema_version_comment__: ClassVar[str] = (
+        "Canonical entity schema version for this block row payload"
+    )
+    __created_at_comment__: ClassVar[str] = "Revision block materialization timestamp"
 
     __tablename__ = "revision_blocks"
     __table_args__ = (
@@ -430,50 +349,6 @@ class RevisionBlock(Base):
         default=uuid.uuid4,
         comment="Unique materialized revision block row identifier (UUID v4)",
     )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "projects.id",
-            name="fk_revision_blocks_project_id_projects",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Owning project identifier",
-    )
-    source_file_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        index=True,
-        comment="Immutable source file identifier for this materialized block row",
-    )
-    extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional extraction profile identifier used for this block row",
-    )
-    source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "jobs.id",
-            name="fk_revision_blocks_source_job_id_jobs",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Job identifier that materialized this block row",
-    )
-    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        comment="Drawing revision identifier that owns this block row",
-    )
-    adapter_run_output_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional adapter run output identifier that produced this block row",
-    )
-    canonical_entity_schema_version: Mapped[str] = mapped_column(
-        String(16),
-        nullable=False,
-        comment="Canonical entity schema version for this block row payload",
-    )
     sequence_index: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
@@ -490,16 +365,28 @@ class RevisionBlock(Base):
         index=True,
         comment="Stable non-null block reference extracted from the canonical block payload",
     )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        default=func.now(),
-        nullable=False,
-        comment="Revision block materialization timestamp",
-    )
 
 
-class RevisionEntity(Base):
+class RevisionEntity(RevisionLineageMixin, ProjectScopedMixin, TimestampMixin, Base):
     """Materialized entity payload rows scoped to a drawing revision."""
+
+    __source_file_comment__: ClassVar[str] = (
+        "Immutable source file identifier for this materialized entity row"
+    )
+    __extraction_profile_comment__: ClassVar[str] = (
+        "Immutable extraction profile identifier used for this entity row"
+    )
+    __source_job_comment__: ClassVar[str] = "Job identifier that materialized this entity row"
+    __drawing_revision_comment__: ClassVar[str] = (
+        "Drawing revision identifier that owns this entity row"
+    )
+    __adapter_run_output_comment__: ClassVar[str] = (
+        "Adapter run output identifier that produced this entity row"
+    )
+    __canonical_entity_schema_version_comment__: ClassVar[str] = (
+        "Canonical entity schema version for this entity row payload"
+    )
+    __created_at_comment__: ClassVar[str] = "Revision entity materialization timestamp"
 
     __tablename__ = "revision_entities"
     __table_args__ = (
@@ -612,50 +499,6 @@ class RevisionEntity(Base):
         default=uuid.uuid4,
         comment="Unique materialized revision entity row identifier (UUID v4)",
     )
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "projects.id",
-            name="fk_revision_entities_project_id_projects",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Owning project identifier",
-    )
-    source_file_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        index=True,
-        comment="Immutable source file identifier for this materialized entity row",
-    )
-    extraction_profile_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional extraction profile identifier used for this entity row",
-    )
-    source_job_id: Mapped[uuid.UUID] = mapped_column(
-        ForeignKey(
-            "jobs.id",
-            name="fk_revision_entities_source_job_id_jobs",
-            ondelete="RESTRICT",
-        ),
-        nullable=False,
-        index=True,
-        comment="Job identifier that materialized this entity row",
-    )
-    drawing_revision_id: Mapped[uuid.UUID] = mapped_column(
-        nullable=False,
-        comment="Drawing revision identifier that owns this entity row",
-    )
-    adapter_run_output_id: Mapped[uuid.UUID | None] = mapped_column(
-        nullable=True,
-        index=True,
-        comment="Optional adapter run output identifier that produced this entity row",
-    )
-    canonical_entity_schema_version: Mapped[str] = mapped_column(
-        String(16),
-        nullable=False,
-        comment="Canonical entity schema version for this entity row payload",
-    )
     sequence_index: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
@@ -740,8 +583,7 @@ class RevisionEntity(Base):
         index=True,
         comment="Stable source identity derived from canonical entity top-level or provenance refs",
     )
-    source_hash: Mapped[str | None] = mapped_column(
-        String(64),
+    source_hash: Mapped[str | None] = sha256_column(
         nullable=True,
         index=True,
         comment="Stable source hash derived from canonical entity top-level or provenance refs",
@@ -777,10 +619,4 @@ class RevisionEntity(Base):
             "Best-effort resolved materialized parent entity row for "
             "parent_entity_ref within the same drawing revision"
         ),
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        default=func.now(),
-        nullable=False,
-        comment="Revision entity materialization timestamp",
     )

--- a/tests/test_db_mixins.py
+++ b/tests/test_db_mixins.py
@@ -1,0 +1,201 @@
+"""Tests for shared SQLAlchemy declarative mixins/helpers."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from sqlalchemy import DateTime, String, Table
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+from app.db.mixins import ProjectScopedMixin, RevisionLineageMixin, TimestampMixin, sha256_column
+from app.models.revision_materialization import (
+    RevisionBlock,
+    RevisionEntity,
+    RevisionEntityManifest,
+    RevisionLayer,
+    RevisionLayout,
+)
+
+
+def _foreign_key_names(column: Any) -> set[str]:
+    return {foreign_key.constraint.name for foreign_key in column.foreign_keys}
+
+
+def _table_for(model_cls: Any) -> Table:
+    return cast(Table, model_cls.__table__)
+
+
+@pytest.mark.parametrize(
+    (
+        "model_cls",
+        "table_name",
+        "source_file_comment",
+        "extraction_profile_comment",
+        "source_job_comment",
+        "drawing_comment",
+        "adapter_comment",
+        "schema_comment",
+        "created_at_comment",
+    ),
+    [
+        (
+            RevisionEntityManifest,
+            "revision_entity_manifests",
+            "Immutable source file identifier for the materialized revision",
+            "Immutable extraction profile identifier used for materialization",
+            "Job identifier that materialized normalized revision entities",
+            "Drawing revision identifier whose normalized entities were materialized",
+            "Adapter run output identifier materialized into revision-scoped entity tables",
+            "Canonical entity schema version for the materialized revision payloads",
+            "Manifest creation timestamp",
+        ),
+        (
+            RevisionLayout,
+            "revision_layouts",
+            "Immutable source file identifier for this materialized layout row",
+            "Immutable extraction profile identifier used for this layout row",
+            "Job identifier that materialized this layout row",
+            "Drawing revision identifier that owns this layout row",
+            "Adapter run output identifier that produced this layout row",
+            "Canonical entity schema version for this layout row payload",
+            "Revision layout materialization timestamp",
+        ),
+        (
+            RevisionLayer,
+            "revision_layers",
+            "Immutable source file identifier for this materialized layer row",
+            "Immutable extraction profile identifier used for this layer row",
+            "Job identifier that materialized this layer row",
+            "Drawing revision identifier that owns this layer row",
+            "Adapter run output identifier that produced this layer row",
+            "Canonical entity schema version for this layer row payload",
+            "Revision layer materialization timestamp",
+        ),
+        (
+            RevisionBlock,
+            "revision_blocks",
+            "Immutable source file identifier for this materialized block row",
+            "Immutable extraction profile identifier used for this block row",
+            "Job identifier that materialized this block row",
+            "Drawing revision identifier that owns this block row",
+            "Adapter run output identifier that produced this block row",
+            "Canonical entity schema version for this block row payload",
+            "Revision block materialization timestamp",
+        ),
+        (
+            RevisionEntity,
+            "revision_entities",
+            "Immutable source file identifier for this materialized entity row",
+            "Immutable extraction profile identifier used for this entity row",
+            "Job identifier that materialized this entity row",
+            "Drawing revision identifier that owns this entity row",
+            "Adapter run output identifier that produced this entity row",
+            "Canonical entity schema version for this entity row payload",
+            "Revision entity materialization timestamp",
+        ),
+    ],
+)
+def test_revision_materialization_models_use_shared_mixins(
+    model_cls: Any,
+    table_name: str,
+    source_file_comment: str,
+    extraction_profile_comment: str,
+    source_job_comment: str,
+    drawing_comment: str,
+    adapter_comment: str,
+    schema_comment: str,
+    created_at_comment: str,
+) -> None:
+    assert issubclass(model_cls, ProjectScopedMixin)
+    assert issubclass(model_cls, RevisionLineageMixin)
+    assert issubclass(model_cls, TimestampMixin)
+
+    table = _table_for(model_cls)
+    assert table.name == table_name
+
+    project_id = table.c.project_id
+    assert project_id.nullable is False
+    assert project_id.index is True
+    assert project_id.comment == "Owning project identifier"
+    assert f"fk_{table_name}_project_id_projects" in _foreign_key_names(project_id)
+
+    source_file_id = table.c.source_file_id
+    assert source_file_id.nullable is False
+    assert source_file_id.index is True
+    assert source_file_id.comment == source_file_comment
+
+    extraction_profile_id = table.c.extraction_profile_id
+    assert extraction_profile_id.nullable is True
+    assert extraction_profile_id.index is True
+    assert extraction_profile_id.comment == extraction_profile_comment
+
+    source_job_id = table.c.source_job_id
+    assert source_job_id.nullable is False
+    assert source_job_id.index is True
+    assert source_job_id.comment == source_job_comment
+    assert f"fk_{table_name}_source_job_id_jobs" in _foreign_key_names(source_job_id)
+
+    drawing_revision_id = table.c.drawing_revision_id
+    assert drawing_revision_id.nullable is False
+    assert drawing_revision_id.comment == drawing_comment
+
+    adapter_run_output_id = table.c.adapter_run_output_id
+    assert adapter_run_output_id.nullable is True
+    assert adapter_run_output_id.index is True
+    assert adapter_run_output_id.comment == adapter_comment
+
+    canonical_entity_schema_version = table.c.canonical_entity_schema_version
+    assert isinstance(canonical_entity_schema_version.type, String)
+    assert canonical_entity_schema_version.type.length == 16
+    assert canonical_entity_schema_version.nullable is False
+    assert canonical_entity_schema_version.comment == schema_comment
+
+    created_at = table.c.created_at
+    assert isinstance(created_at.type, DateTime)
+    assert created_at.type.timezone is True
+    assert created_at.nullable is False
+    assert created_at.default is not None
+    assert created_at.comment == created_at_comment
+
+
+def test_revision_entity_source_hash_preserves_sha256_contract() -> None:
+    table = _table_for(RevisionEntity)
+    source_hash = table.c.source_hash
+
+    assert isinstance(source_hash.type, String)
+    assert source_hash.type.length == 64
+    assert source_hash.nullable is True
+    assert source_hash.index is True
+    assert source_hash.comment == (
+        "Stable source hash derived from canonical entity top-level or provenance refs"
+    )
+
+    check_constraint_names = {
+        constraint.name for constraint in table.constraints if constraint.name
+    }
+    assert "ck_revision_entities_source_hash" in check_constraint_names
+
+
+def test_sha256_column_helper_standardizes_string_length() -> None:
+    class Sha256Probe(Base):
+        __tablename__ = "test_sha256_probe"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+        digest: Mapped[str | None] = sha256_column(
+            nullable=True,
+            index=True,
+            comment="Probe digest",
+        )
+
+    try:
+        table = _table_for(Sha256Probe)
+        digest = table.c.digest
+        assert isinstance(digest.type, String)
+        assert digest.type.length == 64
+        assert digest.nullable is True
+        assert digest.index is True
+        assert digest.comment == "Probe digest"
+    finally:
+        Base.metadata.remove(table)


### PR DESCRIPTION
Closes #281

## Summary
- extract shared declarative SQLAlchemy mixins into `app/db/mixins.py`
- apply the mixins to revision materialization models without moving table-level constraints
- add focused tests covering metadata invariants and the `sha256_column()` helper

## Test plan
- [x] uv run ruff check app/db app/models/revision_materialization.py tests/test_db_mixins.py
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_db_mixins.py
- [x] git push -u origin refactor/declarative-model-mixins

## Notes
- `alembic check` still reports pre-existing metadata drift outside the revision materialization tables
- local `tests/test_db.py::TestAlembicMigrations::test_alembic_downgrade_base` can fail when persisted `export_job_inputs` rows exist in the local test database