### PR TITLE
refactor(api): consolidate cursor encode/decode + pagination constants

### DIFF
--- a/app/api/pagination.py
+++ b/app/api/pagination.py
@@ -4,12 +4,18 @@ import base64
 import binascii
 import json
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any, Never, cast
+from uuid import UUID
 
 from fastapi import HTTPException, status
+from pydantic import BaseModel, ValidationError
 
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 200
 
 
 def encode_cursor_payload(
@@ -18,10 +24,14 @@ def encode_cursor_payload(
     compact: bool = False,
 ) -> str:
     """Encode a JSON cursor payload as URL-safe base64 without padding."""
-    json_payload = json.dumps(
-        payload,
-        separators=(",", ":"),
-    ) if compact else json.dumps(payload)
+    json_payload = (
+        json.dumps(
+            payload,
+            separators=(",", ":"),
+        )
+        if compact
+        else json.dumps(payload)
+    )
     return base64.urlsafe_b64encode(json_payload.encode("utf-8")).decode("utf-8").rstrip("=")
 
 
@@ -35,6 +45,61 @@ def decode_cursor_payload(cursor: str) -> dict[str, Any]:
             raise TypeError("Cursor payload must be a JSON object")
         return cast(dict[str, Any], payload_raw)
     except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def encode_keyset_cursor(
+    payload: Mapping[str, object] | BaseModel,
+    *,
+    compact: bool = False,
+) -> str:
+    """Encode a mapping or Pydantic model as an opaque keyset cursor."""
+    if isinstance(payload, BaseModel):
+        return (
+            base64.urlsafe_b64encode(payload.model_dump_json().encode("utf-8"))
+            .decode("utf-8")
+            .rstrip("=")
+        )
+    return encode_cursor_payload(payload, compact=compact)
+
+
+def decode_keyset_cursor[CursorModelT: BaseModel](
+    cursor: str, cursor_model: type[CursorModelT]
+) -> CursorModelT:
+    """Decode an opaque keyset cursor into a typed Pydantic model."""
+    try:
+        return cursor_model.model_validate(decode_cursor_payload(cursor))
+    except ValidationError as exc:
+        raise_invalid_cursor(exc)
+
+
+def read_cursor_datetime(payload: Mapping[str, object], key: str) -> datetime:
+    """Read an ISO datetime field from a decoded cursor payload."""
+    try:
+        value = payload[key]
+        if not isinstance(value, str):
+            raise TypeError(f"Cursor field {key!r} must be a string")
+        return datetime.fromisoformat(value)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def read_cursor_uuid(payload: Mapping[str, object], key: str) -> UUID:
+    """Read a UUID field from a decoded cursor payload."""
+    try:
+        return UUID(str(payload[key]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise_invalid_cursor(exc)
+
+
+def read_cursor_int(payload: Mapping[str, object], key: str) -> int:
+    """Read an integer field from a decoded cursor payload."""
+    try:
+        value = payload[key]
+        if not isinstance(value, str | int):
+            raise TypeError(f"Cursor field {key!r} must be a string or integer")
+        return int(value)
+    except (KeyError, TypeError, ValueError) as exc:
         raise_invalid_cursor(exc)
 
 

--- a/app/api/v1/estimation.py
+++ b/app/api/v1/estimation.py
@@ -26,7 +26,12 @@ from app.api.idempotency import (
     replay_idempotency_response,
     run_idempotent_mutation,
 )
-from app.api.pagination import decode_cursor_payload, encode_cursor_payload, raise_invalid_cursor
+from app.api.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    decode_keyset_cursor,
+    encode_keyset_cursor,
+)
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
@@ -73,7 +78,7 @@ class _TimestampCursor(BaseModel):
 
 
 def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
-    return encode_cursor_payload(
+    return encode_keyset_cursor(
         {
             "created_at": created_at.isoformat(),
             "id": str(row_id),
@@ -82,10 +87,7 @@ def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
 
 
 def _decode_timestamp_cursor(cursor: str) -> tuple[datetime, UUID]:
-    try:
-        payload = _TimestampCursor.model_validate(decode_cursor_payload(cursor))
-    except Exception as exc:  # pragma: no cover - normalized by helper
-        raise_invalid_cursor(exc)
+    payload = decode_keyset_cursor(cursor, _TimestampCursor)
     return payload.created_at, payload.id
 
 
@@ -724,7 +726,10 @@ async def get_rate(
 async def list_rates(
     db: Annotated[AsyncSession, Depends(get_db)],
     cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
-    limit: Annotated[int, Query(ge=1, le=200, description="Page size")] = 50,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=MAX_PAGE_SIZE, description="Page size"),
+    ] = DEFAULT_PAGE_SIZE,
     scope_type: Annotated[
         CatalogScopeType | None,
         Query(description="Filter by scope type"),
@@ -850,7 +855,10 @@ async def get_material(
 async def list_materials(
     db: Annotated[AsyncSession, Depends(get_db)],
     cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
-    limit: Annotated[int, Query(ge=1, le=200, description="Page size")] = 50,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=MAX_PAGE_SIZE, description="Page size"),
+    ] = DEFAULT_PAGE_SIZE,
     scope_type: Annotated[
         CatalogScopeType | None,
         Query(description="Filter by scope type"),
@@ -976,7 +984,10 @@ async def get_formula(
 async def list_formulas(
     db: Annotated[AsyncSession, Depends(get_db)],
     cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
-    limit: Annotated[int, Query(ge=1, le=200, description="Page size")] = 50,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=MAX_PAGE_SIZE, description="Page size"),
+    ] = DEFAULT_PAGE_SIZE,
     scope_type: Annotated[
         CatalogScopeType | None,
         Query(description="Filter by scope type"),

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -23,9 +23,12 @@ from app.api.idempotency import (
     run_idempotent_mutation,
 )
 from app.api.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
     decode_cursor_payload,
-    encode_cursor_payload,
-    raise_invalid_cursor,
+    encode_keyset_cursor,
+    read_cursor_datetime,
+    read_cursor_uuid,
 )
 from app.core.config import settings
 from app.core.errors import ErrorCode
@@ -75,7 +78,7 @@ def enqueue_ingest_job(job_id: UUID) -> None:
 
 def _encode_cursor(created_at: datetime, file_id: UUID) -> str:
     """Encode cursor from created_at and file_id."""
-    return encode_cursor_payload(
+    return encode_keyset_cursor(
         {
             "created_at": created_at.isoformat(),
             "id": str(file_id),
@@ -85,11 +88,8 @@ def _encode_cursor(created_at: datetime, file_id: UUID) -> str:
 
 def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
     """Decode cursor to typed created_at and id values."""
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
+    cursor_data = decode_cursor_payload(cursor)
+    return read_cursor_datetime(cursor_data, "created_at"), read_cursor_uuid(cursor_data, "id")
 
 
 def _sniff_format(initial_bytes: bytes) -> str | None:
@@ -751,7 +751,10 @@ async def list_project_files(
     project_id: UUID,
     db: Annotated[AsyncSession, Depends(get_db)],
     cursor: Annotated[str | None, Query(description="Cursor for pagination")] = None,
-    limit: Annotated[int, Query(ge=1, le=200, description="Number of items to return")] = 50,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=MAX_PAGE_SIZE, description="Number of items to return"),
+    ] = DEFAULT_PAGE_SIZE,
 ) -> FileListResponse:
     """List files for a project with cursor pagination."""
     await _get_active_project_or_404(db, project_id)

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -20,9 +20,14 @@ from app.api.idempotency import (
     run_idempotent_mutation,
 )
 from app.api.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
     decode_cursor_payload,
-    encode_cursor_payload,
+    encode_keyset_cursor,
     raise_invalid_cursor,
+    read_cursor_datetime,
+    read_cursor_int,
+    read_cursor_uuid,
 )
 from app.core.errors import ErrorCode
 from app.core.exceptions import raise_not_found
@@ -40,8 +45,6 @@ from app.schemas.job import JobEventPage, JobEventRead, JobRead
 
 jobs_router = APIRouter()
 
-_DEFAULT_EVENTS_LIMIT = 50
-_MAX_EVENTS_LIMIT = 200
 _TERMINAL_JOB_STATUSES = {"failed", "succeeded", "cancelled"}
 
 _IDEMPOTENT_MUTATION_OPS = IdempotentMutationOps(
@@ -175,7 +178,7 @@ def _encode_job_events_cursor(event: JobEvent) -> str:
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=UTC)
 
-    return encode_cursor_payload(
+    return encode_keyset_cursor(
         {
             "created_at": created_at.astimezone(UTC).isoformat(),
             "sequence_id": event.sequence_id,
@@ -187,16 +190,16 @@ def _encode_job_events_cursor(event: JobEvent) -> str:
 
 def _decode_job_events_cursor(cursor: str) -> tuple[datetime, int | None, UUID]:
     """Decode a pagination cursor into its sort key values."""
-    try:
-        payload = decode_cursor_payload(cursor)
-        created_at = datetime.fromisoformat(str(payload["created_at"]))
-        sequence_id_raw = payload.get("sequence_id")
-        sequence_id = int(sequence_id_raw) if sequence_id_raw is not None else None
-        if sequence_id is not None and sequence_id < 0:
-            raise ValueError("sequence_id must be non-negative")
-        cursor_id = UUID(str(payload["id"]))
-    except (ValueError, TypeError, KeyError) as exc:
-        raise_invalid_cursor(exc)
+    payload = decode_cursor_payload(cursor)
+    created_at = read_cursor_datetime(payload, "created_at")
+    sequence_id = (
+        read_cursor_int(payload, "sequence_id")
+        if "sequence_id" in payload and payload["sequence_id"] is not None
+        else None
+    )
+    if sequence_id is not None and sequence_id < 0:
+        raise_invalid_cursor(ValueError("sequence_id must be non-negative"))
+    cursor_id = read_cursor_uuid(payload, "id")
 
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=UTC)
@@ -231,8 +234,8 @@ async def list_job_events(
     cursor: Annotated[str | None, Query(description="Opaque pagination cursor")] = None,
     limit: Annotated[
         int,
-        Query(ge=1, le=_MAX_EVENTS_LIMIT, description="Page size"),
-    ] = _DEFAULT_EVENTS_LIMIT,
+        Query(ge=1, le=MAX_PAGE_SIZE, description="Page size"),
+    ] = DEFAULT_PAGE_SIZE,
 ) -> JobEventPage:
     """Return cursor-paginated lifecycle events for a single job."""
     await _get_job_or_404(db, job_id)

--- a/app/api/v1/projects.py
+++ b/app/api/v1/projects.py
@@ -20,9 +20,12 @@ from app.api.idempotency import (
     run_idempotent_mutation,
 )
 from app.api.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
     decode_cursor_payload,
-    encode_cursor_payload,
-    raise_invalid_cursor,
+    encode_keyset_cursor,
+    read_cursor_datetime,
+    read_cursor_uuid,
 )
 from app.core.errors import ErrorCode
 from app.core.exceptions import raise_not_found
@@ -67,7 +70,7 @@ async def _get_active_project_or_404(
 
 def _encode_cursor(created_at: datetime, project_id: UUID) -> str:
     """Encode cursor from created_at and project_id."""
-    return encode_cursor_payload(
+    return encode_keyset_cursor(
         {
             "created_at": created_at.isoformat(),
             "id": str(project_id),
@@ -77,11 +80,8 @@ def _encode_cursor(created_at: datetime, project_id: UUID) -> str:
 
 def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
     """Decode cursor to typed created_at and id values."""
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
+    cursor_data = decode_cursor_payload(cursor)
+    return read_cursor_datetime(cursor_data, "created_at"), read_cursor_uuid(cursor_data, "id")
 
 
 @project_router.post(
@@ -137,7 +137,10 @@ async def create_project(
 async def list_projects(
     db: Annotated[AsyncSession, Depends(get_db)],
     cursor: Annotated[str | None, Query(description="Cursor for pagination")] = None,
-    limit: Annotated[int, Query(ge=1, le=200, description="Number of items to return")] = 50,
+    limit: Annotated[
+        int,
+        Query(ge=1, le=MAX_PAGE_SIZE, description="Number of items to return"),
+    ] = DEFAULT_PAGE_SIZE,
 ) -> ProjectListResponse:
     """List projects with cursor pagination.
 

--- a/app/api/v1/revision_cursors.py
+++ b/app/api/v1/revision_cursors.py
@@ -1,13 +1,18 @@
 """Revision cursor helpers."""
 
-import base64
-import binascii
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
-from app.api.pagination import decode_cursor_payload, encode_cursor_payload, raise_invalid_cursor
+from app.api.pagination import (
+    decode_cursor_payload,
+    decode_keyset_cursor,
+    encode_keyset_cursor,
+    read_cursor_datetime,
+    read_cursor_int,
+    read_cursor_uuid,
+)
 
 
 class _DrawingRevisionCursor(BaseModel):
@@ -28,37 +33,25 @@ class _GeneratedArtifactCursor(BaseModel):
 def _encode_cursor(payload: BaseModel) -> str:
     """Encode a pagination cursor payload as an opaque token."""
 
-    return (
-        base64.urlsafe_b64encode(payload.model_dump_json().encode("utf-8"))
-        .decode("utf-8")
-        .rstrip("=")
-    )
+    return encode_keyset_cursor(payload)
 
 
 def _decode_revision_cursor(cursor: str) -> _DrawingRevisionCursor:
     """Decode and validate an opaque drawing revision cursor."""
 
-    try:
-        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
-        return _DrawingRevisionCursor.model_validate_json(decoded)
-    except (ValueError, ValidationError, binascii.Error) as exc:
-        raise_invalid_cursor(exc)
+    return decode_keyset_cursor(cursor, _DrawingRevisionCursor)
 
 
 def _decode_artifact_cursor(cursor: str) -> _GeneratedArtifactCursor:
     """Decode and validate an opaque generated artifact cursor."""
 
-    try:
-        decoded = base64.urlsafe_b64decode(f"{cursor}{'=' * (-len(cursor) % 4)}")
-        return _GeneratedArtifactCursor.model_validate_json(decoded)
-    except (ValueError, ValidationError, binascii.Error) as exc:
-        raise_invalid_cursor(exc)
+    return decode_keyset_cursor(cursor, _GeneratedArtifactCursor)
 
 
 def _encode_materialization_cursor(sequence_index: int, row_id: UUID) -> str:
     """Encode a materialization cursor from sequence index and row identifier."""
 
-    return encode_cursor_payload(
+    return encode_keyset_cursor(
         {
             "sequence_index": sequence_index,
             "id": str(row_id),
@@ -69,56 +62,44 @@ def _encode_materialization_cursor(sequence_index: int, row_id: UUID) -> str:
 def _encode_timestamp_cursor(created_at: datetime, row_id: UUID) -> str:
     """Encode an opaque timestamp/id pagination cursor."""
 
-    return encode_cursor_payload({"created_at": created_at.isoformat(), "id": str(row_id)})
+    return encode_keyset_cursor({"created_at": created_at.isoformat(), "id": str(row_id)})
 
 
 def _encode_estimate_item_cursor(line_number: int, row_id: UUID) -> str:
     """Encode an opaque line-number/id pagination cursor."""
 
-    return encode_cursor_payload({"line_number": line_number, "id": str(row_id)})
+    return encode_keyset_cursor({"line_number": line_number, "id": str(row_id)})
 
 
 def _encode_estimate_snapshot_entry_cursor(sort_order: int, row_id: UUID) -> str:
     """Encode an opaque sort-order/id pagination cursor."""
 
-    return encode_cursor_payload({"sort_order": sort_order, "id": str(row_id)})
+    return encode_keyset_cursor({"sort_order": sort_order, "id": str(row_id)})
 
 
 def _decode_timestamp_cursor(cursor: str) -> tuple[datetime, UUID]:
     """Decode a timestamp/id pagination cursor."""
 
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return datetime.fromisoformat(str(cursor_data["created_at"])), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
+    cursor_data = decode_cursor_payload(cursor)
+    return read_cursor_datetime(cursor_data, "created_at"), read_cursor_uuid(cursor_data, "id")
 
 
 def _decode_estimate_item_cursor(cursor: str) -> tuple[int, UUID]:
     """Decode a line-number/id pagination cursor."""
 
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return int(cursor_data["line_number"]), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
+    cursor_data = decode_cursor_payload(cursor)
+    return read_cursor_int(cursor_data, "line_number"), read_cursor_uuid(cursor_data, "id")
 
 
 def _decode_estimate_snapshot_entry_cursor(cursor: str) -> tuple[int, UUID]:
     """Decode a sort-order/id pagination cursor."""
 
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return int(cursor_data["sort_order"]), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
+    cursor_data = decode_cursor_payload(cursor)
+    return read_cursor_int(cursor_data, "sort_order"), read_cursor_uuid(cursor_data, "id")
 
 
 def _decode_materialization_cursor(cursor: str) -> tuple[int, UUID]:
     """Decode a materialization cursor into typed values."""
 
-    try:
-        cursor_data = decode_cursor_payload(cursor)
-        return int(cursor_data["sequence_index"]), UUID(str(cursor_data["id"]))
-    except (KeyError, TypeError, ValueError) as exc:
-        raise_invalid_cursor(exc)
+    cursor_data = decode_cursor_payload(cursor)
+    return read_cursor_int(cursor_data, "sequence_index"), read_cursor_uuid(cursor_data, "id")

--- a/app/api/v1/revision_routes/estimates.py
+++ b/app/api/v1/revision_routes/estimates.py
@@ -30,6 +30,8 @@ from app.api.idempotency import (
 from app.api.idempotency import (
     replay_idempotency_response as _replay_idempotency_response_direct,
 )
+from app.api.pagination import DEFAULT_PAGE_SIZE as _DEFAULT_PAGE_SIZE
+from app.api.pagination import MAX_PAGE_SIZE as _MAX_PAGE_SIZE
 from app.api.v1.revision_cursors import (
     _decode_estimate_item_cursor,
     _decode_estimate_snapshot_entry_cursor,
@@ -127,8 +129,6 @@ from app.schemas.job import JobRead
 
 estimates_router = APIRouter()
 
-_DEFAULT_PAGE_SIZE = 50
-_MAX_PAGE_SIZE = 200
 _MISSING = object()
 
 type _NormalizedEstimateCatalogRef = _NormalizedEstimateCatalogRefDirect

--- a/app/api/v1/revision_routes/file_revisions.py
+++ b/app/api/v1/revision_routes/file_revisions.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.pagination import DEFAULT_PAGE_SIZE as _DEFAULT_PAGE_SIZE
+from app.api.pagination import MAX_PAGE_SIZE as _MAX_PAGE_SIZE
 from app.api.v1.revision_compat import _get_active_file
 from app.api.v1.revision_cursors import (
     _decode_revision_cursor,
@@ -21,9 +23,6 @@ from app.models.project import Project
 from app.schemas.revision import DrawingRevisionListResponse, DrawingRevisionRead
 
 file_revisions_router = APIRouter()
-
-_DEFAULT_PAGE_SIZE = 50
-_MAX_PAGE_SIZE = 200
 
 
 @file_revisions_router.get("/files/{file_id}/revisions", response_model=DrawingRevisionListResponse)

--- a/app/api/v1/revision_routes/generated_artifacts.py
+++ b/app/api/v1/revision_routes/generated_artifacts.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.pagination import DEFAULT_PAGE_SIZE as _DEFAULT_PAGE_SIZE
+from app.api.pagination import MAX_PAGE_SIZE as _MAX_PAGE_SIZE
 from app.api.v1.revision_compat import _get_active_file, _get_active_revision
 from app.api.v1.revision_cursors import (
     _decode_artifact_cursor,
@@ -21,9 +23,6 @@ from app.models.project import Project
 from app.schemas.revision import GeneratedArtifactListResponse, GeneratedArtifactRead
 
 generated_artifacts_router = APIRouter()
-
-_DEFAULT_PAGE_SIZE = 50
-_MAX_PAGE_SIZE = 200
 
 
 @generated_artifacts_router.get(

--- a/app/api/v1/revision_routes/materialization.py
+++ b/app/api/v1/revision_routes/materialization.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.pagination import DEFAULT_PAGE_SIZE as _DEFAULT_PAGE_SIZE
+from app.api.pagination import MAX_PAGE_SIZE as _MAX_PAGE_SIZE
 from app.api.v1.revision_compat import (
     _get_active_revision_manifest_or_409,
     _manifest_counts,
@@ -36,9 +38,6 @@ from app.schemas.revision import (
 )
 
 materialization_router = APIRouter()
-
-_DEFAULT_PAGE_SIZE = 50
-_MAX_PAGE_SIZE = 200
 
 
 @materialization_router.get(

--- a/app/api/v1/revision_routes/quantity_takeoffs.py
+++ b/app/api/v1/revision_routes/quantity_takeoffs.py
@@ -29,6 +29,8 @@ from app.api.idempotency import (
 from app.api.idempotency import (
     replay_idempotency_response as _replay_idempotency_response_direct,
 )
+from app.api.pagination import DEFAULT_PAGE_SIZE as _DEFAULT_PAGE_SIZE
+from app.api.pagination import MAX_PAGE_SIZE as _MAX_PAGE_SIZE
 from app.api.v1.revision_cursors import _decode_timestamp_cursor, _encode_timestamp_cursor
 from app.api.v1.revision_lineage import (
     _get_active_revision as _get_active_revision_direct,
@@ -81,8 +83,6 @@ from app.schemas.quantity_takeoff import (
 quantity_takeoffs_router = APIRouter()
 quantity_takeoff_create_router = APIRouter()
 
-_DEFAULT_PAGE_SIZE = 50
-_MAX_PAGE_SIZE = 200
 _MISSING = object()
 
 type _ActiveRevisionGetter = Callable[..., Awaitable[DrawingRevision | None]]

--- a/app/api/v1/revisions.py
+++ b/app/api/v1/revisions.py
@@ -17,6 +17,7 @@ from app.api.idempotency import (
 from app.api.idempotency import (
     replay_idempotency_response as _replay_idempotency_response,
 )
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from app.api.v1.revision_estimate_inputs import (
     _build_estimate_job_input_payload as _estimate_inputs_build_estimate_job_input_payload,
 )
@@ -146,8 +147,8 @@ from app.schemas.estimate import (
 
 revisions_router = APIRouter()
 
-_DEFAULT_PAGE_SIZE = 50
-_MAX_PAGE_SIZE = 200
+_DEFAULT_PAGE_SIZE = DEFAULT_PAGE_SIZE
+_MAX_PAGE_SIZE = MAX_PAGE_SIZE
 
 
 _get_active_file = _lineage_get_active_file

--- a/tests/test_api_pagination.py
+++ b/tests/test_api_pagination.py
@@ -1,0 +1,135 @@
+"""Tests for shared API pagination helpers."""
+
+from datetime import UTC, datetime
+from typing import Any, cast
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+from app.api.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    decode_cursor_payload,
+    decode_keyset_cursor,
+    encode_keyset_cursor,
+    read_cursor_datetime,
+    read_cursor_int,
+    read_cursor_uuid,
+)
+from app.core.errors import ErrorCode
+
+_ROW_ID = UUID("12345678-1234-5678-1234-567812345678")
+
+
+class _TimestampCursor(BaseModel):
+    """Typed timestamp/id cursor used by API routes."""
+
+    created_at: datetime
+    id: UUID
+
+
+class _LineCursor(BaseModel):
+    """Typed line/id cursor used by API routes."""
+
+    line_number: int
+    id: UUID
+
+
+def _assert_invalid_cursor(exc: HTTPException) -> None:
+    assert exc.status_code == 400
+    detail = cast(dict[str, Any], exc.detail)
+    assert detail == {
+        "error": {
+            "code": ErrorCode.INVALID_CURSOR.value,
+            "message": "Invalid cursor format",
+            "details": None,
+        }
+    }
+
+
+def test_shared_pagination_limits_match_trd_contract() -> None:
+    assert DEFAULT_PAGE_SIZE == 50
+    assert MAX_PAGE_SIZE == 200
+
+
+def test_encode_keyset_cursor_round_trips_mapping_payload() -> None:
+    payload = {"created_at": "2024-01-02T03:04:05+00:00", "id": str(_ROW_ID)}
+
+    cursor = encode_keyset_cursor(payload)
+
+    assert decode_cursor_payload(cursor) == payload
+
+
+def test_encode_keyset_cursor_round_trips_pydantic_payload() -> None:
+    payload = _TimestampCursor(created_at=datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), id=_ROW_ID)
+
+    cursor = encode_keyset_cursor(payload)
+
+    decoded = decode_keyset_cursor(cursor, _TimestampCursor)
+
+    assert decoded == payload
+
+
+def test_decode_keyset_cursor_rejects_invalid_cursor_envelope() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        decode_keyset_cursor("not-valid-base64", _TimestampCursor)
+
+    _assert_invalid_cursor(exc_info.value)
+
+
+def test_decode_keyset_cursor_rejects_schema_mismatch_with_invalid_cursor() -> None:
+    cursor = encode_keyset_cursor({"created_at": "2024-01-02T03:04:05+00:00"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        decode_keyset_cursor(cursor, _TimestampCursor)
+
+    _assert_invalid_cursor(exc_info.value)
+
+
+def test_mapping_legacy_golden_cursor_payload_still_decodes() -> None:
+    legacy_cursor = (
+        "eyJjcmVhdGVkX2F0IjogIjIwMjQtMDEtMDJUMDM6MDQ6MDUrMDA6MDAiLCAiaWQiOiAiMTIzND"
+        "U2NzgtMTIzNC01Njc4LTEyMzQtNTY3ODEyMzQ1Njc4In0"
+    )
+
+    decoded = decode_cursor_payload(legacy_cursor)
+
+    assert decoded == {"created_at": "2024-01-02T03:04:05+00:00", "id": str(_ROW_ID)}
+
+
+def test_pydantic_legacy_golden_cursor_payload_still_round_trips() -> None:
+    legacy_cursor = (
+        "eyJjcmVhdGVkX2F0IjoiMjAyNC0wMS0wMlQwMzowNDowNVoiLCJpZCI6IjEyMzQ1Njc4LTEy"
+        "MzQtNTY3OC0xMjM0LTU2NzgxMjM0NTY3OCJ9"
+    )
+    payload = _TimestampCursor(created_at=datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC), id=_ROW_ID)
+
+    assert encode_keyset_cursor(payload) == legacy_cursor
+    assert decode_keyset_cursor(legacy_cursor, _TimestampCursor) == payload
+
+
+def test_typed_cursor_payload_readers_parse_expected_types() -> None:
+    payload = {
+        "created_at": "2024-01-02T03:04:05+00:00",
+        "id": str(_ROW_ID),
+        "line_number": "7",
+    }
+
+    assert read_cursor_datetime(payload, "created_at") == datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    assert read_cursor_uuid(payload, "id") == _ROW_ID
+    assert read_cursor_int(payload, "line_number") == 7
+
+
+def test_typed_cursor_payload_readers_raise_invalid_cursor() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        read_cursor_int({"line_number": "not-an-int"}, "line_number")
+
+    _assert_invalid_cursor(exc_info.value)
+
+
+def test_decode_keyset_cursor_validates_integer_cursor_model() -> None:
+    cursor = encode_keyset_cursor({"line_number": 7, "id": str(_ROW_ID)})
+
+    assert decode_keyset_cursor(cursor, _LineCursor) == _LineCursor(line_number=7, id=_ROW_ID)


### PR DESCRIPTION
Closes #282

## Summary
- centralize shared API pagination constants in app.api.pagination
- route cursor encode/decode call sites through shared helpers while preserving legacy opaque cursor shapes
- add focused pagination helper regression coverage for compatibility and INVALID_CURSOR handling

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_api_pagination.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_projects.py tests/test_files.py tests/test_jobs_api.py tests/test_estimation_catalog_api.py tests/test_revision_materialization_api.py tests/test_validation_report_api.py tests/test_quantity_takeoff_api.py tests/test_estimate_read_api.py