### PR TITLE
fix(api): align Formula DSL validation status #284

### DIFF
--- a/app/api/v1/estimation.py
+++ b/app/api/v1/estimation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from datetime import date, datetime
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, NoReturn, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -61,6 +61,8 @@ from app.schemas.estimation_catalog import (
     EstimationRateCreate,
     EstimationRateListResponse,
     EstimationRateRead,
+    ValidatedEstimationFormulaCreate,
+    validate_formula_create,
 )
 
 estimation_router = APIRouter()
@@ -129,9 +131,20 @@ def _catalog_conflict_result(kind: str) -> IdempotentMutationKnownError:
     )
 
 
-def _raise_input_invalid(message: str) -> None:
+def _raise_input_invalid(message: str) -> NoReturn:
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
+        detail=create_error_response(
+            code=ErrorCode.INPUT_INVALID,
+            message=message,
+            details=None,
+        ),
+    )
+
+
+def _raise_unprocessable_input_invalid(message: str) -> NoReturn:
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         detail=create_error_response(
             code=ErrorCode.INPUT_INVALID,
             message=message,
@@ -496,7 +509,7 @@ def _validate_material_supersession(
 
 
 def _validate_formula_supersession(
-    payload: EstimationFormulaCreate,
+    payload: EstimationFormulaCreate | ValidatedEstimationFormulaCreate,
     predecessor: EstimationFormula,
 ) -> None:
     if (
@@ -605,7 +618,7 @@ def _build_material(material_in: EstimationMaterialCreate) -> EstimationMaterial
     )
 
 
-def _build_formula(formula_in: EstimationFormulaCreate) -> EstimationFormula:
+def _build_formula(formula_in: ValidatedEstimationFormulaCreate) -> EstimationFormula:
     return EstimationFormula(
         scope_type=formula_in.scope_type,
         project_id=formula_in.project_id,
@@ -932,15 +945,20 @@ async def create_formula(
     db: Annotated[AsyncSession, Depends(get_db)],
     idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
 ) -> EstimationFormulaRead | Response:
+    try:
+        validated_formula_in = validate_formula_create(formula_in)
+    except ValueError as exc:
+        _raise_unprocessable_input_invalid(str(exc))
+
     return await _create_catalog_entry(
-        payload=formula_in,
+        payload=validated_formula_in,
         db=db,
         idempotency_key=idempotency_key,
         fingerprint_namespace="estimation.formulas.create",
         path="/estimation/formulas",
         conflict_kind="Formula definition",
-        project_id=formula_in.project_id,
-        supersedes_id=formula_in.supersedes_formula_id,
+        project_id=validated_formula_in.project_id,
+        supersedes_id=validated_formula_in.supersedes_formula_id,
         get_predecessor=_get_formula_predecessor_or_404,
         validate_predecessor=_validate_formula_supersession,
         validate_effective_window=None,

--- a/app/schemas/estimation_catalog.py
+++ b/app/schemas/estimation_catalog.py
@@ -235,6 +235,39 @@ class EstimationFormulaCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255, description="Human-readable formula name")
     dsl_version: str = Field(..., min_length=1, max_length=32, description="Formula DSL version")
     output_key: str = Field(..., min_length=1, max_length=255, description="Output field key")
+    output_contract_json: object = Field(..., description="Formula output contract JSON")
+    declared_inputs_json: object = Field(
+        ...,
+        description="Formula declared input JSON array",
+    )
+    expression_json: object = Field(..., description="Formula expression JSON object")
+    rounding_json: object | None = Field(
+        None,
+        description="Optional formula-level rounding JSON object",
+    )
+    supersedes_formula_id: UUID | None = Field(
+        None,
+        description="Optional predecessor formula definition to supersede atomically",
+    )
+
+    @model_validator(mode="after")
+    def validate_scope(self) -> EstimationFormulaCreate:
+        _validate_scope(self.scope_type, self.project_id)
+        return self
+
+
+class ValidatedEstimationFormulaCreate(BaseModel):
+    """Internally validated formula definition payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scope_type: CatalogScopeType = Field(..., description="Formula scope type")
+    project_id: UUID | None = Field(None, description="Owning project for project-scoped formulas")
+    formula_id: str = Field(..., min_length=1, max_length=255, description="Stable formula id")
+    version: int = Field(..., ge=1, description="Positive formula version")
+    name: str = Field(..., min_length=1, max_length=255, description="Human-readable formula name")
+    dsl_version: str = Field(..., min_length=1, max_length=32, description="Formula DSL version")
+    output_key: str = Field(..., min_length=1, max_length=255, description="Output field key")
     output_contract_json: dict[str, object] = Field(..., description="Formula output contract JSON")
     declared_inputs_json: list[dict[str, object]] = Field(
         ...,
@@ -250,45 +283,62 @@ class EstimationFormulaCreate(BaseModel):
         description="Optional predecessor formula definition to supersede atomically",
     )
 
-    @field_validator("output_contract_json", mode="before")
-    @classmethod
-    def validate_output_contract_json(cls, value: object) -> dict[str, object]:
-        return _require_json_object(value, field_name="output_contract_json")
-
-    @field_validator("declared_inputs_json", mode="before")
-    @classmethod
-    def validate_declared_inputs_json(cls, value: object) -> list[dict[str, object]]:
-        return _require_json_object_array(value, field_name="declared_inputs_json")
-
-    @field_validator("expression_json", mode="before")
-    @classmethod
-    def validate_expression_json(cls, value: object) -> dict[str, object]:
-        return _require_json_object(value, field_name="expression_json")
-
-    @field_validator("rounding_json", mode="before")
-    @classmethod
-    def validate_rounding_json(cls, value: object) -> dict[str, object] | None:
-        if value is None:
-            return None
-        return _require_json_object(value, field_name="rounding_json")
-
     @model_validator(mode="after")
-    def validate_scope_and_definition(self) -> EstimationFormulaCreate:
+    def validate_scope(self) -> ValidatedEstimationFormulaCreate:
         _validate_scope(self.scope_type, self.project_id)
-        formula_checksum_sha256(
-            scope_type=self.scope_type,
-            project_id=self.project_id,
-            formula_id=self.formula_id,
-            version=self.version,
-            name=self.name,
-            dsl_version=self.dsl_version,
-            output_key=self.output_key,
-            output_contract_json=self.output_contract_json,
-            declared_inputs_json=self.declared_inputs_json,
-            expression_json=self.expression_json,
-            rounding_json=self.rounding_json,
-        )
         return self
+
+
+def validate_formula_create(
+    payload: EstimationFormulaCreate,
+) -> ValidatedEstimationFormulaCreate:
+    output_contract_json = _require_json_object(
+        payload.output_contract_json,
+        field_name="output_contract_json",
+    )
+    declared_inputs_json = _require_json_object_array(
+        payload.declared_inputs_json,
+        field_name="declared_inputs_json",
+    )
+    expression_json = _require_json_object(
+        payload.expression_json,
+        field_name="expression_json",
+    )
+    rounding_json = None
+    if payload.rounding_json is not None:
+        rounding_json = _require_json_object(
+            payload.rounding_json,
+            field_name="rounding_json",
+        )
+
+    formula_checksum_sha256(
+        scope_type=payload.scope_type,
+        project_id=payload.project_id,
+        formula_id=payload.formula_id,
+        version=payload.version,
+        name=payload.name,
+        dsl_version=payload.dsl_version,
+        output_key=payload.output_key,
+        output_contract_json=output_contract_json,
+        declared_inputs_json=declared_inputs_json,
+        expression_json=expression_json,
+        rounding_json=rounding_json,
+    )
+
+    return ValidatedEstimationFormulaCreate(
+        scope_type=payload.scope_type,
+        project_id=payload.project_id,
+        formula_id=payload.formula_id,
+        version=payload.version,
+        name=payload.name,
+        dsl_version=payload.dsl_version,
+        output_key=payload.output_key,
+        output_contract_json=output_contract_json,
+        declared_inputs_json=declared_inputs_json,
+        expression_json=expression_json,
+        rounding_json=rounding_json,
+        supersedes_formula_id=payload.supersedes_formula_id,
+    )
 
 
 class EstimationFormulaRead(BaseModel):

--- a/docs/TRD.md
+++ b/docs/TRD.md
@@ -978,8 +978,10 @@ Standard error behavior:
 - Errors use the standard envelope `{error:{code,message,details}}`.
 - Return `404` when the addressed project is missing or soft-deleted, or when
   the requested catalog/formula resource does not exist.
-- Return `422` with `INPUT_INVALID` for invalid Formula DSL payloads or invalid
-  request shape.
+- Return `422` with `VALIDATION_ERROR` for generic request body, path, or query
+  parsing/validation failures.
+- Return `422` with `INPUT_INVALID` for invalid Formula DSL subdocument shape or
+  Formula DSL semantic failures.
 - Return `409` with `DB_CONFLICT` for uniqueness conflicts, effective-date
   overlap conflicts, or invalid supersession/conflict cases.
 

--- a/tests/test_estimation_catalog_api.py
+++ b/tests/test_estimation_catalog_api.py
@@ -586,11 +586,77 @@ class TestEstimationCatalogApiErrorPaths:
         create_response = await async_client.post("/v1/estimation/formulas", json=payload)
 
         assert create_response.status_code == 422
-        assert create_response.json()["error"]["code"] == "VALIDATION_ERROR"
+        assert create_response.json()["error"]["code"] == "INPUT_INVALID"
 
         list_response = await async_client.get("/v1/estimation/formulas")
         assert list_response.status_code == 200
         assert list_response.json()["items"] == []
+
+    async def test_create_formula_rejects_subdocument_shape_with_input_invalid(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(async_client, name="Formula Shape Validation Project")
+        payload = _valid_formula_payload(project_id=project_id)
+        payload["rounding_json"] = []
+
+        create_response = await async_client.post("/v1/estimation/formulas", json=payload)
+
+        assert create_response.status_code == 422
+        assert create_response.json()["error"]["code"] == "INPUT_INVALID"
+
+        list_response = await async_client.get("/v1/estimation/formulas")
+        assert list_response.status_code == 200
+        assert list_response.json()["items"] == []
+
+    async def test_create_formula_invalid_dsl_does_not_poison_idempotency_key(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+    ) -> None:
+        _ = self
+        _ = cleanup_projects
+
+        project_id = await _create_project(
+            async_client,
+            name="Formula Idempotency Validation Project",
+        )
+        invalid_payload = _valid_formula_payload(project_id=project_id)
+        invalid_payload["expression_json"] = {
+            "op": "multiply",
+            "args": [
+                {"kind": "input", "name": "rate"},
+                {"kind": "input", "name": "quantity"},
+            ],
+        }
+        valid_payload = _valid_formula_payload(project_id=project_id)
+        headers = {"Idempotency-Key": "formula-invalid-then-valid-key"}
+
+        invalid_response = await async_client.post(
+            "/v1/estimation/formulas",
+            json=invalid_payload,
+            headers=headers,
+        )
+        first_valid_response = await async_client.post(
+            "/v1/estimation/formulas",
+            json=valid_payload,
+            headers=headers,
+        )
+        replayed_valid_response = await async_client.post(
+            "/v1/estimation/formulas",
+            json=valid_payload,
+            headers=headers,
+        )
+
+        assert invalid_response.status_code == 422
+        assert invalid_response.json()["error"]["code"] == "INPUT_INVALID"
+        assert first_valid_response.status_code == 201
+        assert replayed_valid_response.status_code == 201
+        assert first_valid_response.json() == replayed_valid_response.json()
 
 
 @requires_database


### PR DESCRIPTION
Closes #284

## Summary
- Align Formula DSL subdocument shape/semantic failures with the documented 422 INPUT_INVALID contract.
- Keep generic request parsing as 422 VALIDATION_ERROR and workflow/gate eligibility as 400 INPUT_INVALID.
- Add regression coverage for invalid DSL idempotency-key retry behavior.

## Test plan
- [x] uv run ruff check app/api/v1/estimation.py app/schemas/estimation_catalog.py tests/test_estimation_catalog_api.py
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_estimation_catalog_api.py tests/test_errors.py
- [x] pre-push hook: uv run pytest