### PR TITLE
feat(cad): implement changeset apply engine #289

### DIFF
--- a/app/cad/changeset/__init__.py
+++ b/app/cad/changeset/__init__.py
@@ -1,0 +1,55 @@
+"""Pure CAD changeset apply contracts and conflict helpers."""
+
+from app.cad.changeset.apply import (
+    ALLOWED_PROPERTY_PATHS,
+    SUPPORTED_OPERATION_TYPES,
+    apply_change_set,
+)
+from app.cad.changeset.conflicts import (
+    build_stale_base_conflict,
+    build_stale_base_conflict_details,
+)
+from app.cad.changeset.contracts import (
+    AppliedEntity,
+    ChangeSetApplyConflict,
+    ChangeSetApplyConflictDetails,
+    ChangeSetApplyConflictTarget,
+    ChangeSetApplyEffects,
+    ChangeSetApplyError,
+    ChangeSetApplyResult,
+    ChangeSetApplySuccess,
+    ChangeSetOperation,
+    ChangeSetOperationTarget,
+    RevisionEntitySnapshot,
+    RevisionRef,
+)
+from app.cad.changeset.loading import (
+    ChangeSetApplyLoadError,
+    LoadedChangeSetApplyInput,
+    load_and_apply_change_set,
+    load_change_set_apply_input,
+)
+
+__all__ = [
+    "ALLOWED_PROPERTY_PATHS",
+    "SUPPORTED_OPERATION_TYPES",
+    "AppliedEntity",
+    "ChangeSetApplyConflict",
+    "ChangeSetApplyConflictDetails",
+    "ChangeSetApplyConflictTarget",
+    "ChangeSetApplyEffects",
+    "ChangeSetApplyError",
+    "ChangeSetApplyLoadError",
+    "ChangeSetApplyResult",
+    "ChangeSetApplySuccess",
+    "ChangeSetOperation",
+    "ChangeSetOperationTarget",
+    "LoadedChangeSetApplyInput",
+    "RevisionEntitySnapshot",
+    "RevisionRef",
+    "apply_change_set",
+    "build_stale_base_conflict",
+    "build_stale_base_conflict_details",
+    "load_and_apply_change_set",
+    "load_change_set_apply_input",
+]

--- a/app/cad/changeset/apply.py
+++ b/app/cad/changeset/apply.py
@@ -1,0 +1,860 @@
+"""Pure copy-on-write changeset apply engine."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import Any, Literal, cast
+
+from app.cad.changeset.conflicts import build_stale_base_conflict
+from app.cad.changeset.contracts import (
+    AppliedEntity,
+    ChangeSetApplyConflictTarget,
+    ChangeSetApplyEffects,
+    ChangeSetApplyError,
+    ChangeSetApplyResult,
+    ChangeSetApplySuccess,
+    ChangeSetOperation,
+    ChangeSetOperationTarget,
+    RevisionEntitySnapshot,
+    RevisionRef,
+)
+
+SUPPORTED_OPERATION_TYPES = frozenset(
+    {
+        "change_layer",
+        "update_property",
+        "add_entity",
+        "remove_entity",
+        "annotate_entity",
+        "flag_for_review",
+    }
+)
+
+ALLOWED_LAYER_KEYS = ("layer_ref", "layer", "layer_name", "new_layer")
+ALLOWED_PROPERTY_PATHS = frozenset(
+    {
+        "properties.description",
+        "properties.label",
+        "properties.mark",
+        "properties.notes",
+        "properties.review_status",
+        "properties.metadata",
+    }
+)
+
+_EFFECT_PRIORITY = {
+    "unchanged": 0,
+    "metadata_only": 1,
+    "changed": 2,
+    "added": 3,
+    "removed": 4,
+}
+_ADD_ENTITY_NAMESPACE = uuid.UUID("1e9ec7ab-0355-44a5-b69f-c34790709a44")
+_CHANGESET_ADAPTER_KEY = "changeset"
+_CHANGESET_PROVENANCE_ORIGIN = "user_created"
+
+type _AppliedEffect = Literal["unchanged", "changed", "added", "removed", "metadata_only"]
+
+_MISSING = object()
+
+
+def apply_change_set(
+    *,
+    change_set_id: uuid.UUID,
+    base_revision: RevisionRef,
+    current_revision: RevisionRef,
+    operations: Sequence[ChangeSetOperation],
+    entities: Sequence[RevisionEntitySnapshot],
+) -> ChangeSetApplyResult:
+    if current_revision != base_revision:
+        conflict = build_stale_base_conflict(
+            change_set_id=change_set_id,
+            base_revision=base_revision,
+            current_revision=current_revision,
+            conflicting_targets=tuple(
+                _build_conflict_target(operation) for operation in operations
+            ),
+        )
+        if conflict is None:
+            return ChangeSetApplyError(
+                change_set_id=change_set_id,
+                error_code="INVALID_OPERATION",
+                message="Stale revision check returned no conflict for mismatched revisions.",
+            )
+        return conflict
+
+    working_entities = list(entities)
+    survivor_effects: dict[uuid.UUID, tuple[uuid.UUID, str]] = {}
+    removed_entities: dict[uuid.UUID, AppliedEntity] = {}
+
+    for operation in operations:
+        if operation.operation_type not in SUPPORTED_OPERATION_TYPES:
+            return _operation_error(
+                change_set_id=change_set_id,
+                operation=operation,
+                error_code="UNSUPPORTED_OPERATION",
+                message=f"Unsupported changeset operation '{operation.operation_type}'.",
+            )
+
+        if operation.operation_type == "add_entity":
+            apply_error = _apply_add_entity(
+                change_set_id=change_set_id,
+                operation=operation,
+                working_entities=working_entities,
+                survivor_effects=survivor_effects,
+            )
+            if apply_error is not None:
+                return apply_error
+            continue
+
+        target_index = _resolve_target_index(
+            change_set_id=change_set_id,
+            operation=operation,
+            entities=working_entities,
+        )
+        if isinstance(target_index, ChangeSetApplyError):
+            return target_index
+
+        if operation.operation_type == "change_layer":
+            apply_error = _apply_change_layer(
+                change_set_id=change_set_id,
+                operation=operation,
+                target_index=target_index,
+                working_entities=working_entities,
+                survivor_effects=survivor_effects,
+            )
+            if apply_error is not None:
+                return apply_error
+            continue
+
+        if operation.operation_type == "update_property":
+            apply_error = _apply_update_property(
+                change_set_id=change_set_id,
+                operation=operation,
+                target_index=target_index,
+                working_entities=working_entities,
+                survivor_effects=survivor_effects,
+            )
+            if apply_error is not None:
+                return apply_error
+            continue
+
+        if operation.operation_type == "remove_entity":
+            removed_entity = working_entities.pop(target_index)
+            removed_entities[removed_entity.id] = AppliedEntity(
+                operation_id=operation.operation_id,
+                effect="removed",
+                entity=removed_entity,
+            )
+            survivor_effects.pop(removed_entity.id, None)
+            continue
+
+        if operation.operation_type == "annotate_entity":
+            apply_error = _apply_metadata_append(
+                change_set_id=change_set_id,
+                operation=operation,
+                target_index=target_index,
+                working_entities=working_entities,
+                survivor_effects=survivor_effects,
+                metadata_key="annotations",
+                payload_key="annotation",
+            )
+            if apply_error is not None:
+                return apply_error
+            continue
+
+        if operation.operation_type == "flag_for_review":
+            apply_error = _apply_metadata_append(
+                change_set_id=change_set_id,
+                operation=operation,
+                target_index=target_index,
+                working_entities=working_entities,
+                survivor_effects=survivor_effects,
+                metadata_key="review_flags",
+                payload_key="review_flag",
+            )
+            if apply_error is not None:
+                return apply_error
+            continue
+
+    normalized_entities = _normalize_sequence_indexes(working_entities)
+    normalized_by_id = {entity.id: entity for entity in normalized_entities}
+
+    unchanged_entities: list[AppliedEntity] = []
+    changed_entities: list[AppliedEntity] = []
+    added_entities: list[AppliedEntity] = []
+    metadata_only_entities: list[AppliedEntity] = []
+
+    for entity in normalized_entities:
+        effect_record = survivor_effects.get(entity.id)
+        if effect_record is None:
+            unchanged_entities.append(
+                AppliedEntity(
+                    operation_id=uuid.UUID(int=0),
+                    effect="unchanged",
+                    entity=entity,
+                )
+            )
+            continue
+
+        operation_id, effect = effect_record
+        applied_entity = AppliedEntity(
+            operation_id=operation_id,
+            effect=cast(_AppliedEffect, effect),
+            entity=normalized_by_id[entity.id],
+        )
+        if effect == "changed":
+            changed_entities.append(applied_entity)
+        elif effect == "added":
+            added_entities.append(applied_entity)
+        elif effect == "metadata_only":
+            metadata_only_entities.append(applied_entity)
+        else:
+            unchanged_entities.append(applied_entity)
+
+    return ChangeSetApplySuccess(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        operations=tuple(operations),
+        entities=tuple(normalized_entities),
+        effects=ChangeSetApplyEffects(
+            unchanged_entities=tuple(unchanged_entities),
+            changed_entities=tuple(changed_entities),
+            added_entities=tuple(added_entities),
+            metadata_only_entities=tuple(metadata_only_entities),
+            removed_entities=tuple(removed_entities.values()),
+        ),
+    )
+
+
+def _apply_add_entity(
+    *,
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    working_entities: list[RevisionEntitySnapshot],
+    survivor_effects: dict[uuid.UUID, tuple[uuid.UUID, str]],
+) -> ChangeSetApplyError | None:
+    if _target_has_selectors(operation):
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message="add_entity must not target an existing entity.",
+        )
+
+    operation_payload = operation.operation_json
+    top_level_canonical_entity = _mapping_field(operation_payload, "canonical_entity")
+    entity_payload = (
+        _mapping_field(operation_payload, "entity")
+        or top_level_canonical_entity
+        or operation_payload
+    )
+    canonical_entity_payload = (
+        _mapping_field(entity_payload, "canonical_entity_json")
+        or _mapping_field(entity_payload, "canonical_entity")
+        or (top_level_canonical_entity if entity_payload is top_level_canonical_entity else None)
+    )
+    if not entity_payload:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message="add_entity requires an entity payload.",
+        )
+
+    entity_type = _required_string_field(entity_payload, "entity_type")
+    if isinstance(entity_type, ChangeSetApplyError):
+        return _with_operation_context(change_set_id, operation, entity_type)
+
+    entity_schema_version = _optional_string_field(entity_payload, "entity_schema_version") or "1"
+    confidence_score = _number_field(entity_payload, "confidence_score", default=1.0)
+    if isinstance(confidence_score, ChangeSetApplyError):
+        return _with_operation_context(change_set_id, operation, confidence_score)
+
+    confidence_json = _mapping_field(entity_payload, "confidence_json") or {}
+    geometry_json = _mapping_field(entity_payload, "geometry_json") or _mapping_field(
+        entity_payload, "geometry"
+    )
+    if geometry_json is None and entity_payload is not operation_payload:
+        geometry_json = _mapping_field(operation_payload, "geometry")
+    if geometry_json is None:
+        geometry_json = {}
+    properties_json = _mapping_field(entity_payload, "properties_json") or {}
+    source_identity = _derived_added_entity_source_identity(
+        change_set_id=change_set_id,
+        operation_id=operation.operation_id,
+    )
+    source_hash = _derived_added_entity_source_hash(source_identity)
+    provenance_json = _build_added_entity_provenance(
+        source_identity=source_identity,
+        source_hash=source_hash,
+    )
+
+    entity_id = _optional_string_field(entity_payload, "entity_id") or _derived_entity_id(
+        change_set_id=change_set_id,
+        operation_id=operation.operation_id,
+    )
+    revision_entity_id = _uuid_field(
+        entity_payload,
+        "revision_entity_id",
+    ) or _derived_revision_entity_id(
+        change_set_id=change_set_id,
+        operation_id=operation.operation_id,
+    )
+
+    if any(entity.id == revision_entity_id for entity in working_entities):
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="DUPLICATE_ENTITY",
+            message=f"Revision entity '{revision_entity_id}' already exists.",
+        )
+    if any(entity.entity_id == entity_id for entity in working_entities):
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="DUPLICATE_ENTITY",
+            message=f"Entity '{entity_id}' already exists.",
+        )
+
+    added_entity = RevisionEntitySnapshot(
+        id=revision_entity_id,
+        sequence_index=len(working_entities),
+        entity_id=entity_id,
+        entity_type=entity_type,
+        entity_schema_version=entity_schema_version,
+        confidence_score=confidence_score,
+        confidence_json=_clone_json_mapping(confidence_json),
+        geometry_json=_clone_json_mapping(geometry_json),
+        properties_json=_clone_json_mapping(properties_json),
+        provenance_json=_clone_json_mapping(provenance_json),
+        parent_entity_ref=_optional_string_field(entity_payload, "parent_entity_ref"),
+        canonical_entity_json=_clone_optional_mapping(canonical_entity_payload),
+        layout_ref=_optional_string_field(entity_payload, "layout_ref"),
+        layer_ref=_read_layer_value(entity_payload),
+        block_ref=_optional_string_field(entity_payload, "block_ref"),
+        source_identity=source_identity,
+        source_hash=source_hash,
+    )
+    working_entities.append(added_entity)
+    _record_survivor_effect(
+        survivor_effects=survivor_effects,
+        entity_id=added_entity.id,
+        operation_id=operation.operation_id,
+        effect="added",
+    )
+    return None
+
+
+def _apply_change_layer(
+    *,
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    target_index: int,
+    working_entities: list[RevisionEntitySnapshot],
+    survivor_effects: dict[uuid.UUID, tuple[uuid.UUID, str]],
+) -> ChangeSetApplyError | None:
+    entity = working_entities[target_index]
+    layer_ref = _read_layer_value(operation.operation_json)
+    if layer_ref is None:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message="change_layer requires a non-empty layer value.",
+        )
+
+    updated_entity = replace(
+        entity,
+        layer_ref=layer_ref,
+        properties_json=_sync_layer_aliases(entity.properties_json, layer_ref),
+        canonical_entity_json=_sync_canonical_layer_aliases(
+            entity.canonical_entity_json,
+            layer_ref,
+        ),
+    )
+    if updated_entity == entity:
+        _record_survivor_effect(
+            survivor_effects=survivor_effects,
+            entity_id=entity.id,
+            operation_id=operation.operation_id,
+            effect="unchanged",
+        )
+        return None
+
+    working_entities[target_index] = updated_entity
+    _record_survivor_effect(
+        survivor_effects=survivor_effects,
+        entity_id=updated_entity.id,
+        operation_id=operation.operation_id,
+        effect="changed",
+    )
+    return None
+
+
+def _apply_update_property(
+    *,
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    target_index: int,
+    working_entities: list[RevisionEntitySnapshot],
+    survivor_effects: dict[uuid.UUID, tuple[uuid.UUID, str]],
+) -> ChangeSetApplyError | None:
+    entity = working_entities[target_index]
+    property_path = _property_path(operation.operation_json)
+    if property_path not in ALLOWED_PROPERTY_PATHS:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message=f"Unsupported property path '{property_path}'.",
+            details={"allowed_property_paths": tuple(sorted(ALLOWED_PROPERTY_PATHS))},
+        )
+    new_value = _operation_value(operation.operation_json)
+    if new_value is _MISSING:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message="update_property requires a value.",
+        )
+
+    property_key = property_path.removeprefix("properties.")
+    properties_json = _clone_json_mapping(entity.properties_json)
+    properties_json[property_key] = new_value
+    updated_entity = replace(
+        entity,
+        properties_json=properties_json,
+        canonical_entity_json=_sync_canonical_property(
+            entity.canonical_entity_json,
+            property_key,
+            new_value,
+        ),
+    )
+    if updated_entity == entity:
+        _record_survivor_effect(
+            survivor_effects=survivor_effects,
+            entity_id=entity.id,
+            operation_id=operation.operation_id,
+            effect="unchanged",
+        )
+        return None
+
+    working_entities[target_index] = updated_entity
+    _record_survivor_effect(
+        survivor_effects=survivor_effects,
+        entity_id=updated_entity.id,
+        operation_id=operation.operation_id,
+        effect="metadata_only",
+    )
+    return None
+
+
+def _apply_metadata_append(
+    *,
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    target_index: int,
+    working_entities: list[RevisionEntitySnapshot],
+    survivor_effects: dict[uuid.UUID, tuple[uuid.UUID, str]],
+    metadata_key: str,
+    payload_key: str,
+) -> ChangeSetApplyError | None:
+    entity = working_entities[target_index]
+    payload = _mapping_field(operation.operation_json, payload_key) or operation.operation_json
+    if not payload:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message=f"{operation.operation_type} requires a metadata payload.",
+        )
+
+    properties_json = _clone_json_mapping(entity.properties_json)
+    metadata_value = properties_json.get("metadata")
+    if metadata_value is None:
+        metadata: dict[str, Any] = {}
+    elif isinstance(metadata_value, Mapping):
+        metadata = _clone_json_mapping(metadata_value)
+    else:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message="Entity properties.metadata must be an object for metadata-only operations.",
+        )
+
+    existing_entries = metadata.get(metadata_key)
+    if existing_entries is None:
+        entries: list[Any] = []
+    elif isinstance(existing_entries, list):
+        entries = cast(list[Any], _clone_json_value(existing_entries))
+    else:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message=f"Entity properties.metadata.{metadata_key} must be an array when present.",
+        )
+
+    entries.append(_clone_json_mapping(payload))
+    metadata[metadata_key] = entries
+    properties_json["metadata"] = metadata
+
+    updated_entity = replace(entity, properties_json=properties_json)
+    working_entities[target_index] = updated_entity
+    _record_survivor_effect(
+        survivor_effects=survivor_effects,
+        entity_id=updated_entity.id,
+        operation_id=operation.operation_id,
+        effect="metadata_only",
+    )
+    return None
+
+
+def _resolve_target_index(
+    *,
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    entities: Sequence[RevisionEntitySnapshot],
+) -> int | ChangeSetApplyError:
+    target = operation.target
+    selectors = (
+        target.target_revision_entity_id,
+        target.entity_id,
+        target.expected_source_identity,
+        target.expected_source_hash,
+    )
+    if not any(selector is not None for selector in selectors):
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="INVALID_OPERATION",
+            message="Entity-targeted changeset operations require a target selector.",
+        )
+
+    matches = [
+        index
+        for index, entity in enumerate(entities)
+        if _matches_target(entity=entity, target=target)
+    ]
+    if not matches:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="TARGET_NOT_FOUND",
+            message="Target entity was not found.",
+        )
+    if len(matches) > 1:
+        return _operation_error(
+            change_set_id=change_set_id,
+            operation=operation,
+            error_code="AMBIGUOUS_TARGET",
+            message="Target selectors matched multiple entities.",
+        )
+    return matches[0]
+
+
+def _matches_target(
+    *,
+    entity: RevisionEntitySnapshot,
+    target: ChangeSetOperationTarget,
+) -> bool:
+    if (
+        target.target_revision_entity_id is not None
+        and entity.id != target.target_revision_entity_id
+    ):
+        return False
+    if target.entity_id is not None and entity.entity_id != target.entity_id:
+        return False
+    if (
+        target.expected_source_identity is not None
+        and entity.source_identity != target.expected_source_identity
+    ):
+        return False
+    return target.expected_source_hash is None or entity.source_hash == target.expected_source_hash
+
+
+def _build_conflict_target(operation: ChangeSetOperation) -> ChangeSetApplyConflictTarget:
+    return ChangeSetApplyConflictTarget(
+        operation_id=operation.operation_id,
+        sequence_index=operation.sequence_index,
+        operation_type=operation.operation_type,
+        target_revision_entity_id=operation.target.target_revision_entity_id,
+        entity_id=operation.target.entity_id,
+        expected_source_identity=operation.target.expected_source_identity,
+        expected_source_hash=operation.target.expected_source_hash,
+    )
+
+
+def _record_survivor_effect(
+    *,
+    survivor_effects: dict[uuid.UUID, tuple[uuid.UUID, str]],
+    entity_id: uuid.UUID,
+    operation_id: uuid.UUID,
+    effect: str,
+) -> None:
+    current = survivor_effects.get(entity_id)
+    if current is None or _EFFECT_PRIORITY[effect] > _EFFECT_PRIORITY[current[1]]:
+        survivor_effects[entity_id] = (operation_id, effect)
+
+
+def _normalize_sequence_indexes(
+    entities: Sequence[RevisionEntitySnapshot],
+) -> tuple[RevisionEntitySnapshot, ...]:
+    return tuple(
+        entity if entity.sequence_index == index else replace(entity, sequence_index=index)
+        for index, entity in enumerate(entities)
+    )
+
+
+def _sync_layer_aliases(payload: Mapping[str, Any], layer_ref: str) -> dict[str, Any]:
+    updated_payload = _clone_json_mapping(payload)
+    for key in ALLOWED_LAYER_KEYS:
+        if key in updated_payload:
+            updated_payload[key] = layer_ref
+    return updated_payload
+
+
+def _sync_canonical_layer_aliases(
+    canonical_entity_json: Mapping[str, Any] | None,
+    layer_ref: str,
+) -> dict[str, Any] | None:
+    if canonical_entity_json is None:
+        return None
+
+    updated_canonical = _sync_layer_aliases(canonical_entity_json, layer_ref)
+    properties_value = updated_canonical.get("properties")
+    if isinstance(properties_value, Mapping):
+        updated_canonical["properties"] = _sync_layer_aliases(
+            cast(Mapping[str, Any], properties_value),
+            layer_ref,
+        )
+    return updated_canonical
+
+
+def _sync_canonical_property(
+    canonical_entity_json: Mapping[str, Any] | None,
+    property_key: str,
+    value: Any,
+) -> dict[str, Any] | None:
+    if canonical_entity_json is None:
+        return None
+
+    updated_canonical = _clone_json_mapping(canonical_entity_json)
+    properties_value = updated_canonical.get("properties")
+    if not isinstance(properties_value, Mapping):
+        return updated_canonical
+
+    updated_properties = _clone_json_mapping(cast(Mapping[str, Any], properties_value))
+    if property_key not in updated_properties:
+        return updated_canonical
+
+    updated_properties[property_key] = _clone_json_value(value)
+    updated_canonical["properties"] = updated_properties
+    return updated_canonical
+
+
+def _property_path(operation_json: Mapping[str, Any]) -> str:
+    for key in ("property_path", "path", "property"):
+        value = operation_json.get(key)
+        if isinstance(value, str):
+            return value
+
+    for key in ("property_name", "property_key", "name"):
+        value = operation_json.get(key)
+        if isinstance(value, str) and value.strip():
+            property_key = value.strip()
+            if property_key.startswith("properties."):
+                return property_key
+            return f"properties.{property_key}"
+    return ""
+
+
+def _operation_value(operation_json: Mapping[str, Any]) -> Any:
+    for key in ("value", "new_value"):
+        if key in operation_json:
+            return _clone_json_value(operation_json[key])
+    return _MISSING
+
+
+def _target_has_selectors(operation: ChangeSetOperation) -> bool:
+    return any(
+        value is not None
+        for value in (
+            operation.target.target_revision_entity_id,
+            operation.target.entity_id,
+            operation.target.expected_source_identity,
+            operation.target.expected_source_hash,
+        )
+    )
+
+
+def _read_layer_value(payload: Mapping[str, Any]) -> str | None:
+    for key in ALLOWED_LAYER_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _required_string_field(payload: Mapping[str, Any], key: str) -> str | ChangeSetApplyError:
+    value = _optional_string_field(payload, key)
+    if value is None:
+        return ChangeSetApplyError(
+            change_set_id=uuid.UUID(int=0),
+            error_code="INVALID_OPERATION",
+            message=f"Field '{key}' must be a non-empty string.",
+        )
+    return value
+
+
+def _optional_string_field(payload: Mapping[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _number_field(
+    payload: Mapping[str, Any],
+    key: str,
+    *,
+    default: float,
+) -> float | ChangeSetApplyError:
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return ChangeSetApplyError(
+            change_set_id=uuid.UUID(int=0),
+            error_code="INVALID_OPERATION",
+            message=f"Field '{key}' must be a finite number.",
+        )
+    value_float = float(value)
+    if not math.isfinite(value_float):
+        return ChangeSetApplyError(
+            change_set_id=uuid.UUID(int=0),
+            error_code="INVALID_OPERATION",
+            message=f"Field '{key}' must be a finite number.",
+        )
+    return value_float
+
+
+def _uuid_field(payload: Mapping[str, Any], key: str) -> uuid.UUID | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, uuid.UUID):
+        return value
+    if isinstance(value, str):
+        try:
+            return uuid.UUID(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _mapping_field(payload: Mapping[str, Any], key: str) -> Mapping[str, Any] | None:
+    value = payload.get(key)
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value)
+    return None
+
+
+def _clone_optional_mapping(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return _clone_json_mapping(value)
+
+
+def _clone_json_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _clone_json_value(item) for key, item in value.items()}
+
+
+def _clone_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _clone_json_mapping(cast(Mapping[str, Any], value))
+    if isinstance(value, list):
+        return [_clone_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_clone_json_value(item) for item in value]
+    return value
+
+
+def _derived_entity_id(*, change_set_id: uuid.UUID, operation_id: uuid.UUID) -> str:
+    return f"changeset:{change_set_id}:operation:{operation_id}"
+
+
+def _derived_added_entity_source_identity(
+    *,
+    change_set_id: uuid.UUID,
+    operation_id: uuid.UUID,
+) -> str:
+    return _derived_entity_id(change_set_id=change_set_id, operation_id=operation_id)
+
+
+def _derived_added_entity_source_hash(source_identity: str) -> str:
+    return hashlib.sha256(source_identity.encode("utf-8")).hexdigest()
+
+
+def _build_added_entity_provenance(
+    *,
+    source_identity: str,
+    source_hash: str,
+) -> dict[str, Any]:
+    return {
+        "origin": _CHANGESET_PROVENANCE_ORIGIN,
+        "adapter": _CHANGESET_ADAPTER_KEY,
+        "source_identity": source_identity,
+        "source_hash": source_hash,
+    }
+
+
+def _derived_revision_entity_id(*, change_set_id: uuid.UUID, operation_id: uuid.UUID) -> uuid.UUID:
+    return uuid.uuid5(
+        _ADD_ENTITY_NAMESPACE,
+        f"changeset:{change_set_id}:operation:{operation_id}:revision-entity",
+    )
+
+
+def _with_operation_context(
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    error: ChangeSetApplyError,
+) -> ChangeSetApplyError:
+    return _operation_error(
+        change_set_id=change_set_id,
+        operation=operation,
+        error_code=error.error_code,
+        message=error.message,
+        details=error.details,
+    )
+
+
+def _operation_error(
+    *,
+    change_set_id: uuid.UUID,
+    operation: ChangeSetOperation,
+    error_code: str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+) -> ChangeSetApplyError:
+    base_details: dict[str, Any] = {
+        "operation_id": str(operation.operation_id),
+        "sequence_index": operation.sequence_index,
+        "operation_type": operation.operation_type,
+    }
+    if details is not None:
+        base_details.update(dict(details))
+    return ChangeSetApplyError(
+        change_set_id=change_set_id,
+        error_code=error_code,
+        message=message,
+        details=base_details,
+    )

--- a/app/cad/changeset/conflicts.py
+++ b/app/cad/changeset/conflicts.py
@@ -1,0 +1,58 @@
+"""Pure helpers for CAD changeset apply conflict payloads."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+from app.cad.changeset.contracts import (
+    ChangeSetApplyConflict,
+    ChangeSetApplyConflictDetails,
+    ChangeSetApplyConflictTarget,
+    RevisionRef,
+)
+
+
+def build_stale_base_conflict_details(
+    *,
+    change_set_id: uuid.UUID,
+    base_revision: RevisionRef,
+    current_revision: RevisionRef,
+    conflicting_targets: Sequence[ChangeSetApplyConflictTarget] = (),
+) -> ChangeSetApplyConflictDetails | None:
+    if _is_matching_revision(base_revision=base_revision, current_revision=current_revision):
+        return None
+
+    return ChangeSetApplyConflictDetails(
+        base_revision_id=base_revision.revision_id,
+        base_revision_sequence=base_revision.revision_sequence,
+        current_revision_id=current_revision.revision_id,
+        current_revision_sequence=current_revision.revision_sequence,
+        change_set_id=change_set_id,
+        conflicting_targets=tuple(conflicting_targets),
+    )
+
+
+def build_stale_base_conflict(
+    *,
+    change_set_id: uuid.UUID,
+    base_revision: RevisionRef,
+    current_revision: RevisionRef,
+    conflicting_targets: Sequence[ChangeSetApplyConflictTarget] = (),
+) -> ChangeSetApplyConflict | None:
+    details = build_stale_base_conflict_details(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        conflicting_targets=conflicting_targets,
+    )
+    if details is None:
+        return None
+    return ChangeSetApplyConflict(details=details)
+
+
+def _is_matching_revision(*, base_revision: RevisionRef, current_revision: RevisionRef) -> bool:
+    return (
+        base_revision.revision_id == current_revision.revision_id
+        and base_revision.revision_sequence == current_revision.revision_sequence
+    )

--- a/app/cad/changeset/contracts.py
+++ b/app/cad/changeset/contracts.py
@@ -1,0 +1,118 @@
+"""Pure DTO contracts for CAD changeset apply workflows."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionRef:
+    revision_id: uuid.UUID
+    revision_sequence: int
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetOperationTarget:
+    target_revision_entity_id: uuid.UUID | None = None
+    entity_id: str | None = None
+    expected_source_identity: str | None = None
+    expected_source_hash: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetOperation:
+    operation_id: uuid.UUID
+    sequence_index: int
+    operation_type: str
+    operation_json: Mapping[str, Any]
+    target: ChangeSetOperationTarget = field(default_factory=ChangeSetOperationTarget)
+
+
+@dataclass(frozen=True, slots=True)
+class RevisionEntitySnapshot:
+    id: uuid.UUID
+    sequence_index: int
+    entity_id: str
+    entity_type: str
+    entity_schema_version: str
+    confidence_score: float
+    confidence_json: Mapping[str, Any]
+    geometry_json: Mapping[str, Any]
+    properties_json: Mapping[str, Any]
+    provenance_json: Mapping[str, Any]
+    parent_entity_ref: str | None = None
+    canonical_entity_json: Mapping[str, Any] | None = None
+    layout_ref: str | None = None
+    layer_ref: str | None = None
+    block_ref: str | None = None
+    source_identity: str | None = None
+    source_hash: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedEntity:
+    operation_id: uuid.UUID
+    effect: Literal["unchanged", "changed", "added", "removed", "metadata_only"]
+    entity: RevisionEntitySnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetApplyEffects:
+    unchanged_entities: tuple[AppliedEntity, ...] = ()
+    changed_entities: tuple[AppliedEntity, ...] = ()
+    added_entities: tuple[AppliedEntity, ...] = ()
+    metadata_only_entities: tuple[AppliedEntity, ...] = ()
+    removed_entities: tuple[AppliedEntity, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetApplyConflictTarget:
+    operation_id: uuid.UUID
+    sequence_index: int
+    operation_type: str
+    target_revision_entity_id: uuid.UUID | None = None
+    entity_id: str | None = None
+    expected_source_identity: str | None = None
+    expected_source_hash: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetApplyConflictDetails:
+    base_revision_id: uuid.UUID
+    base_revision_sequence: int
+    current_revision_id: uuid.UUID
+    current_revision_sequence: int
+    change_set_id: uuid.UUID
+    conflicting_targets: tuple[ChangeSetApplyConflictTarget, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetApplySuccess:
+    change_set_id: uuid.UUID
+    base_revision: RevisionRef
+    current_revision: RevisionRef
+    operations: tuple[ChangeSetOperation, ...]
+    entities: tuple[RevisionEntitySnapshot, ...] = ()
+    effects: ChangeSetApplyEffects = field(default_factory=ChangeSetApplyEffects)
+    status: Literal["applied"] = "applied"
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetApplyConflict:
+    details: ChangeSetApplyConflictDetails
+    status: Literal["revision_conflict"] = "revision_conflict"
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeSetApplyError:
+    change_set_id: uuid.UUID
+    error_code: str
+    message: str
+    details: Mapping[str, Any] | None = None
+    status: Literal["apply_failed"] = "apply_failed"
+
+
+type ChangeSetApplyResult = ChangeSetApplySuccess | ChangeSetApplyConflict | ChangeSetApplyError

--- a/app/cad/changeset/loading.py
+++ b/app/cad/changeset/loading.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import copy
+import uuid
+from dataclasses import dataclass
+from typing import cast
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cad.changeset.apply import apply_change_set
+from app.cad.changeset.conflicts import build_stale_base_conflict
+from app.cad.changeset.contracts import (
+    ChangeSetApplyConflict,
+    ChangeSetApplyConflictTarget,
+    ChangeSetApplyResult,
+    ChangeSetOperation,
+    ChangeSetOperationTarget,
+    RevisionEntitySnapshot,
+    RevisionRef,
+)
+from app.models.cad_changeset import (
+    CadChangeOperation,
+    CadChangeSet,
+    CadChangeSetValidationResult,
+)
+from app.models.drawing_revision import DrawingRevision
+from app.models.revision_materialization import RevisionEntity
+
+_APPROVED_CHANGE_SET_STATUS = "approved"
+_VALID_CHANGE_SET_VALIDATION_STATUSES = frozenset({"valid", "valid_with_warnings"})
+
+
+class ChangeSetApplyLoadError(ValueError):
+    """Raised when persisted changeset state cannot be safely applied."""
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedChangeSetApplyInput:
+    change_set_id: uuid.UUID
+    base_revision: RevisionRef
+    current_revision: RevisionRef
+    operations: tuple[ChangeSetOperation, ...]
+    entities: tuple[RevisionEntitySnapshot, ...]
+
+
+async def load_change_set_apply_input(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    change_set_id: uuid.UUID,
+) -> LoadedChangeSetApplyInput | ChangeSetApplyConflict:
+    """Load persisted changeset state into the pure apply contract."""
+
+    change_set = await _load_change_set(session, project_id=project_id, change_set_id=change_set_id)
+    _require_approved_change_set(change_set)
+    await _require_latest_valid_validation(
+        session,
+        project_id=project_id,
+        change_set_id=change_set_id,
+    )
+
+    base_revision_model = await _load_base_revision(
+        session,
+        project_id=project_id,
+        base_revision_id=change_set.base_revision_id,
+    )
+    base_revision = RevisionRef(
+        revision_id=base_revision_model.id,
+        revision_sequence=base_revision_model.revision_sequence,
+    )
+
+    current_revision_model = await _load_current_revision(
+        session,
+        project_id=project_id,
+        source_file_id=base_revision_model.source_file_id,
+    )
+    current_revision = RevisionRef(
+        revision_id=current_revision_model.id,
+        revision_sequence=current_revision_model.revision_sequence,
+    )
+
+    operations = await _load_change_set_operations(
+        session,
+        project_id=project_id,
+        change_set_id=change_set_id,
+    )
+    if current_revision != base_revision:
+        conflict = build_stale_base_conflict(
+            change_set_id=change_set_id,
+            base_revision=base_revision,
+            current_revision=current_revision,
+            conflicting_targets=_build_conflict_targets(operations),
+        )
+        assert conflict is not None
+        return conflict
+
+    entities = await _load_revision_entities(
+        session,
+        project_id=project_id,
+        drawing_revision_id=current_revision_model.id,
+    )
+    return LoadedChangeSetApplyInput(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        operations=operations,
+        entities=entities,
+    )
+
+
+async def load_and_apply_change_set(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    change_set_id: uuid.UUID,
+) -> ChangeSetApplyResult:
+    """Load persisted changeset state and delegate application to the pure engine."""
+
+    loaded = await load_change_set_apply_input(
+        session,
+        project_id=project_id,
+        change_set_id=change_set_id,
+    )
+    if isinstance(loaded, ChangeSetApplyConflict):
+        return loaded
+
+    return apply_change_set(
+        change_set_id=loaded.change_set_id,
+        base_revision=loaded.base_revision,
+        current_revision=loaded.current_revision,
+        operations=loaded.operations,
+        entities=loaded.entities,
+    )
+
+
+async def _load_change_set(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    change_set_id: uuid.UUID,
+) -> CadChangeSet:
+    with session.no_autoflush:
+        result = await session.execute(
+            select(CadChangeSet).where(
+                CadChangeSet.project_id == project_id,
+                CadChangeSet.id == change_set_id,
+            )
+        )
+    change_set = result.scalar_one_or_none()
+    if change_set is None:
+        raise ChangeSetApplyLoadError(f"Changeset {change_set_id} was not found.")
+    return change_set
+
+
+def _require_approved_change_set(change_set: CadChangeSet) -> None:
+    if _normalize_status(change_set.status) != _APPROVED_CHANGE_SET_STATUS:
+        raise ChangeSetApplyLoadError(
+            f"Changeset {change_set.id} must be approved before apply loading."
+        )
+
+
+async def _require_latest_valid_validation(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    change_set_id: uuid.UUID,
+) -> None:
+    with session.no_autoflush:
+        result = await session.execute(
+            select(CadChangeSetValidationResult)
+            .where(
+                CadChangeSetValidationResult.project_id == project_id,
+                CadChangeSetValidationResult.change_set_id == change_set_id,
+            )
+            .order_by(
+                CadChangeSetValidationResult.created_at.desc(),
+                CadChangeSetValidationResult.id.desc(),
+            )
+            .limit(1)
+        )
+    latest_validation = result.scalar_one_or_none()
+    if latest_validation is None:
+        raise ChangeSetApplyLoadError(
+            f"Changeset {change_set_id} requires a latest validation result before apply loading."
+        )
+    normalized_validation_status = _normalize_status(latest_validation.validation_status)
+    if normalized_validation_status not in _VALID_CHANGE_SET_VALIDATION_STATUSES:
+        raise ChangeSetApplyLoadError(
+            "Changeset "
+            f"{change_set_id} latest validation must be valid or "
+            "valid_with_warnings before apply loading."
+        )
+
+
+async def _load_base_revision(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    base_revision_id: uuid.UUID,
+) -> DrawingRevision:
+    with session.no_autoflush:
+        result = await session.execute(
+            select(DrawingRevision).where(
+                DrawingRevision.project_id == project_id,
+                DrawingRevision.id == base_revision_id,
+            )
+        )
+    base_revision = result.scalar_one_or_none()
+    if base_revision is None:
+        raise ChangeSetApplyLoadError(f"Base revision {base_revision_id} was not found.")
+    return base_revision
+
+
+async def _load_current_revision(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    source_file_id: uuid.UUID,
+) -> DrawingRevision:
+    with session.no_autoflush:
+        result = await session.execute(
+            select(DrawingRevision)
+            .where(
+                DrawingRevision.project_id == project_id,
+                DrawingRevision.source_file_id == source_file_id,
+            )
+            .order_by(DrawingRevision.revision_sequence.desc(), DrawingRevision.id.desc())
+            .limit(1)
+        )
+    current_revision = result.scalar_one_or_none()
+    if current_revision is None:
+        raise ChangeSetApplyLoadError(
+            f"Current revision for project {project_id} file {source_file_id} was not found."
+        )
+    return current_revision
+
+
+async def _load_change_set_operations(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    change_set_id: uuid.UUID,
+) -> tuple[ChangeSetOperation, ...]:
+    with session.no_autoflush:
+        result = await session.execute(
+            select(CadChangeOperation)
+            .where(
+                CadChangeOperation.project_id == project_id,
+                CadChangeOperation.change_set_id == change_set_id,
+            )
+            .order_by(CadChangeOperation.sequence_index.asc(), CadChangeOperation.id.asc())
+        )
+    return tuple(_change_set_operation_from_model(operation) for operation in result.scalars())
+
+
+def _change_set_operation_from_model(operation: CadChangeOperation) -> ChangeSetOperation:
+    persisted_operation_json = operation.operation_json
+    return ChangeSetOperation(
+        operation_id=operation.id,
+        sequence_index=operation.sequence_index,
+        operation_type=operation.operation_type,
+        operation_json=_extract_operation_payload(persisted_operation_json),
+        target=ChangeSetOperationTarget(
+            target_revision_entity_id=operation.target_revision_entity_id,
+            entity_id=_extract_operation_target_entity_id(persisted_operation_json),
+            expected_source_identity=operation.expected_source_identity,
+            expected_source_hash=operation.expected_source_hash,
+        ),
+    )
+
+
+def _extract_operation_payload(operation_json: object) -> dict[str, object]:
+    if _is_persisted_operation_envelope(operation_json):
+        envelope = cast(dict[str, object], operation_json)
+        payload = envelope.get("payload")
+        if isinstance(payload, dict):
+            return copy.deepcopy(payload)
+        raise ChangeSetApplyLoadError(
+            "Persisted changeset operation envelope payload must be a JSON object."
+        )
+    if not isinstance(operation_json, dict):
+        raise ChangeSetApplyLoadError(
+            "Persisted changeset operation payload must be a JSON object."
+        )
+    return copy.deepcopy(operation_json)
+
+
+def _extract_operation_target_entity_id(operation_json: object) -> str | None:
+    if not _is_persisted_operation_envelope(operation_json):
+        return None
+    envelope = cast(dict[str, object], operation_json)
+    target = envelope.get("target")
+    if not isinstance(target, dict):
+        return None
+    entity_id = target.get("entity_id")
+    return entity_id if isinstance(entity_id, str) else None
+
+
+def _is_persisted_operation_envelope(operation_json: object) -> bool:
+    return (
+        isinstance(operation_json, dict)
+        and "payload_version" in operation_json
+        and "payload" in operation_json
+    )
+
+
+def _build_conflict_targets(
+    operations: tuple[ChangeSetOperation, ...],
+) -> tuple[ChangeSetApplyConflictTarget, ...]:
+    return tuple(
+        ChangeSetApplyConflictTarget(
+            operation_id=operation.operation_id,
+            sequence_index=operation.sequence_index,
+            operation_type=operation.operation_type,
+            target_revision_entity_id=operation.target.target_revision_entity_id,
+            entity_id=operation.target.entity_id,
+            expected_source_identity=operation.target.expected_source_identity,
+            expected_source_hash=operation.target.expected_source_hash,
+        )
+        for operation in operations
+    )
+
+
+async def _load_revision_entities(
+    session: AsyncSession,
+    *,
+    project_id: uuid.UUID,
+    drawing_revision_id: uuid.UUID,
+) -> tuple[RevisionEntitySnapshot, ...]:
+    with session.no_autoflush:
+        result = await session.execute(
+            select(RevisionEntity)
+            .where(
+                RevisionEntity.project_id == project_id,
+                RevisionEntity.drawing_revision_id == drawing_revision_id,
+            )
+            .order_by(RevisionEntity.sequence_index.asc(), RevisionEntity.id.asc())
+        )
+    return tuple(_revision_entity_snapshot_from_model(entity) for entity in result.scalars())
+
+
+def _revision_entity_snapshot_from_model(entity: RevisionEntity) -> RevisionEntitySnapshot:
+    return RevisionEntitySnapshot(
+        id=entity.id,
+        sequence_index=entity.sequence_index,
+        entity_id=entity.entity_id,
+        entity_type=entity.entity_type,
+        entity_schema_version=entity.entity_schema_version,
+        confidence_score=entity.confidence_score,
+        confidence_json=copy.deepcopy(entity.confidence_json),
+        geometry_json=copy.deepcopy(entity.geometry_json),
+        properties_json=copy.deepcopy(entity.properties_json),
+        provenance_json=copy.deepcopy(entity.provenance_json),
+        parent_entity_ref=entity.parent_entity_ref,
+        canonical_entity_json=copy.deepcopy(entity.canonical_entity_json),
+        layout_ref=entity.layout_ref,
+        layer_ref=entity.layer_ref,
+        block_ref=entity.block_ref,
+        source_identity=entity.source_identity,
+        source_hash=entity.source_hash,
+    )
+
+
+def _normalize_status(value: str) -> str:
+    return value.strip().lower()
+
+
+__all__ = [
+    "ChangeSetApplyLoadError",
+    "LoadedChangeSetApplyInput",
+    "load_and_apply_change_set",
+    "load_change_set_apply_input",
+]

--- a/scripts/pre_push_check.py
+++ b/scripts/pre_push_check.py
@@ -128,6 +128,7 @@ DB_TEST_FILE_KEY_LANE_ARGS = {
     "export_job_input_contract": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
     "quantity_takeoff_persistence": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
     "append_only_lineage_tables": DB_LINEAGE_PYTEST_ARGS,
+    "changeset_apply": DB_LINEAGE_PYTEST_ARGS,
     "changeset_persistence": DB_LINEAGE_PYTEST_ARGS,
     "changeset_validation": DB_LINEAGE_PYTEST_ARGS,
     "lineage_delete_restrictions": DB_LINEAGE_PYTEST_ARGS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,6 +320,7 @@ _DB_LANE_BY_TEST_FILE_KEY: dict[str, str] = {
     "append_only_lineage_tables": "db_lineage",
     "changeset_validation": "db_lineage",
     "changeset_persistence": "db_lineage",
+    "changeset_apply": "db_lineage",
     "lineage_delete_restrictions": "db_lineage",
     "db": "db_migration",
     "jobs_base_revision_migration": "db_migration",

--- a/tests/test_changeset_apply.py
+++ b/tests/test_changeset_apply.py
@@ -1,0 +1,1263 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cad.changeset import (
+    AppliedEntity,
+    ChangeSetApplyConflict,
+    ChangeSetApplyConflictDetails,
+    ChangeSetApplyConflictTarget,
+    ChangeSetApplyError,
+    ChangeSetApplyLoadError,
+    ChangeSetApplySuccess,
+    ChangeSetOperation,
+    ChangeSetOperationTarget,
+    LoadedChangeSetApplyInput,
+    RevisionEntitySnapshot,
+    RevisionRef,
+    apply_change_set,
+    build_stale_base_conflict,
+    build_stale_base_conflict_details,
+    load_and_apply_change_set,
+    load_change_set_apply_input,
+)
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.cad_changeset import CadChangeOperation, CadChangeSet, CadChangeSetValidationResult
+from app.models.drawing_revision import DrawingRevision
+from app.models.extraction_profile import ExtractionProfile
+from app.models.file import File
+from app.models.job import Job
+from app.models.project import Project
+from app.models.revision_materialization import RevisionEntity, RevisionEntityManifest
+from tests.conftest import requires_database
+
+
+def test_build_stale_base_conflict_details_returns_none_for_matching_current_revision() -> None:
+    revision_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    base_revision = RevisionRef(revision_id=revision_id, revision_sequence=7)
+    current_revision = RevisionRef(revision_id=revision_id, revision_sequence=7)
+
+    details = build_stale_base_conflict_details(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        base_revision=base_revision,
+        current_revision=current_revision,
+        conflicting_targets=(
+            ChangeSetApplyConflictTarget(
+                operation_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+                sequence_index=1,
+                operation_type="change_layer",
+                entity_id="entity-1",
+            ),
+        ),
+    )
+
+    assert details is None
+
+
+def test_build_stale_base_conflict_details_returns_expected_payload_for_stale_base() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    base_revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    current_revision = RevisionRef(
+        revision_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        revision_sequence=9,
+    )
+    conflict_target = ChangeSetApplyConflictTarget(
+        operation_id=uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        sequence_index=2,
+        operation_type="update_property",
+        target_revision_entity_id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        entity_id="entity-7",
+        expected_source_identity="wall:entity-7",
+        expected_source_hash="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    )
+
+    details = build_stale_base_conflict_details(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        conflicting_targets=[conflict_target],
+    )
+    conflict = build_stale_base_conflict(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        conflicting_targets=[conflict_target],
+    )
+
+    assert details == ChangeSetApplyConflictDetails(
+        base_revision_id=base_revision.revision_id,
+        base_revision_sequence=base_revision.revision_sequence,
+        current_revision_id=current_revision.revision_id,
+        current_revision_sequence=current_revision.revision_sequence,
+        change_set_id=change_set_id,
+        conflicting_targets=(conflict_target,),
+    )
+    assert conflict == ChangeSetApplyConflict(details=details)
+
+
+def test_apply_change_set_returns_copy_on_write_entities_and_effects() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    base_revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    current_revision = RevisionRef(
+        revision_id=base_revision.revision_id,
+        revision_sequence=base_revision.revision_sequence,
+    )
+    wall = _entity_snapshot(
+        revision_entity_id=uuid.UUID("10000000-0000-0000-0000-000000000001"),
+        sequence_index=1,
+        entity_id="wall-1",
+        layer_ref="A-WALL",
+        properties_json={
+            "description": "Wall",
+            "layer_name": "A-WALL",
+            "metadata": {"tags": ["base"]},
+        },
+        canonical_entity_json={
+            "layer_name": "A-WALL",
+            "properties": {"description": "Wall", "layer": "A-WALL"},
+        },
+        source_identity="wall:1",
+        source_hash="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    )
+    door = _entity_snapshot(
+        revision_entity_id=uuid.UUID("10000000-0000-0000-0000-000000000002"),
+        sequence_index=2,
+        entity_id="door-1",
+        layer_ref="A-DOOR",
+        properties_json={"label": "Door A"},
+        canonical_entity_json={"properties": {"label": "Door A", "notes": "stale"}},
+        source_identity="door:1",
+        source_hash="fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+    )
+    tag = _entity_snapshot(
+        revision_entity_id=uuid.UUID("10000000-0000-0000-0000-000000000003"),
+        sequence_index=3,
+        entity_id="tag-1",
+        layer_ref="A-TAG",
+        properties_json={"notes": "keep"},
+    )
+
+    operations = (
+        ChangeSetOperation(
+            operation_id=uuid.UUID("20000000-0000-0000-0000-000000000001"),
+            sequence_index=1,
+            operation_type="change_layer",
+            operation_json={"new_layer": "A-WALL-NEW"},
+            target=ChangeSetOperationTarget(entity_id="wall-1"),
+        ),
+        ChangeSetOperation(
+            operation_id=uuid.UUID("20000000-0000-0000-0000-000000000002"),
+            sequence_index=2,
+            operation_type="update_property",
+            operation_json={"property_path": "properties.notes", "value": "inspect"},
+            target=ChangeSetOperationTarget(target_revision_entity_id=door.id),
+        ),
+        ChangeSetOperation(
+            operation_id=uuid.UUID("20000000-0000-0000-0000-000000000003"),
+            sequence_index=3,
+            operation_type="annotate_entity",
+            operation_json={"annotation": {"code": "verify", "message": "check swing"}},
+            target=ChangeSetOperationTarget(entity_id="door-1"),
+        ),
+        ChangeSetOperation(
+            operation_id=uuid.UUID("20000000-0000-0000-0000-000000000004"),
+            sequence_index=4,
+            operation_type="remove_entity",
+            operation_json={},
+            target=ChangeSetOperationTarget(entity_id="tag-1"),
+        ),
+        ChangeSetOperation(
+            operation_id=uuid.UUID("20000000-0000-0000-0000-000000000005"),
+            sequence_index=5,
+            operation_type="add_entity",
+            operation_json={
+                "entity": {
+                    "entity_type": "text",
+                    "entity_schema_version": "1",
+                    "geometry_json": {"kind": "point", "x": 2.0, "y": 3.0},
+                    "properties_json": {"label": "N-1"},
+                    "provenance_json": {"origin": "user_created"},
+                    "layer": "A-NOTE",
+                }
+            },
+        ),
+        ChangeSetOperation(
+            operation_id=uuid.UUID("20000000-0000-0000-0000-000000000006"),
+            sequence_index=6,
+            operation_type="flag_for_review",
+            operation_json={"review_flag": {"reason": "manual_check", "severity": "warning"}},
+            target=ChangeSetOperationTarget(entity_id="door-1"),
+        ),
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        operations=operations,
+        entities=(wall, door, tag),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    assert [entity.entity_id for entity in result.entities] == [
+        "wall-1",
+        "door-1",
+        _added_entity_id(change_set_id, operations[4].operation_id),
+    ]
+    assert [entity.sequence_index for entity in result.entities] == [0, 1, 2]
+    assert wall.layer_ref == "A-WALL"
+    assert door.properties_json == {"label": "Door A"}
+    assert tag.sequence_index == 3
+
+    changed_wall = result.entities[0]
+    metadata_door = result.entities[1]
+    added_note = result.entities[2]
+
+    assert changed_wall.layer_ref == "A-WALL-NEW"
+    assert changed_wall.properties_json == {
+        "description": "Wall",
+        "layer_name": "A-WALL-NEW",
+        "metadata": {"tags": ["base"]},
+    }
+    assert changed_wall.canonical_entity_json == {
+        "layer_name": "A-WALL-NEW",
+        "properties": {"description": "Wall", "layer": "A-WALL-NEW"},
+    }
+    assert metadata_door.properties_json == {
+        "label": "Door A",
+        "notes": "inspect",
+        "metadata": {
+            "annotations": [{"code": "verify", "message": "check swing"}],
+            "review_flags": [{"reason": "manual_check", "severity": "warning"}],
+        },
+    }
+    assert metadata_door.canonical_entity_json == {
+        "properties": {"label": "Door A", "notes": "inspect"}
+    }
+    assert added_note.layer_ref == "A-NOTE"
+    assert added_note.id == _added_revision_entity_id(change_set_id, operations[4].operation_id)
+
+    assert result.effects.changed_entities == (
+        AppliedEntity(
+            operation_id=operations[0].operation_id,
+            effect="changed",
+            entity=changed_wall,
+        ),
+    )
+    assert result.effects.metadata_only_entities == (
+        AppliedEntity(
+            operation_id=operations[1].operation_id,
+            effect="metadata_only",
+            entity=metadata_door,
+        ),
+    )
+    assert result.effects.added_entities == (
+        AppliedEntity(
+            operation_id=operations[4].operation_id,
+            effect="added",
+            entity=added_note,
+        ),
+    )
+    assert result.effects.removed_entities == (
+        AppliedEntity(
+            operation_id=operations[3].operation_id,
+            effect="removed",
+            entity=tag,
+        ),
+    )
+    assert result.effects.unchanged_entities == ()
+
+
+def test_apply_change_set_marks_no_op_update_as_unchanged() -> None:
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    entity = _entity_snapshot(
+        revision_entity_id=uuid.UUID("10000000-0000-0000-0000-000000000001"),
+        sequence_index=1,
+        entity_id="wall-1",
+        properties_json={"notes": "keep"},
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000010"),
+        sequence_index=1,
+        operation_type="update_property",
+        operation_json={"property": "properties.notes", "value": "keep"},
+        target=ChangeSetOperationTarget(entity_id="wall-1"),
+    )
+
+    result = apply_change_set(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(entity,),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    assert result.entities[0].sequence_index == 0
+    assert result.entities[0].entity_id == entity.entity_id
+    assert result.entities[0].properties_json == entity.properties_json
+    assert result.effects.unchanged_entities == (
+        AppliedEntity(
+            operation_id=operation.operation_id,
+            effect="unchanged",
+            entity=result.entities[0],
+        ),
+    )
+
+
+def test_apply_change_set_accepts_add_entity_alias_payloads() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000021"),
+        sequence_index=1,
+        operation_type="add_entity",
+        operation_json={
+            "entity": {
+                "entity_type": "text",
+                "geometry": {"kind": "point", "x": 2.0, "y": 3.0},
+                "canonical_entity": {
+                    "geometry": {"kind": "point", "x": 2.0, "y": 3.0},
+                    "properties": {"label": "N-1"},
+                },
+                "properties_json": {"label": "N-1"},
+                "layer_ref": "A-NOTE",
+            }
+        },
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    added_entity = result.entities[0]
+    assert added_entity.geometry_json == {"kind": "point", "x": 2.0, "y": 3.0}
+    assert added_entity.canonical_entity_json == {
+        "geometry": {"kind": "point", "x": 2.0, "y": 3.0},
+        "properties": {"label": "N-1"},
+    }
+    assert added_entity.layer_ref == "A-NOTE"
+
+
+def test_apply_change_set_accepts_top_level_canonical_entity_payload() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000025"),
+        sequence_index=1,
+        operation_type="add_entity",
+        operation_json={
+            "canonical_entity": {
+                "entity_type": "text",
+                "geometry": {"kind": "point", "x": 2.0, "y": 3.0},
+                "properties": {"label": "N-1"},
+                "layer_name": "A-NOTE",
+            }
+        },
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    added_entity = result.entities[0]
+    assert added_entity.entity_type == "text"
+    assert added_entity.geometry_json == {"kind": "point", "x": 2.0, "y": 3.0}
+    assert added_entity.canonical_entity_json == {
+        "entity_type": "text",
+        "geometry": {"kind": "point", "x": 2.0, "y": 3.0},
+        "properties": {"label": "N-1"},
+        "layer_name": "A-NOTE",
+    }
+    assert added_entity.layer_ref == "A-NOTE"
+
+
+def test_apply_change_set_accepts_top_level_geometry_alias_for_canonical_entity_payload() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000026"),
+        sequence_index=1,
+        operation_type="add_entity",
+        operation_json={
+            "canonical_entity": {
+                "entity_type": "text",
+                "layer_ref": "A-NOTE",
+            },
+            "geometry": {"kind": "point", "x": 2.0, "y": 3.0},
+        },
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    added_entity = result.entities[0]
+    assert added_entity.geometry_json == {"kind": "point", "x": 2.0, "y": 3.0}
+    assert added_entity.canonical_entity_json == {
+        "entity_type": "text",
+        "layer_ref": "A-NOTE",
+    }
+    assert added_entity.layer_ref == "A-NOTE"
+
+
+@pytest.mark.parametrize("property_alias", ["property_name", "property_key", "name"])
+def test_apply_change_set_accepts_update_property_aliases(property_alias: str) -> None:
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    entity = _entity_snapshot(
+        revision_entity_id=uuid.UUID("10000000-0000-0000-0000-000000000001"),
+        sequence_index=1,
+        entity_id="wall-1",
+        properties_json={"notes": "keep"},
+        canonical_entity_json={"properties": {"notes": "keep"}},
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000022"),
+        sequence_index=1,
+        operation_type="update_property",
+        operation_json={property_alias: "notes", "new_value": "review"},
+        target=ChangeSetOperationTarget(entity_id="wall-1"),
+    )
+
+    result = apply_change_set(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(entity,),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    assert result.entities[0].properties_json == {"notes": "review"}
+    assert result.entities[0].canonical_entity_json == {"properties": {"notes": "review"}}
+
+
+def test_apply_change_set_derives_provenance_for_added_entity_without_input_provenance() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    operation_id = uuid.UUID("20000000-0000-0000-0000-000000000023")
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=operation_id,
+        sequence_index=1,
+        operation_type="add_entity",
+        operation_json={
+            "entity_type": "text",
+            "geometry_json": {"kind": "point", "x": 2.0, "y": 3.0},
+        },
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    added_entity = result.entities[0]
+    expected_source_identity = _added_entity_id(change_set_id, operation_id)
+    expected_source_hash = hashlib.sha256(expected_source_identity.encode("utf-8")).hexdigest()
+    assert added_entity.source_identity == expected_source_identity
+    assert added_entity.source_hash == expected_source_hash
+    assert added_entity.provenance_json == {
+        "origin": "user_created",
+        "adapter": "changeset",
+        "source_identity": expected_source_identity,
+        "source_hash": expected_source_hash,
+    }
+
+
+def test_apply_change_set_prevents_provenance_spoofing_for_added_entity() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    operation_id = uuid.UUID("20000000-0000-0000-0000-000000000024")
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=operation_id,
+        sequence_index=1,
+        operation_type="add_entity",
+        operation_json={
+            "entity_type": "text",
+            "geometry_json": {"kind": "point", "x": 2.0, "y": 3.0},
+            "source_identity": "spoofed:source",
+            "source_hash": "f" * 64,
+            "provenance_json": {
+                "origin": "source_direct",
+                "adapter": "spoofed_adapter",
+                "source_identity": "spoofed:provenance",
+                "source_hash": "e" * 64,
+            },
+        },
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert isinstance(result, ChangeSetApplySuccess)
+    added_entity = result.entities[0]
+    expected_source_identity = _added_entity_id(change_set_id, operation_id)
+    expected_source_hash = hashlib.sha256(expected_source_identity.encode("utf-8")).hexdigest()
+    assert added_entity.source_identity == expected_source_identity
+    assert added_entity.source_hash == expected_source_hash
+    assert added_entity.provenance_json == {
+        "origin": "user_created",
+        "adapter": "changeset",
+        "source_identity": expected_source_identity,
+        "source_hash": expected_source_hash,
+    }
+
+
+def test_apply_change_set_returns_explicit_error_for_invalid_property_path() -> None:
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    entity = _entity_snapshot(
+        revision_entity_id=uuid.UUID("10000000-0000-0000-0000-000000000001"),
+        sequence_index=1,
+        entity_id="wall-1",
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000011"),
+        sequence_index=1,
+        operation_type="update_property",
+        operation_json={"property_path": "properties.height", "value": 42},
+        target=ChangeSetOperationTarget(entity_id="wall-1"),
+    )
+
+    result = apply_change_set(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(entity,),
+    )
+
+    assert result == ChangeSetApplyError(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        error_code="INVALID_OPERATION",
+        message="Unsupported property path 'properties.height'.",
+        details={
+            "operation_id": str(operation.operation_id),
+            "sequence_index": 1,
+            "operation_type": "update_property",
+            "allowed_property_paths": (
+                "properties.description",
+                "properties.label",
+                "properties.mark",
+                "properties.metadata",
+                "properties.notes",
+                "properties.review_status",
+            ),
+        },
+    )
+
+
+def test_apply_change_set_returns_explicit_error_for_missing_target() -> None:
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000012"),
+        sequence_index=1,
+        operation_type="remove_entity",
+        operation_json={},
+    )
+
+    result = apply_change_set(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert result == ChangeSetApplyError(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        error_code="INVALID_OPERATION",
+        message="Entity-targeted changeset operations require a target selector.",
+        details={
+            "operation_id": str(operation.operation_id),
+            "sequence_index": 1,
+            "operation_type": "remove_entity",
+        },
+    )
+
+
+def test_apply_change_set_returns_explicit_error_for_unsupported_operation() -> None:
+    revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000014"),
+        sequence_index=1,
+        operation_type="explode_block",
+        operation_json={},
+    )
+
+    result = apply_change_set(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        base_revision=revision,
+        current_revision=revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert result == ChangeSetApplyError(
+        change_set_id=uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        error_code="UNSUPPORTED_OPERATION",
+        message="Unsupported changeset operation 'explode_block'.",
+        details={
+            "operation_id": str(operation.operation_id),
+            "sequence_index": 1,
+            "operation_type": "explode_block",
+        },
+    )
+
+
+def test_apply_change_set_returns_conflict_for_stale_current_revision() -> None:
+    change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    base_revision = RevisionRef(
+        revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        revision_sequence=7,
+    )
+    current_revision = RevisionRef(
+        revision_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        revision_sequence=8,
+    )
+    operation = ChangeSetOperation(
+        operation_id=uuid.UUID("20000000-0000-0000-0000-000000000013"),
+        sequence_index=1,
+        operation_type="change_layer",
+        operation_json={"layer_ref": "A-NEW"},
+        target=ChangeSetOperationTarget(entity_id="wall-1"),
+    )
+
+    result = apply_change_set(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        operations=(operation,),
+        entities=(),
+    )
+
+    assert result == build_stale_base_conflict(
+        change_set_id=change_set_id,
+        base_revision=base_revision,
+        current_revision=current_revision,
+        conflicting_targets=(
+            ChangeSetApplyConflictTarget(
+                operation_id=operation.operation_id,
+                sequence_index=1,
+                operation_type="change_layer",
+                entity_id="wall-1",
+            ),
+        ),
+    )
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_load_change_set_apply_input_orders_operations_and_entities() -> None:
+    session, seeded = await _seed_loader_case()
+    try:
+        loaded = await load_change_set_apply_input(
+            session,
+            project_id=seeded.project.id,
+            change_set_id=seeded.change_set.id,
+        )
+        applied = await load_and_apply_change_set(
+            session,
+            project_id=seeded.project.id,
+            change_set_id=seeded.change_set.id,
+        )
+
+        assert isinstance(loaded, LoadedChangeSetApplyInput)
+        assert loaded.base_revision == RevisionRef(
+            revision_id=seeded.base_revision.id,
+            revision_sequence=seeded.base_revision.revision_sequence,
+        )
+        assert loaded.current_revision == loaded.base_revision
+        assert [operation.sequence_index for operation in loaded.operations] == [1, 2]
+        assert [operation.operation_id for operation in loaded.operations] == [
+            seeded.first_operation.id,
+            seeded.second_operation.id,
+        ]
+        assert [operation.operation_json for operation in loaded.operations] == [
+            {"new_layer": "A-WALL-UPDATED"},
+            {"property_path": "properties.notes", "value": "review"},
+        ]
+        assert [operation.target.entity_id for operation in loaded.operations] == [
+            seeded.first_entity.entity_id,
+            seeded.second_entity.entity_id,
+        ]
+        assert [entity.sequence_index for entity in loaded.entities] == [1, 4]
+        assert [entity.id for entity in loaded.entities] == [
+            seeded.first_entity.id,
+            seeded.second_entity.id,
+        ]
+        assert isinstance(applied, ChangeSetApplySuccess)
+        assert [entity.sequence_index for entity in applied.entities] == [0, 1]
+        assert applied.entities[0].layer_ref == "A-WALL-UPDATED"
+        assert applied.entities[1].properties_json == {"label": "Door", "notes": "review"}
+    finally:
+        await session.close()
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_load_change_set_apply_input_requires_latest_valid_validation() -> None:
+    session, seeded = await _seed_loader_case(
+        latest_validation_status="invalid",
+        older_validation_status="valid",
+    )
+    try:
+        with pytest.raises(
+            ChangeSetApplyLoadError,
+            match="latest validation must be valid or valid_with_warnings",
+        ):
+            await load_change_set_apply_input(
+                session,
+                project_id=seeded.project.id,
+                change_set_id=seeded.change_set.id,
+            )
+    finally:
+        await session.close()
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_load_change_set_apply_input_selects_do_not_autoflush_pending_changes() -> None:
+    session, seeded = await _seed_loader_case()
+    pending_project = Project(id=uuid.UUID("90000000-0000-0000-0000-000000000099"))
+    try:
+        session.add(pending_project)
+
+        loaded = await load_change_set_apply_input(
+            session,
+            project_id=seeded.project.id,
+            change_set_id=seeded.change_set.id,
+        )
+
+        assert isinstance(loaded, LoadedChangeSetApplyInput)
+        assert pending_project in session.new
+    finally:
+        await session.rollback()
+        await session.close()
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_load_and_apply_change_set_short_circuits_stale_current_before_entity_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session, seeded = await _seed_loader_case(include_current_revision=True)
+    try:
+        import app.cad.changeset.loading as loading_module
+
+        def _fail_if_called(_: RevisionEntity) -> RevisionEntitySnapshot:
+            raise AssertionError("entity mapping should not run for stale current revisions")
+
+        monkeypatch.setattr(
+            loading_module,
+            "_revision_entity_snapshot_from_model",
+            _fail_if_called,
+        )
+        result = await load_and_apply_change_set(
+            session,
+            project_id=seeded.project.id,
+            change_set_id=seeded.change_set.id,
+        )
+    finally:
+        await session.close()
+
+    assert result == build_stale_base_conflict(
+        change_set_id=seeded.change_set.id,
+        base_revision=RevisionRef(
+            revision_id=seeded.base_revision.id,
+            revision_sequence=seeded.base_revision.revision_sequence,
+        ),
+        current_revision=RevisionRef(
+            revision_id=seeded.current_revision.id,
+            revision_sequence=seeded.current_revision.revision_sequence,
+        ),
+        conflicting_targets=(
+            ChangeSetApplyConflictTarget(
+                operation_id=seeded.first_operation.id,
+                sequence_index=1,
+                operation_type="change_layer",
+                target_revision_entity_id=seeded.first_entity.id,
+                entity_id=seeded.first_entity.entity_id,
+                expected_source_identity=seeded.first_entity.source_identity,
+                expected_source_hash=seeded.first_entity.source_hash,
+            ),
+            ChangeSetApplyConflictTarget(
+                operation_id=seeded.second_operation.id,
+                sequence_index=2,
+                operation_type="update_property",
+                target_revision_entity_id=seeded.second_entity.id,
+                entity_id=seeded.second_entity.entity_id,
+                expected_source_identity=seeded.second_entity.source_identity,
+                expected_source_hash=seeded.second_entity.source_hash,
+            ),
+        ),
+    )
+
+
+def _entity_snapshot(
+    *,
+    revision_entity_id: uuid.UUID,
+    sequence_index: int,
+    entity_id: str,
+    layer_ref: str | None = None,
+    properties_json: dict[str, object] | None = None,
+    canonical_entity_json: dict[str, object] | None = None,
+    source_identity: str | None = None,
+    source_hash: str | None = None,
+) -> RevisionEntitySnapshot:
+    return RevisionEntitySnapshot(
+        id=revision_entity_id,
+        sequence_index=sequence_index,
+        entity_id=entity_id,
+        entity_type="polyline",
+        entity_schema_version="1",
+        confidence_score=1.0,
+        confidence_json={},
+        geometry_json={"kind": "polyline", "vertices": [{"x": 0.0, "y": 0.0}]},
+        properties_json=properties_json or {},
+        provenance_json={"origin": "source_direct"},
+        canonical_entity_json=canonical_entity_json,
+        layer_ref=layer_ref,
+        source_identity=source_identity,
+        source_hash=source_hash,
+    )
+
+
+def _added_entity_id(change_set_id: uuid.UUID, operation_id: uuid.UUID) -> str:
+    return f"changeset:{change_set_id}:operation:{operation_id}"
+
+
+def _added_revision_entity_id(change_set_id: uuid.UUID, operation_id: uuid.UUID) -> uuid.UUID:
+    return uuid.uuid5(
+        uuid.UUID("1e9ec7ab-0355-44a5-b69f-c34790709a44"),
+        f"changeset:{change_set_id}:operation:{operation_id}:revision-entity",
+    )
+
+
+def _persisted_operation_envelope(
+    *,
+    entity_id: str,
+    payload: dict[str, object],
+    expected_source_identity: str | None = None,
+    expected_source_hash: str | None = None,
+) -> dict[str, object]:
+    target: dict[str, object] = {"entity_id": entity_id}
+    if expected_source_identity is not None:
+        target["expected_source_identity"] = expected_source_identity
+    if expected_source_hash is not None:
+        target["expected_source_hash"] = expected_source_hash
+    return {
+        "payload_version": 1,
+        "target": target,
+        "payload": payload,
+        "reason": "seeded-loader-test",
+        "provenance": {"origin": "user_created"},
+    }
+
+
+class _SeededLoaderCase:
+    def __init__(
+        self,
+        *,
+        project: Project,
+        change_set: CadChangeSet,
+        base_revision: DrawingRevision,
+        current_revision: DrawingRevision,
+        first_operation: CadChangeOperation,
+        second_operation: CadChangeOperation,
+        first_entity: RevisionEntity,
+        second_entity: RevisionEntity,
+    ) -> None:
+        self.project = project
+        self.change_set = change_set
+        self.base_revision = base_revision
+        self.current_revision = current_revision
+        self.first_operation = first_operation
+        self.second_operation = second_operation
+        self.first_entity = first_entity
+        self.second_entity = second_entity
+
+
+async def _seed_loader_case(
+    *,
+    latest_validation_status: str = "valid_with_warnings",
+    older_validation_status: str | None = None,
+    include_current_revision: bool = False,
+) -> tuple[AsyncSession, _SeededLoaderCase]:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    session = session_maker()
+    project_id = uuid.UUID("90000000-0000-0000-0000-000000000001")
+    file_id = uuid.UUID("90000000-0000-0000-0000-000000000002")
+    profile_id = uuid.UUID("90000000-0000-0000-0000-000000000003")
+    ingest_job_id = uuid.UUID("90000000-0000-0000-0000-000000000004")
+    reprocess_job_id = uuid.UUID("90000000-0000-0000-0000-000000000005")
+    base_adapter_id = uuid.UUID("90000000-0000-0000-0000-000000000006")
+    current_adapter_id = uuid.UUID("90000000-0000-0000-0000-000000000007")
+    base_revision_id = uuid.UUID("90000000-0000-0000-0000-000000000008")
+    current_revision_id = uuid.UUID("90000000-0000-0000-0000-000000000009")
+    change_set_id = uuid.UUID("90000000-0000-0000-0000-000000000010")
+    first_entity_id = uuid.UUID("90000000-0000-0000-0000-000000000011")
+    second_entity_id = uuid.UUID("90000000-0000-0000-0000-000000000012")
+    first_operation_id = uuid.UUID("90000000-0000-0000-0000-000000000013")
+    second_operation_id = uuid.UUID("90000000-0000-0000-0000-000000000014")
+
+    project = Project(id=project_id, name="Loader project")
+    file = File(
+        id=file_id,
+        project_id=project_id,
+        original_filename="loader-test.dxf",
+        media_type="image/vnd.dxf",
+        detected_format="dxf",
+        storage_uri="storage://loader-test.dxf",
+        size_bytes=128,
+        checksum_sha256="1" * 64,
+    )
+    profile = ExtractionProfile(
+        id=profile_id,
+        project_id=project_id,
+        profile_version="1",
+        layout_mode="modelspace",
+        xref_handling="ignore",
+        block_handling="expand",
+    )
+    ingest_job = Job(
+        id=ingest_job_id,
+        project_id=project_id,
+        file_id=file_id,
+        extraction_profile_id=profile_id,
+        job_type="ingest",
+        status="succeeded",
+    )
+    reprocess_job = Job(
+        id=reprocess_job_id,
+        project_id=project_id,
+        file_id=file_id,
+        extraction_profile_id=profile_id,
+        base_revision_id=base_revision_id,
+        job_type="reprocess",
+        status="succeeded",
+    )
+    base_adapter = AdapterRunOutput(
+        id=base_adapter_id,
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=ingest_job_id,
+        adapter_key="test_adapter",
+        adapter_version="1",
+        input_family="dxf",
+        canonical_entity_schema_version="1",
+        canonical_json={"entities": []},
+        provenance_json={"adapter": "test_adapter"},
+        confidence_json={},
+        confidence_score=1.0,
+        warnings_json=[],
+        diagnostics_json=[],
+        result_checksum_sha256="2" * 64,
+    )
+    current_adapter = AdapterRunOutput(
+        id=current_adapter_id,
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=reprocess_job_id,
+        adapter_key="test_adapter",
+        adapter_version="1",
+        input_family="dxf",
+        canonical_entity_schema_version="1",
+        canonical_json={"entities": []},
+        provenance_json={"adapter": "test_adapter"},
+        confidence_json={},
+        confidence_score=1.0,
+        warnings_json=[],
+        diagnostics_json=[],
+        result_checksum_sha256="3" * 64,
+    )
+    base_revision = DrawingRevision(
+        id=base_revision_id,
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=ingest_job_id,
+        adapter_run_output_id=base_adapter_id,
+        revision_sequence=1,
+        revision_kind="ingest",
+        review_state="approved",
+        canonical_entity_schema_version="1",
+        confidence_score=1.0,
+    )
+    current_revision = base_revision
+    if include_current_revision:
+        current_revision = DrawingRevision(
+            id=current_revision_id,
+            project_id=project_id,
+            source_file_id=file_id,
+            extraction_profile_id=profile_id,
+            source_job_id=reprocess_job_id,
+            adapter_run_output_id=current_adapter_id,
+            predecessor_revision_id=base_revision_id,
+            revision_sequence=2,
+            revision_kind="reprocess",
+            review_state="approved",
+            canonical_entity_schema_version="1",
+            confidence_score=1.0,
+        )
+
+    change_set = CadChangeSet(
+        id=change_set_id,
+        project_id=project_id,
+        base_revision_id=base_revision_id,
+        status="approved",
+        created_by="tester",
+    )
+    first_entity = RevisionEntity(
+        id=first_entity_id,
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=base_revision.source_job_id,
+        drawing_revision_id=base_revision_id,
+        adapter_run_output_id=base_adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=1,
+        entity_id="wall-1",
+        entity_type="polyline",
+        entity_schema_version="1",
+        confidence_score=1.0,
+        confidence_json={},
+        geometry_json={"kind": "polyline", "vertices": [{"x": 0.0, "y": 0.0}]},
+        properties_json={"description": "Wall"},
+        provenance_json={"origin": "source_direct"},
+        canonical_entity_json={"properties": {"description": "Wall"}},
+        layer_ref="A-WALL",
+        source_identity="wall:1",
+        source_hash="4" * 64,
+    )
+    second_entity = RevisionEntity(
+        id=second_entity_id,
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=base_revision.source_job_id,
+        drawing_revision_id=base_revision_id,
+        adapter_run_output_id=base_adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=4,
+        entity_id="door-1",
+        entity_type="text",
+        entity_schema_version="1",
+        confidence_score=1.0,
+        confidence_json={},
+        geometry_json={"kind": "point", "x": 1.0, "y": 2.0},
+        properties_json={"label": "Door"},
+        provenance_json={"origin": "source_direct"},
+        canonical_entity_json={"properties": {"label": "Door"}},
+        layer_ref="A-DOOR",
+        source_identity="door:1",
+        source_hash="5" * 64,
+    )
+    first_operation = CadChangeOperation(
+        id=first_operation_id,
+        project_id=project_id,
+        change_set_id=change_set_id,
+        sequence_index=1,
+        operation_type="change_layer",
+        target_revision_entity_id=first_entity_id,
+        expected_source_identity=first_entity.source_identity,
+        expected_source_hash=first_entity.source_hash,
+        operation_json=_persisted_operation_envelope(
+            entity_id=first_entity.entity_id,
+            payload={"new_layer": "A-WALL-UPDATED"},
+            expected_source_identity=first_entity.source_identity,
+            expected_source_hash=first_entity.source_hash,
+        ),
+    )
+    second_operation = CadChangeOperation(
+        id=second_operation_id,
+        project_id=project_id,
+        change_set_id=change_set_id,
+        sequence_index=2,
+        operation_type="update_property",
+        target_revision_entity_id=second_entity_id,
+        expected_source_identity=second_entity.source_identity,
+        expected_source_hash=second_entity.source_hash,
+        operation_json=_persisted_operation_envelope(
+            entity_id=second_entity.entity_id,
+            payload={"property_path": "properties.notes", "value": "review"},
+            expected_source_identity=second_entity.source_identity,
+            expected_source_hash=second_entity.source_hash,
+        ),
+    )
+
+    first_validation_at = datetime(2026, 1, 1, tzinfo=UTC)
+    validations: list[CadChangeSetValidationResult] = []
+    if older_validation_status is not None:
+        validations.append(
+            CadChangeSetValidationResult(
+                id=uuid.UUID("90000000-0000-0000-0000-000000000015"),
+                project_id=project_id,
+                change_set_id=change_set_id,
+                validation_status=older_validation_status,
+                validator_name="changeset_validation_service",
+                validator_version="1",
+                result_json={"outcome": older_validation_status},
+                created_at=first_validation_at,
+            )
+        )
+    validations.append(
+        CadChangeSetValidationResult(
+            id=uuid.UUID("90000000-0000-0000-0000-000000000016"),
+            project_id=project_id,
+            change_set_id=change_set_id,
+            validation_status=latest_validation_status,
+            validator_name="changeset_validation_service",
+            validator_version="1",
+            result_json={"outcome": latest_validation_status},
+            created_at=first_validation_at + timedelta(minutes=1),
+        )
+    )
+
+    base_manifest = RevisionEntityManifest(
+        id=uuid.UUID("90000000-0000-0000-0000-000000000017"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=ingest_job_id,
+        drawing_revision_id=base_revision_id,
+        adapter_run_output_id=base_adapter_id,
+        canonical_entity_schema_version="1",
+        counts_json={"entities": 2},
+    )
+
+    try:
+        session.add(project)
+        await session.flush()
+
+        session.add_all([file, profile])
+        await session.flush()
+
+        session.add(ingest_job)
+        await session.flush()
+
+        session.add(base_adapter)
+        await session.flush()
+
+        session.add_all([base_revision, base_manifest])
+        await session.flush()
+
+        session.add_all([first_entity, second_entity])
+        await session.flush()
+
+        if include_current_revision:
+            current_manifest = RevisionEntityManifest(
+                id=uuid.UUID("90000000-0000-0000-0000-000000000018"),
+                project_id=project_id,
+                source_file_id=file_id,
+                extraction_profile_id=profile_id,
+                source_job_id=reprocess_job_id,
+                drawing_revision_id=current_revision_id,
+                adapter_run_output_id=current_adapter_id,
+                canonical_entity_schema_version="1",
+                counts_json={"entities": 0},
+            )
+            session.add(reprocess_job)
+            await session.flush()
+
+            session.add(current_adapter)
+            await session.flush()
+
+            session.add_all([current_revision, current_manifest])
+            await session.flush()
+
+        session.add(change_set)
+        await session.flush()
+
+        session.add_all([second_operation, first_operation, *validations])
+        await session.flush()
+        return session, _SeededLoaderCase(
+            project=project,
+            change_set=change_set,
+            base_revision=base_revision,
+            current_revision=current_revision,
+            first_operation=first_operation,
+            second_operation=second_operation,
+            first_entity=first_entity,
+            second_entity=second_entity,
+        )
+    except Exception:
+        await session.rollback()
+        await session.close()
+        raise


### PR DESCRIPTION
Closes #289

## Summary
- Add a pure deterministic changeset apply engine with stale-base conflict details.
- Add a read-only no-autoflush loader for approved/latest-valid changesets.
- Add DB-backed apply coverage and pre-push lane mapping for changeset apply tests.

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] uv run pytest -q tests/test_pre_push_check.py
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_changeset_apply.py tests/test_changeset_validation.py tests/test_changeset_persistence.py