### PR TITLE
feat: finalize changeset apply worker

### DIFF
--- a/app/api/v1/revision_routes/changesets.py
+++ b/app/api/v1/revision_routes/changesets.py
@@ -31,6 +31,11 @@ from app.cad.changeset_validation import (
 from app.core.errors import ErrorCode
 from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
+from app.jobs.worker import (
+    enqueue_changeset_apply_job,
+    prepare_job_enqueue_intent,
+    publish_job_enqueue_intent,
+)
 from app.models.cad_changeset import (
     CadChangeOperation,
     CadChangeSet,
@@ -66,6 +71,9 @@ _encode_keyset_cursor = pagination.encode_keyset_cursor
 _decode_keyset_cursor = pagination.decode_keyset_cursor
 _load_change_set_apply_input = changeset_loading.load_change_set_apply_input
 _validate_change_set = validate_change_set
+_prepare_job_enqueue_intent = prepare_job_enqueue_intent
+_publish_job_enqueue_intent = publish_job_enqueue_intent
+_enqueue_changeset_apply_job = enqueue_changeset_apply_job
 
 _CHANGESET_APPLY_VALIDATION_STATUSES = ("valid", "valid_with_warnings")
 
@@ -310,6 +318,17 @@ def _serialize_validation_action(
 
 def _serialize_job(job: Job) -> JobRead:
     return JobRead.model_validate(job)
+
+
+def _extract_job_id_from_response(response: Response) -> UUID | None:
+    body = getattr(response, "body", None)
+    if not body:
+        return None
+
+    try:
+        return JobRead.model_validate_json(body).id
+    except (TypeError, ValueError, ValidationError):
+        return None
 
 
 def _build_validation_service_known_error(
@@ -607,6 +626,8 @@ async def apply_revision_changeset(
     db: DbSession,
     idempotency_key: IdempotencyKey,
 ) -> Response:
+    enqueue_job_id: UUID | None = None
+
     async def preclaim() -> Response | None:
         await _require_active_revision_changeset(
             db,
@@ -618,6 +639,8 @@ async def apply_revision_changeset(
     async def mutate() -> (
         idempotency.IdempotentMutationSuccess[JobRead] | idempotency.IdempotentMutationKnownError
     ):
+        nonlocal enqueue_job_id
+
         try:
             revision, change_set = await _require_active_revision_changeset(
                 db,
@@ -634,6 +657,7 @@ async def apply_revision_changeset(
             change_set_id=change_set.id,
         )
         if existing_job is not None:
+            enqueue_job_id = existing_job.id
             return _IdempotentMutationSuccess(
                 value=_serialize_job(existing_job),
                 status_code=status.HTTP_202_ACCEPTED,
@@ -670,6 +694,7 @@ async def apply_revision_changeset(
             job_type=JobType.CHANGESET_APPLY,
             status=JobStatus.PENDING,
         )
+        _prepare_job_enqueue_intent(job)
         db.add(job)
         await db.flush()
 
@@ -686,12 +711,14 @@ async def apply_revision_changeset(
         )
         await db.flush()
 
+        enqueue_job_id = job.id
+
         return _IdempotentMutationSuccess(
             value=_serialize_job(job),
             status_code=status.HTTP_202_ACCEPTED,
         )
 
-    return await _run_idempotent_mutation(
+    response = await _run_idempotent_mutation(
         db,
         key=idempotency_key,
         fingerprint=_build_apply_fingerprint(revision_id, change_set_id),
@@ -701,3 +728,15 @@ async def apply_revision_changeset(
         serialize_result=lambda result: result.model_dump(mode="json"),
         preclaim=preclaim,
     )
+
+    published_job_id = enqueue_job_id
+    if response.status_code == status.HTTP_202_ACCEPTED and published_job_id is None:
+        published_job_id = _extract_job_id_from_response(response)
+    if published_job_id is not None:
+        await _publish_job_enqueue_intent(
+            published_job_id,
+            publisher=_enqueue_changeset_apply_job,
+            suppress_exceptions=True,
+        )
+
+    return response

--- a/app/jobs/runner.py
+++ b/app/jobs/runner.py
@@ -7,7 +7,14 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Final, Literal
 
-type JobTypeName = Literal["ingest", "reprocess", "quantity_takeoff", "estimate", "export"]
+type JobTypeName = Literal[
+    "ingest",
+    "reprocess",
+    "quantity_takeoff",
+    "estimate",
+    "export",
+    "changeset_apply",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,6 +91,15 @@ JOB_HANDLERS: Final[tuple[JobHandler, ...]] = (
         enqueue_publisher_name="enqueue_export_job",
         enqueue_error_message="Failed to enqueue export job",
     ),
+    JobHandler(
+        job_type_name="changeset_apply",
+        execute_name="_execute_changeset_apply_job_attempt",
+        finalize_name="_finalize_changeset_apply_job",
+        process_name="process_changeset_apply_job",
+        run_task_name="run_changeset_apply_job",
+        enqueue_publisher_name="enqueue_changeset_apply_job",
+        enqueue_error_message="Failed to enqueue changeset apply job",
+    ),
 )
 
 _JOB_HANDLERS_BY_TYPE: Final[dict[str, JobHandler]] = {
@@ -146,6 +162,18 @@ BEGIN_OR_RESUME_ROUTES: Final[tuple[BeginOrResumeRoute, ...]] = (
             reclaimed_stale_running="export_job_reclaimed_stale_running_status",
             duplicate_delivery="export_job_duplicate_delivery_skipped_running_attempt",
             cancelled="export_job_cancelled",
+        ),
+    ),
+    BeginOrResumeRoute(
+        process_name="process_changeset_apply_job",
+        supported_job_types=_job_types_for_process("process_changeset_apply_job"),
+        log_keys=BeginOrResumeLogKeys(
+            unsupported_type="changeset_apply_job_unsupported_type_skipped",
+            terminal_status="changeset_apply_job_skipped_terminal_status",
+            inactive_source="changeset_apply_job_cancelled_inactive_source",
+            reclaimed_stale_running="changeset_apply_job_reclaimed_stale_running_status",
+            duplicate_delivery="changeset_apply_job_duplicate_delivery_skipped_running_attempt",
+            cancelled="changeset_apply_job_cancelled",
         ),
     ),
 )

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -11,7 +11,7 @@ import json
 import math
 import threading
 import uuid
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Callable, Coroutine, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -24,6 +24,13 @@ from celery.signals import worker_ready
 from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.cad.changeset import (
+    ChangeSetApplyConflict,
+    ChangeSetApplyError,
+    ChangeSetApplyLoadError,
+    ChangeSetApplySuccess,
+    load_and_apply_change_set,
+)
 from app.core.clock import utcnow as _clock_utcnow
 from app.core.config import settings
 from app.core.errors import ErrorCode
@@ -74,6 +81,8 @@ from app.ingestion.runner import IngestionRunnerError, IngestionRunRequest, run_
 from app.jobs import lifecycle as job_lifecycle
 from app.jobs import runner as job_runner
 from app.models.adapter_run_output import AdapterRunOutput
+from app.models.cad_changeset import CadChangeSet
+from app.models.changeset_apply_job_input import ChangeSetApplyJobInput
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_job_input import EstimateJobInput, EstimateJobInputCatalogRef
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
@@ -122,14 +131,19 @@ _ENQUEUE_ESTIMATE_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_T
 _ENQUEUE_EXPORT_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
     JobType.EXPORT.value
 ]
+_ENQUEUE_CHANGESET_APPLY_JOB_ERROR_MESSAGE = job_runner.ENQUEUE_ERROR_MESSAGES_BY_JOB_TYPE[
+    JobType.CHANGESET_APPLY.value
+]
 _FINALIZE_INGEST_JOB_ERROR_MESSAGE = "Failed to finalize ingest job"
 _PROCESS_INGEST_JOB_ERROR_MESSAGE = "Ingest job failed unexpectedly."
 _FINALIZE_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Failed to finalize quantity takeoff job"
 _FINALIZE_ESTIMATE_JOB_ERROR_MESSAGE = "Failed to finalize estimate job"
 _FINALIZE_EXPORT_JOB_ERROR_MESSAGE = "Failed to finalize export job"
+_FINALIZE_CHANGESET_APPLY_JOB_ERROR_MESSAGE = "Failed to finalize changeset apply job"
 _PROCESS_QUANTITY_TAKEOFF_JOB_ERROR_MESSAGE = "Quantity takeoff job failed unexpectedly."
 _PROCESS_ESTIMATE_JOB_ERROR_MESSAGE = "Estimate job failed unexpectedly."
 _PROCESS_EXPORT_JOB_ERROR_MESSAGE = "Export job failed unexpectedly."
+_PROCESS_CHANGESET_APPLY_JOB_ERROR_MESSAGE = "Changeset apply job failed unexpectedly."
 _INITIAL_INGEST_REVISION_KIND = "ingest"
 _REPROCESS_REVISION_KIND = "reprocess"
 _DEBUG_OVERLAY_ARTIFACT_KIND = "debug_overlay"
@@ -267,8 +281,23 @@ class _ExportJobInputError(Exception):
         return self.message
 
 
+@dataclass(frozen=True, slots=True)
+class _ChangeSetApplyJobError(Exception):
+    """Raised for deterministic changeset apply execution failures."""
+
+    error_code: ErrorCode
+    message: str
+    details: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
 type _RegisteredJobInputError = (
-    _QuantityTakeoffJobError | _EstimateJobInputError | _ExportJobInputError
+    _QuantityTakeoffJobError
+    | _EstimateJobInputError
+    | _ExportJobInputError
+    | _ChangeSetApplyJobError
 )
 
 
@@ -368,6 +397,21 @@ _EXPORT_PROCESS_SPEC = _RegisteredJobProcessSpec(
     succeeded_log_event="export_job_succeeded",
     process_error_message=_PROCESS_EXPORT_JOB_ERROR_MESSAGE,
     finalize_error_message=_FINALIZE_EXPORT_JOB_ERROR_MESSAGE,
+)
+
+_CHANGESET_APPLY_PROCESS_SPEC = _RegisteredJobProcessSpec(
+    job_type_name="changeset_apply",
+    input_error_type=_ChangeSetApplyJobError,
+    input_failure_log_event="changeset_apply_job_input_failed",
+    stale_attempt_log_event="changeset_apply_job_stale_attempt_skipped",
+    revision_conflict_log_event="changeset_apply_job_revision_conflict",
+    cancelled_during_execution_log_event="changeset_apply_job_cancelled_during_execution",
+    cancelled_during_finalization_log_event="changeset_apply_job_cancelled_during_finalization",
+    process_failed_log_event="changeset_apply_job_failed",
+    finalization_failed_log_event="changeset_apply_job_finalization_failed",
+    succeeded_log_event="changeset_apply_job_succeeded",
+    process_error_message=_PROCESS_CHANGESET_APPLY_JOB_ERROR_MESSAGE,
+    finalize_error_message=_FINALIZE_CHANGESET_APPLY_JOB_ERROR_MESSAGE,
 )
 
 
@@ -855,6 +899,18 @@ async def _get_existing_estimate_version(
     return result.scalar_one_or_none()
 
 
+async def _get_existing_drawing_revision(
+    session: AsyncSession,
+    *,
+    source_job_id: UUID,
+) -> DrawingRevision | None:
+    """Load an existing committed drawing revision for a job."""
+    result = await session.execute(
+        select(DrawingRevision).where(DrawingRevision.source_job_id == source_job_id)
+    )
+    return result.scalar_one_or_none()
+
+
 async def _get_existing_generated_artifact(
     session: AsyncSession,
     *,
@@ -901,6 +957,24 @@ async def _get_drawing_revision(
     return await session.get(DrawingRevision, revision_id)
 
 
+async def _get_drawing_revision_for_changeset(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    change_set_id: UUID,
+) -> DrawingRevision | None:
+    """Load the committed drawing revision anchored to a changeset."""
+    result = await session.execute(
+        select(DrawingRevision)
+        .where(
+            (DrawingRevision.project_id == project_id)
+            & (DrawingRevision.changeset_id == change_set_id)
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def _get_validation_report_for_revision(
     session: AsyncSession,
     *,
@@ -915,6 +989,66 @@ async def _get_validation_report_for_revision(
         )
     )
     return result.scalar_one_or_none()
+
+
+async def _get_revision_layouts_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    source_file_id: UUID,
+    drawing_revision_id: UUID,
+) -> list[RevisionLayout]:
+    """Load deterministic layout rows for a drawing revision."""
+    result = await session.execute(
+        select(RevisionLayout)
+        .where(
+            (RevisionLayout.project_id == project_id)
+            & (RevisionLayout.source_file_id == source_file_id)
+            & (RevisionLayout.drawing_revision_id == drawing_revision_id)
+        )
+        .order_by(RevisionLayout.sequence_index.asc(), RevisionLayout.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def _get_revision_layers_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    source_file_id: UUID,
+    drawing_revision_id: UUID,
+) -> list[RevisionLayer]:
+    """Load deterministic layer rows for a drawing revision."""
+    result = await session.execute(
+        select(RevisionLayer)
+        .where(
+            (RevisionLayer.project_id == project_id)
+            & (RevisionLayer.source_file_id == source_file_id)
+            & (RevisionLayer.drawing_revision_id == drawing_revision_id)
+        )
+        .order_by(RevisionLayer.sequence_index.asc(), RevisionLayer.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def _get_revision_blocks_for_revision(
+    session: AsyncSession,
+    *,
+    project_id: UUID,
+    source_file_id: UUID,
+    drawing_revision_id: UUID,
+) -> list[RevisionBlock]:
+    """Load deterministic block rows for a drawing revision."""
+    result = await session.execute(
+        select(RevisionBlock)
+        .where(
+            (RevisionBlock.project_id == project_id)
+            & (RevisionBlock.source_file_id == source_file_id)
+            & (RevisionBlock.drawing_revision_id == drawing_revision_id)
+        )
+        .order_by(RevisionBlock.sequence_index.asc(), RevisionBlock.id.asc())
+    )
+    return list(result.scalars().all())
 
 
 async def _get_revision_entity_manifest_for_revision(
@@ -1153,6 +1287,78 @@ def _build_persisted_validation_report_json(
     report_json["generated_at"] = payload.generated_at.isoformat()
     report_json["summary"] = summary
     report_json["checks"] = checks
+
+    return report_json
+
+
+def _build_changeset_validation_report_json(
+    base_report: ValidationReport,
+    *,
+    change_set_id: UUID,
+    drawing_revision_id: UUID,
+    predecessor_revision_id: UUID,
+    pinned_validation_result_id: UUID | None,
+    pinned_validation_status: str | None,
+    source_job_id: UUID,
+    validation_report_id: UUID,
+    generated_at: datetime,
+) -> dict[str, Any]:
+    """Copy a predecessor validation report onto a changeset-origin revision."""
+    base_json = base_report.report_json
+    report_json = deepcopy(base_json) if isinstance(base_json, dict) else {}
+
+    validator_json = report_json.get("validator")
+    validator = dict(validator_json) if isinstance(validator_json, dict) else {}
+    validator["name"] = base_report.validator_name
+    validator["version"] = base_report.validator_version
+
+    summary_json = report_json.get("summary")
+    summary = dict(summary_json) if isinstance(summary_json, dict) else {}
+    summary["validation_status"] = base_report.validation_status
+    summary["review_state"] = base_report.review_state
+    summary["quantity_gate"] = base_report.quantity_gate
+    summary["effective_confidence"] = base_report.effective_confidence
+
+    checks_json = report_json.get("checks")
+    checks = list(checks_json) if isinstance(checks_json, list) else []
+    if not checks:
+        checks.append(
+            {
+                "code": "changeset_validation_report_persisted",
+                "status": "passed",
+                "message": (
+                    "Changeset-origin revisions inherit the predecessor validation gate "
+                    "for quantity workflow compatibility."
+                ),
+            }
+        )
+
+    provenance_json = report_json.get("provenance")
+    provenance = dict(provenance_json) if isinstance(provenance_json, dict) else {}
+    provenance["source_validation_report_id"] = str(base_report.id)
+    provenance["source_drawing_revision_id"] = str(predecessor_revision_id)
+    provenance["change_set_id"] = str(change_set_id)
+    if pinned_validation_result_id is not None:
+        provenance["pinned_validation_result_id"] = str(pinned_validation_result_id)
+    if pinned_validation_status is not None:
+        provenance["pinned_validation_status"] = pinned_validation_status
+
+    report_json["validation_report_id"] = str(validation_report_id)
+    report_json["drawing_revision_id"] = str(drawing_revision_id)
+    report_json["source_job_id"] = str(source_job_id)
+    report_json["validation_report_schema_version"] = base_report.validation_report_schema_version
+    report_json["canonical_entity_schema_version"] = base_report.canonical_entity_schema_version
+    report_json["validation_status"] = base_report.validation_status
+    report_json["review_state"] = base_report.review_state
+    report_json["quantity_gate"] = base_report.quantity_gate
+    report_json["effective_confidence"] = base_report.effective_confidence
+    report_json["validator"] = validator
+    report_json["summary"] = summary
+    report_json["checks"] = checks
+    report_json["provenance"] = provenance
+    report_json["generated_at"] = generated_at.isoformat()
+    report_json["change_set_id"] = str(change_set_id)
+    report_json["predecessor_revision_id"] = str(predecessor_revision_id)
 
     return report_json
 
@@ -2524,6 +2730,117 @@ def _build_revision_materialization_rows(
     )
 
 
+def _copy_revision_collection_rows(
+    rows: Sequence[RevisionLayout | RevisionLayer | RevisionBlock],
+    *,
+    ref_key: str,
+) -> list[dict[str, Any]]:
+    """Copy persisted collection rows into a new in-memory materialization plan."""
+    copied_rows: list[dict[str, Any]] = []
+    for row in sorted(
+        rows,
+        key=lambda item: (int(item.sequence_index), str(getattr(item, ref_key)), str(item.id)),
+    ):
+        copied_rows.append(
+            {
+                "id": uuid.uuid4(),
+                "sequence_index": row.sequence_index,
+                "payload_json": _materialized_payload_json(row.payload_json),
+                ref_key: cast(str, getattr(row, ref_key)),
+            }
+        )
+    return copied_rows
+
+
+def _copy_json_mapping(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Deep-copy mapping-backed JSON contract fields into plain dicts."""
+    if value is None:
+        return {}
+    return deepcopy(dict(value))
+
+
+def _build_changeset_revision_materialization_rows(
+    apply_result: ChangeSetApplySuccess,
+    *,
+    base_manifest: RevisionEntityManifest,
+    base_layouts: Sequence[RevisionLayout],
+    base_layers: Sequence[RevisionLayer],
+    base_blocks: Sequence[RevisionBlock],
+) -> _RevisionMaterializationRows:
+    """Map applied changeset entities plus base collections into insert-ready rows."""
+    layouts = _copy_revision_collection_rows(base_layouts, ref_key="layout_ref")
+    layers = _copy_revision_collection_rows(base_layers, ref_key="layer_ref")
+    blocks = _copy_revision_collection_rows(base_blocks, ref_key="block_ref")
+
+    layout_ids_by_ref = {row["layout_ref"]: row["id"] for row in layouts}
+    layer_ids_by_ref = {row["layer_ref"]: row["id"] for row in layers}
+    block_ids_by_ref = {row["block_ref"]: row["id"] for row in blocks}
+
+    entities: list[dict[str, Any]] = []
+    for entity in sorted(
+        apply_result.entities,
+        key=lambda item: (item.sequence_index, item.entity_id, str(item.id)),
+    ):
+        layout_ref = _string_ref(entity.layout_ref)
+        layer_ref = _string_ref(entity.layer_ref)
+        block_ref = _string_ref(entity.block_ref)
+        parent_entity_ref = _string_ref(entity.parent_entity_ref)
+        entities.append(
+            {
+                "id": uuid.uuid4(),
+                "sequence_index": entity.sequence_index,
+                "entity_id": entity.entity_id,
+                "entity_type": entity.entity_type,
+                "entity_schema_version": entity.entity_schema_version,
+                "parent_entity_ref": parent_entity_ref,
+                "confidence_score": entity.confidence_score,
+                "confidence_json": _copy_json_mapping(entity.confidence_json),
+                "geometry_json": _copy_json_mapping(entity.geometry_json),
+                "properties_json": _copy_json_mapping(entity.properties_json),
+                "provenance_json": _copy_json_mapping(entity.provenance_json),
+                "canonical_entity_json": (
+                    _copy_json_mapping(entity.canonical_entity_json)
+                    if entity.canonical_entity_json is not None
+                    else None
+                ),
+                "layout_ref": layout_ref,
+                "layer_ref": layer_ref,
+                "block_ref": block_ref,
+                "source_identity": _string_ref(entity.source_identity),
+                "source_hash": _hash_ref(entity.source_hash),
+                "layout_id": layout_ids_by_ref.get(layout_ref) if layout_ref is not None else None,
+                "layer_id": layer_ids_by_ref.get(layer_ref) if layer_ref is not None else None,
+                "block_id": block_ids_by_ref.get(block_ref) if block_ref is not None else None,
+            }
+        )
+
+    entity_row_ids_by_entity_id = {row["entity_id"]: row["id"] for row in entities}
+    for row in entities:
+        parent_entity_ref = row["parent_entity_ref"]
+        row["parent_entity_row_id"] = (
+            entity_row_ids_by_entity_id.get(parent_entity_ref)
+            if parent_entity_ref is not None
+            else None
+        )
+
+    counts_json = _json_object(base_manifest.counts_json)
+    counts_json.update(
+        {
+            "layouts": len(layouts),
+            "layers": len(layers),
+            "blocks": len(blocks),
+            "entities": len(entities),
+        }
+    )
+    return _RevisionMaterializationRows(
+        counts_json=counts_json,
+        layouts=layouts,
+        layers=layers,
+        blocks=blocks,
+        entities=entities,
+    )
+
+
 def _order_revision_entity_insert_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Order entity rows so parent self-FKs insert before children when possible."""
     if len(rows) < 2:
@@ -2671,6 +2988,77 @@ async def _persist_revision_materialization(
                 }
                 for row in materialization_rows.entities
             ]
+        ),
+    )
+
+    return manifest_id
+
+
+async def _persist_changeset_revision_materialization(
+    session: AsyncSession,
+    *,
+    job: Job,
+    source_file: File,
+    drawing_revision_id: UUID,
+    apply_result: ChangeSetApplySuccess,
+    base_manifest: RevisionEntityManifest,
+    base_layouts: Sequence[RevisionLayout],
+    base_layers: Sequence[RevisionLayer],
+    base_blocks: Sequence[RevisionBlock],
+) -> UUID:
+    """Persist changeset-origin revision materialization with null ingest lineage fields."""
+    materialization_rows = _build_changeset_revision_materialization_rows(
+        apply_result,
+        base_manifest=base_manifest,
+        base_layouts=base_layouts,
+        base_layers=base_layers,
+        base_blocks=base_blocks,
+    )
+    manifest_id = uuid.uuid4()
+    base_row = {
+        "project_id": job.project_id,
+        "source_file_id": source_file.id,
+        "extraction_profile_id": None,
+        "source_job_id": job.id,
+        "drawing_revision_id": drawing_revision_id,
+        "adapter_run_output_id": None,
+        "canonical_entity_schema_version": base_manifest.canonical_entity_schema_version,
+    }
+
+    session.add(
+        RevisionEntityManifest(
+            id=manifest_id,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=job.id,
+            drawing_revision_id=drawing_revision_id,
+            adapter_run_output_id=None,
+            canonical_entity_schema_version=base_manifest.canonical_entity_schema_version,
+            counts_json=materialization_rows.counts_json,
+        )
+    )
+
+    await _bulk_insert_model_rows(
+        session,
+        RevisionLayout,
+        [{**base_row, **row} for row in materialization_rows.layouts],
+    )
+    await _bulk_insert_model_rows(
+        session,
+        RevisionLayer,
+        [{**base_row, **row} for row in materialization_rows.layers],
+    )
+    await _bulk_insert_model_rows(
+        session,
+        RevisionBlock,
+        [{**base_row, **row} for row in materialization_rows.blocks],
+    )
+    await _bulk_insert_model_rows(
+        session,
+        RevisionEntity,
+        _order_revision_entity_insert_rows(
+            [{**base_row, **row} for row in materialization_rows.entities]
         ),
     )
 
@@ -4830,6 +5218,14 @@ async def _begin_or_resume_export_job(job_id: UUID) -> _JobAttemptLease | None:
     return await _begin_or_resume_registered_job(job_id, process_name="process_export_job")
 
 
+async def _begin_or_resume_changeset_apply_job(job_id: UUID) -> _JobAttemptLease | None:
+    """Claim, resume, or cancel a persisted changeset apply job under a row lock."""
+    return await _begin_or_resume_registered_job(
+        job_id,
+        process_name="process_changeset_apply_job",
+    )
+
+
 async def _execute_ingest_job_attempt(
     job_id: UUID,
     *,
@@ -4943,12 +5339,20 @@ async def _process_registered_job(job_id: UUID, *, spec: _RegisteredJobProcessSp
         logger.info(spec.stale_attempt_log_event, job_id=str(job_id))
         return
     except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event=spec.revision_conflict_log_event,
-            exc=exc,
-        )
+        if spec.job_type_name == "changeset_apply":
+            await _mark_changeset_apply_job_failed_for_revision_conflict(
+                job_id,
+                attempt_token=lease.token,
+                log_event=spec.revision_conflict_log_event,
+                exc=exc,
+            )
+        else:
+            await _mark_job_failed_for_revision_conflict(
+                job_id,
+                attempt_token=lease.token,
+                log_event=spec.revision_conflict_log_event,
+                exc=exc,
+            )
         if spec.reraise_revision_conflict:
             raise
         return
@@ -4963,23 +5367,32 @@ async def _process_registered_job(job_id: UUID, *, spec: _RegisteredJobProcessSp
         if spec.input_error_type is not None and isinstance(exc, spec.input_error_type):
             input_error = cast(_RegisteredJobInputError, exc)
             failure_details = input_error.details
-            await _mark_job_failed(
-                job_id,
-                error_message=input_error.message,
-                error_code=input_error.error_code,
-                attempt_token=lease.token,
-                error_details=failure_details,
-            )
             if spec.input_failure_log_event is None:
                 raise AssertionError(
                     f"Registered job '{spec.job_type_name}' is missing input_failure_log_event"
                 ) from exc
-            logger.warning(
-                spec.input_failure_log_event,
-                job_id=str(job_id),
-                error_code=input_error.error_code.value,
-                **(failure_details or {}),
-            )
+            if spec.job_type_name == "changeset_apply":
+                assert isinstance(input_error, _ChangeSetApplyJobError)
+                await _mark_changeset_apply_job_failed_for_input_error(
+                    job_id,
+                    attempt_token=lease.token,
+                    log_event=spec.input_failure_log_event,
+                    exc=input_error,
+                )
+            else:
+                await _mark_job_failed(
+                    job_id,
+                    error_message=input_error.message,
+                    error_code=input_error.error_code,
+                    attempt_token=lease.token,
+                    error_details=failure_details,
+                )
+                logger.warning(
+                    spec.input_failure_log_event,
+                    job_id=str(job_id),
+                    error_code=input_error.error_code.value,
+                    **(failure_details or {}),
+                )
             return
 
         if spec.execution_error_type is not None and isinstance(exc, spec.execution_error_type):
@@ -5030,12 +5443,20 @@ async def _process_registered_job(job_id: UUID, *, spec: _RegisteredJobProcessSp
         )
         raise
     except _RevisionConflictError as exc:
-        await _mark_job_failed_for_revision_conflict(
-            job_id,
-            attempt_token=lease.token,
-            log_event=spec.revision_conflict_log_event,
-            exc=exc,
-        )
+        if spec.job_type_name == "changeset_apply":
+            await _mark_changeset_apply_job_failed_for_revision_conflict(
+                job_id,
+                attempt_token=lease.token,
+                log_event=spec.revision_conflict_log_event,
+                exc=exc,
+            )
+        else:
+            await _mark_job_failed_for_revision_conflict(
+                job_id,
+                attempt_token=lease.token,
+                log_event=spec.revision_conflict_log_event,
+                exc=exc,
+            )
         if spec.reraise_revision_conflict:
             raise
         return
@@ -5160,6 +5581,576 @@ async def _execute_export_job(
     return _RegisteredJobAttemptResult(
         finalize_kwargs={"execution": execution, "rendered": rendered}
     )
+
+
+async def _query_changeset_apply_job_inputs(
+    session: AsyncSession,
+    *,
+    job_id: UUID,
+) -> list[ChangeSetApplyJobInput]:
+    """Load persisted immutable inputs for one changeset-apply job."""
+    with session.no_autoflush:
+        result = await session.execute(
+            select(ChangeSetApplyJobInput)
+            .where(ChangeSetApplyJobInput.source_job_id == job_id)
+            .order_by(
+                ChangeSetApplyJobInput.created_at.asc(),
+                ChangeSetApplyJobInput.source_job_id.asc(),
+            )
+        )
+    return list(result.scalars().all())
+
+
+async def _load_changeset_apply_job_input(
+    session: AsyncSession,
+    *,
+    job: Job,
+) -> ChangeSetApplyJobInput:
+    """Validate that one immutable apply input exists and matches the persisted job."""
+    apply_inputs = await _query_changeset_apply_job_inputs(session, job_id=job.id)
+    if not apply_inputs:
+        raise _ChangeSetApplyJobError(
+            error_code=ErrorCode.NOT_FOUND,
+            message="Changeset apply job input is missing.",
+            details=None,
+        )
+    if len(apply_inputs) != 1:
+        raise _ChangeSetApplyJobError(
+            error_code=ErrorCode.INPUT_INVALID,
+            message="Changeset apply job has multiple immutable inputs.",
+            details={"input_count": len(apply_inputs)},
+        )
+
+    apply_input = apply_inputs[0]
+    if (
+        apply_input.project_id != job.project_id
+        or apply_input.source_file_id != job.file_id
+        or apply_input.drawing_revision_id != job.base_revision_id
+        or apply_input.source_job_id != job.id
+        or apply_input.source_job_type != JobType.CHANGESET_APPLY.value
+    ):
+        raise _ChangeSetApplyJobError(
+            error_code=ErrorCode.INPUT_INVALID,
+            message="Changeset apply job input lineage does not match the persisted job.",
+            details={
+                "source_job_type": apply_input.source_job_type,
+                "source_file_id": str(apply_input.source_file_id),
+                "file_id": str(job.file_id),
+                "drawing_revision_id": str(apply_input.drawing_revision_id),
+                "base_revision_id": (
+                    str(job.base_revision_id) if job.base_revision_id is not None else None
+                ),
+            },
+        )
+    return apply_input
+
+
+async def _load_changeset_apply_job_input_if_valid(
+    session: AsyncSession,
+    *,
+    job: Job,
+) -> ChangeSetApplyJobInput | None:
+    """Return the immutable apply input when exactly one lineage-matching row exists."""
+    apply_inputs = await _query_changeset_apply_job_inputs(session, job_id=job.id)
+    if len(apply_inputs) != 1:
+        return None
+
+    apply_input = apply_inputs[0]
+    if (
+        apply_input.project_id != job.project_id
+        or apply_input.source_file_id != job.file_id
+        or apply_input.drawing_revision_id != job.base_revision_id
+        or apply_input.source_job_id != job.id
+        or apply_input.source_job_type != JobType.CHANGESET_APPLY.value
+    ):
+        return None
+    return apply_input
+
+
+def _parse_uuid_value(value: Any) -> UUID | None:
+    """Best-effort UUID parsing for persisted error payloads."""
+    if isinstance(value, UUID):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return UUID(value)
+    except ValueError:
+        return None
+
+
+async def _resolve_changeset_apply_failure_target(
+    session: AsyncSession,
+    *,
+    job: Job,
+    fallback_change_set_id: UUID | None = None,
+) -> CadChangeSet | None:
+    """Resolve the mutable changeset row for an apply-job terminal failure."""
+    apply_input = await _load_changeset_apply_job_input_if_valid(session, job=job)
+    change_set_id = apply_input.change_set_id if apply_input is not None else fallback_change_set_id
+    if change_set_id is None:
+        return None
+
+    change_set = await session.get(CadChangeSet, change_set_id)
+    if change_set is None or change_set.project_id != job.project_id:
+        return None
+    if job.base_revision_id is not None and change_set.base_revision_id != job.base_revision_id:
+        return None
+    return change_set
+
+
+async def _mark_changeset_apply_job_failed(
+    job_id: UUID,
+    *,
+    error_message: str,
+    error_code: ErrorCode,
+    attempt_token: UUID,
+    error_details: dict[str, Any] | None,
+    change_set_status: str | None,
+) -> bool:
+    """Persist a changeset-apply job failure and matching changeset status atomically."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    fallback_change_set_id = _parse_uuid_value((error_details or {}).get("change_set_id"))
+    async with session_maker() as session:
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            return False
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            return False
+
+        if (
+            locked_source.project.deleted_at is not None
+            or locked_source.source_file is None
+            or locked_source.source_file.deleted_at is not None
+        ):
+            return await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+
+        if change_set_status is not None:
+            change_set = await _resolve_changeset_apply_failure_target(
+                session,
+                job=job,
+                fallback_change_set_id=fallback_change_set_id,
+            )
+            if change_set is not None and change_set.status != "applied":
+                change_set.status = change_set_status
+
+        await _persist_job_failed(
+            session,
+            job,
+            error_message=error_message,
+            error_code=error_code,
+            error_details=error_details,
+        )
+        await session.commit()
+
+    return True
+
+
+async def _mark_changeset_apply_job_failed_for_revision_conflict(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    log_event: str,
+    exc: _RevisionConflictError,
+) -> None:
+    """Persist and log a changeset-apply revision conflict atomically."""
+    await _mark_changeset_apply_job_failed(
+        job_id,
+        error_message=exc.message,
+        error_code=ErrorCode.REVISION_CONFLICT,
+        attempt_token=attempt_token,
+        error_details=exc.details,
+        change_set_status="revision_conflict",
+    )
+    logger.warning(
+        log_event,
+        job_id=str(job_id),
+        error_code=ErrorCode.REVISION_CONFLICT.value,
+        **exc.details,
+    )
+
+
+async def _mark_changeset_apply_job_failed_for_input_error(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    log_event: str,
+    exc: _ChangeSetApplyJobError,
+) -> None:
+    """Persist and log a deterministic changeset-apply failure atomically."""
+    failure_details = exc.details
+    await _mark_changeset_apply_job_failed(
+        job_id,
+        error_message=exc.message,
+        error_code=exc.error_code,
+        attempt_token=attempt_token,
+        error_details=failure_details,
+        change_set_status="apply_failed",
+    )
+    logger.warning(
+        log_event,
+        job_id=str(job_id),
+        error_code=exc.error_code.value,
+        **(failure_details or {}),
+    )
+
+
+def _build_changeset_apply_conflict_details(
+    result: ChangeSetApplyConflict,
+) -> dict[str, Any]:
+    """Convert a stale apply conflict into the shared job failure detail shape."""
+    return {
+        "change_set_id": str(result.details.change_set_id),
+        "base_revision_id": str(result.details.base_revision_id),
+        "base_revision_sequence": result.details.base_revision_sequence,
+        "current_revision_id": str(result.details.current_revision_id),
+        "current_revision_sequence": result.details.current_revision_sequence,
+        "conflicting_targets": [
+            {
+                "operation_id": str(target.operation_id),
+                "sequence_index": target.sequence_index,
+                "operation_type": target.operation_type,
+                "target_revision_entity_id": (
+                    str(target.target_revision_entity_id)
+                    if target.target_revision_entity_id is not None
+                    else None
+                ),
+                "entity_id": target.entity_id,
+                "expected_source_identity": target.expected_source_identity,
+                "expected_source_hash": target.expected_source_hash,
+            }
+            for target in result.details.conflicting_targets
+        ],
+    }
+
+
+def _build_changeset_apply_error_details(result: ChangeSetApplyError) -> dict[str, Any]:
+    """Convert a deterministic apply-engine failure into worker job failure details."""
+    details: dict[str, Any] = {
+        "change_set_id": str(result.change_set_id),
+        "apply_error_code": result.error_code,
+    }
+    if result.details:
+        details.update(dict(result.details))
+    return details
+
+
+async def _execute_changeset_apply_job_attempt(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+) -> _RegisteredJobAttemptResult | None:
+    """Load immutable apply input, re-run apply loading, and defer success finalization."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        job = await session.get(Job, job_id)
+        if job is None:
+            raise LookupError(f"Job with identifier '{job_id}' not found")
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            raise _StaleJobAttemptError(f"Job attempt for '{job_id}' no longer owns the lease")
+        if job.job_type != JobType.CHANGESET_APPLY.value:
+            raise ValueError(f"Unsupported changeset apply job type '{job.job_type}'")
+        if job.base_revision_id is None:
+            raise _RevisionConflictError(
+                message="Changeset apply job is missing its finalized base revision.",
+                details={
+                    "base_revision_id": None,
+                    "current_revision_id": None,
+                },
+            )
+
+        apply_input = await _load_changeset_apply_job_input(session, job=job)
+        try:
+            apply_result = await load_and_apply_change_set(
+                session,
+                project_id=job.project_id,
+                change_set_id=apply_input.change_set_id,
+            )
+        except ChangeSetApplyLoadError as exc:
+            raise _ChangeSetApplyJobError(
+                error_code=ErrorCode.INPUT_INVALID,
+                message=str(exc),
+                details={
+                    "change_set_id": str(apply_input.change_set_id),
+                },
+            ) from exc
+
+    if isinstance(apply_result, ChangeSetApplyConflict):
+        raise _RevisionConflictError(
+            message="Changeset apply base revision is stale relative to the current revision.",
+            details=_build_changeset_apply_conflict_details(apply_result),
+        )
+    if isinstance(apply_result, ChangeSetApplyError):
+        raise _ChangeSetApplyJobError(
+            error_code=ErrorCode.INPUT_INVALID,
+            message=apply_result.message,
+            details=_build_changeset_apply_error_details(apply_result),
+        )
+
+    assert isinstance(apply_result, ChangeSetApplySuccess)
+    return _RegisteredJobAttemptResult(finalize_kwargs={"apply_result": apply_result})
+
+
+async def _finalize_changeset_apply_job(
+    job_id: UUID,
+    *,
+    attempt_token: UUID,
+    apply_result: ChangeSetApplySuccess,
+) -> bool:
+    """Atomically publish a changeset-origin revision and terminal job success."""
+    session_maker = get_session_maker()
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        locked_source = await _lock_job_source_for_terminal_mutation(session, job_id)
+        job = locked_source.job
+        source_file = locked_source.source_file
+
+        if job.status in _TERMINAL_JOB_STATUSES:
+            logger.info(
+                "changeset_apply_job_completion_skipped_terminal_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if not _job_attempt_is_current(job, attempt_token=attempt_token):
+            logger.info(
+                "changeset_apply_job_completion_skipped_stale_attempt",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if job.cancel_requested:
+            _finalize_job_cancelled(job)
+            await emit_job_event(
+                job.id,
+                level="warning",
+                message="Job cancelled",
+                data_json={"status": "cancelled"},
+                session=session,
+            )
+            await session.commit()
+            logger.info("changeset_apply_job_cancelled", job_id=str(job_id))
+            return False
+
+        if job.status != "running":
+            logger.info(
+                "changeset_apply_job_completion_skipped_non_running_status",
+                job_id=str(job_id),
+                status=job.status,
+            )
+            return False
+
+        if (
+            locked_source.project.deleted_at is not None
+            or source_file is None
+            or source_file.deleted_at is not None
+        ):
+            await _cancel_job_for_inactive_source(
+                session,
+                job,
+                reason="source_deleted",
+                attempt_token=attempt_token,
+            )
+            logger.info("changeset_apply_job_cancelled_inactive_source", job_id=str(job_id))
+            return False
+
+        if job.base_revision_id != apply_result.base_revision.revision_id:
+            raise _RevisionConflictError(
+                message="Changeset apply base revision changed before finalization.",
+                details={
+                    "base_revision_id": (
+                        str(job.base_revision_id) if job.base_revision_id is not None else None
+                    ),
+                    "apply_result_base_revision_id": str(apply_result.base_revision.revision_id),
+                },
+            )
+
+        existing_revision = await _get_existing_drawing_revision(session, source_job_id=job.id)
+        if existing_revision is not None:
+            logger.info(
+                "changeset_apply_job_completion_skipped_existing_revision",
+                job_id=str(job_id),
+                drawing_revision_id=str(existing_revision.id),
+            )
+            return False
+
+        current_revision = await _get_latest_drawing_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+        )
+        if (
+            current_revision is None
+            or current_revision.id != apply_result.current_revision.revision_id
+        ):
+            base_revision = await _get_drawing_revision(
+                session,
+                revision_id=apply_result.base_revision.revision_id,
+            )
+            raise _RevisionConflictError(
+                message="Changeset apply base revision became stale before finalization.",
+                details={
+                    **_build_revision_conflict_details(
+                        base_revision=base_revision,
+                        current_revision=current_revision,
+                    ),
+                    "change_set_id": str(apply_result.change_set_id),
+                },
+            )
+
+        validation_report = await _get_validation_report_for_revision(
+            session,
+            project_id=job.project_id,
+            drawing_revision_id=current_revision.id,
+        )
+        if validation_report is None:
+            raise RuntimeError("Changeset apply base revision is missing its validation report.")
+
+        apply_input = await _load_changeset_apply_job_input_if_valid(session, job=job)
+
+        base_manifest = await _get_revision_entity_manifest_for_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+            drawing_revision_id=current_revision.id,
+        )
+        if base_manifest is None:
+            raise RuntimeError("Changeset apply base revision is missing normalized entities.")
+
+        base_layouts = await _get_revision_layouts_for_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+            drawing_revision_id=current_revision.id,
+        )
+        base_layers = await _get_revision_layers_for_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+            drawing_revision_id=current_revision.id,
+        )
+        base_blocks = await _get_revision_blocks_for_revision(
+            session,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+            drawing_revision_id=current_revision.id,
+        )
+
+        change_set = await session.get(CadChangeSet, apply_result.change_set_id)
+        if change_set is None:
+            raise RuntimeError("Changeset apply change set no longer exists.")
+        if (
+            change_set.project_id != job.project_id
+            or change_set.base_revision_id != apply_result.base_revision.revision_id
+        ):
+            raise ValueError("Changeset apply change set lineage does not match the source job")
+
+        drawing_revision_id = uuid.uuid4()
+        validation_report_id = uuid.uuid4()
+        finished_at = _utcnow()
+        drawing_revision = DrawingRevision(
+            id=drawing_revision_id,
+            project_id=job.project_id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=job.id,
+            adapter_run_output_id=None,
+            changeset_id=apply_result.change_set_id,
+            predecessor_revision_id=current_revision.id,
+            revision_sequence=current_revision.revision_sequence + 1,
+            revision_kind="changeset",
+            review_state=validation_report.review_state,
+            canonical_entity_schema_version=base_manifest.canonical_entity_schema_version,
+            confidence_score=validation_report.effective_confidence,
+        )
+
+        session.add(drawing_revision)
+        await session.flush()
+
+        session.add(
+            ValidationReport(
+                id=validation_report_id,
+                project_id=job.project_id,
+                drawing_revision_id=drawing_revision_id,
+                source_job_id=job.id,
+                validation_report_schema_version=validation_report.validation_report_schema_version,
+                canonical_entity_schema_version=validation_report.canonical_entity_schema_version,
+                validation_status=validation_report.validation_status,
+                review_state=validation_report.review_state,
+                quantity_gate=validation_report.quantity_gate,
+                effective_confidence=validation_report.effective_confidence,
+                validator_name=validation_report.validator_name,
+                validator_version=validation_report.validator_version,
+                report_json=_build_changeset_validation_report_json(
+                    validation_report,
+                    change_set_id=apply_result.change_set_id,
+                    drawing_revision_id=drawing_revision_id,
+                    predecessor_revision_id=current_revision.id,
+                    pinned_validation_result_id=(
+                        apply_input.latest_validation_result_id if apply_input is not None else None
+                    ),
+                    pinned_validation_status=(
+                        apply_input.latest_validation_status if apply_input is not None else None
+                    ),
+                    source_job_id=job.id,
+                    validation_report_id=validation_report_id,
+                    generated_at=finished_at,
+                ),
+                generated_at=finished_at,
+            )
+        )
+        await _persist_changeset_revision_materialization(
+            session,
+            job=job,
+            source_file=source_file,
+            drawing_revision_id=drawing_revision_id,
+            apply_result=apply_result,
+            base_manifest=base_manifest,
+            base_layouts=base_layouts,
+            base_layers=base_layers,
+            base_blocks=base_blocks,
+        )
+
+        change_set.status = "applied"
+        job.status = "succeeded"
+        job.finished_at = finished_at
+        job.error_code = None
+        job.error_message = None
+        _clear_job_attempt_lease(job)
+        await emit_job_event(
+            job.id,
+            level="info",
+            message="Job succeeded",
+            data_json={
+                "status": "succeeded",
+                "attempts": job.attempts,
+                "drawing_revision_id": str(drawing_revision_id),
+                "validation_report_id": str(validation_report_id),
+                "change_set_id": str(apply_result.change_set_id),
+            },
+            session=session,
+        )
+        await session.commit()
+
+    return True
 
 
 async def process_ingest_job(job_id: UUID) -> None:
@@ -5323,6 +6314,11 @@ async def process_export_job(job_id: UUID) -> None:
     await _process_registered_job(job_id, spec=_EXPORT_PROCESS_SPEC)
 
 
+async def process_changeset_apply_job(job_id: UUID) -> None:
+    """Load a persisted changeset apply job through the shared worker shell."""
+    await _process_registered_job(job_id, spec=_CHANGESET_APPLY_PROCESS_SPEC)
+
+
 @celery_app.task(
     name="app.jobs.worker.run_export_job",
     ignore_result=True,
@@ -5338,3 +6334,19 @@ def enqueue_export_job(job_id: UUID) -> None:
     """Publish a persisted export job to Celery."""
 
     run_export_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)
+
+
+@celery_app.task(
+    name="app.jobs.worker.run_changeset_apply_job",
+    ignore_result=True,
+    acks_late=True,
+    reject_on_worker_lost=True,
+)
+def run_changeset_apply_job(job_id: str) -> None:
+    """Celery task wrapper for persisted changeset apply jobs."""
+    _run_worker_loop(lambda: process_changeset_apply_job(UUID(job_id)))
+
+
+def enqueue_changeset_apply_job(job_id: UUID) -> None:
+    """Publish a persisted changeset apply job to Celery."""
+    run_changeset_apply_job.apply_async(args=(str(job_id),), task_id=str(job_id), retry=False)

--- a/tests/test_changeset_api.py
+++ b/tests/test_changeset_api.py
@@ -565,6 +565,28 @@ async def test_apply_changeset_creates_pending_job_and_immutable_input(
         "_load_change_set_apply_input",
         fake_load_change_set_apply_input,
     )
+    published_job_ids: list[UUID] = []
+
+    async def fake_publish_job_enqueue_intent(
+        job_id: UUID,
+        *,
+        publisher: object | None = None,
+        suppress_exceptions: bool = False,
+    ) -> bool:
+        published_job_ids.append(job_id)
+        assert publisher is changeset_routes._enqueue_changeset_apply_job
+        assert suppress_exceptions is True
+        assert session_module.AsyncSessionLocal is not None
+        async with session_module.AsyncSessionLocal() as session:
+            persisted_job = await session.get(Job, job_id)
+            assert persisted_job is not None
+        return True
+
+    monkeypatch.setattr(
+        changeset_routes,
+        "_publish_job_enqueue_intent",
+        fake_publish_job_enqueue_intent,
+    )
 
     response = await async_client.post(_action_route_path(lineage, change_set_id, "apply"))
 
@@ -590,10 +612,11 @@ async def test_apply_changeset_creates_pending_job_and_immutable_input(
     assert session_module.AsyncSessionLocal is not None
     async with session_module.AsyncSessionLocal() as session:
         job = await session.get(Job, job_id)
-        assert job is not None
-        assert job.enqueue_status == "pending"
-        assert job.enqueue_attempts == 0
-        assert job.enqueue_published_at is None
+    assert job is not None
+    assert job.enqueue_status == "pending"
+    assert job.enqueue_attempts == 0
+    assert job.enqueue_published_at is None
+    assert published_job_ids == [job_id]
 
 
 async def test_apply_changeset_reuses_existing_pending_job_without_duplicate_input(

--- a/tests/test_changeset_apply.py
+++ b/tests/test_changeset_apply.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import hashlib
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import cast
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +29,8 @@ from app.cad.changeset import (
     load_and_apply_change_set,
     load_change_set_apply_input,
 )
+from app.core.errors import ErrorCode
+from app.jobs import worker as worker_module
 from app.models.adapter_run_output import AdapterRunOutput
 from app.models.cad_changeset import (
     CadChangeOperation,
@@ -40,9 +44,13 @@ from app.models.file import File
 from app.models.job import Job, JobType
 from app.models.project import Project
 from app.models.revision_materialization import (
+    RevisionBlock,
     RevisionEntity,
     RevisionEntityManifest,
+    RevisionLayer,
+    RevisionLayout,
 )
+from app.models.validation_report import ValidationReport
 from tests.conftest import requires_database
 
 _DEFAULT_CHANGESET_APPLY_JOB_ID = uuid.UUID("90000000-0000-0000-0000-000000000100")
@@ -721,6 +729,224 @@ def test_apply_change_set_returns_conflict_for_stale_current_revision() -> None:
     )
 
 
+def test_build_changeset_revision_materialization_rows_copies_base_rows_and_remaps_ids() -> None:
+    project_id = uuid.UUID("30000000-0000-0000-0000-000000000001")
+    file_id = uuid.UUID("30000000-0000-0000-0000-000000000002")
+    profile_id = uuid.UUID("30000000-0000-0000-0000-000000000003")
+    job_id = uuid.UUID("30000000-0000-0000-0000-000000000004")
+    revision_id = uuid.UUID("30000000-0000-0000-0000-000000000005")
+    adapter_id = uuid.UUID("30000000-0000-0000-0000-000000000006")
+    change_set_id = uuid.UUID("30000000-0000-0000-0000-000000000007")
+
+    base_manifest = RevisionEntityManifest(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000008"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        counts_json={"layouts": 99, "layers": 99, "blocks": 99, "entities": 2},
+    )
+    base_layout = RevisionLayout(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000009"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=0,
+        payload_json={"name": "Model"},
+        layout_ref="model",
+    )
+    wall_layer = RevisionLayer(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000010"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=0,
+        payload_json={"name": "A-WALL"},
+        layer_ref="A-WALL",
+    )
+    updated_wall_layer = RevisionLayer(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000011"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=1,
+        payload_json={"name": "A-WALL-UPDATED"},
+        layer_ref="A-WALL-UPDATED",
+    )
+    door_layer = RevisionLayer(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000012"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=2,
+        payload_json={"name": "A-DOOR"},
+        layer_ref="A-DOOR",
+    )
+    note_layer = RevisionLayer(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000013"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=3,
+        payload_json={"name": "A-NOTE"},
+        layer_ref="A-NOTE",
+    )
+    base_block = RevisionBlock(
+        id=uuid.UUID("30000000-0000-0000-0000-000000000014"),
+        project_id=project_id,
+        source_file_id=file_id,
+        extraction_profile_id=profile_id,
+        source_job_id=job_id,
+        drawing_revision_id=revision_id,
+        adapter_run_output_id=adapter_id,
+        canonical_entity_schema_version="1",
+        sequence_index=0,
+        payload_json={"name": "door-block"},
+        block_ref="door-block",
+    )
+
+    apply_result = ChangeSetApplySuccess(
+        change_set_id=change_set_id,
+        base_revision=RevisionRef(revision_id=revision_id, revision_sequence=1),
+        current_revision=RevisionRef(revision_id=revision_id, revision_sequence=1),
+        operations=(),
+        entities=(
+            _entity_snapshot(
+                revision_entity_id=uuid.UUID("30000000-0000-0000-0000-000000000015"),
+                sequence_index=0,
+                entity_id="wall-1",
+                layout_ref="model",
+                layer_ref="A-WALL-UPDATED",
+                properties_json={"description": "Wall"},
+                canonical_entity_json={"properties": {"description": "Wall"}},
+                source_identity="wall:1",
+                source_hash="a" * 64,
+            ),
+            _entity_snapshot(
+                revision_entity_id=uuid.UUID("30000000-0000-0000-0000-000000000016"),
+                sequence_index=1,
+                entity_id="door-1",
+                layout_ref="model",
+                layer_ref="A-DOOR",
+                block_ref="door-block",
+                parent_entity_ref="wall-1",
+                properties_json={"label": "Door"},
+                canonical_entity_json={"properties": {"label": "Door"}},
+                source_identity="door:1",
+                source_hash="b" * 64,
+            ),
+            _entity_snapshot(
+                revision_entity_id=uuid.UUID("30000000-0000-0000-0000-000000000017"),
+                sequence_index=2,
+                entity_id="note-1",
+                layout_ref="model",
+                layer_ref="A-NOTE",
+                properties_json={"label": "N-1"},
+                canonical_entity_json={"properties": {"label": "N-1"}},
+                source_identity="note:1",
+                source_hash="c" * 64,
+            ),
+        ),
+    )
+
+    rows = worker_module._build_changeset_revision_materialization_rows(
+        apply_result,
+        base_manifest=base_manifest,
+        base_layouts=(base_layout,),
+        base_layers=(wall_layer, updated_wall_layer, door_layer, note_layer),
+        base_blocks=(base_block,),
+    )
+
+    assert rows.counts_json == {"layouts": 1, "layers": 4, "blocks": 1, "entities": 3}
+    assert len(rows.layouts) == 1
+    assert len(rows.layers) == 4
+    assert len(rows.blocks) == 1
+    assert len(rows.entities) == 3
+
+    copied_layout = rows.layouts[0]
+    copied_block = rows.blocks[0]
+    layer_ids_by_ref = {row["layer_ref"]: row["id"] for row in rows.layers}
+    entity_rows_by_entity_id = {row["entity_id"]: row for row in rows.entities}
+
+    assert copied_layout["id"] != base_layout.id
+    assert copied_layout["sequence_index"] == base_layout.sequence_index
+    assert copied_layout["payload_json"] == base_layout.payload_json
+    assert copied_layout["layout_ref"] == base_layout.layout_ref
+
+    assert copied_block["id"] != base_block.id
+    assert copied_block["sequence_index"] == base_block.sequence_index
+    assert copied_block["payload_json"] == base_block.payload_json
+    assert copied_block["block_ref"] == base_block.block_ref
+
+    assert layer_ids_by_ref["A-WALL-UPDATED"] != updated_wall_layer.id
+    assert layer_ids_by_ref["A-DOOR"] != door_layer.id
+    assert layer_ids_by_ref["A-NOTE"] != note_layer.id
+
+    wall_row = entity_rows_by_entity_id["wall-1"]
+    door_row = entity_rows_by_entity_id["door-1"]
+    note_row = entity_rows_by_entity_id["note-1"]
+
+    assert wall_row["sequence_index"] == 0
+    assert wall_row["layout_ref"] == "model"
+    assert wall_row["layout_id"] == copied_layout["id"]
+    assert wall_row["layer_ref"] == "A-WALL-UPDATED"
+    assert wall_row["layer_id"] == layer_ids_by_ref["A-WALL-UPDATED"]
+    assert wall_row["block_id"] is None
+    assert wall_row["parent_entity_row_id"] is None
+    assert wall_row["canonical_entity_json"] == {"properties": {"description": "Wall"}}
+
+    assert door_row["sequence_index"] == 1
+    assert door_row["layout_id"] == copied_layout["id"]
+    assert door_row["layer_id"] == layer_ids_by_ref["A-DOOR"]
+    assert door_row["block_ref"] == "door-block"
+    assert door_row["block_id"] == copied_block["id"]
+    assert door_row["parent_entity_ref"] == "wall-1"
+    assert door_row["parent_entity_row_id"] == wall_row["id"]
+    assert door_row["canonical_entity_json"] == {"properties": {"label": "Door"}}
+
+    assert note_row["sequence_index"] == 2
+    assert note_row["layout_id"] == copied_layout["id"]
+    assert note_row["layer_id"] == layer_ids_by_ref["A-NOTE"]
+    assert note_row["block_id"] is None
+    assert note_row["parent_entity_row_id"] is None
+    assert note_row["canonical_entity_json"] == {"properties": {"label": "N-1"}}
+
+    leaked_origin_keys = {
+        "project_id",
+        "source_file_id",
+        "source_job_id",
+        "drawing_revision_id",
+        "extraction_profile_id",
+        "adapter_run_output_id",
+        "canonical_entity_schema_version",
+    }
+    for row in [*rows.layouts, *rows.layers, *rows.blocks, *rows.entities]:
+        assert leaked_origin_keys.isdisjoint(row)
+
+
 @requires_database
 @pytest.mark.usefixtures("cleanup_projects")
 @pytest.mark.asyncio
@@ -1089,12 +1315,705 @@ async def test_load_and_apply_change_set_short_circuits_stale_current_before_ent
     )
 
 
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_execute_changeset_apply_job_attempt_returns_success_for_finalization() -> None:
+    session, seeded = await _seed_loader_case()
+    attempt_token = uuid.UUID("90000000-0000-0000-0000-000000000120")
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000121"),
+    )
+    job.status = "running"
+    job.attempts = 1
+    job.attempt_token = attempt_token
+    job.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+
+        result = await worker_module._execute_changeset_apply_job_attempt(
+            job.id,
+            attempt_token=attempt_token,
+        )
+    finally:
+        await session.close()
+
+    assert isinstance(result, worker_module._RegisteredJobAttemptResult)
+    apply_result = result.finalize_kwargs["apply_result"]
+    assert isinstance(apply_result, ChangeSetApplySuccess)
+    assert apply_result.change_set_id == seeded.change_set.id
+    assert apply_result.base_revision == RevisionRef(
+        revision_id=seeded.base_revision.id,
+        revision_sequence=seeded.base_revision.revision_sequence,
+    )
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_missing_input_fails_deterministically() -> None:
+    session, seeded = await _seed_loader_case()
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000122"),
+    )
+    try:
+        session.add(job)
+        await session.commit()
+    finally:
+        await session.close()
+
+    await worker_module.process_changeset_apply_job(job.id)
+
+    persisted = await _get_job(job.id)
+    assert persisted is not None
+    assert persisted.status == "failed"
+    assert persisted.error_code == ErrorCode.NOT_FOUND.value
+    assert persisted.error_message == "Changeset apply job input is missing."
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_multiple_inputs_fail_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session, seeded = await _seed_loader_case()
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000123"),
+    )
+    apply_input = _build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id)
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(apply_input)
+        await session.commit()
+    finally:
+        await session.close()
+
+    async def _duplicate_inputs(*args: object, **kwargs: object) -> list[ChangeSetApplyJobInput]:
+        _ = (args, kwargs)
+        return [apply_input, apply_input]
+
+    monkeypatch.setattr(worker_module, "_query_changeset_apply_job_inputs", _duplicate_inputs)
+
+    await worker_module.process_changeset_apply_job(job.id)
+
+    persisted = await _get_job(job.id)
+    assert persisted is not None
+    assert persisted.status == "failed"
+    assert persisted.error_code == ErrorCode.INPUT_INVALID.value
+    assert persisted.error_message == "Changeset apply job has multiple immutable inputs."
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_input_mismatch_fails_deterministically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session, seeded = await _seed_loader_case()
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000124"),
+    )
+    apply_input = _build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id)
+    mismatched_input = _build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id)
+    mismatched_input.drawing_revision_id = uuid.UUID("90000000-0000-0000-0000-000000000199")
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(apply_input)
+        await session.commit()
+    finally:
+        await session.close()
+
+    async def _mismatched_inputs(*args: object, **kwargs: object) -> list[ChangeSetApplyJobInput]:
+        _ = (args, kwargs)
+        return [mismatched_input]
+
+    monkeypatch.setattr(worker_module, "_query_changeset_apply_job_inputs", _mismatched_inputs)
+
+    await worker_module.process_changeset_apply_job(job.id)
+
+    persisted = await _get_job(job.id)
+    assert persisted is not None
+    assert persisted.status == "failed"
+    assert persisted.error_code == ErrorCode.INPUT_INVALID.value
+    assert (
+        persisted.error_message
+        == "Changeset apply job input lineage does not match the persisted job."
+    )
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_stale_base_maps_to_revision_conflict() -> None:
+    session, seeded = await _seed_loader_case(include_current_revision=True)
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000125"),
+    )
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+    finally:
+        await session.close()
+
+    await worker_module.process_changeset_apply_job(job.id)
+
+    persisted = await _get_job(job.id)
+    assert persisted is not None
+    assert persisted.status == "failed"
+    assert persisted.error_code == ErrorCode.REVISION_CONFLICT.value
+    assert (
+        persisted.error_message
+        == "Changeset apply base revision is stale relative to the current revision."
+    )
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "revision_conflict"
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_apply_error_fails_deterministically() -> None:
+    session, seeded = await _seed_loader_case()
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000126"),
+    )
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+    finally:
+        await session.close()
+
+    async def _return_apply_error(*args: object, **kwargs: object) -> ChangeSetApplyError:
+        _ = (args, kwargs)
+        return ChangeSetApplyError(
+            change_set_id=seeded.change_set.id,
+            error_code="UNSUPPORTED_OPERATION",
+            message="Unsupported changeset operation 'explode_block'.",
+        )
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(worker_module, "load_and_apply_change_set", _return_apply_error)
+    try:
+        await worker_module.process_changeset_apply_job(job.id)
+    finally:
+        monkeypatch.undo()
+
+    persisted = await _get_job(job.id)
+    assert persisted is not None
+    assert persisted.status == "failed"
+    assert persisted.error_code == ErrorCode.INPUT_INVALID.value
+    assert persisted.error_message == "Unsupported changeset operation 'explode_block'."
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "apply_failed"
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_persists_changeset_revision_and_validation_report() -> (
+    None
+):
+    session, seeded = await _seed_loader_case()
+    attempt_token = uuid.UUID("90000000-0000-0000-0000-000000000127")
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000128"),
+    )
+    job.status = "running"
+    job.attempts = 1
+    job.attempt_token = attempt_token
+    job.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+    finally:
+        await session.close()
+
+    await worker_module.process_changeset_apply_job(job.id)
+
+    persisted_job = await _get_job(job.id)
+    assert persisted_job is not None
+    assert persisted_job.status == "succeeded"
+    assert persisted_job.error_code is None
+    assert persisted_job.error_message is None
+
+    persisted_revision = await _get_drawing_revision_by_source_job(job.id)
+    assert persisted_revision is not None
+    assert persisted_revision.project_id == seeded.project.id
+    assert persisted_revision.source_file_id == seeded.base_revision.source_file_id
+    assert persisted_revision.source_job_id == job.id
+    assert persisted_revision.revision_kind == "changeset"
+    assert persisted_revision.predecessor_revision_id == seeded.base_revision.id
+    assert persisted_revision.changeset_id == seeded.change_set.id
+    assert persisted_revision.revision_sequence == seeded.base_revision.revision_sequence + 1
+    assert persisted_revision.extraction_profile_id is None
+    assert persisted_revision.adapter_run_output_id is None
+
+    persisted_report = await _get_validation_report_by_source_job(job.id)
+    assert persisted_report is not None
+    assert persisted_report.drawing_revision_id == persisted_revision.id
+    assert persisted_report.project_id == seeded.project.id
+    assert persisted_report.validation_status == "valid"
+    assert persisted_report.review_state == "approved"
+    assert persisted_report.quantity_gate == "allowed"
+    assert persisted_report.report_json["change_set_id"] == str(seeded.change_set.id)
+    assert persisted_report.report_json["predecessor_revision_id"] == str(seeded.base_revision.id)
+    assert persisted_report.report_json["provenance"]["pinned_validation_result_id"] == str(
+        seeded.latest_validation.id
+    )
+    assert (
+        persisted_report.report_json["provenance"]["pinned_validation_status"]
+        == seeded.latest_validation.validation_status
+    )
+
+    persisted_entities = await _get_revision_entities_for_revision(persisted_revision.id)
+    assert [entity.entity_id for entity in persisted_entities] == ["wall-1", "door-1"]
+    assert persisted_entities[0].layer_ref == "A-WALL-UPDATED"
+    assert persisted_entities[0].source_job_id == job.id
+    assert persisted_entities[0].extraction_profile_id is None
+    assert persisted_entities[0].adapter_run_output_id is None
+    assert persisted_entities[1].properties_json == {"label": "Door", "notes": "review"}
+
+    persisted_manifest = await _get_revision_entity_manifest_for_revision(persisted_revision.id)
+    assert persisted_manifest is not None
+    assert persisted_manifest.source_job_id == job.id
+    assert persisted_manifest.extraction_profile_id is None
+    assert persisted_manifest.adapter_run_output_id is None
+    assert persisted_manifest.counts_json["entities"] == 2
+
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "applied"
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_finalize_changeset_apply_job_revision_conflict() -> None:
+    session, seeded = await _seed_loader_case()
+    attempt_token = uuid.UUID("90000000-0000-0000-0000-000000000129")
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000130"),
+    )
+    job.status = "running"
+    job.attempts = 1
+    job.attempt_token = attempt_token
+    job.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+
+        result = await worker_module._execute_changeset_apply_job_attempt(
+            job.id,
+            attempt_token=attempt_token,
+        )
+    finally:
+        await session.close()
+
+    assert result is not None
+    apply_result = result.finalize_kwargs["apply_result"]
+    assert isinstance(apply_result, ChangeSetApplySuccess)
+
+    await _append_competing_revision(seeded=seeded)
+
+    with pytest.raises(
+        worker_module._RevisionConflictError,
+        match=r"Changeset apply base revision became stale before finalization\.",
+    ):
+        await worker_module._finalize_changeset_apply_job(
+            job.id,
+            attempt_token=attempt_token,
+            apply_result=apply_result,
+        )
+
+    persisted_revision = await _get_drawing_revision_by_source_job(job.id)
+    assert persisted_revision is None
+    persisted_report = await _get_validation_report_by_source_job(job.id)
+    assert persisted_report is None
+
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "approved"
+    persisted_job = await _get_job(job.id)
+    assert persisted_job is not None
+    assert persisted_job.status == "running"
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_finalization_conflict() -> None:
+    session, seeded = await _seed_loader_case()
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000136"),
+    )
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+    finally:
+        await session.close()
+
+    real_execute = worker_module._execute_changeset_apply_job_attempt
+
+    async def _execute_with_competing_revision(
+        job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> worker_module._RegisteredJobAttemptResult | None:
+        result = await real_execute(job_id, attempt_token=attempt_token)
+        assert result is not None
+        await _append_competing_revision(seeded=seeded)
+        return result
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        worker_module,
+        "_execute_changeset_apply_job_attempt",
+        _execute_with_competing_revision,
+    )
+    try:
+        await worker_module.process_changeset_apply_job(job.id)
+    finally:
+        monkeypatch.undo()
+
+    persisted_job = await _get_job(job.id)
+    assert persisted_job is not None
+    assert persisted_job.status == "failed"
+    assert persisted_job.error_code == ErrorCode.REVISION_CONFLICT.value
+    assert (
+        persisted_job.error_message
+        == "Changeset apply base revision became stale before finalization."
+    )
+
+    persisted_revision = await _get_drawing_revision_by_source_job(job.id)
+    assert persisted_revision is None
+    persisted_report = await _get_validation_report_by_source_job(job.id)
+    assert persisted_report is None
+
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "revision_conflict"
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_finalize_changeset_apply_job_cancellation_before_output_creates_no_revision() -> (
+    None
+):
+    session, seeded = await _seed_loader_case()
+    attempt_token = uuid.UUID("90000000-0000-0000-0000-000000000134")
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000135"),
+    )
+    job.status = "running"
+    job.attempts = 1
+    job.attempt_token = attempt_token
+    job.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+
+        result = await worker_module._execute_changeset_apply_job_attempt(
+            job.id,
+            attempt_token=attempt_token,
+        )
+    finally:
+        await session.close()
+
+    assert result is not None
+    apply_result = result.finalize_kwargs["apply_result"]
+    assert isinstance(apply_result, ChangeSetApplySuccess)
+
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+    async with session_maker() as update_session:
+        persisted_job = await update_session.get(Job, job.id)
+        assert persisted_job is not None
+        persisted_job.cancel_requested = True
+        await update_session.commit()
+
+    finalized = await worker_module._finalize_changeset_apply_job(
+        job.id,
+        attempt_token=attempt_token,
+        apply_result=apply_result,
+    )
+
+    assert finalized is False
+    persisted_job = await _get_job(job.id)
+    assert persisted_job is not None
+    assert persisted_job.status == "cancelled"
+    assert persisted_job.finished_at is not None
+    assert await _get_drawing_revision_by_source_job(job.id) is None
+    assert await _get_validation_report_by_source_job(job.id) is None
+
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "approved"
+
+
+@requires_database
+@pytest.mark.usefixtures("cleanup_projects")
+@pytest.mark.asyncio
+async def test_finalize_changeset_apply_job_stale_attempt_creates_no_revision() -> None:
+    session, seeded = await _seed_loader_case()
+    stale_attempt_token = uuid.UUID("90000000-0000-0000-0000-000000000136")
+    current_attempt_token = uuid.UUID("90000000-0000-0000-0000-000000000137")
+    job = _build_changeset_apply_job(
+        seeded=seeded,
+        job_id=uuid.UUID("90000000-0000-0000-0000-000000000138"),
+    )
+    job.status = "running"
+    job.attempts = 1
+    job.attempt_token = stale_attempt_token
+    job.started_at = datetime(2026, 1, 1, tzinfo=UTC)
+    try:
+        session.add(job)
+        await session.flush()
+        session.add(_build_changeset_apply_job_input(seeded=seeded, source_job_id=job.id))
+        await session.commit()
+
+        result = await worker_module._execute_changeset_apply_job_attempt(
+            job.id,
+            attempt_token=stale_attempt_token,
+        )
+    finally:
+        await session.close()
+
+    assert result is not None
+    apply_result = result.finalize_kwargs["apply_result"]
+    assert isinstance(apply_result, ChangeSetApplySuccess)
+
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+    async with session_maker() as update_session:
+        persisted_job = await update_session.get(Job, job.id)
+        assert persisted_job is not None
+        persisted_job.attempt_token = current_attempt_token
+        persisted_job.attempts = 2
+        await update_session.commit()
+
+    finalized = await worker_module._finalize_changeset_apply_job(
+        job.id,
+        attempt_token=stale_attempt_token,
+        apply_result=apply_result,
+    )
+
+    assert finalized is False
+    persisted_job = await _get_job(job.id)
+    assert persisted_job is not None
+    assert persisted_job.status == "running"
+    assert persisted_job.attempt_token == current_attempt_token
+    assert persisted_job.finished_at is None
+    assert await _get_drawing_revision_by_source_job(job.id) is None
+    assert await _get_validation_report_by_source_job(job.id) is None
+
+    persisted_change_set = await _get_change_set(seeded.change_set.id)
+    assert persisted_change_set is not None
+    assert persisted_change_set.status == "approved"
+
+
+async def _get_job(job_id: uuid.UUID) -> Job | None:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        return await session.get(Job, job_id)
+
+
+async def _get_change_set(change_set_id: uuid.UUID) -> CadChangeSet | None:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        return await session.get(CadChangeSet, change_set_id)
+
+
+async def _get_drawing_revision_by_source_job(source_job_id: uuid.UUID) -> DrawingRevision | None:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        return cast(
+            DrawingRevision | None,
+            await session.scalar(
+                select(DrawingRevision).where(DrawingRevision.source_job_id == source_job_id)
+            ),
+        )
+
+
+async def _get_validation_report_by_source_job(source_job_id: uuid.UUID) -> ValidationReport | None:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        return cast(
+            ValidationReport | None,
+            await session.scalar(
+                select(ValidationReport).where(ValidationReport.source_job_id == source_job_id)
+            ),
+        )
+
+
+async def _get_revision_entities_for_revision(
+    drawing_revision_id: uuid.UUID,
+) -> list[RevisionEntity]:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        result = await session.execute(
+            select(RevisionEntity)
+            .where(RevisionEntity.drawing_revision_id == drawing_revision_id)
+            .order_by(RevisionEntity.sequence_index.asc(), RevisionEntity.id.asc())
+        )
+        return list(result.scalars().all())
+
+
+async def _get_revision_entity_manifest_for_revision(
+    drawing_revision_id: uuid.UUID,
+) -> RevisionEntityManifest | None:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        return cast(
+            RevisionEntityManifest | None,
+            await session.scalar(
+                select(RevisionEntityManifest).where(
+                    RevisionEntityManifest.drawing_revision_id == drawing_revision_id
+                )
+            ),
+        )
+
+
+async def _append_competing_revision(*, seeded: _SeededLoaderCase) -> None:
+    import app.db.session as session_module
+
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        conflict_job_id = uuid.UUID("90000000-0000-0000-0000-000000000131")
+        conflict_adapter_id = uuid.UUID("90000000-0000-0000-0000-000000000132")
+        conflict_revision_id = uuid.UUID("90000000-0000-0000-0000-000000000133")
+        session.add(
+            Job(
+                id=conflict_job_id,
+                project_id=seeded.project.id,
+                file_id=seeded.base_revision.source_file_id,
+                extraction_profile_id=uuid.UUID("90000000-0000-0000-0000-000000000003"),
+                base_revision_id=seeded.base_revision.id,
+                job_type=JobType.REPROCESS.value,
+                status="succeeded",
+            )
+        )
+        await session.flush()
+        session.add(
+            AdapterRunOutput(
+                id=conflict_adapter_id,
+                project_id=seeded.project.id,
+                source_file_id=seeded.base_revision.source_file_id,
+                extraction_profile_id=uuid.UUID("90000000-0000-0000-0000-000000000003"),
+                source_job_id=conflict_job_id,
+                adapter_key="test_adapter",
+                adapter_version="1",
+                input_family="dxf",
+                canonical_entity_schema_version="1",
+                canonical_json={"entities": []},
+                provenance_json={"adapter": "test_adapter"},
+                confidence_json={},
+                confidence_score=1.0,
+                warnings_json=[],
+                diagnostics_json=[],
+                result_checksum_sha256="8" * 64,
+            )
+        )
+        await session.flush()
+        session.add(
+            DrawingRevision(
+                id=conflict_revision_id,
+                project_id=seeded.project.id,
+                source_file_id=seeded.base_revision.source_file_id,
+                extraction_profile_id=uuid.UUID("90000000-0000-0000-0000-000000000003"),
+                source_job_id=conflict_job_id,
+                adapter_run_output_id=conflict_adapter_id,
+                predecessor_revision_id=seeded.base_revision.id,
+                revision_sequence=seeded.base_revision.revision_sequence + 1,
+                revision_kind="reprocess",
+                review_state="approved",
+                canonical_entity_schema_version="1",
+                confidence_score=1.0,
+            )
+        )
+        await session.commit()
+
+
 def _entity_snapshot(
     *,
     revision_entity_id: uuid.UUID,
     sequence_index: int,
     entity_id: str,
+    entity_type: str = "polyline",
+    parent_entity_ref: str | None = None,
+    layout_ref: str | None = None,
     layer_ref: str | None = None,
+    block_ref: str | None = None,
+    geometry_json: dict[str, object] | None = None,
     properties_json: dict[str, object] | None = None,
     canonical_entity_json: dict[str, object] | None = None,
     source_identity: str | None = None,
@@ -1104,15 +2023,18 @@ def _entity_snapshot(
         id=revision_entity_id,
         sequence_index=sequence_index,
         entity_id=entity_id,
-        entity_type="polyline",
+        entity_type=entity_type,
         entity_schema_version="1",
         confidence_score=1.0,
         confidence_json={},
-        geometry_json={"kind": "polyline", "vertices": [{"x": 0.0, "y": 0.0}]},
+        geometry_json=geometry_json or {"kind": "polyline", "vertices": [{"x": 0.0, "y": 0.0}]},
         properties_json=properties_json or {},
         provenance_json={"origin": "source_direct"},
+        parent_entity_ref=parent_entity_ref,
         canonical_entity_json=canonical_entity_json,
+        layout_ref=layout_ref,
         layer_ref=layer_ref,
+        block_ref=block_ref,
         source_identity=source_identity,
         source_hash=source_hash,
     )
@@ -1471,6 +2393,35 @@ async def _seed_loader_case(
         canonical_entity_schema_version="1",
         counts_json={"entities": 2},
     )
+    base_validation_report = ValidationReport(
+        id=uuid.UUID("90000000-0000-0000-0000-000000000019"),
+        project_id=project_id,
+        drawing_revision_id=base_revision_id,
+        source_job_id=ingest_job_id,
+        validation_report_schema_version="0.1",
+        canonical_entity_schema_version="1",
+        validation_status="valid",
+        review_state="approved",
+        quantity_gate="allowed",
+        effective_confidence=1.0,
+        validator_name="test_validation_service",
+        validator_version="1",
+        report_json={
+            "summary": {
+                "validation_status": "valid",
+                "review_state": "approved",
+                "quantity_gate": "allowed",
+            },
+            "checks": [
+                {
+                    "code": "seeded_validation",
+                    "status": "passed",
+                    "message": "Seeded base validation report.",
+                }
+            ],
+        },
+        generated_at=first_validation_at,
+    )
 
     try:
         session.add(project)
@@ -1485,7 +2436,7 @@ async def _seed_loader_case(
         session.add(base_adapter)
         await session.flush()
 
-        session.add_all([base_revision, base_manifest])
+        session.add_all([base_revision, base_manifest, base_validation_report])
         await session.flush()
 
         session.add_all([first_entity, second_entity])

--- a/tests/test_jobs_worker_lifecycle.py
+++ b/tests/test_jobs_worker_lifecycle.py
@@ -45,6 +45,7 @@ def test_job_handler_registry_explicitly_covers_worker_job_types() -> None:
         JobType.QUANTITY_TAKEOFF.value,
         JobType.ESTIMATE.value,
         JobType.EXPORT.value,
+        JobType.CHANGESET_APPLY.value,
     )
     expected_ingest_worker_job_types = (
         JobType.INGEST.value,
@@ -58,6 +59,7 @@ def test_job_handler_registry_explicitly_covers_worker_job_types() -> None:
         "process_quantity_takeoff_job": (JobType.QUANTITY_TAKEOFF.value,),
         "process_estimate_job": (JobType.ESTIMATE.value,),
         "process_export_job": (JobType.EXPORT.value,),
+        "process_changeset_apply_job": (JobType.CHANGESET_APPLY.value,),
     }
 
     assert [handler.job_type_name for handler in runner_module.JOB_HANDLERS] == [
@@ -66,6 +68,7 @@ def test_job_handler_registry_explicitly_covers_worker_job_types() -> None:
         JobType.QUANTITY_TAKEOFF.value,
         JobType.ESTIMATE.value,
         JobType.EXPORT.value,
+        JobType.CHANGESET_APPLY.value,
     ]
     assert expected_recoverable_job_types == runner_module.RECOVERABLE_ENQUEUE_JOB_TYPES
     assert expected_ingest_worker_job_types == runner_module.INGEST_WORKER_JOB_TYPES
@@ -77,14 +80,18 @@ def test_job_handler_registry_explicitly_covers_worker_job_types() -> None:
     ingest_handler = runner_module.get_job_handler(JobType.INGEST.value)
     reprocess_handler = runner_module.get_job_handler(JobType.REPROCESS.value)
     export_handler = runner_module.get_job_handler(JobType.EXPORT.value)
+    changeset_apply_handler = runner_module.get_job_handler(JobType.CHANGESET_APPLY.value)
     ingest_route = runner_module.get_begin_or_resume_route("process_ingest_job")
     export_route = runner_module.get_begin_or_resume_route("process_export_job")
+    changeset_apply_route = runner_module.get_begin_or_resume_route("process_changeset_apply_job")
 
     assert ingest_handler is not None
     assert reprocess_handler is not None
     assert export_handler is not None
+    assert changeset_apply_handler is not None
     assert ingest_route is not None
     assert export_route is not None
+    assert changeset_apply_route is not None
     assert reprocess_handler.execute_name == ingest_handler.execute_name
     assert ingest_handler.execute_name == "_execute_ingest_job_attempt"
     assert reprocess_handler.finalize_name == ingest_handler.finalize_name == "_finalize_ingest_job"
@@ -108,6 +115,17 @@ def test_job_handler_registry_explicitly_covers_worker_job_types() -> None:
     assert (
         export_route.log_keys.reclaimed_stale_running == "export_job_reclaimed_stale_running_status"
     )
+    assert changeset_apply_handler.execute_name == "_execute_changeset_apply_job_attempt"
+    assert changeset_apply_handler.finalize_name == "_finalize_changeset_apply_job"
+    assert changeset_apply_handler.process_name == "process_changeset_apply_job"
+    assert changeset_apply_handler.run_task_name == "run_changeset_apply_job"
+    assert changeset_apply_handler.enqueue_publisher_name == "enqueue_changeset_apply_job"
+    assert changeset_apply_handler.enqueue_error_message == "Failed to enqueue changeset apply job"
+    assert changeset_apply_route.supported_job_types == (JobType.CHANGESET_APPLY.value,)
+    assert (
+        changeset_apply_route.log_keys.reclaimed_stale_running
+        == "changeset_apply_job_reclaimed_stale_running_status"
+    )
 
 
 def test_worker_registry_derived_helpers_preserve_public_compatibility(
@@ -116,6 +134,7 @@ def test_worker_registry_derived_helpers_preserve_public_compatibility(
     """Worker metadata helpers should remain registry-derived and monkeypatch-friendly."""
     published_ingest_job_ids: list[uuid.UUID] = []
     published_export_job_ids: list[uuid.UUID] = []
+    published_changeset_apply_job_ids: list[uuid.UUID] = []
 
     def _fake_recovery_enqueue(job_id: uuid.UUID) -> None:
         published_ingest_job_ids.append(job_id)
@@ -123,8 +142,16 @@ def test_worker_registry_derived_helpers_preserve_public_compatibility(
     def _fake_export_enqueue(job_id: uuid.UUID) -> None:
         published_export_job_ids.append(job_id)
 
+    def _fake_changeset_apply_enqueue(job_id: uuid.UUID) -> None:
+        published_changeset_apply_job_ids.append(job_id)
+
     monkeypatch.setattr(worker_module, "enqueue_ingest_job", _fake_recovery_enqueue)
     monkeypatch.setattr(worker_module, "enqueue_export_job", _fake_export_enqueue)
+    monkeypatch.setattr(
+        worker_module,
+        "enqueue_changeset_apply_job",
+        _fake_changeset_apply_enqueue,
+    )
 
     assert worker_module.is_ingest_worker_job_type(JobType.INGEST) is True
     assert worker_module.is_ingest_worker_job_type(JobType.REPROCESS.value) is True
@@ -136,6 +163,7 @@ def test_worker_registry_derived_helpers_preserve_public_compatibility(
         JobType.QUANTITY_TAKEOFF,
         JobType.ESTIMATE,
         JobType.EXPORT,
+        JobType.CHANGESET_APPLY,
     ):
         assert worker_module.is_recoverable_enqueue_job_type(job_type) is True
 
@@ -143,6 +171,8 @@ def test_worker_registry_derived_helpers_preserve_public_compatibility(
     assert publisher is _fake_recovery_enqueue
     export_publisher = worker_module.get_job_enqueue_publisher(JobType.EXPORT)
     assert export_publisher is _fake_export_enqueue
+    changeset_apply_publisher = worker_module.get_job_enqueue_publisher(JobType.CHANGESET_APPLY)
+    assert changeset_apply_publisher is _fake_changeset_apply_enqueue
 
     sample_job_id = uuid.uuid4()
     assert publisher is not None
@@ -154,11 +184,19 @@ def test_worker_registry_derived_helpers_preserve_public_compatibility(
     export_publisher(sample_export_job_id)
     assert published_export_job_ids == [sample_export_job_id]
 
+    sample_changeset_apply_job_id = uuid.uuid4()
+    assert changeset_apply_publisher is not None
+    changeset_apply_publisher(sample_changeset_apply_job_id)
+    assert published_changeset_apply_job_ids == [sample_changeset_apply_job_id]
+
     assert worker_module._get_enqueue_job_error_message(JobType.REPROCESS.value) == (
         "Failed to enqueue reprocess job"
     )
     assert worker_module._get_enqueue_job_error_message(JobType.EXPORT.value) == (
         "Failed to enqueue export job"
+    )
+    assert worker_module._get_enqueue_job_error_message(JobType.CHANGESET_APPLY.value) == (
+        "Failed to enqueue changeset apply job"
     )
     assert worker_module._get_enqueue_job_error_message("unknown") == "Failed to enqueue job"
 
@@ -286,18 +324,84 @@ async def test_process_export_job_wrapper_late_binds_registered_callables(
     ]
 
 
+@pytest.mark.asyncio
+async def test_process_changeset_apply_job_wrapper_late_binds_registered_callables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changeset apply wrapper should late-bind registered execution/finalization callables."""
+    job_id = uuid.uuid4()
+    attempt_token = uuid.uuid4()
+    observed_calls: list[tuple[Any, ...]] = []
+
+    async def _fake_begin_or_resume_registered_job(
+        received_job_id: uuid.UUID,
+        *,
+        process_name: str,
+    ) -> types.SimpleNamespace:
+        observed_calls.append(("begin", received_job_id, process_name))
+        return types.SimpleNamespace(token=attempt_token)
+
+    async def _fake_execute_changeset_apply_job_attempt(
+        received_job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+    ) -> worker_module._RegisteredJobAttemptResult:
+        observed_calls.append(("execute", received_job_id, attempt_token))
+        return worker_module._RegisteredJobAttemptResult(
+            finalize_kwargs={"apply_result": "apply_result"}
+        )
+
+    async def _fake_finalize_changeset_apply_job(
+        received_job_id: uuid.UUID,
+        *,
+        attempt_token: uuid.UUID,
+        apply_result: str,
+    ) -> bool:
+        observed_calls.append(("finalize", received_job_id, attempt_token, apply_result))
+        return True
+
+    monkeypatch.setattr(worker_module, "_ensure_worker_database_configured", lambda: None)
+    monkeypatch.setattr(
+        worker_module,
+        "_begin_or_resume_registered_job",
+        _fake_begin_or_resume_registered_job,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "_execute_changeset_apply_job_attempt",
+        _fake_execute_changeset_apply_job_attempt,
+    )
+    monkeypatch.setattr(
+        worker_module,
+        "_finalize_changeset_apply_job",
+        _fake_finalize_changeset_apply_job,
+    )
+
+    await worker_module.process_changeset_apply_job(job_id)
+
+    assert observed_calls == [
+        ("begin", job_id, "process_changeset_apply_job"),
+        ("execute", job_id, attempt_token),
+        ("finalize", job_id, attempt_token, "apply_result"),
+    ]
+
+
 def test_worker_task_names_preserve_public_compatibility() -> None:
     """Celery task names should stay aligned with the registered public wrappers."""
     assert worker_module.run_ingest_job.name == "app.jobs.worker.run_ingest_job"
     assert worker_module.run_export_job.name == "app.jobs.worker.run_export_job"
+    assert worker_module.run_changeset_apply_job.name == "app.jobs.worker.run_changeset_apply_job"
 
     ingest_handler = runner_module.get_job_handler(JobType.INGEST.value)
     export_handler = runner_module.get_job_handler(JobType.EXPORT.value)
+    changeset_apply_handler = runner_module.get_job_handler(JobType.CHANGESET_APPLY.value)
 
     assert ingest_handler is not None
     assert export_handler is not None
+    assert changeset_apply_handler is not None
     assert ingest_handler.run_task_name == worker_module.run_ingest_job.__name__
     assert export_handler.run_task_name == worker_module.run_export_job.__name__
+    assert changeset_apply_handler.run_task_name == worker_module.run_changeset_apply_job.__name__
 
 
 @pytest.mark.usefixtures(fake_ingestion_runner.__name__)


### PR DESCRIPTION
Closes #291

## Summary
- Register and enqueue the changeset-apply worker job type.
- Execute immutable changeset apply inputs and finalize changeset-origin revisions atomically.
- Add worker/API regression coverage for enqueue, conflict, cancellation, and retry semantics.

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_phase2_test uv run pytest -q tests/test_changeset_api.py tests/test_changeset_apply.py tests/test_jobs_worker_lifecycle.py tests/test_jobs_worker_quantity.py tests/test_append_only_lineage_tables.py
- [x] pre-push hook pytest suite (576 passed, 593 skipped)