### PR TITLE
feat(exports): generate revised DXF artifacts #258

### DIFF
--- a/alembic/versions/2026_06_04_0029_add_revised_dxf_export_kind.py
+++ b/alembic/versions/2026_06_04_0029_add_revised_dxf_export_kind.py
@@ -1,0 +1,176 @@
+"""Add revised DXF export kind contract.
+
+Revision ID: 2026_06_04_0029
+Revises: 2026_06_03_0028
+Create Date: 2026-06-04 00:29:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2026_06_04_0029"
+down_revision: str | None = "2026_06_03_0028"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def _drop_export_contract_constraints() -> None:
+    op.drop_constraint(
+        "ck_export_job_inputs_export_kind_valid",
+        "export_job_inputs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_export_job_inputs_export_format_valid",
+        "export_job_inputs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_export_job_inputs_media_type_valid",
+        "export_job_inputs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_export_job_inputs_kind_format_media_type_matrix",
+        "export_job_inputs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_export_job_inputs_quantity_lineage",
+        "export_job_inputs",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_export_job_inputs_estimate_lineage",
+        "export_job_inputs",
+        type_="check",
+    )
+
+
+def _create_export_contract_constraints(*, include_revised_dxf: bool) -> None:
+    export_kind_values = "'revision_json', 'quantity_csv', 'estimate_csv', 'estimate_pdf'"
+    export_format_values = "'json', 'csv', 'pdf'"
+    media_type_values = "'application/json', 'text/csv', 'application/pdf'"
+    kind_format_media_type_matrix = (
+        "(export_kind = 'revision_json' AND export_format = 'json' "
+        "AND media_type = 'application/json') OR "
+        "(export_kind = 'quantity_csv' AND export_format = 'csv' "
+        "AND media_type = 'text/csv') OR "
+        "(export_kind = 'estimate_csv' AND export_format = 'csv' "
+        "AND media_type = 'text/csv') OR "
+        "(export_kind = 'estimate_pdf' AND export_format = 'pdf' "
+        "AND media_type = 'application/pdf')"
+    )
+    quantity_lineage = (
+        "(export_kind = 'quantity_csv' AND quantity_takeoff_id IS NOT NULL "
+        "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+        "(export_kind IN ('estimate_csv', 'estimate_pdf') AND quantity_takeoff_id IS NOT NULL "
+        "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+        "(export_kind = 'revision_json' AND quantity_takeoff_id IS NULL "
+        "AND quantity_gate IS NULL AND trusted_totals IS NULL)"
+    )
+    estimate_lineage = (
+        "(export_kind IN ('estimate_csv', 'estimate_pdf') "
+        "AND quantity_takeoff_id IS NOT NULL AND estimate_version_id IS NOT NULL) OR "
+        "(export_kind IN ('quantity_csv', 'revision_json') "
+        "AND estimate_version_id IS NULL)"
+    )
+
+    if include_revised_dxf:
+        export_kind_values = (
+            "'revision_json', 'revised_dxf', 'quantity_csv', 'estimate_csv', 'estimate_pdf'"
+        )
+        export_format_values = "'json', 'dxf', 'csv', 'pdf'"
+        media_type_values = "'application/json', 'application/dxf', 'text/csv', 'application/pdf'"
+        kind_format_media_type_matrix = (
+            "(export_kind = 'revision_json' AND export_format = 'json' "
+            "AND media_type = 'application/json') OR "
+            "(export_kind = 'revised_dxf' AND export_format = 'dxf' "
+            "AND media_type = 'application/dxf') OR "
+            "(export_kind = 'quantity_csv' AND export_format = 'csv' "
+            "AND media_type = 'text/csv') OR "
+            "(export_kind = 'estimate_csv' AND export_format = 'csv' "
+            "AND media_type = 'text/csv') OR "
+            "(export_kind = 'estimate_pdf' AND export_format = 'pdf' "
+            "AND media_type = 'application/pdf')"
+        )
+        quantity_lineage = (
+            "(export_kind = 'quantity_csv' AND quantity_takeoff_id IS NOT NULL "
+            "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+            "(export_kind IN ('estimate_csv', 'estimate_pdf') AND quantity_takeoff_id IS NOT NULL "
+            "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
+            "(export_kind IN ('revision_json', 'revised_dxf') AND quantity_takeoff_id IS NULL "
+            "AND quantity_gate IS NULL AND trusted_totals IS NULL)"
+        )
+        estimate_lineage = (
+            "(export_kind IN ('estimate_csv', 'estimate_pdf') "
+            "AND quantity_takeoff_id IS NOT NULL AND estimate_version_id IS NOT NULL) OR "
+            "(export_kind IN ('quantity_csv', 'revision_json', 'revised_dxf') "
+            "AND estimate_version_id IS NULL)"
+        )
+
+    op.create_check_constraint(
+        "ck_export_job_inputs_export_kind_valid",
+        "export_job_inputs",
+        f"export_kind IN ({export_kind_values})",
+    )
+    op.create_check_constraint(
+        "ck_export_job_inputs_export_format_valid",
+        "export_job_inputs",
+        f"export_format IN ({export_format_values})",
+    )
+    op.create_check_constraint(
+        "ck_export_job_inputs_media_type_valid",
+        "export_job_inputs",
+        f"media_type IN ({media_type_values})",
+    )
+    op.create_check_constraint(
+        "ck_export_job_inputs_kind_format_media_type_matrix",
+        "export_job_inputs",
+        kind_format_media_type_matrix,
+    )
+    op.create_check_constraint(
+        "ck_export_job_inputs_quantity_lineage",
+        "export_job_inputs",
+        quantity_lineage,
+    )
+    op.create_check_constraint(
+        "ck_export_job_inputs_estimate_lineage",
+        "export_job_inputs",
+        estimate_lineage,
+    )
+
+
+def _assert_downgrade_safe() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text("LOCK TABLE export_job_inputs IN ACCESS EXCLUSIVE MODE"))
+
+    revised_dxf_row_exists = bind.execute(
+        sa.text(
+            """
+            SELECT 1
+            FROM export_job_inputs
+            WHERE export_kind = 'revised_dxf'
+            LIMIT 1
+            """
+        )
+    ).scalar()
+    if revised_dxf_row_exists is not None:
+        raise RuntimeError("Cannot downgrade: persisted revised_dxf export_job_inputs rows present")
+
+
+def upgrade() -> None:
+    _drop_export_contract_constraints()
+    _create_export_contract_constraints(include_revised_dxf=True)
+
+
+def downgrade() -> None:
+    _assert_downgrade_safe()
+    _drop_export_contract_constraints()
+    _create_export_contract_constraints(include_revised_dxf=False)

--- a/app/api/v1/revision_routes/exports.py
+++ b/app/api/v1/revision_routes/exports.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, status
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.idempotency import (
@@ -36,7 +36,8 @@ from app.api.v1.revision_lineage import (
 from app.api.v1.revision_lineage import (
     _get_revision_quantity_takeoff_or_404 as _get_revision_quantity_takeoff_or_404_direct,
 )
-from app.core.exceptions import raise_not_found
+from app.core.errors import ErrorCode
+from app.core.exceptions import create_error_response, raise_not_found
 from app.db.session import get_db
 from app.jobs.worker import enqueue_export_job as _enqueue_export_job_direct
 from app.jobs.worker import prepare_job_enqueue_intent as _prepare_job_enqueue_intent_direct
@@ -60,6 +61,7 @@ exports_router = APIRouter()
 
 type _ExportPreclaimLoader = Callable[[], Awaitable[None]]
 type _ExportJobCreator = Callable[[], Awaitable[Job]]
+type _ExportPreclaim = Callable[[], Awaitable[Response | None]]
 
 
 async def _get_active_revision(
@@ -175,6 +177,24 @@ def _parent_job_id_for_revision(revision: DrawingRevision) -> UUID | None:
     """Return the source parent job id for revision-scoped exports."""
 
     return revision.source_job_id
+
+
+def _revision_supports_revised_dxf_export(revision: DrawingRevision) -> bool:
+    """Return whether the revision is eligible for revised DXF export."""
+
+    return revision.revision_kind == "changeset" and revision.changeset_id is not None
+
+
+def _revised_dxf_export_revision_invalid_response() -> Response:
+    """Return the standard invalid-route response for non-changeset revisions."""
+
+    return JSONResponse(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        content=create_error_response(
+            ErrorCode.INPUT_INVALID,
+            "Revised DXF export requires an active changeset-origin revision.",
+        ),
+    )
 
 
 def _parent_job_id_for_takeoff(
@@ -385,21 +405,26 @@ async def _create_export_route_job(
     path: str,
     load_before_claim: _ExportPreclaimLoader,
     create_export_job: _ExportJobCreator,
+    preclaim: _ExportPreclaim | None = None,
 ) -> Job | Response:
     """Run the shared export-create flow with optional idempotency helpers."""
 
-    if idempotency_key is None:
+    async def default_preclaim() -> Response | None:
         await load_before_claim()
+        return None
+
+    preclaim_fn = preclaim or default_preclaim
+
+    if idempotency_key is None:
+        preclaim_response = await preclaim_fn()
+        if preclaim_response is not None:
+            return preclaim_response
         export_job = await create_export_job()
         await db.commit()
         await _publish_export_enqueue(export_job.id)
         return export_job
 
     assert fingerprint is not None
-
-    async def preclaim() -> Response | None:
-        await load_before_claim()
-        return None
 
     async def mutate() -> IdempotentMutationSuccess[Job]:
         export_job = await create_export_job()
@@ -423,7 +448,7 @@ async def _create_export_route_job(
         serialize_result=lambda export_job: JobRead.model_validate(export_job).model_dump(
             mode="json"
         ),
-        preclaim=preclaim,
+        preclaim=preclaim_fn,
         reload_after_claim=load_before_claim,
         ops=_export_create_idempotency_ops(),
     )
@@ -481,6 +506,72 @@ async def create_revision_json_export(
         path=path,
         load_before_claim=load_before_claim,
         create_export_job=create_export_job,
+    )
+
+
+@exports_router.post(
+    "/revisions/{revision_id}/exports/revised-dxf",
+    response_model=JobRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_revised_dxf_export(
+    revision_id: UUID,
+    request: RevisionJsonExportCreateRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    idempotency_key: Annotated[str | None, Depends(get_idempotency_key)] = None,
+) -> Job | Response:
+    """Create a pending revised DXF export job for an active changeset revision."""
+
+    export_kind = ExportKind.REVISED_DXF
+    path = f"/revisions/{revision_id}/exports/revised-dxf"
+    normalized_body = _build_export_request_body(
+        export_kind,
+        options=request.options,
+    )
+    fingerprint: str | None = None
+    if idempotency_key is not None:
+        fingerprint = _build_idempotency_fingerprint(
+            f"revisions.exports.revised_dxf:{revision_id}",
+            {
+                "revision_id": str(revision_id),
+                "body": normalized_body,
+            },
+        )
+
+    revision: DrawingRevision | None = None
+
+    invalid_preclaim_response: Response | None = None
+
+    async def load_before_claim() -> None:
+        nonlocal invalid_preclaim_response
+        nonlocal revision
+        invalid_preclaim_response = None
+        revision = await _get_locked_active_revision_or_404(revision_id, db)
+        if not _revision_supports_revised_dxf_export(revision):
+            invalid_preclaim_response = _revised_dxf_export_revision_invalid_response()
+
+    async def preclaim() -> Response | None:
+        await load_before_claim()
+        return invalid_preclaim_response
+
+    async def create_export_job() -> Job:
+        assert revision is not None
+        return await _persist_export_job(
+            db,
+            revision,
+            parent_job_id=_parent_job_id_for_revision(revision),
+            export_kind=export_kind,
+            options_json=request.options,
+        )
+
+    return await _create_export_route_job(
+        db,
+        idempotency_key=idempotency_key,
+        fingerprint=fingerprint,
+        path=path,
+        load_before_claim=load_before_claim,
+        create_export_job=create_export_job,
+        preclaim=preclaim,
     )
 
 

--- a/app/exports/revised_dxf.py
+++ b/app/exports/revised_dxf.py
@@ -1,0 +1,532 @@
+"""Deterministic revised DXF export service."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.exports._base import (
+    ExportArtifactWithOptions,
+    JSONValue,
+    build_artifact,
+    normalize_datetime,
+    normalize_json_value_tree,
+)
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterDescriptor,
+    AdapterExecutionOptions,
+    AdapterExportRequest,
+    AdapterStatus,
+    ExportAdapter,
+    ProbeIssue,
+    ProbeObservation,
+)
+from app.ingestion.contracts import (
+    JSONValue as AdapterJSONValue,
+)
+from app.ingestion.loader import load_export_adapter
+from app.ingestion.selection import select_export_descriptor
+from app.models.drawing_revision import DrawingRevision
+from app.models.revision_materialization import (
+    RevisionBlock,
+    RevisionEntity,
+    RevisionEntityManifest,
+    RevisionLayer,
+    RevisionLayout,
+)
+
+REVISED_DXF_EXPORT_FORMAT = "revised_dxf"
+REVISED_DXF_EXPORT_MEDIA_TYPE = "application/dxf"
+REVISED_DXF_EXPORT_GENERATOR_NAME = "revised_dxf_export"
+REVISED_DXF_EXPORT_GENERATOR_VERSION = "1"
+
+_PASSTHROUGH_INPUT_ERROR_CODES = frozenset(
+    {
+        "INPUT_INVALID",
+        "MANIFEST_NOT_FOUND",
+        "MATERIALIZATION_MISSING",
+        "MISSING_LAYER",
+        "MISSING_LAYOUT",
+        "NONFINITE_COORDINATE",
+        "NONZERO_Z_COORDINATE",
+        "REVISION_NOT_FOUND",
+    }
+)
+
+
+class RevisedDxfExportError(Exception):
+    """Raised when a revised DXF export cannot be rendered."""
+
+    code: str
+    message: str
+    details: Mapping[str, JSONValue]
+
+    def __init__(
+        self,
+        *,
+        code: str,
+        message: str,
+        details: Mapping[str, JSONValue] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.details = details or {}
+
+
+@dataclass(frozen=True, slots=True)
+class RevisedDxfExportResult(ExportArtifactWithOptions):
+    """Pure rendered revised DXF export artifact metadata."""
+
+
+async def render_revised_dxf_export(
+    db: AsyncSession,
+    revision_id: UUID,
+    *,
+    options: Mapping[str, object] | None = None,
+) -> RevisedDxfExportResult:
+    """Render a materialized drawing revision into deterministic DXF bytes."""
+
+    options_snapshot = _normalize_options(options)
+
+    revision = await db.get(DrawingRevision, revision_id)
+    if revision is None:
+        raise RevisedDxfExportError(
+            code="REVISION_NOT_FOUND",
+            message=f"Drawing revision {revision_id} was not found.",
+            details={"revision_id": str(revision_id)},
+        )
+    if revision.revision_kind != "changeset" or revision.changeset_id is None:
+        raise RevisedDxfExportError(
+            code="INPUT_INVALID",
+            message="Revised DXF export requires a changeset-origin drawing revision.",
+            details={
+                "revision_id": str(revision_id),
+                "revision_kind": revision.revision_kind,
+            },
+        )
+
+    manifest = await _load_manifest(db, revision_id)
+    if manifest is None:
+        raise RevisedDxfExportError(
+            code="MANIFEST_NOT_FOUND",
+            message=f"Revision entity manifest for drawing revision {revision_id} was not found.",
+            details={"revision_id": str(revision_id)},
+        )
+
+    layouts = await _load_layouts(db, revision_id)
+    layers = await _load_layers(db, revision_id)
+    blocks = await _load_blocks(db, revision_id)
+    entities = await _load_entities(db, revision_id)
+    _validate_manifest_counts(
+        manifest=manifest,
+        layouts=layouts,
+        layers=layers,
+        blocks=blocks,
+        entities=entities,
+    )
+
+    payload = _build_canonical_payload(
+        layouts=layouts,
+        layers=layers,
+        blocks=blocks,
+        entities=entities,
+    )
+
+    descriptor = _select_export_descriptor()
+    adapter = _load_adapter(descriptor)
+    availability = adapter.probe()
+    _require_available(availability=availability, descriptor_key=descriptor.key)
+
+    try:
+        export_result = await adapter.export(
+            AdapterExportRequest(
+                canonical=cast(Mapping[str, AdapterJSONValue], payload),
+                output_format=REVISED_DXF_EXPORT_FORMAT,
+            ),
+            AdapterExecutionOptions(),
+        )
+    except RevisedDxfExportError:
+        raise
+    except Exception as exc:
+        raise _map_export_exception(exc, descriptor_key=descriptor.key) from exc
+
+    if export_result.output_format != REVISED_DXF_EXPORT_FORMAT:
+        raise RevisedDxfExportError(
+            code="ADAPTER_FAILED",
+            message="Revised DXF export adapter returned an unexpected output format.",
+            details={
+                "adapter_key": descriptor.key,
+                "expected_output_format": REVISED_DXF_EXPORT_FORMAT,
+                "output_format": export_result.output_format,
+            },
+        )
+
+    if export_result.media_type != REVISED_DXF_EXPORT_MEDIA_TYPE:
+        raise RevisedDxfExportError(
+            code="ADAPTER_FAILED",
+            message="Revised DXF export adapter returned an unexpected media type.",
+            details={
+                "adapter_key": descriptor.key,
+                "expected_media_type": REVISED_DXF_EXPORT_MEDIA_TYPE,
+                "media_type": export_result.media_type,
+            },
+        )
+
+    return build_artifact(
+        RevisedDxfExportResult,
+        content_bytes=export_result.content,
+        media_type=REVISED_DXF_EXPORT_MEDIA_TYPE,
+        generator_name=REVISED_DXF_EXPORT_GENERATOR_NAME,
+        generator_version=REVISED_DXF_EXPORT_GENERATOR_VERSION,
+        options=options_snapshot,
+    )
+
+
+async def _load_manifest(
+    db: AsyncSession,
+    revision_id: UUID,
+) -> RevisionEntityManifest | None:
+    result = await db.execute(
+        select(RevisionEntityManifest).where(
+            RevisionEntityManifest.drawing_revision_id == revision_id
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _load_layouts(db: AsyncSession, revision_id: UUID) -> list[RevisionLayout]:
+    result = await db.execute(
+        select(RevisionLayout)
+        .where(RevisionLayout.drawing_revision_id == revision_id)
+        .order_by(RevisionLayout.sequence_index.asc(), RevisionLayout.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def _load_layers(db: AsyncSession, revision_id: UUID) -> list[RevisionLayer]:
+    result = await db.execute(
+        select(RevisionLayer)
+        .where(RevisionLayer.drawing_revision_id == revision_id)
+        .order_by(RevisionLayer.sequence_index.asc(), RevisionLayer.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def _load_blocks(db: AsyncSession, revision_id: UUID) -> list[RevisionBlock]:
+    result = await db.execute(
+        select(RevisionBlock)
+        .where(RevisionBlock.drawing_revision_id == revision_id)
+        .order_by(RevisionBlock.sequence_index.asc(), RevisionBlock.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def _load_entities(db: AsyncSession, revision_id: UUID) -> list[RevisionEntity]:
+    result = await db.execute(
+        select(RevisionEntity)
+        .where(RevisionEntity.drawing_revision_id == revision_id)
+        .order_by(RevisionEntity.sequence_index.asc(), RevisionEntity.id.asc())
+    )
+    return list(result.scalars().all())
+
+
+def _validate_manifest_counts(
+    *,
+    manifest: RevisionEntityManifest,
+    layouts: list[RevisionLayout],
+    layers: list[RevisionLayer],
+    blocks: list[RevisionBlock],
+    entities: list[RevisionEntity],
+) -> None:
+    counts = _manifest_counts(manifest)
+    actual_counts = {
+        "layouts": len(layouts),
+        "layers": len(layers),
+        "blocks": len(blocks),
+        "entities": len(entities),
+    }
+    for component, expected_count in counts.items():
+        actual_count = actual_counts[component]
+        if actual_count != expected_count:
+            raise RevisedDxfExportError(
+                code="MATERIALIZATION_MISSING",
+                message="Revision materialization rows do not match the manifest counts.",
+                details={
+                    "revision_id": str(manifest.drawing_revision_id),
+                    "component": component,
+                    "expected_count": expected_count,
+                    "actual_count": actual_count,
+                },
+            )
+
+
+def _manifest_counts(manifest: RevisionEntityManifest) -> dict[str, int]:
+    raw_counts = manifest.counts_json
+    return {
+        "layouts": int(raw_counts.get("layouts", 0)),
+        "layers": int(raw_counts.get("layers", 0)),
+        "blocks": int(raw_counts.get("blocks", 0)),
+        "entities": int(raw_counts.get("entities", 0)),
+    }
+
+
+def _build_canonical_payload(
+    *,
+    layouts: list[RevisionLayout],
+    layers: list[RevisionLayer],
+    blocks: list[RevisionBlock],
+    entities: list[RevisionEntity],
+) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "layouts": [_build_layout_payload(layout) for layout in layouts],
+        "layers": [_build_layer_payload(layer) for layer in layers],
+        "blocks": [_build_block_payload(block) for block in blocks],
+        "entities": [_build_entity_payload(entity) for entity in entities],
+    }
+    units = _infer_top_level_units(entities)
+    if units is not None:
+        payload["units"] = units
+    return payload
+
+
+def _build_layout_payload(layout: RevisionLayout) -> dict[str, JSONValue]:
+    payload = dict(layout.payload_json)
+    payload.setdefault("id", layout.layout_ref)
+    payload.setdefault("layout_ref", layout.layout_ref)
+    payload.setdefault("name", layout.layout_ref)
+    return payload
+
+
+def _build_layer_payload(layer: RevisionLayer) -> dict[str, JSONValue]:
+    payload = dict(layer.payload_json)
+    payload.setdefault("id", layer.layer_ref)
+    payload.setdefault("layer_ref", layer.layer_ref)
+    payload.setdefault("name", layer.layer_ref)
+    return payload
+
+
+def _build_block_payload(block: RevisionBlock) -> dict[str, JSONValue]:
+    payload = dict(block.payload_json)
+    payload.setdefault("id", block.block_ref)
+    payload.setdefault("block_ref", block.block_ref)
+    payload.setdefault("name", block.block_ref)
+    return payload
+
+
+def _build_entity_payload(entity: RevisionEntity) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "entity_id": entity.entity_id,
+        "entity_type": entity.entity_type,
+        "entity_schema_version": entity.entity_schema_version,
+        "sequence_index": entity.sequence_index,
+        "layout_ref": entity.layout_ref,
+        "layer_ref": entity.layer_ref,
+        "block_ref": entity.block_ref,
+        "geometry_json": dict(entity.geometry_json),
+        "properties_json": dict(entity.properties_json),
+    }
+    if entity.canonical_entity_json is not None:
+        payload["canonical_entity_json"] = dict(entity.canonical_entity_json)
+    return payload
+
+
+def _infer_top_level_units(entities: list[RevisionEntity]) -> dict[str, JSONValue] | None:
+    normalized_unit: str | None = None
+    for entity in entities:
+        geometry = entity.geometry_json
+        units = geometry.get("units")
+        if not isinstance(units, Mapping):
+            continue
+        candidate = units.get("normalized")
+        if not isinstance(candidate, str) or not candidate:
+            continue
+        if normalized_unit is None:
+            normalized_unit = candidate
+            continue
+        if candidate != normalized_unit:
+            return None
+
+    if normalized_unit is None:
+        return None
+    return {"normalized": normalized_unit}
+
+
+def _select_export_descriptor() -> AdapterDescriptor:
+    try:
+        return select_export_descriptor(REVISED_DXF_EXPORT_FORMAT)
+    except Exception as exc:
+        raise RevisedDxfExportError(
+            code="ADAPTER_UNAVAILABLE",
+            message="Revised DXF export adapter is not configured.",
+            details={"output_format": REVISED_DXF_EXPORT_FORMAT},
+        ) from exc
+
+
+def _load_adapter(descriptor: AdapterDescriptor) -> ExportAdapter:
+    try:
+        return load_export_adapter(descriptor)
+    except Exception as exc:
+        raise RevisedDxfExportError(
+            code="ADAPTER_LOAD_FAILED",
+            message="Revised DXF export adapter could not be loaded.",
+            details={
+                "adapter_key": descriptor.key,
+                "output_format": REVISED_DXF_EXPORT_FORMAT,
+                "error_type": type(exc).__name__,
+            },
+        ) from exc
+
+
+def _require_available(*, availability: AdapterAvailability, descriptor_key: str) -> None:
+    if availability.status == AdapterStatus.AVAILABLE:
+        return
+
+    raise RevisedDxfExportError(
+        code="ADAPTER_UNAVAILABLE",
+        message="Revised DXF export adapter is unavailable.",
+        details={
+            "adapter_key": descriptor_key,
+            "output_format": REVISED_DXF_EXPORT_FORMAT,
+            "status": availability.status.value,
+            "availability_reason": (
+                None
+                if availability.availability_reason is None
+                else availability.availability_reason.value
+            ),
+            "license_state": availability.license_state.value,
+            "issues": [_serialize_issue(issue) for issue in availability.issues],
+            "observed": [
+                _serialize_observation(observation) for observation in availability.observed
+            ],
+            "details": (
+                None
+                if availability.details is None
+                else _normalize_json_mapping(availability.details)
+            ),
+        },
+    )
+
+
+def _map_export_exception(exc: Exception, *, descriptor_key: str) -> RevisedDxfExportError:
+    error_code = getattr(exc, "code", None)
+    if isinstance(error_code, str) and error_code:
+        details = getattr(exc, "details", None)
+        normalized_details: dict[str, JSONValue] = {
+            "adapter_key": descriptor_key,
+            "output_format": REVISED_DXF_EXPORT_FORMAT,
+        }
+        if isinstance(details, Mapping):
+            normalized_details.update(_normalize_json_mapping(details))
+        if error_code in {
+            "ADAPTER_UNAVAILABLE",
+            "ADAPTER_LOAD_FAILED",
+        } or _is_passthrough_input_error_code(error_code):
+            return RevisedDxfExportError(
+                code=error_code,
+                message=str(exc),
+                details=normalized_details,
+            )
+        normalized_details["original_error_code"] = error_code
+        return RevisedDxfExportError(
+            code="ADAPTER_FAILED",
+            message=str(exc),
+            details=normalized_details,
+        )
+
+    return RevisedDxfExportError(
+        code="ADAPTER_FAILED",
+        message="Revised DXF export rendering failed.",
+        details={
+            "adapter_key": descriptor_key,
+            "output_format": REVISED_DXF_EXPORT_FORMAT,
+            "error_type": type(exc).__name__,
+        },
+    )
+
+
+def _is_passthrough_input_error_code(code: str) -> bool:
+    return code in _PASSTHROUGH_INPUT_ERROR_CODES or code.startswith(("INVALID_", "UNSUPPORTED_"))
+
+
+def _serialize_issue(issue: ProbeIssue) -> dict[str, JSONValue]:
+    return {
+        "kind": issue.kind.value,
+        "name": issue.name,
+        "observed_status": issue.observed_status.value,
+        "adapter_status": issue.adapter_status.value,
+        "detail": issue.detail,
+    }
+
+
+def _serialize_observation(observation: ProbeObservation) -> dict[str, JSONValue]:
+    payload: dict[str, JSONValue] = {
+        "kind": observation.kind.value,
+        "name": observation.name,
+        "status": observation.status.value,
+    }
+    if observation.detail is not None:
+        payload["detail"] = observation.detail
+    return payload
+
+
+def _normalize_options(options: Mapping[str, object] | None) -> dict[str, JSONValue]:
+    if options is None:
+        return {}
+
+    return {
+        _normalize_mapping_key(key): _normalize_json_value(value) for key, value in options.items()
+    }
+
+
+def _normalize_json_mapping(mapping: Mapping[Any, Any]) -> dict[str, JSONValue]:
+    return {
+        _normalize_mapping_key(key): _normalize_json_value(value) for key, value in mapping.items()
+    }
+
+
+def _normalize_json_value(value: object) -> JSONValue:
+    return normalize_json_value_tree(
+        value,
+        normalize_scalar=_normalize_json_scalar,
+        normalize_mapping_key=_normalize_mapping_key,
+        unsupported_value=_unsupported_json_value,
+    )
+
+
+def _normalize_json_scalar(value: object) -> tuple[bool, JSONValue]:
+    if isinstance(value, UUID):
+        return True, str(value)
+    if isinstance(value, datetime):
+        return True, _normalize_datetime(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True, value
+    return False, None
+
+
+def _unsupported_json_value(value: object) -> Exception:
+    return TypeError(f"Unsupported revised DXF export value type: {type(value)!r}")
+
+
+def _normalize_mapping_key(key: object) -> str:
+    if isinstance(key, str):
+        return key
+    if isinstance(key, UUID):
+        return str(key)
+    if isinstance(key, datetime):
+        return _normalize_datetime(key)
+    if isinstance(key, (int, float, bool)):
+        return str(key)
+
+    raise TypeError(f"Unsupported revised DXF export mapping key type: {type(key)!r}")
+
+
+def _normalize_datetime(value: datetime) -> str:
+    return normalize_datetime(value)

--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -69,6 +69,7 @@ from app.exports.estimate_pdf import (
     EstimatePdfExportError,
     render_estimate_pdf_export,
 )
+from app.exports.revised_dxf import RevisedDxfExportError, render_revised_dxf_export
 from app.exports.revision_json import (
     RevisionJsonExportError,
     render_revision_json_export,
@@ -425,6 +426,7 @@ class _ExportExecutionInput:
     media_type: str
     artifact_name: str
     options_json: dict[str, Any]
+    changeset_id: UUID | None = None
     quantity_takeoff_id: UUID | None = None
     estimate_version_id: UUID | None = None
 
@@ -434,10 +436,24 @@ _ExportRenderFn = Callable[
     Coroutine[Any, Any, ExportArtifact],
 ]
 _ExportErrorDetailsFn = Callable[[_ExportExecutionInput], dict[str, Any]]
+_ExportErrorMapperFn = Callable[[Exception, _ExportExecutionInput], _ExportJobInputError]
 
 _EXPORT_LINEAGE_ANCHOR_REVISION = "revision"
+_EXPORT_LINEAGE_ANCHOR_CHANGESET = "changeset"
 _EXPORT_LINEAGE_ANCHOR_QUANTITY_TAKEOFF = "quantity_takeoff"
 _EXPORT_LINEAGE_ANCHOR_ESTIMATE_VERSION = "estimate_version"
+_REVISED_DXF_INPUT_ERROR_CODES = frozenset(
+    {
+        "INPUT_INVALID",
+        "MANIFEST_NOT_FOUND",
+        "MATERIALIZATION_MISSING",
+        "MISSING_LAYER",
+        "MISSING_LAYOUT",
+        "NONFINITE_COORDINATE",
+        "NONZERO_Z_COORDINATE",
+        "REVISION_NOT_FOUND",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -450,11 +466,20 @@ class _ExportKindSpec:
     error_type: type[Exception]
     lineage_anchor: str
     error_details_fn: _ExportErrorDetailsFn
+    error_mapper_fn: _ExportErrorMapperFn | None = None
 
 
 def _export_revision_error_details(execution: _ExportExecutionInput) -> dict[str, Any]:
     """Build not-found details for revision-scoped exports."""
     return {"drawing_revision_id": str(execution.drawing_revision_id)}
+
+
+def _export_changeset_error_details(execution: _ExportExecutionInput) -> dict[str, Any]:
+    """Build details for changeset-scoped exports."""
+    return {
+        "drawing_revision_id": str(execution.drawing_revision_id),
+        "changeset_id": str(execution.changeset_id) if execution.changeset_id is not None else None,
+    }
 
 
 def _export_quantity_error_details(execution: _ExportExecutionInput) -> dict[str, Any]:
@@ -481,6 +506,46 @@ async def _render_revision_json_export_artifact(
 ) -> ExportArtifact:
     """Render a revision JSON export artifact."""
     return await render_revision_json_export(
+        session,
+        execution.drawing_revision_id,
+        options=execution.options_json,
+    )
+
+
+def _map_revised_dxf_export_error(
+    exc: Exception,
+    execution: _ExportExecutionInput,
+) -> _ExportJobInputError:
+    """Map revised-DXF renderer failures to deterministic job errors."""
+    assert isinstance(exc, RevisedDxfExportError)
+    details = _export_changeset_error_details(execution)
+    details.update(deepcopy(exc.details or {}))
+    details["renderer_error_code"] = exc.code
+    return _build_export_job_input_error(
+        str(exc),
+        error_code=(
+            ErrorCode.ADAPTER_UNAVAILABLE
+            if exc.code in {"ADAPTER_UNAVAILABLE", "ADAPTER_LOAD_FAILED"}
+            else (
+                ErrorCode.INPUT_INVALID
+                if _is_revised_dxf_input_error_code(exc.code)
+                else ErrorCode.ADAPTER_FAILED
+            )
+        ),
+        details=details,
+    )
+
+
+def _is_revised_dxf_input_error_code(code: str) -> bool:
+    return code in _REVISED_DXF_INPUT_ERROR_CODES or code.startswith(("INVALID_", "UNSUPPORTED_"))
+
+
+async def _render_revised_dxf_export_artifact(
+    session: AsyncSession,
+    execution: _ExportExecutionInput,
+) -> ExportArtifact:
+    """Render a revised DXF export artifact."""
+    return await render_revised_dxf_export(
         session,
         execution.drawing_revision_id,
         options=execution.options_json,
@@ -550,6 +615,15 @@ _EXPORT_KIND_SPECS: dict[str, _ExportKindSpec] = {
         error_type=EstimatePdfExportError,
         lineage_anchor=_EXPORT_LINEAGE_ANCHOR_ESTIMATE_VERSION,
         error_details_fn=_export_estimate_error_details,
+    ),
+    "revised_dxf": _ExportKindSpec(
+        format="dxf",
+        media_type="application/dxf",
+        render_fn=_render_revised_dxf_export_artifact,
+        error_type=RevisedDxfExportError,
+        lineage_anchor=_EXPORT_LINEAGE_ANCHOR_CHANGESET,
+        error_details_fn=_export_changeset_error_details,
+        error_mapper_fn=_map_revised_dxf_export_error,
     ),
 }
 
@@ -3786,6 +3860,7 @@ def _build_export_artifact_name(
     export_kind: str,
     export_format: str,
     drawing_revision_id: UUID,
+    changeset_id: UUID | None = None,
     quantity_takeoff_id: UUID | None = None,
     estimate_version_id: UUID | None = None,
 ) -> str:
@@ -3793,6 +3868,9 @@ def _build_export_artifact_name(
     export_spec = _get_export_kind_spec(export_kind)
     if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_REVISION:
         return f"revision-{drawing_revision_id}.{export_format}"
+    if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_CHANGESET:
+        assert changeset_id is not None
+        return f"changeset-{changeset_id}.{export_format}"
     if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_QUANTITY_TAKEOFF:
         assert quantity_takeoff_id is not None
         return f"quantity-takeoff-{quantity_takeoff_id}.{export_format}"
@@ -3818,6 +3896,29 @@ def _build_export_artifact_lineage_json(
     execution: _ExportExecutionInput,
 ) -> dict[str, Any]:
     """Build lineage metadata for a persisted export artifact."""
+    drawing_revision_lineage: dict[str, Any] = {"id": str(execution.drawing_revision_id)}
+    if execution.changeset_id is not None:
+        drawing_revision_lineage["changeset_id"] = str(execution.changeset_id)
+
+    export_lineage: dict[str, Any] = {
+        "kind": execution.export_kind,
+        "format": execution.export_format,
+        "media_type": execution.media_type,
+        "quantity_takeoff_id": (
+            str(execution.quantity_takeoff_id)
+            if execution.quantity_takeoff_id is not None
+            else None
+        ),
+        "estimate_version_id": (
+            str(execution.estimate_version_id)
+            if execution.estimate_version_id is not None
+            else None
+        ),
+        "options": deepcopy(execution.options_json),
+    }
+    if execution.changeset_id is not None:
+        export_lineage["changeset_id"] = str(execution.changeset_id)
+
     return {
         "source_file": {
             "id": str(source_file.id),
@@ -3833,23 +3934,8 @@ def _build_export_artifact_lineage_json(
                 str(job.base_revision_id) if job.base_revision_id is not None else None
             ),
         },
-        "drawing_revision": {"id": str(execution.drawing_revision_id)},
-        "export": {
-            "kind": execution.export_kind,
-            "format": execution.export_format,
-            "media_type": execution.media_type,
-            "quantity_takeoff_id": (
-                str(execution.quantity_takeoff_id)
-                if execution.quantity_takeoff_id is not None
-                else None
-            ),
-            "estimate_version_id": (
-                str(execution.estimate_version_id)
-                if execution.estimate_version_id is not None
-                else None
-            ),
-            "options": deepcopy(execution.options_json),
-        },
+        "drawing_revision": drawing_revision_lineage,
+        "export": export_lineage,
     }
 
 
@@ -3863,6 +3949,8 @@ async def _render_export_artifact(
         result = await export_spec.render_fn(session, execution)
     except Exception as exc:
         if isinstance(exc, export_spec.error_type):
+            if export_spec.error_mapper_fn is not None:
+                raise export_spec.error_mapper_fn(exc, execution) from exc
             raise _build_export_job_input_error(
                 str(exc),
                 error_code=ErrorCode.NOT_FOUND,
@@ -3963,7 +4051,10 @@ async def _build_export_execution_input(
             )
 
         options_json = deepcopy(export_input.options_json)
-        if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_REVISION:
+        if export_spec.lineage_anchor in {
+            _EXPORT_LINEAGE_ANCHOR_REVISION,
+            _EXPORT_LINEAGE_ANCHOR_CHANGESET,
+        }:
             if (
                 export_input.quantity_takeoff_id is not None
                 or export_input.estimate_version_id is not None
@@ -3971,8 +4062,34 @@ async def _build_export_execution_input(
                 or export_input.trusted_totals is not None
             ):
                 raise _build_export_job_input_error(
-                    "Revision JSON export input contains unexpected quantity or estimate lineage.",
+                    (
+                        "Revision-scoped export input contains unexpected quantity or estimate "
+                        "lineage."
+                    ),
                     details={"export_kind": export_input.export_kind},
+                )
+            if export_spec.lineage_anchor == _EXPORT_LINEAGE_ANCHOR_CHANGESET:
+                if (
+                    drawing_revision.revision_kind != "changeset"
+                    or drawing_revision.changeset_id is None
+                ):
+                    raise _build_export_job_input_error(
+                        "Revised DXF export requires a changeset-origin drawing revision.",
+                        details={"drawing_revision_id": str(drawing_revision.id)},
+                    )
+                return _ExportExecutionInput(
+                    drawing_revision_id=drawing_revision.id,
+                    changeset_id=drawing_revision.changeset_id,
+                    export_kind=export_input.export_kind,
+                    export_format=export_input.export_format,
+                    media_type=export_input.media_type,
+                    artifact_name=_build_export_artifact_name(
+                        export_kind=export_input.export_kind,
+                        export_format=export_input.export_format,
+                        drawing_revision_id=drawing_revision.id,
+                        changeset_id=drawing_revision.changeset_id,
+                    ),
+                    options_json=options_json,
                 )
             return _ExportExecutionInput(
                 drawing_revision_id=drawing_revision.id,
@@ -4223,6 +4340,7 @@ async def _finalize_export_job(
                     source_file_id=source_file.id,
                     job_id=job.id,
                     drawing_revision_id=execution.drawing_revision_id,
+                    changeset_id=execution.changeset_id,
                     artifact_kind=execution.export_kind,
                     name=execution.artifact_name,
                     format=execution.export_format,

--- a/app/models/export_job_input.py
+++ b/app/models/export_job_input.py
@@ -27,6 +27,7 @@ class ExportKind(StrEnum):
     """Supported export payload kinds."""
 
     REVISION_JSON = "revision_json"
+    REVISED_DXF = "revised_dxf"
     QUANTITY_CSV = "quantity_csv"
     ESTIMATE_CSV = "estimate_csv"
     ESTIMATE_PDF = "estimate_pdf"
@@ -36,6 +37,7 @@ class ExportFormat(StrEnum):
     """Supported export artifact formats."""
 
     JSON = "json"
+    DXF = "dxf"
     CSV = "csv"
     PDF = "pdf"
 
@@ -44,6 +46,7 @@ _EXPORT_KIND_VALUES = tuple(kind.value for kind in ExportKind)
 _EXPORT_FORMAT_VALUES = tuple(export_format.value for export_format in ExportFormat)
 _EXPORT_MEDIA_TYPES = (
     "application/json",
+    "application/dxf",
     "text/csv",
     "application/pdf",
 )
@@ -145,6 +148,8 @@ class ExportJobInput(Base):
         CheckConstraint(
             "(export_kind = 'revision_json' AND export_format = 'json' "
             "AND media_type = 'application/json') OR "
+            "(export_kind = 'revised_dxf' AND export_format = 'dxf' "
+            "AND media_type = 'application/dxf') OR "
             "(export_kind = 'quantity_csv' AND export_format = 'csv' "
             "AND media_type = 'text/csv') OR "
             "(export_kind = 'estimate_csv' AND export_format = 'csv' "
@@ -158,14 +163,14 @@ class ExportJobInput(Base):
             "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
             "(export_kind IN ('estimate_csv', 'estimate_pdf') AND quantity_takeoff_id IS NOT NULL "
             "AND quantity_gate = 'allowed' AND trusted_totals IS TRUE) OR "
-            "(export_kind = 'revision_json' AND quantity_takeoff_id IS NULL "
+            "(export_kind IN ('revision_json', 'revised_dxf') AND quantity_takeoff_id IS NULL "
             "AND quantity_gate IS NULL AND trusted_totals IS NULL)",
             name="ck_export_job_inputs_quantity_lineage",
         ),
         CheckConstraint(
             "(export_kind IN ('estimate_csv', 'estimate_pdf') "
             "AND quantity_takeoff_id IS NOT NULL AND estimate_version_id IS NOT NULL) OR "
-            "(export_kind IN ('quantity_csv', 'revision_json') "
+            "(export_kind IN ('quantity_csv', 'revision_json', 'revised_dxf') "
             "AND estimate_version_id IS NULL)",
             name="ck_export_job_inputs_estimate_lineage",
         ),
@@ -209,7 +214,10 @@ class ExportJobInput(Base):
     export_kind: Mapped[str] = mapped_column(
         String(64),
         nullable=False,
-        comment="Export kind selector (revision_json, quantity_csv, estimate_csv, estimate_pdf).",
+        comment=(
+            "Export kind selector (revision_json, revised_dxf, quantity_csv, "
+            "estimate_csv, estimate_pdf)."
+        ),
     )
     export_format: Mapped[str] = mapped_column(
         String(32),
@@ -231,8 +239,8 @@ class ExportJobInput(Base):
         nullable=True,
         index=True,
         comment=(
-            "Trusted quantity takeoff required for quantity_csv, estimate_csv, "
-            "and estimate_pdf exports."
+            "Trusted quantity takeoff required for quantity_csv, estimate_csv, and "
+            "estimate_pdf exports."
         ),
     )
     quantity_gate: Mapped[str | None] = mapped_column(

--- a/app/schemas/export.py
+++ b/app/schemas/export.py
@@ -15,6 +15,7 @@ class ExportKind(StrEnum):
     """Export kind string constants."""
 
     REVISION_JSON = "revision_json"
+    REVISED_DXF = "revised_dxf"
     QUANTITY_CSV = "quantity_csv"
     ESTIMATE_CSV = "estimate_csv"
     ESTIMATE_PDF = "estimate_pdf"
@@ -24,17 +25,20 @@ class ExportFormat(StrEnum):
     """Export format string constants."""
 
     JSON = "json"
+    DXF = "dxf"
     CSV = "csv"
     PDF = "pdf"
 
 
 EXPORT_KIND_MATRIX: dict[ExportKind, tuple[ExportFormat, str]] = {
     ExportKind.REVISION_JSON: (ExportFormat.JSON, "application/json"),
+    ExportKind.REVISED_DXF: (ExportFormat.DXF, "application/dxf"),
     ExportKind.QUANTITY_CSV: (ExportFormat.CSV, "text/csv"),
     ExportKind.ESTIMATE_CSV: (ExportFormat.CSV, "text/csv"),
     ExportKind.ESTIMATE_PDF: (ExportFormat.PDF, "application/pdf"),
 }
 ESTIMATE_EXPORT_KINDS = {ExportKind.ESTIMATE_CSV, ExportKind.ESTIMATE_PDF}
+REVISION_SCOPED_EXPORT_KINDS = {ExportKind.REVISION_JSON, ExportKind.REVISED_DXF}
 
 
 def _validate_json_safe_option_value(value: Any, *, path: str) -> None:
@@ -107,10 +111,14 @@ class ExportJobInputBase(BaseModel):
                 raise ValueError(
                     "estimate exports require both quantity_takeoff_id and estimate_version_id"
                 )
+        elif self.export_kind in REVISION_SCOPED_EXPORT_KINDS:
+            if self.quantity_takeoff_id is not None or self.estimate_version_id is not None:
+                raise ValueError(
+                    "revision_json and revised_dxf exports forbid quantity_takeoff_id and "
+                    "estimate_version_id"
+                )
         elif self.quantity_takeoff_id is not None or self.estimate_version_id is not None:
-            raise ValueError(
-                "revision_json exports forbid quantity_takeoff_id and estimate_version_id"
-            )
+            raise ValueError(f"Unsupported export_kind: {self.export_kind}")
 
         return self
 

--- a/scripts/pre_push_check.py
+++ b/scripts/pre_push_check.py
@@ -116,6 +116,7 @@ DB_TEST_FILE_KEY_LANE_ARGS = {
     "jobs_worker_exports": DB_WORKER_PYTEST_ARGS,
     "ingest_output_persistence": DB_WORKER_PYTEST_ARGS,
     "csv_exports": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
+    "revised_dxf_export": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
     "revision_json_export": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
     "estimate_pdf_export": DB_ESTIMATION_EXPORT_PYTEST_ARGS,
     "estimate_engine_persistence_payloads": DB_ESTIMATION_EXPORT_PYTEST_ARGS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,6 +307,7 @@ _DB_LANE_BY_TEST_FILE_KEY: dict[str, str] = {
     "jobs_worker_exports": "db_worker",
     "ingest_output_persistence": "db_worker",
     "csv_exports": "db_estimation_export",
+    "revised_dxf_export": "db_estimation_export",
     "revision_json_export": "db_estimation_export",
     "estimate_pdf_export": "db_estimation_export",
     "estimate_engine_persistence_payloads": "db_estimation_export",

--- a/tests/test_export_create_api.py
+++ b/tests/test_export_create_api.py
@@ -13,6 +13,7 @@ import app.db.session as session_module
 from app.api.idempotency import hash_idempotency_key
 from app.api.v1.revision_routes import exports as export_routes
 from app.models.adapter_run_output import AdapterRunOutput
+from app.models.cad_changeset import CadChangeSet
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_version import EstimateVersion
 from app.models.export_job_input import ExportJobInput
@@ -39,9 +40,11 @@ class ExportLineage:
     project_id: UUID
     file_id: UUID
     revision_id: UUID
+    changeset_revision_id: UUID
     takeoff_id: UUID
     estimate_version_id: UUID
     revision_source_job_id: UUID
+    changeset_revision_source_job_id: UUID
     takeoff_source_job_id: UUID
     estimate_source_job_id: UUID
 
@@ -168,6 +171,49 @@ async def _seed_export_lineage() -> ExportLineage:
         session.add(revision)
         await session.flush()
 
+        change_set = CadChangeSet(
+            project_id=project.id,
+            base_revision_id=revision.id,
+            status="approved",
+            created_by="test-suite",
+        )
+        session.add(change_set)
+        await session.flush()
+
+        changeset_revision_source_job = Job(
+            project_id=project.id,
+            file_id=source_file.id,
+            extraction_profile_id=None,
+            base_revision_id=revision.id,
+            parent_job_id=revision_source_job.id,
+            job_type=getattr(JobType, "CHANGESET_APPLY", JobType.EXPORT).value,
+            status="succeeded",
+            attempts=1,
+            max_attempts=3,
+            enqueue_status="pending",
+            enqueue_attempts=0,
+            cancel_requested=False,
+        )
+        session.add(changeset_revision_source_job)
+        await session.flush()
+
+        changeset_revision = DrawingRevision(
+            project_id=project.id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=changeset_revision_source_job.id,
+            adapter_run_output_id=None,
+            predecessor_revision_id=revision.id,
+            revision_sequence=2,
+            revision_kind="changeset",
+            review_state="approved",
+            canonical_entity_schema_version="1.0",
+            confidence_score=0.99,
+            changeset_id=change_set.id,
+        )
+        session.add(changeset_revision)
+        await session.flush()
+
         takeoff_source_job = Job(
             project_id=project.id,
             file_id=source_file.id,
@@ -235,9 +281,11 @@ async def _seed_export_lineage() -> ExportLineage:
             project_id=project.id,
             file_id=source_file.id,
             revision_id=revision.id,
+            changeset_revision_id=changeset_revision.id,
             takeoff_id=takeoff.id,
             estimate_version_id=estimate_version.id,
             revision_source_job_id=revision_source_job.id,
+            changeset_revision_source_job_id=changeset_revision_source_job.id,
             takeoff_source_job_id=takeoff_source_job.id,
             estimate_source_job_id=estimate_source_job.id,
         )
@@ -267,6 +315,13 @@ def _expected_parent_job_id(case: ExportCreateCase, lineage: ExportLineage) -> U
 
 
 async def _count_export_side_effects(lineage: ExportLineage) -> tuple[int, int, int]:
+    return await _count_export_side_effects_for_revision(lineage, lineage.revision_id)
+
+
+async def _count_export_side_effects_for_revision(
+    lineage: ExportLineage,
+    revision_id: UUID,
+) -> tuple[int, int, int]:
     assert session_module.AsyncSessionLocal is not None
 
     async with session_module.AsyncSessionLocal() as session:
@@ -277,7 +332,7 @@ async def _count_export_side_effects(lineage: ExportLineage) -> tuple[int, int, 
                 Job.job_type == JobType.EXPORT.value,
                 Job.project_id == lineage.project_id,
                 Job.file_id == lineage.file_id,
-                Job.base_revision_id == lineage.revision_id,
+                Job.base_revision_id == revision_id,
             )
         )
         export_input_count = await session.scalar(
@@ -286,7 +341,7 @@ async def _count_export_side_effects(lineage: ExportLineage) -> tuple[int, int, 
             .where(
                 ExportJobInput.project_id == lineage.project_id,
                 ExportJobInput.source_file_id == lineage.file_id,
-                ExportJobInput.drawing_revision_id == lineage.revision_id,
+                ExportJobInput.drawing_revision_id == revision_id,
             )
         )
         generated_artifact_count = await session.scalar(
@@ -295,7 +350,7 @@ async def _count_export_side_effects(lineage: ExportLineage) -> tuple[int, int, 
             .where(
                 GeneratedArtifact.project_id == lineage.project_id,
                 GeneratedArtifact.source_file_id == lineage.file_id,
-                GeneratedArtifact.drawing_revision_id == lineage.revision_id,
+                GeneratedArtifact.drawing_revision_id == revision_id,
             )
         )
 
@@ -548,6 +603,93 @@ async def test_create_export_persists_pending_job_and_input(
             )
         )
         assert generated_artifact_count == 0
+
+
+async def test_create_revised_dxf_export_persists_pending_job_and_input(
+    async_client: AsyncClient,
+) -> None:
+    lineage = await _seed_export_lineage()
+
+    response = await async_client.post(
+        f"/v1/revisions/{lineage.changeset_revision_id}/exports/revised-dxf",
+        json={"options": {"target_version": "R2010", "include_review_flags": True}},
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    job_id = UUID(body["id"])
+    assert body["project_id"] == str(lineage.project_id)
+    assert body["file_id"] == str(lineage.file_id)
+    assert body["base_revision_id"] == str(lineage.changeset_revision_id)
+    assert body["parent_job_id"] == str(lineage.changeset_revision_source_job_id)
+    assert body["job_type"] == JobType.EXPORT.value
+    assert body["status"] == "pending"
+
+    expected_format, expected_media_type = EXPORT_KIND_MATRIX[ExportKind.REVISED_DXF]
+
+    assert session_module.AsyncSessionLocal is not None
+    async with session_module.AsyncSessionLocal() as session:
+        export_jobs = list(
+            await session.scalars(
+                select(Job).where(
+                    Job.job_type == JobType.EXPORT.value,
+                    Job.project_id == lineage.project_id,
+                    Job.file_id == lineage.file_id,
+                    Job.base_revision_id == lineage.changeset_revision_id,
+                )
+            )
+        )
+        assert len(export_jobs) == 1
+        export_job = export_jobs[0]
+        assert export_job.id == job_id
+        assert export_job.parent_job_id == lineage.changeset_revision_source_job_id
+
+        export_inputs = list(
+            await session.scalars(
+                select(ExportJobInput).where(
+                    ExportJobInput.project_id == lineage.project_id,
+                    ExportJobInput.source_file_id == lineage.file_id,
+                    ExportJobInput.drawing_revision_id == lineage.changeset_revision_id,
+                )
+            )
+        )
+        assert len(export_inputs) == 1
+        export_input = export_inputs[0]
+        assert export_input.source_job_id == export_job.id
+        assert export_input.export_kind == ExportKind.REVISED_DXF.value
+        assert export_input.export_format == expected_format.value
+        assert export_input.media_type == expected_media_type
+        assert export_input.options_json == {
+            "target_version": "R2010",
+            "include_review_flags": True,
+        }
+        assert export_input.quantity_takeoff_id is None
+        assert export_input.quantity_gate is None
+        assert export_input.trusted_totals is None
+        assert export_input.estimate_version_id is None
+
+    assert await _count_export_side_effects_for_revision(
+        lineage,
+        lineage.changeset_revision_id,
+    ) == (1, 1, 0)
+
+
+async def test_create_revised_dxf_export_rejects_non_changeset_revision_before_claim(
+    async_client: AsyncClient,
+) -> None:
+    lineage = await _seed_export_lineage()
+    idempotency_key = f"revised-dxf-ingest-{uuid4().hex}"
+
+    response = await async_client.post(
+        f"/v1/revisions/{lineage.revision_id}/exports/revised-dxf",
+        json={"options": {"target_version": "R2010"}},
+        headers={"Idempotency-Key": idempotency_key},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INPUT_INVALID"
+    assert await _count_export_side_effects(lineage) == (0, 0, 0)
+    assert await _count_idempotency_rows(idempotency_key) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_export_job_input_contract.py
+++ b/tests/test_export_job_input_contract.py
@@ -33,7 +33,7 @@ _MIGRATION_PATH = (
     Path(__file__).resolve().parents[1]
     / "alembic"
     / "versions"
-    / "2026_05_27_0024_add_export_job_input_contract.py"
+    / "2026_06_04_0029_add_revised_dxf_export_kind.py"
 )
 
 
@@ -196,7 +196,7 @@ async def _assert_append_only_sql_mutation_fails(
 
 def _load_migration_module() -> Any:
     spec = importlib.util.spec_from_file_location(
-        "migration_2026_05_27_0024_add_export_job_input_contract",
+        "migration_2026_06_04_0029_add_revised_dxf_export_kind",
         _MIGRATION_PATH,
     )
     assert spec is not None
@@ -375,6 +375,24 @@ async def test_export_job_input_schema_matches_contract() -> None:
         assert constraint_name in check_constraints["export_job_inputs"]
 
     assert (
+        "revised_dxf"
+        in check_constraints["export_job_inputs"]["ck_export_job_inputs_export_kind_valid"]
+    )
+    assert (
+        "dxf" in check_constraints["export_job_inputs"]["ck_export_job_inputs_export_format_valid"]
+    )
+    assert (
+        "application/dxf"
+        in check_constraints["export_job_inputs"]["ck_export_job_inputs_media_type_valid"]
+    )
+    assert (
+        "revised_dxf"
+        in check_constraints["export_job_inputs"][
+            "ck_export_job_inputs_kind_format_media_type_matrix"
+        ]
+    )
+
+    assert (
         (
             "source_job_id",
             "project_id",
@@ -429,6 +447,7 @@ async def test_export_job_input_persists_valid_revision_quantity_and_estimate_in
     estimate_version_id = await _create_estimate_version(db_session, seed)
 
     revision_job_id = await _create_export_job(db_session, seed)
+    revised_dxf_job_id = await _create_export_job(db_session, seed)
     quantity_job_id = await _create_export_job(db_session, seed)
     estimate_csv_job_id = await _create_export_job(db_session, seed)
     estimate_pdf_job_id = await _create_export_job(db_session, seed)
@@ -441,6 +460,17 @@ async def test_export_job_input_persists_valid_revision_quantity_and_estimate_in
                 export_kind="revision_json",
                 export_format="json",
                 media_type="application/json",
+                quantity_takeoff_id=None,
+                quantity_gate=None,
+                trusted_totals=None,
+                estimate_version_id=None,
+            ),
+            _build_export_input(
+                seed,
+                source_job_id=revised_dxf_job_id,
+                export_kind="revised_dxf",
+                export_format="dxf",
+                media_type="application/dxf",
                 quantity_takeoff_id=None,
                 quantity_gate=None,
                 trusted_totals=None,
@@ -492,7 +522,7 @@ async def test_export_job_input_persists_valid_revision_quantity_and_estimate_in
         .scalars()
         .all()
     )
-    assert len(persisted) == 4
+    assert len(persisted) == 5
     by_job_id = {row.source_job_id: row for row in persisted}
 
     assert by_job_id[revision_job_id].export_kind == "revision_json"
@@ -500,6 +530,12 @@ async def test_export_job_input_persists_valid_revision_quantity_and_estimate_in
     assert by_job_id[revision_job_id].media_type == "application/json"
     assert by_job_id[revision_job_id].quantity_takeoff_id is None
     assert by_job_id[revision_job_id].estimate_version_id is None
+
+    assert by_job_id[revised_dxf_job_id].export_kind == "revised_dxf"
+    assert by_job_id[revised_dxf_job_id].export_format == "dxf"
+    assert by_job_id[revised_dxf_job_id].media_type == "application/dxf"
+    assert by_job_id[revised_dxf_job_id].quantity_takeoff_id is None
+    assert by_job_id[revised_dxf_job_id].estimate_version_id is None
 
     assert by_job_id[quantity_job_id].export_kind == "quantity_csv"
     assert by_job_id[quantity_job_id].export_format == "csv"
@@ -555,7 +591,7 @@ async def test_export_job_input_contract_rejects_ambiguous_and_invalid_lineage_i
         "ck_jobs_revision_scoped_extraction_profile_forbidden",
     )
 
-    bad_job_ids = [await _create_export_job(db_session, seed) for _ in range(9)]
+    bad_job_ids = [await _create_export_job(db_session, seed) for _ in range(11)]
     await db_session.commit()
 
     invalid_cases: list[tuple[dict[str, object], str | tuple[str, ...]]] = [
@@ -574,6 +610,18 @@ async def test_export_job_input_contract_rejects_ambiguous_and_invalid_lineage_i
         ),
         (
             {
+                "export_kind": "revised_dxf",
+                "export_format": "json",
+                "media_type": "application/json",
+                "quantity_takeoff_id": None,
+                "quantity_gate": None,
+                "trusted_totals": None,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_kind_format_media_type_matrix",
+        ),
+        (
+            {
                 "export_kind": "quantity_csv",
                 "export_format": "pdf",
                 "media_type": "application/pdf",
@@ -583,6 +631,18 @@ async def test_export_job_input_contract_rejects_ambiguous_and_invalid_lineage_i
                 "estimate_version_id": None,
             },
             "ck_export_job_inputs_kind_format_media_type_matrix",
+        ),
+        (
+            {
+                "export_kind": "revised_dxf",
+                "export_format": "dxf",
+                "media_type": "application/dxf",
+                "quantity_takeoff_id": seed.quantity_takeoff_id,
+                "quantity_gate": "allowed",
+                "trusted_totals": True,
+                "estimate_version_id": None,
+            },
+            "ck_export_job_inputs_quantity_lineage",
         ),
         (
             {
@@ -710,7 +770,7 @@ async def test_export_job_input_contract_rejects_ambiguous_and_invalid_lineage_i
         )
 
 
-async def test_export_job_inputs_are_append_only_and_downgrade_guarded(
+async def test_export_job_inputs_are_append_only_and_revised_dxf_downgrade_guarded(
     async_client: httpx.AsyncClient,
     db_session: AsyncSession,
 ) -> None:
@@ -720,8 +780,7 @@ async def test_export_job_inputs_are_append_only_and_downgrade_guarded(
     export_job_without_rows = await _create_export_job(db_session, seed)
     await db_session.commit()
 
-    with pytest.raises(RuntimeError, match="persisted export jobs present"):
-        await _run_downgrade_guard(db_session)
+    await _run_downgrade_guard(db_session)
 
     estimate_version_id = await _create_estimate_version(db_session, seed)
     row_job_id = await _create_export_job(db_session, seed)
@@ -739,6 +798,8 @@ async def test_export_job_inputs_are_append_only_and_downgrade_guarded(
         )
     )
     await db_session.commit()
+
+    await _run_downgrade_guard(db_session)
 
     await _assert_append_only_sql_mutation_fails(
         db_session,
@@ -762,5 +823,21 @@ async def test_export_job_inputs_are_append_only_and_downgrade_guarded(
     )
 
     _ = export_job_without_rows
-    with pytest.raises(RuntimeError, match="persisted export_job_inputs rows present"):
+    revised_dxf_job_id = await _create_export_job(db_session, seed)
+    db_session.add(
+        _build_export_input(
+            seed,
+            source_job_id=revised_dxf_job_id,
+            export_kind="revised_dxf",
+            export_format="dxf",
+            media_type="application/dxf",
+            quantity_takeoff_id=None,
+            quantity_gate=None,
+            trusted_totals=None,
+            estimate_version_id=None,
+        )
+    )
+    await db_session.commit()
+
+    with pytest.raises(RuntimeError, match="persisted revised_dxf export_job_inputs rows present"):
         await _run_downgrade_guard(db_session)

--- a/tests/test_jobs_worker_exports.py
+++ b/tests/test_jobs_worker_exports.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -23,7 +23,9 @@ from app.core.errors import ErrorCode
 from app.exports._base import ExportArtifact
 from app.exports.csv import CsvExportResult, render_estimate_csv_export, render_quantity_csv_export
 from app.exports.estimate_pdf import EstimatePdfExportResult, render_estimate_pdf_export
+from app.exports.revised_dxf import RevisedDxfExportError
 from app.exports.revision_json import RevisionJsonExportResult, render_revision_json_export
+from app.models.cad_changeset import CadChangeSet
 from app.models.drawing_revision import DrawingRevision
 from app.models.estimate_version import EstimateItem, EstimateSnapshotEntry, EstimateVersion
 from app.models.export_job_input import ExportJobInput
@@ -54,6 +56,7 @@ class _ExportTestLineage:
     drawing_revision_id: uuid.UUID
     quantity_takeoff_id: uuid.UUID
     estimate_version_id: uuid.UUID
+    changeset_id: uuid.UUID | None = None
 
 
 class _StorageSpy:
@@ -288,6 +291,57 @@ async def _create_export_test_lineage(async_client: httpx.AsyncClient) -> _Expor
     )
 
 
+async def _create_revised_dxf_export_test_lineage(
+    async_client: httpx.AsyncClient,
+) -> _ExportTestLineage:
+    lineage = await _create_export_test_lineage(async_client)
+    base_revision = await _get_latest_revision(lineage.file_id)
+    changeset_id = uuid.uuid4()
+    changeset_revision_id = uuid.uuid4()
+    changeset_job = await _create_completed_job(
+        project_id=lineage.project_id,
+        file_id=lineage.file_id,
+        base_revision_id=base_revision.id,
+        job_type=JobType.CHANGESET_APPLY,
+    )
+    session_maker = _get_session_maker()
+
+    async with session_maker() as session:
+        session.add(
+            CadChangeSet(
+                id=changeset_id,
+                project_id=lineage.project_id,
+                base_revision_id=base_revision.id,
+                status="applied",
+                created_by="test",
+            )
+        )
+        session.add(
+            DrawingRevision(
+                id=changeset_revision_id,
+                project_id=lineage.project_id,
+                source_file_id=lineage.file_id,
+                extraction_profile_id=None,
+                source_job_id=changeset_job.id,
+                adapter_run_output_id=None,
+                changeset_id=changeset_id,
+                predecessor_revision_id=base_revision.id,
+                revision_sequence=base_revision.revision_sequence + 1,
+                revision_kind="changeset",
+                review_state=base_revision.review_state,
+                canonical_entity_schema_version=base_revision.canonical_entity_schema_version,
+                confidence_score=base_revision.confidence_score,
+            )
+        )
+        await session.commit()
+
+    return replace(
+        lineage,
+        drawing_revision_id=changeset_revision_id,
+        changeset_id=changeset_id,
+    )
+
+
 async def _create_export_job(
     *,
     lineage: _ExportTestLineage,
@@ -403,6 +457,30 @@ def _build_export_execution_input(
     )
 
 
+def _build_revised_dxf_execution_input(
+    *,
+    lineage: _ExportTestLineage,
+    changeset_id: uuid.UUID | None = None,
+    options_json: dict[str, object] | None = None,
+) -> worker_module._ExportExecutionInput:
+    resolved_changeset_id = changeset_id or lineage.changeset_id or uuid.uuid4()
+    resolved_options = {} if options_json is None else options_json
+    return worker_module._ExportExecutionInput(
+        drawing_revision_id=lineage.drawing_revision_id,
+        export_kind="revised_dxf",
+        export_format="dxf",
+        media_type="application/dxf",
+        artifact_name=worker_module._build_export_artifact_name(
+            export_kind="revised_dxf",
+            export_format="dxf",
+            drawing_revision_id=lineage.drawing_revision_id,
+            changeset_id=resolved_changeset_id,
+        ),
+        options_json=resolved_options,
+        changeset_id=resolved_changeset_id,
+    )
+
+
 @pytest.mark.parametrize(
     ("export_kind", "export_format", "media_type", "options_json"),
     [
@@ -459,6 +537,9 @@ async def test_process_export_job_supported_kinds_persist_artifact(
     assert artifact.source_file_id == lineage.file_id
     assert artifact.drawing_revision_id == lineage.drawing_revision_id
     assert artifact.generator_config_json == options_json
+    lineage_json = cast(dict[str, Any], artifact.lineage_json)
+    assert lineage_json["drawing_revision"] == {"id": str(lineage.drawing_revision_id)}
+    assert "changeset_id" not in cast(dict[str, Any], lineage_json["export"])
 
     (
         expected_bytes,
@@ -488,6 +569,14 @@ async def test_process_export_job_supported_kinds_persist_artifact(
         "generated_artifact_id": str(artifact.id),
         "export_kind": export_kind,
     }
+
+
+def test_export_kind_spec_revised_dxf_is_registered_with_changeset_anchor() -> None:
+    spec = worker_module._get_export_kind_spec("revised_dxf")
+
+    assert spec.format == "dxf"
+    assert spec.media_type == "application/dxf"
+    assert spec.lineage_anchor == worker_module._EXPORT_LINEAGE_ANCHOR_CHANGESET
 
 
 @pytest.mark.parametrize(
@@ -521,6 +610,170 @@ async def test_render_export_artifact_supported_kinds_return_shared_export_artif
 
     assert isinstance(rendered, ExportArtifact)
     assert rendered.media_type == media_type
+
+
+async def test_process_export_job_revised_dxf_requires_changeset_origin_revision(
+    async_client: httpx.AsyncClient,
+) -> None:
+    lineage = await _create_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revised_dxf",
+        export_format="dxf",
+        media_type="application/dxf",
+        options_json={},
+    )
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INPUT_INVALID.value
+    assert job.error_message == "Revised DXF export requires a changeset-origin drawing revision."
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+
+async def test_process_export_job_revised_dxf_persists_typed_changeset_artifact_and_redelivery_noop(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_revised_dxf_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revised_dxf",
+        export_format="dxf",
+        media_type="application/dxf",
+        options_json={"profile": "default"},
+    )
+
+    async def _render_revised_dxf(
+        db: AsyncSession,
+        revision_id: uuid.UUID,
+        options: dict[str, object] | None = None,
+    ) -> ExportArtifact:
+        _ = db
+        assert revision_id == lineage.drawing_revision_id
+        assert options == {"profile": "default"}
+        content_bytes = b"0\nSECTION\n2\nHEADER\n0\nENDSEC\n0\nEOF\n"
+        return ExportArtifact(
+            content_bytes=content_bytes,
+            checksum_sha256=hashlib.sha256(content_bytes).hexdigest(),
+            size_bytes=len(content_bytes),
+            media_type="application/dxf",
+            generator_name="revised_dxf_export",
+            generator_version="1",
+        )
+
+    monkeypatch.setattr(worker_module, "render_revised_dxf_export", _render_revised_dxf)
+
+    await worker_module.process_export_job(export_job_id)
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "succeeded"
+    assert job.error_code is None
+    artifacts = await _get_generated_artifacts_for_job(export_job_id)
+    assert len(artifacts) == 1
+    artifact = artifacts[0]
+    lineage_json = cast(dict[str, Any], artifact.lineage_json)
+    assert artifact.artifact_kind == "revised_dxf"
+    assert artifact.format == "dxf"
+    assert artifact.media_type == "application/dxf"
+    assert artifact.name == f"changeset-{lineage.changeset_id}.dxf"
+    assert artifact.changeset_id == lineage.changeset_id
+    assert lineage_json["drawing_revision"] == {
+        "id": str(lineage.drawing_revision_id),
+        "changeset_id": str(lineage.changeset_id),
+    }
+    export_lineage = cast(dict[str, Any], lineage_json["export"])
+    assert export_lineage["changeset_id"] == str(lineage.changeset_id)
+
+    success_events = [
+        event for event in await _get_job_events(export_job_id) if event.message == "Job succeeded"
+    ]
+    assert len(success_events) == 1
+
+
+@pytest.mark.parametrize(
+    ("renderer_code", "expected_error_code"),
+    [
+        ("UNSUPPORTED_ENTITY_TYPE", ErrorCode.INPUT_INVALID.value),
+        ("ADAPTER_UNAVAILABLE", ErrorCode.ADAPTER_UNAVAILABLE.value),
+        ("ADAPTER_LOAD_FAILED", ErrorCode.ADAPTER_UNAVAILABLE.value),
+        ("ADAPTER_FAILED", ErrorCode.ADAPTER_FAILED.value),
+        ("EXPORT_FAILED", ErrorCode.ADAPTER_FAILED.value),
+        ("WRITER_CONTRACT_BROKEN", ErrorCode.ADAPTER_FAILED.value),
+    ],
+)
+async def test_process_export_job_revised_dxf_renderer_errors_map_without_artifact(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    renderer_code: str,
+    expected_error_code: str,
+) -> None:
+    lineage = await _create_revised_dxf_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revised_dxf",
+        export_format="dxf",
+        media_type="application/dxf",
+        options_json={},
+    )
+
+    async def _raise_revised_dxf_error(
+        db: AsyncSession,
+        revision_id: uuid.UUID,
+        options: dict[str, object] | None = None,
+    ) -> ExportArtifact:
+        _ = (db, revision_id, options)
+        raise RevisedDxfExportError(
+            code=renderer_code,
+            message=f"renderer failed with {renderer_code}",
+            details={"entity_type": "ARC"},
+        )
+
+    monkeypatch.setattr(worker_module, "render_revised_dxf_export", _raise_revised_dxf_error)
+
+    await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == expected_error_code
+    assert job.error_message is not None
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
+
+
+async def test_process_export_job_revised_dxf_unexpected_renderer_failure_is_internal_error(
+    async_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = await _create_revised_dxf_export_test_lineage(async_client)
+    export_job_id = await _create_export_job(
+        lineage=lineage,
+        export_kind="revised_dxf",
+        export_format="dxf",
+        media_type="application/dxf",
+        options_json={},
+    )
+
+    async def _raise_runtime_error(
+        db: AsyncSession,
+        revision_id: uuid.UUID,
+        options: dict[str, object] | None = None,
+    ) -> ExportArtifact:
+        _ = (db, revision_id, options)
+        raise RuntimeError("unexpected revised dxf failure")
+
+    monkeypatch.setattr(worker_module, "render_revised_dxf_export", _raise_runtime_error)
+
+    with pytest.raises(RuntimeError, match="unexpected revised dxf failure"):
+        await worker_module.process_export_job(export_job_id)
+
+    job = await _get_job(export_job_id)
+    assert job.status == "failed"
+    assert job.error_code == ErrorCode.INTERNAL_ERROR.value
+    assert job.error_message == worker_module._PROCESS_EXPORT_JOB_ERROR_MESSAGE
+    assert await _get_generated_artifacts_for_job(export_job_id) == []
 
 
 async def test_process_export_job_duplicate_terminal_redelivery_is_noop(

--- a/tests/test_revised_dxf_export.py
+++ b/tests/test_revised_dxf_export.py
@@ -1,0 +1,699 @@
+"""Integration tests for deterministic revised DXF export rendering."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import app.db.session as session_module
+from app.exports import revised_dxf as revised_dxf_module
+from app.exports.revised_dxf import (
+    REVISED_DXF_EXPORT_GENERATOR_NAME,
+    REVISED_DXF_EXPORT_GENERATOR_VERSION,
+    REVISED_DXF_EXPORT_MEDIA_TYPE,
+    RevisedDxfExportError,
+    RevisedDxfExportResult,
+    render_revised_dxf_export,
+)
+from app.ingestion.contracts import (
+    AdapterAvailability,
+    AdapterStatus,
+    AvailabilityReason,
+)
+from app.models.adapter_run_output import AdapterRunOutput
+from app.models.cad_changeset import CadChangeSet
+from app.models.drawing_revision import DrawingRevision
+from app.models.extraction_profile import ExtractionProfile
+from app.models.file import File
+from app.models.job import Job, JobStatus, JobType
+from app.models.project import Project
+from app.models.revision_materialization import (
+    RevisionBlock,
+    RevisionEntity,
+    RevisionEntityManifest,
+    RevisionLayer,
+    RevisionLayout,
+)
+from tests.conftest import requires_database
+
+pytestmark = [pytest.mark.asyncio, requires_database]
+
+_FIXTURE_UUID_NAMESPACE = uuid.UUID("b0fbf345-22f4-4107-9982-72587ad61be8")
+_EXPECTED_REVISED_DXF_CHECKSUM = "dd76eb82953872c35d8bdfafc702dfc285fa758f397b3f0abec664c0bb81418d"
+
+
+@dataclass(frozen=True, slots=True)
+class SeededRevisionFixture:
+    project: Project
+    source_file: File
+    extraction_profile: ExtractionProfile
+    source_job: Job
+    adapter_output: AdapterRunOutput
+    base_revision: DrawingRevision
+    revision: DrawingRevision
+    manifest: RevisionEntityManifest | None
+
+
+class _UnavailableAdapter:
+    def probe(self) -> AdapterAvailability:
+        return AdapterAvailability(
+            status=AdapterStatus.UNAVAILABLE,
+            availability_reason=AvailabilityReason.PROBE_FAILED,
+            details={"dependency": "ezdxf"},
+        )
+
+    async def export(self, request: object, options: object) -> object:
+        del request, options
+        raise AssertionError("export should not be called when the adapter is unavailable")
+
+
+class _AvailableAdapter:
+    def probe(self) -> AdapterAvailability:
+        return AdapterAvailability(status=AdapterStatus.AVAILABLE)
+
+
+class _AdapterContractError(RuntimeError):
+    code: ClassVar[str] = "EXPORT_FAILED"
+    details: ClassVar[dict[str, str]] = {"stage": "export"}
+
+
+class _ContractFailingAdapter(_AvailableAdapter):
+    async def export(self, request: object, options: object) -> object:
+        del request, options
+        raise _AdapterContractError("adapter contract failed")
+
+
+@pytest_asyncio.fixture
+async def db_session(cleanup_projects: None) -> AsyncGenerator[AsyncSession, None]:
+    _ = cleanup_projects
+    session_maker = session_module.AsyncSessionLocal
+    if session_maker is None:
+        raise RuntimeError("Database is not configured. Set DATABASE_URL environment variable.")
+
+    async with session_maker() as session:
+        yield session
+        await session.rollback()
+
+
+async def test_render_revised_dxf_export_is_deterministic_and_returns_artifact_metadata(
+    db_session: AsyncSession,
+) -> None:
+    seeded = await _seed_revision_fixture(
+        db_session,
+        layers=(
+            {"layer_ref": "Layer-B", "sequence_index": 1, "payload": {"name": "Layer-B"}},
+            {"layer_ref": "Layer-A", "sequence_index": 0, "payload": {"name": "Layer-A"}},
+        ),
+        entities=(
+            {
+                "entity_id": "polyline-b",
+                "entity_type": "lwpolyline",
+                "entity_schema_version": "1.0",
+                "sequence_index": 1,
+                "layout_ref": "Model",
+                "layer_ref": "Layer-B",
+                "geometry": {
+                    "points": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.5, "y": 0.0},
+                        {"x": 1.5, "y": 1.0},
+                    ],
+                    "units": {"normalized": "m"},
+                },
+                "properties": {"closed": False},
+                "canonical_entity": {
+                    "entity_type": "lwpolyline",
+                    "geometry": {
+                        "points": [
+                            {"x": 0.0, "y": 0.0},
+                            {"x": 1.5, "y": 0.0},
+                            {"x": 1.5, "y": 1.0},
+                        ],
+                        "units": {"normalized": "m"},
+                    },
+                    "properties": {"closed": False},
+                },
+            },
+            {
+                "entity_id": "line-a",
+                "entity_type": "line",
+                "entity_schema_version": "1.0",
+                "sequence_index": 0,
+                "layout_ref": "Model",
+                "layer_ref": "Layer-A",
+                "geometry": {
+                    "start": {"x": 0.0, "y": 0.0},
+                    "end": {"x": 2.0, "y": 0.0},
+                    "units": {"normalized": "m"},
+                },
+                "properties": {},
+                "canonical_entity": {
+                    "entity_type": "line",
+                    "geometry": {
+                        "start": {"x": 0.0, "y": 0.0},
+                        "end": {"x": 2.0, "y": 0.0},
+                        "units": {"normalized": "m"},
+                    },
+                    "properties": {},
+                },
+            },
+        ),
+    )
+    options = {
+        "exported_at": datetime(2026, 6, 2, 18, 45, tzinfo=UTC),
+        "label": "deterministic",
+    }
+
+    first = await render_revised_dxf_export(db_session, seeded.revision.id, options=options)
+    second = await render_revised_dxf_export(db_session, seeded.revision.id, options=options)
+
+    content_text = first.content_bytes.decode("utf-8")
+
+    assert first == second
+    assert first == RevisedDxfExportResult(
+        content_bytes=first.content_bytes,
+        checksum_sha256=_EXPECTED_REVISED_DXF_CHECKSUM,
+        size_bytes=len(first.content_bytes),
+        media_type=REVISED_DXF_EXPORT_MEDIA_TYPE,
+        generator_name=REVISED_DXF_EXPORT_GENERATOR_NAME,
+        generator_version=REVISED_DXF_EXPORT_GENERATOR_VERSION,
+        options={
+            "exported_at": "2026-06-02T18:45:00Z",
+            "label": "deterministic",
+        },
+    )
+    assert first.media_type == REVISED_DXF_EXPORT_MEDIA_TYPE
+    assert first.checksum_sha256 == _EXPECTED_REVISED_DXF_CHECKSUM
+    assert "LINE" in content_text
+    assert "LWPOLYLINE" in content_text
+    assert content_text.index("Layer-A") < content_text.index("Layer-B")
+    assert content_text.index("LINE") < content_text.index("LWPOLYLINE")
+
+
+async def test_render_revised_dxf_export_raises_for_missing_manifest(
+    db_session: AsyncSession,
+) -> None:
+    seeded = await _seed_revision_fixture(db_session, with_manifest=False)
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.revision.id)
+
+    assert exc_info.value.code == "MANIFEST_NOT_FOUND"
+    assert exc_info.value.details == {"revision_id": str(seeded.revision.id)}
+
+
+async def test_render_revised_dxf_export_rejects_non_changeset_origin_revision(
+    db_session: AsyncSession,
+) -> None:
+    seeded = await _seed_revision_fixture(db_session)
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.base_revision.id)
+
+    assert exc_info.value.code == "INPUT_INVALID"
+    assert exc_info.value.details == {
+        "revision_id": str(seeded.base_revision.id),
+        "revision_kind": "ingest",
+    }
+
+
+async def test_render_revised_dxf_export_raises_for_missing_materialization_rows(
+    db_session: AsyncSession,
+) -> None:
+    seeded = await _seed_revision_fixture(
+        db_session,
+        manifest_counts={"layouts": 1, "layers": 1, "blocks": 0, "entities": 1},
+        layouts=({"layout_ref": "Model", "sequence_index": 0, "payload": {"name": "Model"}},),
+        layers=({"layer_ref": "Layer-A", "sequence_index": 0, "payload": {"name": "Layer-A"}},),
+        entities=(),
+    )
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.revision.id)
+
+    assert exc_info.value.code == "MATERIALIZATION_MISSING"
+    assert exc_info.value.details == {
+        "revision_id": str(seeded.revision.id),
+        "component": "entities",
+        "expected_count": 1,
+        "actual_count": 0,
+    }
+
+
+async def test_render_revised_dxf_export_raises_for_unavailable_adapter(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seeded = await _seed_revision_fixture(db_session)
+
+    def _load_unavailable_adapter(descriptor: object) -> _UnavailableAdapter:
+        del descriptor
+        return _UnavailableAdapter()
+
+    monkeypatch.setattr(revised_dxf_module, "load_export_adapter", _load_unavailable_adapter)
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.revision.id)
+
+    assert exc_info.value.code == "ADAPTER_UNAVAILABLE"
+    assert exc_info.value.details == {
+        "adapter_key": "ezdxf_writer",
+        "output_format": "revised_dxf",
+        "status": "unavailable",
+        "availability_reason": "probe_failed",
+        "license_state": "not_required",
+        "issues": [],
+        "observed": [],
+        "details": {"dependency": "ezdxf"},
+    }
+
+
+async def test_render_revised_dxf_export_raises_for_adapter_load_failure(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seeded = await _seed_revision_fixture(db_session)
+
+    def _raise_load_failure(descriptor: object) -> object:
+        del descriptor
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(revised_dxf_module, "load_export_adapter", _raise_load_failure)
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.revision.id)
+
+    assert exc_info.value.code == "ADAPTER_LOAD_FAILED"
+    assert exc_info.value.details == {
+        "adapter_key": "ezdxf_writer",
+        "output_format": "revised_dxf",
+        "error_type": "RuntimeError",
+    }
+
+
+async def test_render_revised_dxf_export_maps_unexpected_adapter_contract_failure(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seeded = await _seed_revision_fixture(db_session)
+
+    def _load_contract_failing_adapter(descriptor: object) -> _ContractFailingAdapter:
+        del descriptor
+        return _ContractFailingAdapter()
+
+    monkeypatch.setattr(revised_dxf_module, "load_export_adapter", _load_contract_failing_adapter)
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.revision.id)
+
+    assert exc_info.value.code == "ADAPTER_FAILED"
+    assert exc_info.value.details == {
+        "adapter_key": "ezdxf_writer",
+        "output_format": "revised_dxf",
+        "stage": "export",
+        "original_error_code": "EXPORT_FAILED",
+    }
+
+
+async def test_render_revised_dxf_export_wraps_unsupported_writer_payload(
+    db_session: AsyncSession,
+) -> None:
+    seeded = await _seed_revision_fixture(
+        db_session,
+        blocks=({"block_ref": "Block-A", "sequence_index": 0, "payload": {"name": "Block-A"}},),
+        entities=(
+            {
+                "entity_id": "line-a",
+                "entity_type": "line",
+                "entity_schema_version": "1.0",
+                "sequence_index": 0,
+                "layout_ref": "Model",
+                "layer_ref": "Layer-A",
+                "geometry": {
+                    "start": {"x": 0.0, "y": 0.0},
+                    "end": {"x": 2.0, "y": 0.0},
+                    "units": {"normalized": "m"},
+                },
+                "properties": {},
+                "canonical_entity": {
+                    "entity_type": "line",
+                    "geometry": {
+                        "start": {"x": 0.0, "y": 0.0},
+                        "end": {"x": 2.0, "y": 0.0},
+                        "units": {"normalized": "m"},
+                    },
+                    "properties": {},
+                },
+            },
+        ),
+    )
+
+    with pytest.raises(RevisedDxfExportError) as exc_info:
+        await render_revised_dxf_export(db_session, seeded.revision.id)
+
+    assert exc_info.value.code == "UNSUPPORTED_ENTITY_TYPE"
+    assert exc_info.value.details == {
+        "adapter_key": "ezdxf_writer",
+        "output_format": "revised_dxf",
+        "path": "blocks",
+    }
+
+
+async def _seed_revision_fixture(
+    db_session: AsyncSession,
+    *,
+    with_manifest: bool = True,
+    manifest_counts: Mapping[str, int] | None = None,
+    layouts: tuple[Mapping[str, Any], ...] = (
+        {"layout_ref": "Model", "sequence_index": 0, "payload": {"name": "Model"}},
+    ),
+    layers: tuple[Mapping[str, Any], ...] = (
+        {"layer_ref": "Layer-A", "sequence_index": 0, "payload": {"name": "Layer-A"}},
+    ),
+    blocks: tuple[Mapping[str, Any], ...] = (),
+    entities: tuple[Mapping[str, Any], ...] = (
+        {
+            "entity_id": "line-a",
+            "entity_type": "line",
+            "entity_schema_version": "1.0",
+            "sequence_index": 0,
+            "layout_ref": "Model",
+            "layer_ref": "Layer-A",
+            "geometry": {
+                "start": {"x": 0.0, "y": 0.0},
+                "end": {"x": 1.0, "y": 0.0},
+                "units": {"normalized": "m"},
+            },
+            "properties": {},
+            "canonical_entity": {
+                "entity_type": "line",
+                "geometry": {
+                    "start": {"x": 0.0, "y": 0.0},
+                    "end": {"x": 1.0, "y": 0.0},
+                    "units": {"normalized": "m"},
+                },
+                "properties": {},
+            },
+        },
+    ),
+) -> SeededRevisionFixture:
+    project = Project(
+        id=_fixture_uuid("project"),
+        name="Revised DXF Export Project",
+        description="Fixture project",
+    )
+    source_file = File(
+        id=_fixture_uuid("source_file"),
+        project_id=project.id,
+        original_filename="fixture.dxf",
+        media_type="application/dxf",
+        detected_format="dxf",
+        storage_uri="file:///tmp/fixture.dxf",
+        size_bytes=128,
+        checksum_sha256="a" * 64,
+        immutable=True,
+        created_at=datetime(2026, 6, 2, 18, 0, tzinfo=UTC),
+    )
+    extraction_profile = ExtractionProfile(
+        id=_fixture_uuid("extraction_profile"),
+        project_id=project.id,
+        profile_version="1.0",
+        layout_mode="all",
+        xref_handling="embed",
+        block_handling="expand",
+        text_extraction=True,
+        dimension_extraction=True,
+        confidence_threshold=0.6,
+        created_at=datetime(2026, 6, 2, 18, 1, tzinfo=UTC),
+    )
+    source_job = Job(
+        id=_fixture_uuid("source_job"),
+        project_id=project.id,
+        file_id=source_file.id,
+        extraction_profile_id=extraction_profile.id,
+        base_revision_id=None,
+        parent_job_id=None,
+        job_type=JobType.INGEST.value,
+        status=JobStatus.SUCCEEDED.value,
+        attempts=1,
+        max_attempts=3,
+        enqueue_status="published",
+        enqueue_attempts=1,
+        cancel_requested=False,
+        created_at=datetime(2026, 6, 2, 18, 2, tzinfo=UTC),
+        finished_at=datetime(2026, 6, 2, 18, 8, tzinfo=UTC),
+    )
+    adapter_output = AdapterRunOutput(
+        id=_fixture_uuid("adapter_output"),
+        project_id=project.id,
+        source_file_id=source_file.id,
+        extraction_profile_id=extraction_profile.id,
+        source_job_id=source_job.id,
+        adapter_key="tests.fake",
+        adapter_version="1.0",
+        input_family="dxf",
+        canonical_entity_schema_version="1.0",
+        canonical_json={"entities": [], "layers": [], "layouts": [], "blocks": []},
+        provenance_json={"adapter": {"key": "tests.fake", "version": "1.0"}},
+        confidence_json={"score": 0.875},
+        confidence_score=0.875,
+        warnings_json=[],
+        diagnostics_json={"duration_ms": 3},
+        result_checksum_sha256="b" * 64,
+        created_at=datetime(2026, 6, 2, 18, 4, tzinfo=UTC),
+    )
+    base_revision = DrawingRevision(
+        id=_fixture_uuid("base_revision"),
+        project_id=project.id,
+        source_file_id=source_file.id,
+        extraction_profile_id=extraction_profile.id,
+        source_job_id=source_job.id,
+        adapter_run_output_id=adapter_output.id,
+        predecessor_revision_id=None,
+        revision_sequence=1,
+        revision_kind="ingest",
+        review_state="approved",
+        canonical_entity_schema_version="1.0",
+        confidence_score=0.875,
+        created_at=datetime(2026, 6, 2, 18, 5, tzinfo=UTC),
+    )
+    changeset_source_job = Job(
+        id=_fixture_uuid("changeset_source_job"),
+        project_id=project.id,
+        file_id=source_file.id,
+        extraction_profile_id=None,
+        base_revision_id=base_revision.id,
+        parent_job_id=source_job.id,
+        job_type=JobType.CHANGESET_APPLY.value,
+        status=JobStatus.SUCCEEDED.value,
+        attempts=1,
+        max_attempts=3,
+        enqueue_status="published",
+        enqueue_attempts=1,
+        cancel_requested=False,
+        created_at=datetime(2026, 6, 2, 18, 8, tzinfo=UTC),
+        finished_at=datetime(2026, 6, 2, 18, 9, tzinfo=UTC),
+    )
+    changeset = CadChangeSet(
+        id=_fixture_uuid("changeset"),
+        project_id=project.id,
+        base_revision_id=base_revision.id,
+        status="applied",
+        created_by="test",
+        created_at=datetime(2026, 6, 2, 18, 9, tzinfo=UTC),
+    )
+    revision = DrawingRevision(
+        id=_fixture_uuid("revision"),
+        project_id=project.id,
+        source_file_id=source_file.id,
+        extraction_profile_id=None,
+        source_job_id=changeset_source_job.id,
+        adapter_run_output_id=None,
+        changeset_id=changeset.id,
+        predecessor_revision_id=base_revision.id,
+        revision_sequence=2,
+        revision_kind="changeset",
+        review_state="approved",
+        canonical_entity_schema_version="1.0",
+        confidence_score=0.875,
+        created_at=datetime(2026, 6, 2, 18, 10, tzinfo=UTC),
+    )
+
+    db_session.add(project)
+    await db_session.flush()
+    db_session.add(source_file)
+    db_session.add(extraction_profile)
+    await db_session.flush()
+    db_session.add(source_job)
+    await db_session.flush()
+    db_session.add(adapter_output)
+    await db_session.flush()
+    db_session.add(base_revision)
+    await db_session.flush()
+    db_session.add(changeset_source_job)
+    db_session.add(changeset)
+    await db_session.flush()
+    db_session.add(revision)
+    await db_session.flush()
+
+    manifest: RevisionEntityManifest | None = None
+    if with_manifest:
+        counts = {
+            "layouts": len(layouts),
+            "layers": len(layers),
+            "blocks": len(blocks),
+            "entities": len(entities),
+        }
+        if manifest_counts is not None:
+            counts.update({key: int(value) for key, value in manifest_counts.items()})
+        manifest = RevisionEntityManifest(
+            id=_fixture_uuid("manifest"),
+            project_id=project.id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=changeset_source_job.id,
+            drawing_revision_id=revision.id,
+            adapter_run_output_id=None,
+            canonical_entity_schema_version="1.0",
+            counts_json=counts,
+            created_at=datetime(2026, 6, 2, 18, 11, tzinfo=UTC),
+        )
+        db_session.add(manifest)
+        await db_session.flush()
+
+    created_layouts: list[RevisionLayout] = []
+    for layout_index, spec in enumerate(layouts):
+        created_layout = RevisionLayout(
+            id=_fixture_uuid(f"layout:{layout_index}"),
+            project_id=project.id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=changeset_source_job.id,
+            drawing_revision_id=revision.id,
+            adapter_run_output_id=None,
+            canonical_entity_schema_version="1.0",
+            sequence_index=int(spec["sequence_index"]),
+            payload_json=dict(spec["payload"]),
+            layout_ref=str(spec["layout_ref"]),
+            created_at=datetime(2026, 6, 2, 18, 11, tzinfo=UTC),
+        )
+        db_session.add(created_layout)
+        created_layouts.append(created_layout)
+    await db_session.flush()
+
+    created_layers: list[RevisionLayer] = []
+    for layer_index, spec in enumerate(layers):
+        created_layer = RevisionLayer(
+            id=_fixture_uuid(f"layer:{layer_index}"),
+            project_id=project.id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=changeset_source_job.id,
+            drawing_revision_id=revision.id,
+            adapter_run_output_id=None,
+            canonical_entity_schema_version="1.0",
+            sequence_index=int(spec["sequence_index"]),
+            payload_json=dict(spec["payload"]),
+            layer_ref=str(spec["layer_ref"]),
+            created_at=datetime(2026, 6, 2, 18, 11, tzinfo=UTC),
+        )
+        db_session.add(created_layer)
+        created_layers.append(created_layer)
+    await db_session.flush()
+
+    created_blocks: list[RevisionBlock] = []
+    for block_index, spec in enumerate(blocks):
+        created_block = RevisionBlock(
+            id=_fixture_uuid(f"block:{block_index}"),
+            project_id=project.id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=changeset_source_job.id,
+            drawing_revision_id=revision.id,
+            adapter_run_output_id=None,
+            canonical_entity_schema_version="1.0",
+            sequence_index=int(spec["sequence_index"]),
+            payload_json=dict(spec["payload"]),
+            block_ref=str(spec["block_ref"]),
+            created_at=datetime(2026, 6, 2, 18, 11, tzinfo=UTC),
+        )
+        db_session.add(created_block)
+        created_blocks.append(created_block)
+    await db_session.flush()
+
+    layout_by_ref = {layout.layout_ref: layout for layout in created_layouts}
+    layer_by_ref = {layer.layer_ref: layer for layer in created_layers}
+    block_by_ref = {block.block_ref: block for block in created_blocks}
+
+    for entity_index, spec in enumerate(entities):
+        layout_ref = _optional_str(spec.get("layout_ref"))
+        layer_ref = _optional_str(spec.get("layer_ref"))
+        block_ref = _optional_str(spec.get("block_ref"))
+        entity = RevisionEntity(
+            id=_fixture_uuid(f"entity:{entity_index}"),
+            project_id=project.id,
+            source_file_id=source_file.id,
+            extraction_profile_id=None,
+            source_job_id=changeset_source_job.id,
+            drawing_revision_id=revision.id,
+            adapter_run_output_id=None,
+            canonical_entity_schema_version="1.0",
+            sequence_index=int(spec["sequence_index"]),
+            entity_id=str(spec["entity_id"]),
+            entity_type=str(spec["entity_type"]),
+            entity_schema_version=str(spec["entity_schema_version"]),
+            parent_entity_ref=None,
+            confidence_score=1.0,
+            confidence_json={},
+            geometry_json=dict(spec["geometry"]),
+            properties_json=dict(spec["properties"]),
+            provenance_json={"origin": "adapter_normalized"},
+            canonical_entity_json=_optional_dict(spec.get("canonical_entity")),
+            layout_ref=layout_ref,
+            layer_ref=layer_ref,
+            block_ref=block_ref,
+            source_identity=None,
+            source_hash=None,
+            layout_id=None if layout_ref is None else layout_by_ref[layout_ref].id,
+            layer_id=None if layer_ref is None else layer_by_ref[layer_ref].id,
+            block_id=None if block_ref is None else block_by_ref[block_ref].id,
+            parent_entity_row_id=None,
+            created_at=datetime(2026, 6, 2, 18, 12, tzinfo=UTC),
+        )
+        db_session.add(entity)
+    await db_session.commit()
+
+    return SeededRevisionFixture(
+        project=project,
+        source_file=source_file,
+        extraction_profile=extraction_profile,
+        source_job=source_job,
+        adapter_output=adapter_output,
+        base_revision=base_revision,
+        revision=revision,
+        manifest=manifest,
+    )
+
+
+def _optional_dict(value: object) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    assert isinstance(value, dict)
+    return dict(value)
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _fixture_uuid(name: str) -> uuid.UUID:
+    return uuid.uuid5(_FIXTURE_UUID_NAMESPACE, f"revised_dxf_export:{name}")

--- a/tests/test_revision_router_contract.py
+++ b/tests/test_revision_router_contract.py
@@ -494,6 +494,27 @@ def test_revision_router_routes_match_baseline_contract() -> None:
         ),
         (
             "POST",
+            "/revisions/{revision_id}/exports/revised-dxf",
+            "create_revised_dxf_export",
+            "create_revised_dxf_export",
+            "JobRead",
+            202,
+            (
+                ("path", "revision_id", True, None, None, None, None),
+                ("dependency", "db", None, None, None, None, "get_db"),
+                (
+                    "dependency",
+                    "idempotency_key",
+                    None,
+                    None,
+                    None,
+                    None,
+                    "get_idempotency_key",
+                ),
+            ),
+        ),
+        (
+            "POST",
             "/revisions/{revision_id}/quantity-takeoffs/{takeoff_id}/exports/quantity-csv",
             "create_revision_quantity_csv_export",
             "create_revision_quantity_csv_export",


### PR DESCRIPTION
Closes #258

## Summary
- add revised-DXF export kind, DB contract, and pending-job API route
- render revised DXF through the export adapter registry from changeset-origin revisions
- persist typed changeset artifact lineage and deterministic worker error mapping

## Test plan
- [x] uv run ruff check app tests alembic scripts
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_export_job_input_contract.py tests/test_export_create_api.py tests/test_revised_dxf_export.py tests/test_jobs_worker_exports.py tests/test_revision_router_contract.py tests/test_ingestion_runner.py -k "revised_dxf or export"
- [x] git push pre-push hook full pytest suite