### PR TITLE
fix(files): clean up upload bytes before commit

### DIFF
--- a/app/api/idempotency.py
+++ b/app/api/idempotency.py
@@ -383,6 +383,7 @@ async def run_idempotent_mutation[ResultT](
     preclaim: Callable[[], Awaitable[Response | None]] | None = None,
     reload_after_claim: Callable[[], Awaitable[None]] | None = None,
     ops: IdempotentMutationOps | None = None,
+    pre_commit_failure_cleanup: Callable[[], Awaitable[None]] | None = None,
 ) -> Response:
     """Run the shared replay/claim/mutate/complete/commit mutation flow."""
 
@@ -413,23 +414,31 @@ async def run_idempotent_mutation[ResultT](
     if reservation_or_response is not None and reload_after_claim is not None:
         await reload_after_claim()
 
-    mutation_result = await mutate()
-    if isinstance(mutation_result, IdempotentMutationKnownError):
-        response_body = mutation_result.response_body
-        after_commit = mutation_result.after_commit
-        status_code = mutation_result.status_code
-    else:
-        response_body = serialize_result(mutation_result.value)
-        after_commit = mutation_result.after_commit
-        status_code = mutation_result.status_code
+    commit_started = False
+    try:
+        mutation_result = await mutate()
+        if isinstance(mutation_result, IdempotentMutationKnownError):
+            response_body = mutation_result.response_body
+            after_commit = mutation_result.after_commit
+            status_code = mutation_result.status_code
+        else:
+            response_body = serialize_result(mutation_result.value)
+            after_commit = mutation_result.after_commit
+            status_code = mutation_result.status_code
 
-    response = await resolved_ops.complete(
-        db,
-        reservation_or_response,
-        status_code=status_code,
-        response_body=response_body,
-    )
-    await db.commit()
+        response = await resolved_ops.complete(
+            db,
+            reservation_or_response,
+            status_code=status_code,
+            response_body=response_body,
+        )
+        commit_started = True
+        await db.commit()
+    except BaseException:
+        if not commit_started and pre_commit_failure_cleanup is not None:
+            await pre_commit_failure_cleanup()
+        raise
+
     if after_commit is not None:
         await after_commit()
     return response

--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -186,6 +186,12 @@ async def _cleanup_persisted_upload(storage: Storage, storage_key: str, storage_
         await storage.delete_failed_put(storage_key, storage_uri=storage_uri)
 
 
+async def _rollback_upload_cleanup_transaction(db: AsyncSession) -> None:
+    """Best-effort rollback before upload cleanup paths."""
+    with suppress(BaseException):
+        await db.rollback()
+
+
 async def _raise_input_invalid_for_upload_metadata(file: UploadFile, message: str) -> None:
     """Close upload and raise standardized client validation error envelope."""
     await file.close()
@@ -442,6 +448,7 @@ async def upload_project_file(
     max_upload_bytes = settings.max_upload_mb * 1024 * 1024
     total_bytes = 0
     checksum_builder = hashlib.sha256()
+    persisted_upload_uri: str | None = None
     try:
         with staging_path.open("xb") as stream:
             initial_bytes = await file.read(_UPLOAD_SNIFF_BYTES)
@@ -494,47 +501,49 @@ async def upload_project_file(
         async def _finalize_upload(persisted_storage_uri: str) -> FileModel:
             try:
                 await _get_active_project_or_404(db, project_id, for_update=True)
-            except Exception:
-                await db.rollback()
+                extraction_profile = _build_extraction_profile(project_id)
+                db.add(extraction_profile)
+
+                ingest_job = Job(
+                    id=uuid.uuid4(),
+                    project_id=project_id,
+                    file_id=file_id,
+                    extraction_profile_id=extraction_profile.id,
+                    job_type="ingest",
+                    status="pending",
+                    attempts=0,
+                    max_attempts=3,
+                    cancel_requested=False,
+                )
+
+                file_row = FileModel(
+                    id=file_id,
+                    project_id=project_id,
+                    original_filename=original_filename,
+                    media_type=media_type,
+                    detected_format=detected_format,
+                    storage_uri=persisted_storage_uri,
+                    size_bytes=total_bytes,
+                    checksum_sha256=checksum,
+                    immutable=True,
+                    initial_job_id=ingest_job.id,
+                    initial_extraction_profile_id=extraction_profile.id,
+                )
+                db.add(file_row)
+                db.add(ingest_job)
+                prepare_job_enqueue_intent(ingest_job)
+                await db.flush()
+                await db.refresh(file_row)
+                await db.refresh(ingest_job)
+
+                return _attach_initial_upload_metadata(file_row)
+            except BaseException:
+                nonlocal persisted_upload_uri
+                await _rollback_upload_cleanup_transaction(db)
                 await _cleanup_persisted_upload(storage, storage_key, persisted_storage_uri)
+                if persisted_upload_uri == persisted_storage_uri:
+                    persisted_upload_uri = None
                 raise
-
-            extraction_profile = _build_extraction_profile(project_id)
-            db.add(extraction_profile)
-
-            ingest_job = Job(
-                id=uuid.uuid4(),
-                project_id=project_id,
-                file_id=file_id,
-                extraction_profile_id=extraction_profile.id,
-                job_type="ingest",
-                status="pending",
-                attempts=0,
-                max_attempts=3,
-                cancel_requested=False,
-            )
-
-            file_row = FileModel(
-                id=file_id,
-                project_id=project_id,
-                original_filename=original_filename,
-                media_type=media_type,
-                detected_format=detected_format,
-                storage_uri=persisted_storage_uri,
-                size_bytes=total_bytes,
-                checksum_sha256=checksum,
-                immutable=True,
-                initial_job_id=ingest_job.id,
-                initial_extraction_profile_id=extraction_profile.id,
-            )
-            db.add(file_row)
-            db.add(ingest_job)
-            prepare_job_enqueue_intent(ingest_job)
-            await db.flush()
-            await db.refresh(file_row)
-            await db.refresh(ingest_job)
-
-            return _attach_initial_upload_metadata(file_row)
 
         if idempotency_key is not None:
             fingerprint = build_idempotency_fingerprint(
@@ -553,9 +562,18 @@ async def upload_project_file(
                 await _get_active_project_or_404(db, project_id)
                 return None
 
+            async def _cleanup_pre_commit_failed_upload() -> None:
+                nonlocal persisted_upload_uri
+                if persisted_upload_uri is None:
+                    return
+                await _rollback_upload_cleanup_transaction(db)
+                await _cleanup_persisted_upload(storage, storage_key, persisted_upload_uri)
+                persisted_upload_uri = None
+
             async def _mutate_upload() -> (
                 IdempotentMutationSuccess[FileModel] | IdempotentMutationKnownError
             ):
+                nonlocal persisted_upload_uri
                 try:
                     stored_object = await storage.put(storage_key, staging_path, immutable=True)
                 except FileExistsError:
@@ -569,7 +587,8 @@ async def upload_project_file(
                     await _cleanup_persisted_upload(storage, storage_key, stored_object.storage_uri)
                     return _known_upload_storage_failure("Stored file checksum mismatch detected.")
 
-                file_row = await _finalize_upload(stored_object.storage_uri)
+                persisted_upload_uri = stored_object.storage_uri
+                file_row = await _finalize_upload(persisted_upload_uri)
                 return IdempotentMutationSuccess(
                     value=file_row,
                     status_code=status.HTTP_201_CREATED,
@@ -587,6 +606,7 @@ async def upload_project_file(
                 preclaim=_preclaim_upload,
                 mutate=_mutate_upload,
                 serialize_result=_serialize_uploaded_file,
+                pre_commit_failure_cleanup=_cleanup_pre_commit_failed_upload,
             )
 
         try:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -19,6 +19,7 @@ import app.db.session as session_module
 import app.jobs.worker as worker_module
 from app.core.config import settings
 from app.core.exceptions import raise_not_found
+from app.models.extraction_profile import ExtractionProfile
 from app.models.file import File as FileModel
 from app.models.job import Job
 from app.models.project import Project
@@ -127,6 +128,82 @@ def _make_get_db_override_with_commit_error(
             await session.close()
 
     return _override_get_db
+
+
+def _make_get_db_override_with_flush_error(
+    flush_error: BaseException,
+) -> Callable[[], AsyncGenerator[Any, None]]:
+    """Create a request-scoped get_db override with a post-flush failure."""
+
+    async def _override_get_db() -> AsyncGenerator[Any, None]:
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        session = session_maker()
+        original_flush = session.flush
+
+        async def _fail_flush(*args: Any, **kwargs: Any) -> None:
+            await original_flush(*args, **kwargs)
+            raise flush_error
+
+        cast(Any, session).flush = _fail_flush
+
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    return _override_get_db
+
+
+def _make_get_db_override_with_flush_and_rollback_error(
+    flush_error: BaseException,
+    rollback_error: BaseException,
+) -> Callable[[], AsyncGenerator[Any, None]]:
+    """Create a request-scoped get_db override with flush and rollback failures."""
+
+    async def _override_get_db() -> AsyncGenerator[Any, None]:
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        session = session_maker()
+        original_flush = session.flush
+
+        async def _fail_flush(*args: Any, **kwargs: Any) -> None:
+            await original_flush(*args, **kwargs)
+            raise flush_error
+
+        async def _fail_rollback() -> None:
+            raise rollback_error
+
+        cast(Any, session).flush = _fail_flush
+        cast(Any, session).rollback = _fail_rollback
+
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    return _override_get_db
+
+
+async def _assert_upload_lineage_absent(project_id: str) -> None:
+    """Assert failed uploads left no persisted lineage rows for the project."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+    project_uuid = uuid.UUID(project_id)
+
+    async with session_maker() as session:
+        file_result = await session.execute(
+            select(FileModel).where(FileModel.project_id == project_uuid)
+        )
+        job_result = await session.execute(select(Job).where(Job.project_id == project_uuid))
+        extraction_profile_result = await session.execute(
+            select(ExtractionProfile).where(ExtractionProfile.project_id == project_uuid)
+        )
+
+    assert file_result.scalars().all() == []
+    assert job_result.scalars().all() == []
+    assert extraction_profile_result.scalars().all() == []
 
 
 class RecordingStorage:
@@ -1060,6 +1137,56 @@ class TestProjectFiles:
 
         assert file_result.scalars().all() == []
         assert job_result.scalars().all() == []
+
+    @pytest.mark.parametrize(
+        "rollback_error",
+        [
+            pytest.param(None, id="rollback-ok"),
+            pytest.param(RuntimeError("forced rollback failure"), id="rollback-fails"),
+            pytest.param(asyncio.CancelledError(), id="rollback-cancelled"),
+        ],
+    )
+    async def test_upload_file_cleans_persisted_upload_when_db_finalization_fails(
+        self,
+        async_client: httpx.AsyncClient,
+        created_project: dict[str, Any],
+        app: FastAPI,
+        rollback_error: BaseException | None,
+    ) -> None:
+        """POST should cleanup persisted bytes when upload DB finalization fails pre-commit."""
+        _ = self
+        payload = b"%PDF-1.7\nflush-failure"
+
+        if rollback_error is None:
+            app.dependency_overrides[session_module.get_db] = (
+                _make_get_db_override_with_flush_error(RuntimeError("forced flush failure"))
+            )
+        else:
+            app.dependency_overrides[session_module.get_db] = (
+                _make_get_db_override_with_flush_and_rollback_error(
+                    RuntimeError("forced flush failure"),
+                    rollback_error,
+                )
+            )
+        try:
+            with pytest.raises(RuntimeError, match="forced flush failure"):
+                await async_client.post(
+                    f"/v1/projects/{created_project['id']}/files",
+                    files={"file": ("flush-fail.pdf", payload, "application/pdf")},
+                )
+        finally:
+            app.dependency_overrides.pop(session_module.get_db, None)
+
+        upload_root = Path(settings.upload_storage_root).resolve()
+        staging_root = upload_root / ".staging"
+        assert not staging_root.exists() or not any(staging_root.iterdir())
+
+        originals_root = upload_root / "originals"
+        assert not originals_root.exists() or not any(
+            path.is_file() for path in originals_root.rglob("*")
+        )
+
+        await _assert_upload_lineage_absent(created_project["id"])
 
     async def test_list_project_files_project_not_found(
         self,

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
-from collections.abc import Mapping
+from collections.abc import AsyncGenerator, Callable, Mapping
+from pathlib import Path
 from typing import Any, cast
 
 import httpx
@@ -14,6 +16,7 @@ from fastapi.responses import JSONResponse, Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.api.idempotency as idempotency_api
 from app.api.idempotency import (
     IdempotencyReplay,
     IdempotencyReservation,
@@ -38,6 +41,8 @@ from app.db import session as session_module
 from app.jobs import worker as worker_module
 from app.jobs.worker import process_ingest_job
 from app.models.drawing_revision import DrawingRevision
+from app.models.extraction_profile import ExtractionProfile
+from app.models.file import File as FileModel
 from app.models.idempotency_key import IdempotencyKey, IdempotencyStatus
 from app.models.job import Job
 from app.models.project import Project
@@ -246,6 +251,43 @@ class _CommitTrackingSession:
     async def commit(self) -> None:
         self.commit_calls += 1
         self._events.append("commit")
+
+
+async def _upload_lineage_counts(project_id: str) -> tuple[int, int, int]:
+    """Return persisted file/job/extraction-profile counts for a project."""
+
+    session_maker = session_module.AsyncSessionLocal
+    assert session_maker is not None
+    project_uuid = uuid.UUID(project_id)
+
+    async with session_maker() as session:
+        file_count = int(
+            (
+                await session.execute(
+                    select(func.count())
+                    .select_from(FileModel)
+                    .where(FileModel.project_id == project_uuid)
+                )
+            ).scalar_one()
+        )
+        job_count = int(
+            (
+                await session.execute(
+                    select(func.count()).select_from(Job).where(Job.project_id == project_uuid)
+                )
+            ).scalar_one()
+        )
+        extraction_profile_count = int(
+            (
+                await session.execute(
+                    select(func.count())
+                    .select_from(ExtractionProfile)
+                    .where(ExtractionProfile.project_id == project_uuid)
+                )
+            ).scalar_one()
+        )
+
+    return file_count, job_count, extraction_profile_count
 
 
 @pytest.mark.asyncio
@@ -695,6 +737,78 @@ async def test_run_idempotent_mutation_propagates_arbitrary_exceptions() -> None
 
 
 @pytest.mark.asyncio
+async def test_run_idempotent_mutation_runs_pre_commit_failure_cleanup_before_commit_starts() -> (
+    None
+):
+    """Pre-commit failures should cleanup before any final commit begins."""
+
+    events: list[str] = []
+    session = _CommitTrackingSession(events)
+
+    async def _replay(db: AsyncSession, *, key: str | None, fingerprint: str) -> Response | None:
+        _ = db
+        events.append("replay")
+        assert (key, fingerprint) == ("cleanup-key-1", "fingerprint-13")
+        return None
+
+    async def _claim(
+        db: AsyncSession,
+        *,
+        key: str | None,
+        fingerprint: str,
+        method: str,
+        path: str,
+    ) -> IdempotencyReservation | Response | None:
+        _ = db
+        events.append("claim")
+        assert (key, fingerprint, method, path) == (
+            "cleanup-key-1",
+            "fingerprint-13",
+            "POST",
+            "/v1/projects/project-3/files",
+        )
+        return IdempotencyReservation(record_id=uuid.uuid4())
+
+    async def _complete(
+        db: AsyncSession,
+        reservation: IdempotencyReservation | None,
+        *,
+        status_code: int,
+        response_body: dict[str, Any] | None,
+    ) -> Response:
+        _ = (db, reservation, status_code, response_body)
+        events.append("complete")
+        raise RuntimeError("complete failed")
+
+    async def _mutate() -> IdempotentMutationSuccess[str]:
+        events.append("mutate")
+        return IdempotentMutationSuccess(value="project-3", status_code=201)
+
+    def _serialize(value: str) -> dict[str, Any]:
+        events.append("serialize")
+        return {"id": value}
+
+    async def _cleanup() -> None:
+        events.append("cleanup")
+
+    with pytest.raises(RuntimeError, match="complete failed"):
+        await run_idempotent_mutation(
+            cast(Any, session),
+            key="cleanup-key-1",
+            fingerprint="fingerprint-13",
+            method="POST",
+            path="/v1/projects/project-3/files",
+            mutate=_mutate,
+            serialize_result=_serialize,
+            ops=IdempotentMutationOps(replay=_replay, claim=_claim, complete=_complete),
+            pre_commit_failure_cleanup=_cleanup,
+        )
+
+    assert session.commit_calls == 0
+    assert events == ["replay", "claim", "mutate", "serialize", "complete", "cleanup"]
+
+
+@pytest.mark.asyncio
 async def test_complete_idempotency_response_marks_snapshot_and_returns_json() -> None:
     """Completion helper should snapshot success bodies without committing the session."""
 
@@ -816,6 +930,29 @@ def _get_async_client_app(async_client: httpx.AsyncClient) -> Any:
     if app is not None:
         return app
     return cast(Any, async_client)._transport.app
+
+
+def _make_get_db_override_with_rollback_error(
+    rollback_error: BaseException,
+) -> Callable[[], AsyncGenerator[Any, None]]:
+    """Create a request-scoped get_db override with an instance-level rollback failure."""
+
+    async def _override_get_db() -> AsyncGenerator[Any, None]:
+        session_maker = session_module.AsyncSessionLocal
+        assert session_maker is not None
+        session = session_maker()
+
+        async def _fail_rollback() -> None:
+            raise rollback_error
+
+        cast(Any, session).rollback = _fail_rollback
+
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    return _override_get_db
 
 
 async def _project_count() -> int:
@@ -1270,6 +1407,71 @@ class TestEndpointIdempotency:
         assert record.response_status_code == 500
         assert record.response_body_json == first.json()
         assert enqueued_job_ids == []
+
+    @pytest.mark.parametrize(
+        "rollback_error",
+        [
+            pytest.param(None, id="rollback-ok"),
+            pytest.param(RuntimeError("forced rollback failure"), id="rollback-fails"),
+            pytest.param(asyncio.CancelledError(), id="rollback-cancelled"),
+        ],
+    )
+    async def test_upload_file_cleans_idempotent_persisted_upload_when_db_finalization_fails(
+        self,
+        async_client: httpx.AsyncClient,
+        cleanup_projects: None,
+        monkeypatch: pytest.MonkeyPatch,
+        rollback_error: BaseException | None,
+    ) -> None:
+        """Idempotent uploads should cleanup persisted bytes on pre-commit finalization failure."""
+
+        _ = self
+        _ = cleanup_projects
+        project = cast(dict[str, Any], (await _create_project(async_client)).json())
+        key = "file-upload-complete-failure-1"
+        upload_root = Path(settings.upload_storage_root).resolve()
+        original_ops = idempotency_api.DEFAULT_IDEMPOTENT_MUTATION_OPS
+        app = _get_async_client_app(async_client)
+
+        async def _fail_complete(
+            db: AsyncSession,
+            reservation: IdempotencyReservation | None,
+            *,
+            status_code: int,
+            response_body: dict[str, Any] | None,
+        ) -> Response:
+            _ = (db, reservation, status_code, response_body)
+            raise RuntimeError("forced idempotent finalization failure")
+
+        monkeypatch.setattr(
+            idempotency_api,
+            "DEFAULT_IDEMPOTENT_MUTATION_OPS",
+            IdempotentMutationOps(
+                replay=original_ops.replay,
+                claim=original_ops.claim,
+                complete=_fail_complete,
+            ),
+        )
+
+        if rollback_error is not None:
+            app.dependency_overrides[session_module.get_db] = (
+                _make_get_db_override_with_rollback_error(rollback_error)
+            )
+
+        try:
+            with pytest.raises(RuntimeError, match="forced idempotent finalization failure"):
+                await _upload_pdf(async_client, project_id=project["id"], idempotency_key=key)
+        finally:
+            app.dependency_overrides.pop(session_module.get_db, None)
+
+        staging_root = upload_root / ".staging"
+        assert not staging_root.exists() or not any(staging_root.iterdir())
+
+        originals_root = upload_root / "originals"
+        assert not originals_root.exists() or not any(
+            path.is_file() for path in originals_root.rglob("*")
+        )
+        assert await _upload_lineage_counts(project["id"]) == (0, 0, 0)
 
     async def test_mark_idempotency_completed_does_not_overwrite_completed_snapshot(
         self,


### PR DESCRIPTION
Closes #329

## Summary
- clean persisted upload bytes when DB finalization fails before commit starts
- add idempotent-upload cleanup hook for pre-commit completion failures
- preserve conservative retention for commit-started failures

## Test plan
- [x] uv run ruff check app/api/v1/files.py app/api/idempotency.py tests/test_files.py tests/test_idempotency.py
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_files.py tests/test_idempotency.py -k "upload_file_cleans_persisted_upload_when_db_finalization_fails or upload_file_cleans_idempotent_persisted_upload_when_db_finalization_fails or upload_file_rejects_storage_checksum_mismatch_and_cleans_persisted_upload or upload_file_cleans_persisted_upload_when_locked_project_recheck_fails or upload_file_commit_failure_retains_written_bytes_conservatively or upload_file_commit_cancelled_error_retains_written_bytes_conservatively or run_idempotent_mutation_runs_pre_commit_failure_cleanup_before_commit_starts"
- [x] pre-push hook pytest suite (597 passed, 621 skipped)