### PR TITLE
fix(changesets): align add_entity layer aliases

### DIFF
--- a/app/cad/changeset_validation.py
+++ b/app/cad/changeset_validation.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, cast
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.cad.changeset.apply import ALLOWED_LAYER_KEYS
 from app.cad.changesets import (
     CadChangeSetValidationResultCreate,
     append_change_set_validation_result,
@@ -257,7 +258,7 @@ async def _validate_operation(
         findings.extend(target_findings)
         layer_ref = _extract_text_reference(
             payload,
-            keys=("layer_ref", "layer", "layer_name", "new_layer"),
+            keys=ALLOWED_LAYER_KEYS,
         )
         if layer_ref is None:
             findings.append(
@@ -357,26 +358,11 @@ async def _validate_operation(
                     )
                 )
 
-        for field_name, reference_value, exists_fn in (
-            (
-                "layer_ref",
-                _extract_text_reference(entity or payload, keys=("layer_ref",)),
-                _layer_exists,
-            ),
-            (
-                "layout_ref",
-                _extract_text_reference(entity or payload, keys=("layout_ref",)),
-                _layout_exists,
-            ),
-            (
-                "block_ref",
-                _extract_text_reference(entity or payload, keys=("block_ref",)),
-                _block_exists,
-            ),
+        for field_name, reference_value in _iter_text_references(
+            entity or payload,
+            keys=ALLOWED_LAYER_KEYS,
         ):
-            if reference_value is None:
-                continue
-            if not await exists_fn(
+            if not await _layer_exists(
                 db,
                 change_set.project_id,
                 change_set.base_revision_id,
@@ -392,6 +378,40 @@ async def _validate_operation(
                             "not exist on the base revision."
                         ),
                         details={field_name: reference_value},
+                    )
+                )
+
+        for field_name, scoped_reference_value, exists_fn in (
+            (
+                "layout_ref",
+                _extract_text_reference(entity or payload, keys=("layout_ref",)),
+                _layout_exists,
+            ),
+            (
+                "block_ref",
+                _extract_text_reference(entity or payload, keys=("block_ref",)),
+                _block_exists,
+            ),
+        ):
+            if scoped_reference_value is None:
+                continue
+            if not await exists_fn(
+                db,
+                change_set.project_id,
+                change_set.base_revision_id,
+                scoped_reference_value,
+            ):
+                findings.append(
+                    _finding(
+                        operation,
+                        severity="error",
+                        code=f"{field_name}_not_found",
+                        message=(
+                            "add_entity references "
+                            f"{field_name} {scoped_reference_value!r} that does "
+                            "not exist on the base revision."
+                        ),
+                        details={field_name: scoped_reference_value},
                     )
                 )
 
@@ -998,13 +1018,25 @@ def _extract_text_reference(
     *,
     keys: Sequence[str],
 ) -> str | None:
+    references = _iter_text_references(payload, keys=keys)
+    if references:
+        return references[0][1]
+    return None
+
+
+def _iter_text_references(
+    payload: Mapping[str, Any],
+    *,
+    keys: Sequence[str],
+) -> tuple[tuple[str, str], ...]:
+    references: list[tuple[str, str]] = []
     for key in keys:
         value = payload.get(key)
         if isinstance(value, str):
             normalized = value.strip()
             if normalized:
-                return normalized
-    return None
+                references.append((key, normalized))
+    return tuple(references)
 
 
 def _extract_block_reference(payload: Mapping[str, Any]) -> str | None:

--- a/tests/test_changeset_apply.py
+++ b/tests/test_changeset_apply.py
@@ -29,6 +29,7 @@ from app.cad.changeset import (
     load_and_apply_change_set,
     load_change_set_apply_input,
 )
+from app.cad.changeset.apply import ALLOWED_LAYER_KEYS
 from app.core.errors import ErrorCode
 from app.jobs import worker as worker_module
 from app.models.adapter_run_output import AdapterRunOutput
@@ -338,7 +339,8 @@ def test_apply_change_set_marks_no_op_update_as_unchanged() -> None:
     )
 
 
-def test_apply_change_set_accepts_add_entity_alias_payloads() -> None:
+@pytest.mark.parametrize("layer_key", ALLOWED_LAYER_KEYS)
+def test_apply_change_set_accepts_add_entity_alias_payloads(layer_key: str) -> None:
     change_set_id = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
     revision = RevisionRef(
         revision_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
@@ -357,7 +359,7 @@ def test_apply_change_set_accepts_add_entity_alias_payloads() -> None:
                     "properties": {"label": "N-1"},
                 },
                 "properties_json": {"label": "N-1"},
-                "layer_ref": "A-NOTE",
+                layer_key: "A-NOTE",
             }
         },
     )

--- a/tests/test_changeset_validation.py
+++ b/tests/test_changeset_validation.py
@@ -14,6 +14,7 @@ from sqlalchemy import MetaData, Table
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.db.session as session_module
+from app.cad.changeset.apply import ALLOWED_LAYER_KEYS
 from app.cad.changeset_validation import (
     ChangeSetValidationErrorCode,
     ChangeSetValidationServiceError,
@@ -902,6 +903,45 @@ async def test_validate_change_set_rejects_invalid_add_entity_geometry_and_refer
 
     assert validation_result.validation_status == "invalid"
     assert expected_code in _result_codes(validation_result.result_json)
+
+
+@pytest.mark.parametrize("layer_key", ALLOWED_LAYER_KEYS)
+async def test_validate_change_set_rejects_missing_add_entity_layer_aliases(
+    db_session: AsyncSession,
+    layer_key: str,
+) -> None:
+    seed = await _seed_revision(db_session)
+    change_set = await create_change_set(
+        db_session,
+        project_id=seed.project_id,
+        base_revision_id=seed.revision_id,
+        status="proposed",
+        created_by="tester",
+        operations=[
+            CadChangeOperationCreate(
+                operation_type="add_entity",
+                operation_json=_operation_envelope(
+                    target={"drawing_revision_scope": "base"},
+                    payload={
+                        "entity": {
+                            "entity_type": "line",
+                            "geometry": {
+                                "type": "line",
+                                "start": {"x": 1.0, "y": 1.0},
+                                "end": {"x": 2.0, "y": 2.0},
+                            },
+                            layer_key: "missing-layer",
+                        }
+                    },
+                ),
+            )
+        ],
+    )
+
+    validation_result = await validate_change_set(db_session, change_set.id)
+
+    assert validation_result.validation_status == "invalid"
+    assert f"{layer_key}_not_found" in _result_codes(validation_result.result_json)
 
 
 async def test_validate_change_set_rejects_invalid_replace_block_reference(


### PR DESCRIPTION
Closes #330

## Summary
- Align add_entity layer validation with the aliases accepted by changeset apply.
- Validate missing base-revision layers for layer_ref, layer, layer_name, and new_layer before apply/finalization.
- Add parametrized regression coverage for validation and apply alias behavior.

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test_330 uv run pytest -q tests/test_changeset_validation.py tests/test_changeset_apply.py tests/test_changeset_api.py
- [x] pre-push hook: uv run pytest