### PR TITLE
fix: persist export artifact typed anchors #331

### DIFF
--- a/app/jobs/worker.py
+++ b/app/jobs/worker.py
@@ -4341,6 +4341,8 @@ async def _finalize_export_job(
                     job_id=job.id,
                     drawing_revision_id=execution.drawing_revision_id,
                     changeset_id=execution.changeset_id,
+                    quantity_takeoff_id=execution.quantity_takeoff_id,
+                    estimate_version_id=execution.estimate_version_id,
                     artifact_kind=execution.export_kind,
                     name=execution.artifact_name,
                     format=execution.export_format,

--- a/tests/test_jobs_worker_exports.py
+++ b/tests/test_jobs_worker_exports.py
@@ -536,6 +536,14 @@ async def test_process_export_job_supported_kinds_persist_artifact(
     assert artifact.project_id == lineage.project_id
     assert artifact.source_file_id == lineage.file_id
     assert artifact.drawing_revision_id == lineage.drawing_revision_id
+    assert artifact.quantity_takeoff_id == (
+        lineage.quantity_takeoff_id
+        if export_kind in {"quantity_csv", "estimate_csv", "estimate_pdf"}
+        else None
+    )
+    assert artifact.estimate_version_id == (
+        lineage.estimate_version_id if export_kind in {"estimate_csv", "estimate_pdf"} else None
+    )
     assert artifact.generator_config_json == options_json
     lineage_json = cast(dict[str, Any], artifact.lineage_json)
     assert lineage_json["drawing_revision"] == {"id": str(lineage.drawing_revision_id)}


### PR DESCRIPTION
Closes #331

## Summary
- Persist typed quantity and estimate lineage anchors on generated export artifacts.
- Add worker regression coverage for revision, quantity, and estimate export anchor expectations.

## Test plan
- [x] uv run ruff check app tests
- [x] uv run mypy app tests
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run alembic upgrade head
- [x] DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/draupnir_test uv run pytest -q tests/test_jobs_worker_exports.py
- [x] git push pre-push hook full pytest suite

## Notes
- No schema or migration changes.